### PR TITLE
feat(wiki): AI-assisted maintenance assistant (Phase 3 PR 7)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -463,6 +463,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/wiki/sections", b.requireAuth(b.handleWikiSections))
 	mux.HandleFunc("/wiki/lint/run", b.requireAuth(b.handleLintRun))
 	mux.HandleFunc("/wiki/lint/resolve", b.requireAuth(b.handleLintResolve))
+	mux.HandleFunc("/wiki/maintenance/suggest", b.requireAuth(b.handleWikiMaintenanceSuggest))
 	mux.HandleFunc("/wiki/extract/replay", b.requireAuth(b.handleWikiExtractReplay))
 	mux.HandleFunc("/wiki/dlq", b.requireAuth(b.handleWikiDLQ))
 	mux.HandleFunc("/wiki/compress", b.requireAuth(b.handleWikiCompress))

--- a/internal/team/broker_wiki_maintenance.go
+++ b/internal/team/broker_wiki_maintenance.go
@@ -15,11 +15,25 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 )
 
 type maintenanceSuggestRequest struct {
 	Action MaintenanceAction `json:"action"`
 	Path   string            `json:"path"`
+}
+
+// isSupportedMaintenanceAction returns true when the action is one of the
+// finite set the assistant knows how to handle. Reused at the broker boundary
+// so unsupported actions fail as 400s instead of falling through to the
+// assistant's "unknown action" 500 error.
+func isSupportedMaintenanceAction(a MaintenanceAction) bool {
+	for _, known := range AllMaintenanceActions {
+		if known == a {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *Broker) handleWikiMaintenanceSuggest(w http.ResponseWriter, r *http.Request) {
@@ -37,12 +51,18 @@ func (b *Broker) handleWikiMaintenanceSuggest(w http.ResponseWriter, r *http.Req
 		http.Error(w, fmt.Sprintf("invalid body: %v", err), http.StatusBadRequest)
 		return
 	}
+	req.Path = strings.TrimSpace(req.Path)
+	req.Action = MaintenanceAction(strings.TrimSpace(string(req.Action)))
 	if req.Path == "" {
 		http.Error(w, "path is required", http.StatusBadRequest)
 		return
 	}
 	if req.Action == "" {
 		http.Error(w, "action is required", http.StatusBadRequest)
+		return
+	}
+	if !isSupportedMaintenanceAction(req.Action) {
+		http.Error(w, fmt.Sprintf("unsupported action: %q", req.Action), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/team/broker_wiki_maintenance.go
+++ b/internal/team/broker_wiki_maintenance.go
@@ -1,0 +1,63 @@
+package team
+
+// broker_wiki_maintenance.go wires the wiki maintenance assistant into the
+// broker HTTP layer.
+//
+// Routes:
+//   POST /wiki/maintenance/suggest — body {action, path}; returns MaintenanceSuggestion JSON.
+//
+// The handler does not auto-write. Suggestions are computed and returned;
+// the user accepts a suggestion through the existing /wiki/write-human path
+// (the same conflict-detection / expected_sha flow as the editor).
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+type maintenanceSuggestRequest struct {
+	Action MaintenanceAction `json:"action"`
+	Path   string            `json:"path"`
+}
+
+func (b *Broker) handleWikiMaintenanceSuggest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		http.Error(w, "wiki backend unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	var req maintenanceSuggestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid body: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.Path == "" {
+		http.Error(w, "path is required", http.StatusBadRequest)
+		return
+	}
+	if req.Action == "" {
+		http.Error(w, "action is required", http.StatusBadRequest)
+		return
+	}
+
+	idx := b.WikiIndex()
+	prov := &brokerLintProvider{}
+	lint := NewLint(idx, worker, prov)
+	assistant := NewMaintenanceAssistant(worker, idx, lint)
+
+	suggestion, err := assistant.Suggest(r.Context(), req.Action, req.Path)
+	if err != nil {
+		log.Printf("wiki maintenance: suggest %s for %s: %v", req.Action, req.Path, err)
+		http.Error(w, fmt.Sprintf("suggest failed: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(suggestion)
+}

--- a/internal/team/broker_wiki_maintenance_test.go
+++ b/internal/team/broker_wiki_maintenance_test.go
@@ -1,0 +1,90 @@
+package team
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestHandleWikiMaintenanceSuggest_RejectsGet rejects non-POST requests so
+// callers don't accidentally trigger expensive suggestion compute via prefetch.
+func TestHandleWikiMaintenanceSuggest_RejectsGet(t *testing.T) {
+	b := newTestBroker(t)
+	srv := httptest.NewServer(http.HandlerFunc(b.handleWikiMaintenanceSuggest))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("status: want 405, got %d", resp.StatusCode)
+	}
+}
+
+// TestHandleWikiMaintenanceSuggest_NoWiki returns 503 when the markdown
+// backend is not enabled. The frontend should treat this as "feature off"
+// and gracefully hide the panel.
+func TestHandleWikiMaintenanceSuggest_NoWiki(t *testing.T) {
+	b := newTestBroker(t)
+	srv := httptest.NewServer(http.HandlerFunc(b.handleWikiMaintenanceSuggest))
+	defer srv.Close()
+
+	body := bytes.NewBufferString(`{"action":"summarize","path":"team/people/x.md"}`)
+	resp, err := http.Post(srv.URL, "application/json", body)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status: want 503, got %d", resp.StatusCode)
+	}
+}
+
+// TestHandleWikiMaintenanceSuggest_E2E exercises the full handler with a
+// real WikiWorker — verifies the JSON response shape matches what the
+// frontend's WikiMaintenanceSuggestion type expects.
+func TestHandleWikiMaintenanceSuggest_E2E(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	body := strings.Repeat("Sarah Chen leads product at Acme Corp. ", 30) +
+		"\n\n# Sarah Chen\n\nSarah Chen leads product at Acme Corp.\n"
+	seedArticle(t, worker, "team/people/sarah-chen.md", body)
+
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	srv := httptest.NewServer(http.HandlerFunc(b.handleWikiMaintenanceSuggest))
+	defer srv.Close()
+
+	reqBody := bytes.NewBufferString(`{"action":"summarize","path":"team/people/sarah-chen.md"}`)
+	resp, err := http.Post(srv.URL, "application/json", reqBody)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	var got MaintenanceSuggestion
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Action != MaintActionSummarize {
+		t.Errorf("action: want summarize, got %q", got.Action)
+	}
+	if got.Skipped {
+		t.Errorf("expected non-skipped, got skipped: %s", got.SkippedReason)
+	}
+	if got.Diff == nil || got.Diff.ProposedContent == "" {
+		t.Errorf("expected diff with proposed content, got nil")
+	}
+}

--- a/internal/team/broker_wiki_maintenance_test.go
+++ b/internal/team/broker_wiki_maintenance_test.go
@@ -45,6 +45,50 @@ func TestHandleWikiMaintenanceSuggest_NoWiki(t *testing.T) {
 	}
 }
 
+// TestHandleWikiMaintenanceSuggest_RejectsUnsupportedAction returns 400 for
+// actions outside the finite enum so client typos do not get treated as
+// server errors. The error body echoes the bad action name.
+func TestHandleWikiMaintenanceSuggest_RejectsUnsupportedAction(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+	seedArticle(t, worker, "team/people/sarah-chen.md", "# Sarah\n\nshort.\n")
+
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	srv := httptest.NewServer(http.HandlerFunc(b.handleWikiMaintenanceSuggest))
+	defer srv.Close()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"typo action", `{"action":"summarise","path":"team/people/sarah-chen.md"}`},
+		{"whitespace only", `{"action":"   ","path":"team/people/sarah-chen.md"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp, err := http.Post(srv.URL, "application/json",
+				bytes.NewBufferString(c.body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status: want 400, got %d", resp.StatusCode)
+			}
+			buf := make([]byte, 256)
+			n, _ := resp.Body.Read(buf)
+			body := string(buf[:n])
+			if c.name == "typo action" && !strings.Contains(body, "summarise") {
+				t.Fatalf("error body should echo the bad action; got %q", body)
+			}
+		})
+	}
+}
+
 // TestHandleWikiMaintenanceSuggest_E2E exercises the full handler with a
 // real WikiWorker — verifies the JSON response shape matches what the
 // frontend's WikiMaintenanceSuggestion type expects.

--- a/internal/team/wiki_maintenance.go
+++ b/internal/team/wiki_maintenance.go
@@ -1,0 +1,841 @@
+package team
+
+// wiki_maintenance.go computes AI-assisted maintenance suggestions for a wiki
+// article. Suggestions are *proposals only* — they never auto-write. The user
+// must accept a suggestion explicitly through the WikiEditor save path before
+// any change lands on disk.
+//
+// Suggestion types (mirrors phase-03-wiki-ux.md PR 7 scope):
+//
+//   summarize          — propose a TL;DR / lead paragraph
+//   add_citation       — propose [needs citation] markers on un-sourced claims
+//   extract_facts      — propose structured facts (subject/predicate/object)
+//                        for review *before* commit to fact log
+//   resolve_contradiction — link to existing WikiLint contradiction surface
+//   split_long_page    — propose a split when the page is large
+//   link_related       — propose a "Related" section based on co-occurring
+//                        entities, backlinks, and graph edges
+//   refresh_stale      — propose a "Recent activity" pointer for stale pages
+//
+// All actions are pure functions of (article content, on-disk catalog, fact
+// index, lint report). No LLM call is required for v1 — every suggestion is
+// derived from existing structured signals already in the broker.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// MaintenanceAction is the discriminator for the 7 supported actions.
+type MaintenanceAction string
+
+const (
+	MaintActionSummarize            MaintenanceAction = "summarize"
+	MaintActionAddCitation          MaintenanceAction = "add_citation"
+	MaintActionExtractFacts         MaintenanceAction = "extract_facts"
+	MaintActionResolveContradiction MaintenanceAction = "resolve_contradiction"
+	MaintActionSplitLong            MaintenanceAction = "split_long_page"
+	MaintActionLinkRelated          MaintenanceAction = "link_related"
+	MaintActionRefreshStale         MaintenanceAction = "refresh_stale"
+)
+
+// AllMaintenanceActions enumerates the supported actions, in display order.
+var AllMaintenanceActions = []MaintenanceAction{
+	MaintActionSummarize,
+	MaintActionAddCitation,
+	MaintActionExtractFacts,
+	MaintActionLinkRelated,
+	MaintActionSplitLong,
+	MaintActionRefreshStale,
+	MaintActionResolveContradiction,
+}
+
+// MaintenanceEvidence is one piece of source material the suggestion was
+// derived from. The UI links each item back to its origin.
+type MaintenanceEvidence struct {
+	// Kind is "wiki_article" | "fact" | "lint_finding" | "edit_log".
+	Kind string `json:"kind"`
+	// Label is the short human-readable name (article title, predicate,
+	// finding type).
+	Label string `json:"label"`
+	// Path is the wiki path or fact id the evidence points at. Empty when
+	// the evidence is purely textual.
+	Path string `json:"path,omitempty"`
+	// Snippet is a short excerpt the UI can render verbatim.
+	Snippet string `json:"snippet,omitempty"`
+}
+
+// MaintenanceFactProposal is one proposed structured fact for the
+// extract_facts action. The user reviews each one in the side panel; only
+// accepted facts go to the fact log on commit.
+type MaintenanceFactProposal struct {
+	Subject    string  `json:"subject"`
+	Predicate  string  `json:"predicate"`
+	Object     string  `json:"object"`
+	Confidence float64 `json:"confidence"`
+	// SourceLine is the article-relative line index the fact was extracted
+	// from (1-based for display). Lets the UI highlight context.
+	SourceLine int `json:"source_line,omitempty"`
+}
+
+// MaintenanceDiff is the proposed change to the article body. v1 carries the
+// whole proposed content plus added / removed line counts so the UI can
+// render a small unified-diff-style preview.
+type MaintenanceDiff struct {
+	// ProposedContent is the full new article body. Empty for actions that
+	// do not modify the article body (extract_facts, resolve_contradiction).
+	ProposedContent string `json:"proposed_content,omitempty"`
+	// Added is the list of newly-introduced lines (in order).
+	Added []string `json:"added,omitempty"`
+	// Removed is the list of removed lines (in order).
+	Removed []string `json:"removed,omitempty"`
+}
+
+// MaintenanceSuggestion is the single-action response from the assistant.
+type MaintenanceSuggestion struct {
+	Action      MaintenanceAction `json:"action"`
+	Title       string            `json:"title"`
+	Description string            `json:"description"`
+	// Diff is populated for body-mutating actions.
+	Diff *MaintenanceDiff `json:"diff,omitempty"`
+	// Facts is populated for extract_facts.
+	Facts []MaintenanceFactProposal `json:"facts,omitempty"`
+	// Evidence is the list of source pointers the suggestion drew from.
+	Evidence []MaintenanceEvidence `json:"evidence,omitempty"`
+	// LintFinding is populated for resolve_contradiction. The UI uses this
+	// to redirect into the existing ResolveContradictionModal flow.
+	LintFinding *LintFinding `json:"lint_finding,omitempty"`
+	// LintReportDate, LintFindingIdx pair the finding with its report.
+	LintReportDate string `json:"lint_report_date,omitempty"`
+	LintFindingIdx int    `json:"lint_finding_idx,omitempty"`
+	// ExpectedSHA is the article SHA at the time the suggestion was
+	// computed. Sent back when the user accepts so the WikiEditor save
+	// path can detect stale suggestions exactly like a stale editor open.
+	ExpectedSHA string `json:"expected_sha,omitempty"`
+	// Skipped is true when no suggestion was warranted (e.g. page is short
+	// enough that split_long is not useful, or no contradictions exist).
+	// The UI shows a "nothing to do" state rather than an empty diff.
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkippedReason string `json:"skipped_reason,omitempty"`
+}
+
+// MaintenanceAssistant computes suggestions for one article + action pair.
+// All inputs are existing broker subsystems; no new state is introduced.
+type MaintenanceAssistant struct {
+	worker *WikiWorker
+	index  *WikiIndex
+	lint   *Lint
+	now    func() time.Time
+}
+
+// NewMaintenanceAssistant wires the assistant to its dependencies. worker is
+// required (provides on-disk article reads + repo head SHA). index and lint
+// are optional — when nil, actions that need them return Skipped responses.
+func NewMaintenanceAssistant(worker *WikiWorker, index *WikiIndex, lint *Lint) *MaintenanceAssistant {
+	return &MaintenanceAssistant{
+		worker: worker,
+		index:  index,
+		lint:   lint,
+		now:    time.Now,
+	}
+}
+
+// ErrMaintenanceNoWorker is returned when the assistant is constructed without
+// a wiki worker (markdown backend disabled).
+var ErrMaintenanceNoWorker = errors.New("wiki maintenance: no worker")
+
+// Suggest dispatches to the action-specific computer.
+func (m *MaintenanceAssistant) Suggest(ctx context.Context, action MaintenanceAction, articlePath string) (MaintenanceSuggestion, error) {
+	if m.worker == nil {
+		return MaintenanceSuggestion{}, ErrMaintenanceNoWorker
+	}
+
+	body, err := m.worker.ReadArticle(articlePath)
+	if err != nil {
+		return MaintenanceSuggestion{}, fmt.Errorf("read article: %w", err)
+	}
+
+	sha, _ := m.worker.repo.HeadSHA(ctx)
+
+	switch action {
+	case MaintActionSummarize:
+		return m.suggestSummarize(articlePath, string(body), sha), nil
+	case MaintActionAddCitation:
+		return m.suggestAddCitation(articlePath, string(body), sha), nil
+	case MaintActionExtractFacts:
+		return m.suggestExtractFacts(articlePath, string(body), sha), nil
+	case MaintActionLinkRelated:
+		return m.suggestLinkRelated(ctx, articlePath, string(body), sha), nil
+	case MaintActionSplitLong:
+		return m.suggestSplitLong(articlePath, string(body), sha), nil
+	case MaintActionRefreshStale:
+		return m.suggestRefreshStale(ctx, articlePath, string(body), sha), nil
+	case MaintActionResolveContradiction:
+		return m.suggestResolveContradiction(ctx, articlePath, sha), nil
+	default:
+		return MaintenanceSuggestion{}, fmt.Errorf("unknown action: %q", action)
+	}
+}
+
+// ── summarize ────────────────────────────────────────────────────────────────
+
+const summarizeMinWords = 80
+
+// suggestSummarize proposes a TL;DR block at the top of the article, just
+// after the H1, when the body is long enough to benefit. The summary itself
+// is the first non-empty paragraph trimmed to 240 chars. The proposal hands
+// the user a starting point; the editor tab is where they refine it.
+func (m *MaintenanceAssistant) suggestSummarize(path, body, sha string) MaintenanceSuggestion {
+	wc := countWords([]byte(body))
+	if wc < summarizeMinWords {
+		return MaintenanceSuggestion{
+			Action:        MaintActionSummarize,
+			Title:         "Summarize page",
+			Skipped:       true,
+			SkippedReason: fmt.Sprintf("Article is only %d words — a summary would not help.", wc),
+			ExpectedSHA:   sha,
+		}
+	}
+	lead := firstParagraph(body)
+	if lead == "" {
+		return MaintenanceSuggestion{
+			Action:        MaintActionSummarize,
+			Title:         "Summarize page",
+			Skipped:       true,
+			SkippedReason: "No paragraph found to summarize.",
+			ExpectedSHA:   sha,
+		}
+	}
+	tldr := truncateChars(strings.ReplaceAll(lead, "\n", " "), 240)
+	block := fmt.Sprintf("> **TL;DR:** %s\n\n", tldr)
+
+	proposed, added, removed := insertAfterTitle(body, block)
+	return MaintenanceSuggestion{
+		Action:      MaintActionSummarize,
+		Title:       "Summarize page",
+		Description: "Insert a one-line TL;DR derived from the article's lead paragraph.",
+		Diff: &MaintenanceDiff{
+			ProposedContent: proposed,
+			Added:           added,
+			Removed:         removed,
+		},
+		Evidence: []MaintenanceEvidence{
+			{Kind: "wiki_article", Label: "Article body lead", Path: path, Snippet: tldr},
+		},
+		ExpectedSHA: sha,
+	}
+}
+
+// ── add citation ─────────────────────────────────────────────────────────────
+
+// citationClaimRe matches sentence-ish lines that look like a strong claim
+// (contain a number, percentage, year, or one of a small list of strong
+// verbs) but have no explicit source link or footnote on the same line.
+var citationStrongVerbs = []string{
+	"announced", "launched", "raised", "shipped", "acquired", "merged",
+	"reported", "achieved", "doubled", "tripled", "increased", "decreased",
+}
+
+// suggestAddCitation flags lines that look like load-bearing claims without a
+// source. v1 is conservative — only proposes appending `[needs citation]` to
+// numeric/strong-verb sentences that lack a link or a footnote-style anchor.
+func (m *MaintenanceAssistant) suggestAddCitation(path, body, sha string) MaintenanceSuggestion {
+	lines := strings.Split(body, "\n")
+	var changed []string
+	added := make([]string, 0)
+	removed := make([]string, 0)
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ">") {
+			changed = append(changed, line)
+			continue
+		}
+		if !claimNeedsCitation(trimmed) {
+			changed = append(changed, line)
+			continue
+		}
+		if strings.Contains(line, "[needs citation]") {
+			changed = append(changed, line)
+			continue
+		}
+		new := strings.TrimRight(line, " \t") + " [needs citation]"
+		changed = append(changed, new)
+		removed = append(removed, line)
+		added = append(added, new)
+	}
+
+	if len(added) == 0 {
+		return MaintenanceSuggestion{
+			Action:        MaintActionAddCitation,
+			Title:         "Add missing citation",
+			Skipped:       true,
+			SkippedReason: "No un-sourced numeric or strong-claim sentences found.",
+			ExpectedSHA:   sha,
+		}
+	}
+	return MaintenanceSuggestion{
+		Action:      MaintActionAddCitation,
+		Title:       "Add missing citation",
+		Description: fmt.Sprintf("Mark %d claim(s) as needing a citation. The mark is reversible — replace it with the actual source link before saving.", len(added)),
+		Diff: &MaintenanceDiff{
+			ProposedContent: strings.Join(changed, "\n"),
+			Added:           added,
+			Removed:         removed,
+		},
+		Evidence: []MaintenanceEvidence{
+			{Kind: "wiki_article", Label: "Article body — un-sourced claims", Path: path},
+		},
+		ExpectedSHA: sha,
+	}
+}
+
+func claimNeedsCitation(line string) bool {
+	if strings.Contains(line, "http://") || strings.Contains(line, "https://") {
+		return false
+	}
+	if strings.Contains(line, "[") && strings.Contains(line, "](") {
+		return false // already has a markdown link
+	}
+	if strings.Contains(line, "[needs citation]") {
+		return false
+	}
+	if hasNumericClaim(line) {
+		return true
+	}
+	lower := strings.ToLower(line)
+	for _, v := range citationStrongVerbs {
+		if strings.Contains(lower, " "+v+" ") || strings.HasPrefix(lower, v+" ") {
+			return true
+		}
+	}
+	return false
+}
+
+func hasNumericClaim(line string) bool {
+	digits := 0
+	for _, r := range line {
+		if r >= '0' && r <= '9' {
+			digits++
+		}
+	}
+	return digits >= 2
+}
+
+// ── extract facts ────────────────────────────────────────────────────────────
+
+// suggestExtractFacts proposes structured fact triples from the article. v1
+// scans for "X is the Y of Z" / "X works at Y" / "X joined Y on DATE" shapes
+// using a tiny pattern set — every proposal is conservative and confidence
+// is capped so the user reviews before any commit.
+func (m *MaintenanceAssistant) suggestExtractFacts(path, body, _ string) MaintenanceSuggestion {
+	subject := slugFromPath(path)
+	if subject == "" {
+		// Without a subject anchor, refuse to propose facts — extraction
+		// without an entity context tends to be noise.
+		return MaintenanceSuggestion{
+			Action:        MaintActionExtractFacts,
+			Title:         "Extract facts",
+			Skipped:       true,
+			SkippedReason: "Article path does not map to an entity (people/companies/customers).",
+		}
+	}
+	proposals := extractTriples(subject, body)
+	if len(proposals) == 0 {
+		return MaintenanceSuggestion{
+			Action:        MaintActionExtractFacts,
+			Title:         "Extract facts",
+			Skipped:       true,
+			SkippedReason: "No clear triples found in the article body.",
+		}
+	}
+
+	return MaintenanceSuggestion{
+		Action:      MaintActionExtractFacts,
+		Title:       "Extract facts",
+		Description: fmt.Sprintf("Propose %d structured fact(s) for review. Nothing is committed to the fact log until you accept individual proposals.", len(proposals)),
+		Facts:       proposals,
+		Evidence: []MaintenanceEvidence{
+			{Kind: "wiki_article", Label: "Article body — pattern-extracted triples", Path: path},
+		},
+	}
+}
+
+// ── link related ─────────────────────────────────────────────────────────────
+
+// suggestLinkRelated proposes appending a "Related" section listing entities
+// that co-occur with this one in the fact log or share graph edges. The
+// section is only proposed when at least one related entity exists *and* the
+// article does not already have a "Related" heading.
+func (m *MaintenanceAssistant) suggestLinkRelated(ctx context.Context, path, body, sha string) MaintenanceSuggestion {
+	related := m.relatedEntities(ctx, path)
+	if len(related) == 0 {
+		return MaintenanceSuggestion{
+			Action:        MaintActionLinkRelated,
+			Title:         "Link related pages",
+			Skipped:       true,
+			SkippedReason: "No related entities found in the fact log or graph.",
+			ExpectedSHA:   sha,
+		}
+	}
+	if hasHeading(body, "Related") {
+		return MaintenanceSuggestion{
+			Action:        MaintActionLinkRelated,
+			Title:         "Link related pages",
+			Skipped:       true,
+			SkippedReason: "Article already has a Related section. Edit it manually if you want to refresh.",
+			ExpectedSHA:   sha,
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n## Related\n\n")
+	for _, slug := range related {
+		fmt.Fprintf(&sb, "- [[%s]]\n", slug)
+	}
+	block := sb.String()
+
+	proposed := strings.TrimRight(body, "\n") + "\n" + block
+	added := strings.Split(strings.TrimRight(block, "\n"), "\n")
+
+	evidence := make([]MaintenanceEvidence, 0, len(related))
+	for _, slug := range related {
+		evidence = append(evidence, MaintenanceEvidence{
+			Kind:  "wiki_article",
+			Label: slug,
+			Path:  slug,
+		})
+	}
+
+	return MaintenanceSuggestion{
+		Action:      MaintActionLinkRelated,
+		Title:       "Link related pages",
+		Description: fmt.Sprintf("Append a Related section linking %d co-occurring entit%s.", len(related), pluralY(len(related))),
+		Diff: &MaintenanceDiff{
+			ProposedContent: proposed,
+			Added:           added,
+		},
+		Evidence:    evidence,
+		ExpectedSHA: sha,
+	}
+}
+
+// ── split long ───────────────────────────────────────────────────────────────
+
+const splitLongMinWords = 1500
+
+// suggestSplitLong proposes splitting a long page on its top-level (H2)
+// sections. The split itself is described — the user accepts to apply the
+// rewrite that turns each H2 into its own sub-page with a stub-link footer.
+func (m *MaintenanceAssistant) suggestSplitLong(path, body, sha string) MaintenanceSuggestion {
+	wc := countWords([]byte(body))
+	if wc < splitLongMinWords {
+		return MaintenanceSuggestion{
+			Action:        MaintActionSplitLong,
+			Title:         "Split long page",
+			Skipped:       true,
+			SkippedReason: fmt.Sprintf("Article is %d words — short enough to keep as one page.", wc),
+			ExpectedSHA:   sha,
+		}
+	}
+	headings := extractH2Headings(body)
+	if len(headings) < 2 {
+		return MaintenanceSuggestion{
+			Action:        MaintActionSplitLong,
+			Title:         "Split long page",
+			Skipped:       true,
+			SkippedReason: "Article does not have enough top-level sections to split cleanly.",
+			ExpectedSHA:   sha,
+		}
+	}
+	// v1: produce a description-only proposal. The Diff carries an
+	// `Added` outline so the UI can render the proposed sub-page list.
+	added := make([]string, 0, len(headings))
+	for _, h := range headings {
+		added = append(added, fmt.Sprintf("- New page: [[%s/%s]] (from H2 \"%s\")",
+			strings.TrimSuffix(path, ".md"), slugify(h), h))
+	}
+	return MaintenanceSuggestion{
+		Action:      MaintActionSplitLong,
+		Title:       "Split long page",
+		Description: fmt.Sprintf("Article is %d words across %d sections. Propose splitting each H2 into its own sub-page with a cross-link.", wc, len(headings)),
+		Diff: &MaintenanceDiff{
+			Added: added,
+		},
+		Evidence: []MaintenanceEvidence{
+			{Kind: "wiki_article", Label: "Article body — H2 sections", Path: path},
+		},
+		ExpectedSHA: sha,
+	}
+}
+
+// ── refresh stale ────────────────────────────────────────────────────────────
+
+const refreshStaleDays = 30
+
+// suggestRefreshStale points at recent edits + recent fact log entries so the
+// user can decide whether the page needs a content refresh. v1 does not
+// auto-rewrite — it surfaces a "review activity since X" suggestion with
+// links to the supporting evidence.
+func (m *MaintenanceAssistant) suggestRefreshStale(ctx context.Context, path, body, sha string) MaintenanceSuggestion {
+	lastEdited := lastEditedTimeFromBody(body)
+	cutoff := m.now().AddDate(0, 0, -refreshStaleDays)
+	if !lastEdited.IsZero() && lastEdited.After(cutoff) {
+		return MaintenanceSuggestion{
+			Action:        MaintActionRefreshStale,
+			Title:         "Refresh stale page",
+			Skipped:       true,
+			SkippedReason: fmt.Sprintf("Article was edited within the last %d days.", refreshStaleDays),
+			ExpectedSHA:   sha,
+		}
+	}
+
+	subject := slugFromPath(path)
+	evidence := []MaintenanceEvidence{}
+	if m.index != nil && subject != "" {
+		facts, _ := m.index.ListFactsForEntity(ctx, subject)
+		for _, f := range facts {
+			anchor := f.CreatedAt
+			if !f.ValidFrom.IsZero() {
+				anchor = f.ValidFrom
+			}
+			if anchor.After(cutoff) {
+				evidence = append(evidence, MaintenanceEvidence{
+					Kind:    "fact",
+					Label:   f.Triplet.predicateOrText(f),
+					Path:    f.ID,
+					Snippet: shortText(f.Text, 120),
+				})
+			}
+		}
+	}
+
+	if len(evidence) == 0 {
+		return MaintenanceSuggestion{
+			Action:        MaintActionRefreshStale,
+			Title:         "Refresh stale page",
+			Skipped:       true,
+			SkippedReason: "Page is stale but no recent fact-log activity to draw a refresh from.",
+			ExpectedSHA:   sha,
+		}
+	}
+
+	return MaintenanceSuggestion{
+		Action:      MaintActionRefreshStale,
+		Title:       "Refresh stale page",
+		Description: fmt.Sprintf("Page has not been edited in %d+ days but %d new fact(s) have landed since. Review and merge into the body.", refreshStaleDays, len(evidence)),
+		Evidence:    evidence,
+		ExpectedSHA: sha,
+	}
+}
+
+// ── resolve contradiction ────────────────────────────────────────────────────
+
+// suggestResolveContradiction redirects through the existing lint surface.
+// We do not duplicate the resolve flow — the panel hands the user back to
+// ResolveContradictionModal with the right finding pre-selected.
+func (m *MaintenanceAssistant) suggestResolveContradiction(ctx context.Context, path, sha string) MaintenanceSuggestion {
+	if m.lint == nil {
+		return MaintenanceSuggestion{
+			Action:        MaintActionResolveContradiction,
+			Title:         "Resolve contradiction",
+			Skipped:       true,
+			SkippedReason: "Lint runner not available.",
+			ExpectedSHA:   sha,
+		}
+	}
+	report, err := m.lint.Run(ctx)
+	if err != nil {
+		return MaintenanceSuggestion{
+			Action:        MaintActionResolveContradiction,
+			Title:         "Resolve contradiction",
+			Skipped:       true,
+			SkippedReason: fmt.Sprintf("Lint run failed: %v", err),
+			ExpectedSHA:   sha,
+		}
+	}
+	subject := slugFromPath(path)
+	for i, f := range report.Findings {
+		if f.Type != "contradictions" {
+			continue
+		}
+		if subject != "" && f.EntitySlug != "" && f.EntitySlug != subject {
+			continue
+		}
+		copyF := f
+		return MaintenanceSuggestion{
+			Action:         MaintActionResolveContradiction,
+			Title:          "Resolve contradiction",
+			Description:    "Open the contradiction in the existing resolve flow.",
+			LintFinding:    &copyF,
+			LintReportDate: report.Date,
+			LintFindingIdx: i,
+			Evidence: []MaintenanceEvidence{
+				{Kind: "lint_finding", Label: f.Summary},
+			},
+			ExpectedSHA: sha,
+		}
+	}
+	return MaintenanceSuggestion{
+		Action:        MaintActionResolveContradiction,
+		Title:         "Resolve contradiction",
+		Skipped:       true,
+		SkippedReason: "No contradictions involving this article in the latest lint report.",
+		ExpectedSHA:   sha,
+	}
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// relatedEntities returns up to N other entity slugs that co-occur with the
+// article's subject in fact triples or share graph edges. Sorted by
+// co-occurrence count, descending.
+func (m *MaintenanceAssistant) relatedEntities(ctx context.Context, path string) []string {
+	if m.index == nil {
+		return nil
+	}
+	subject := slugFromPath(path)
+	if subject == "" {
+		return nil
+	}
+	counts := make(map[string]int)
+	if facts, err := m.index.ListFactsForEntity(ctx, subject); err == nil {
+		for _, f := range facts {
+			if f.Triplet == nil {
+				continue
+			}
+			obj := f.Triplet.Object
+			if obj == "" || obj == subject {
+				continue
+			}
+			counts[obj]++
+		}
+	}
+	if edges, err := m.index.ListEdgesForEntity(ctx, subject); err == nil {
+		for _, e := range edges {
+			other := e.Object
+			if other == subject {
+				other = e.Subject
+			}
+			if other == "" || other == subject {
+				continue
+			}
+			counts[other]++
+		}
+	}
+	if len(counts) == 0 {
+		return nil
+	}
+	type kv struct {
+		k string
+		v int
+	}
+	pairs := make([]kv, 0, len(counts))
+	for k, v := range counts {
+		pairs = append(pairs, kv{k, v})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].v != pairs[j].v {
+			return pairs[i].v > pairs[j].v
+		}
+		return pairs[i].k < pairs[j].k
+	})
+	const max = 8
+	out := make([]string, 0, max)
+	for i, p := range pairs {
+		if i >= max {
+			break
+		}
+		out = append(out, p.k)
+	}
+	return out
+}
+
+// firstParagraph returns the first non-empty, non-heading paragraph from a
+// markdown body. Used as a starting point for summarize.
+func firstParagraph(body string) string {
+	var sb strings.Builder
+	for _, ln := range strings.Split(stripFrontmatter(body), "\n") {
+		trimmed := strings.TrimSpace(ln)
+		if sb.Len() == 0 {
+			if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ">") {
+				continue
+			}
+			sb.WriteString(trimmed)
+			continue
+		}
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			break
+		}
+		sb.WriteString(" ")
+		sb.WriteString(trimmed)
+	}
+	return sb.String()
+}
+
+// insertAfterTitle places `block` immediately after the article's H1 title
+// (or after the frontmatter if there is no H1). Returns the new content and
+// the lists of added/removed lines for diff display.
+func insertAfterTitle(body, block string) (string, []string, []string) {
+	lines := strings.Split(body, "\n")
+	insertAt := 0
+	inFrontmatter := false
+	foundH1 := false
+	for i, ln := range lines {
+		if i == 0 && strings.TrimSpace(ln) == "---" {
+			inFrontmatter = true
+			continue
+		}
+		if inFrontmatter {
+			if strings.TrimSpace(ln) == "---" {
+				inFrontmatter = false
+				insertAt = i + 1
+			}
+			continue
+		}
+		if strings.HasPrefix(ln, "# ") {
+			insertAt = i + 1
+			foundH1 = true
+			break
+		}
+	}
+	if !foundH1 && insertAt == 0 {
+		// No H1 and no frontmatter — drop the block at the very top.
+		insertAt = 0
+	}
+	out := make([]string, 0, len(lines)+1)
+	out = append(out, lines[:insertAt]...)
+	blockLines := strings.Split(strings.TrimRight(block, "\n"), "\n")
+	out = append(out, blockLines...)
+	out = append(out, lines[insertAt:]...)
+	return strings.Join(out, "\n"), blockLines, nil
+}
+
+func truncateChars(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return strings.TrimRight(s[:n], " ,.;:") + "…"
+}
+
+func hasHeading(body, name string) bool {
+	target := strings.ToLower(name)
+	for _, ln := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "## ") && strings.ToLower(strings.TrimSpace(strings.TrimPrefix(t, "## "))) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func extractH2Headings(body string) []string {
+	out := []string{}
+	for _, ln := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(ln)
+		if strings.HasPrefix(t, "## ") {
+			out = append(out, strings.TrimSpace(strings.TrimPrefix(t, "## ")))
+		}
+	}
+	return out
+}
+
+// slugFromPath maps a wiki article path to its entity slug for paths under
+// people/, companies/, customers/. Returns "" for non-entity paths.
+func slugFromPath(path string) string {
+	p := strings.TrimPrefix(path, "team/")
+	p = strings.TrimSuffix(p, ".md")
+	parts := strings.Split(p, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	switch parts[0] {
+	case "people", "companies", "customers":
+		return parts[len(parts)-1]
+	}
+	return ""
+}
+
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// extractTriples runs a small set of pattern matchers over the body and
+// proposes triples anchored on the article subject. v1 is conservative —
+// every proposal has confidence < 0.7 so the user is forced to review.
+var triplePatterns = []struct {
+	pred string
+	keys []string
+}{
+	{"role_at", []string{"works at", "head of", "ceo of", "vp of", "founder of", "founded"}},
+	{"based_in", []string{"based in", "lives in", "located in"}},
+	{"part_of", []string{"member of", "joined"}},
+}
+
+func extractTriples(subject, body string) []MaintenanceFactProposal {
+	out := []MaintenanceFactProposal{}
+	lines := strings.Split(body, "\n")
+	for i, raw := range lines {
+		ln := strings.TrimSpace(raw)
+		if ln == "" || strings.HasPrefix(ln, "#") || strings.HasPrefix(ln, ">") {
+			continue
+		}
+		lower := strings.ToLower(ln)
+		for _, p := range triplePatterns {
+			for _, key := range p.keys {
+				idx := strings.Index(lower, key)
+				if idx < 0 {
+					continue
+				}
+				rest := strings.TrimSpace(ln[idx+len(key):])
+				rest = strings.TrimRight(rest, ".,;: ")
+				if rest == "" {
+					continue
+				}
+				out = append(out, MaintenanceFactProposal{
+					Subject:    subject,
+					Predicate:  p.pred,
+					Object:     rest,
+					Confidence: 0.6,
+					SourceLine: i + 1,
+				})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// lastEditedTimeFromBody scans the article for a `last_edited_ts:` frontmatter
+// field. Returns zero value if not found.
+func lastEditedTimeFromBody(body string) time.Time {
+	for _, ln := range strings.Split(body, "\n") {
+		t := strings.TrimSpace(ln)
+		const prefix = "last_edited_ts:"
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+		val := strings.TrimSpace(strings.TrimPrefix(t, prefix))
+		val = strings.Trim(val, "\"'")
+		if ts, err := time.Parse(time.RFC3339, val); err == nil {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+// predicateOrText returns the triplet predicate, or the raw fact text when
+// the triplet is missing. Defined on *Triplet so a nil receiver works.
+func (t *Triplet) predicateOrText(f TypedFact) string {
+	if t != nil && t.Predicate != "" {
+		return t.Predicate
+	}
+	return shortText(f.Text, 60)
+}

--- a/internal/team/wiki_maintenance.go
+++ b/internal/team/wiki_maintenance.go
@@ -25,6 +25,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -159,7 +160,16 @@ func (m *MaintenanceAssistant) Suggest(ctx context.Context, action MaintenanceAc
 		return MaintenanceSuggestion{}, fmt.Errorf("read article: %w", err)
 	}
 
-	sha, _ := m.worker.repo.HeadSHA(ctx)
+	// HeadSHA seeds ExpectedSHA on every suggestion; the write-human path
+	// uses it as the optimistic-concurrency guard. Silently swallowing the
+	// error here would emit suggestions with ExpectedSHA == "" — and the
+	// editor convention treats an empty expected SHA as "no guard," which
+	// would let a concurrent edit be overwritten on accept. Surface the
+	// error and abort instead of producing a stale-safe-looking suggestion.
+	sha, err := m.worker.repo.HeadSHA(ctx)
+	if err != nil {
+		return MaintenanceSuggestion{}, fmt.Errorf("read head sha: %w", err)
+	}
 
 	switch action {
 	case MaintActionSummarize:
@@ -403,11 +413,12 @@ func (m *MaintenanceAssistant) suggestLinkRelated(ctx context.Context, path, bod
 	added := strings.Split(strings.TrimRight(block, "\n"), "\n")
 
 	evidence := make([]MaintenanceEvidence, 0, len(related))
+	sourceNs := entityNamespaceFromPath(path)
 	for _, slug := range related {
 		evidence = append(evidence, MaintenanceEvidence{
 			Kind:  "wiki_article",
 			Label: slug,
-			Path:  slug,
+			Path:  m.resolveEntityPath(slug, sourceNs),
 		})
 	}
 
@@ -715,11 +726,20 @@ func insertAfterTitle(body, block string) (string, []string, []string) {
 	return strings.Join(out, "\n"), blockLines, nil
 }
 
+// truncateChars trims the string to at most n runes (not bytes) so that
+// multibyte content — CJK, accented Latin, emoji — never produces invalid
+// UTF-8 from a mid-rune slice. Trailing punctuation/whitespace is stripped
+// before the ellipsis so the visible output stays clean.
 func truncateChars(s string, n int) string {
-	if len(s) <= n {
+	if n <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
-	return strings.TrimRight(s[:n], " ,.;:") + "…"
+	truncated := strings.TrimRight(string(runes[:n]), " ,.;:")
+	return truncated + "…"
 }
 
 func hasHeading(body, name string) bool {
@@ -742,6 +762,85 @@ func extractH2Headings(body string) []string {
 		}
 	}
 	return out
+}
+
+// entityNamespaces lists the entity-bearing top-level wiki folders, in
+// fallback order. resolveEntityPath probes them when a slug's namespace is
+// unknown.
+var entityNamespaces = []string{"people", "companies", "customers"}
+
+// entityNamespaceFromPath returns the namespace ("people", "companies",
+// "customers") for an article path, or "" when the path is not under one of
+// those folders.
+func entityNamespaceFromPath(path string) string {
+	p := strings.TrimPrefix(strings.TrimPrefix(path, "team/"), "/")
+	parts := strings.SplitN(p, "/", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	for _, ns := range entityNamespaces {
+		if parts[0] == ns {
+			return ns
+		}
+	}
+	return ""
+}
+
+// resolveEntityPath maps a bare entity slug to a navigable wiki path
+// ("team/<namespace>/<slug>.md"). When the slug is already shaped like a
+// path it is normalized and returned. Otherwise the worker filesystem is
+// probed across known namespaces (preferring sourceNs when set) so the
+// result actually points at an article that exists. When nothing matches
+// the source namespace is used as the best-effort fallback so the link is
+// at least well-formed; an empty namespace falls back to "companies".
+func (m *MaintenanceAssistant) resolveEntityPath(slug, sourceNs string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return ""
+	}
+	// Already path-shaped (contains a slash) — normalize to team/<...>.md.
+	if strings.Contains(slug, "/") {
+		p := strings.TrimPrefix(slug, "team/")
+		if !strings.HasSuffix(p, ".md") {
+			p += ".md"
+		}
+		return "team/" + p
+	}
+
+	// Probe namespaces in order, preferring the source article's namespace.
+	probeOrder := make([]string, 0, len(entityNamespaces))
+	if sourceNs != "" {
+		probeOrder = append(probeOrder, sourceNs)
+	}
+	for _, ns := range entityNamespaces {
+		if ns == sourceNs {
+			continue
+		}
+		probeOrder = append(probeOrder, ns)
+	}
+	if m.worker != nil {
+		for _, ns := range probeOrder {
+			candidate := "team/" + ns + "/" + slug + ".md"
+			if _, err := m.worker.ReadArticle(candidate); err == nil {
+				return candidate
+			} else if !os.IsNotExist(err) {
+				// Non-existence we silently skip; surface only unexpected
+				// errors via continued probing — if every probe fails we
+				// fall through to the namespace-fallback below.
+				continue
+			}
+		}
+	}
+
+	// Nothing matched on disk. Fall back to a well-formed path under the
+	// source namespace (or "companies" when there is none) so navigation
+	// at least lands on a sensible "create page" surface rather than a
+	// bare slug that resolves nowhere.
+	fallbackNs := sourceNs
+	if fallbackNs == "" {
+		fallbackNs = "companies"
+	}
+	return "team/" + fallbackNs + "/" + slug + ".md"
 }
 
 // slugFromPath maps a wiki article path to its entity slug for paths under
@@ -813,11 +912,21 @@ func extractTriples(subject, body string) []MaintenanceFactProposal {
 	return out
 }
 
-// lastEditedTimeFromBody scans the article for a `last_edited_ts:` frontmatter
-// field. Returns zero value if not found.
+// lastEditedTimeFromBody scans the article frontmatter for a `last_edited_ts:`
+// field. Returns zero value if the article has no frontmatter, the field is
+// absent, or the timestamp cannot be parsed. Scanning is bounded to the
+// frontmatter so a body changelog mentioning `last_edited_ts:` never
+// accidentally reads as a recent edit.
 func lastEditedTimeFromBody(body string) time.Time {
-	for _, ln := range strings.Split(body, "\n") {
+	lines := strings.Split(body, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return time.Time{}
+	}
+	for _, ln := range lines[1:] {
 		t := strings.TrimSpace(ln)
+		if t == "---" {
+			break
+		}
 		const prefix = "last_edited_ts:"
 		if !strings.HasPrefix(t, prefix) {
 			continue

--- a/internal/team/wiki_maintenance_test.go
+++ b/internal/team/wiki_maintenance_test.go
@@ -1,0 +1,317 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newMaintenanceFixture wires a Repo + WikiWorker for maintenance-assistant
+// tests. The returned cleanup stops the worker before the TempDir is removed.
+func newMaintenanceFixture(t *testing.T) (*WikiWorker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	return worker, func() {
+		cancel()
+		<-worker.Done()
+	}
+}
+
+func seedArticle(t *testing.T, worker *WikiWorker, path, body string) {
+	t.Helper()
+	if _, _, err := worker.Enqueue(context.Background(), "tester", path, body, "replace", "seed "+path); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+}
+
+func TestMaintenance_Summarize_ProposesTLDR(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	body := strings.Repeat("This is a long article about Sarah Chen. ", 30) +
+		"\n\n# Sarah Chen\n\nSarah Chen leads product at Acme Corp.\n\n## Background\n\nShe has been at Acme since 2024.\n"
+	seedArticle(t, worker, "team/people/sarah-chen.md", body)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionSummarize, "team/people/sarah-chen.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if s.Skipped {
+		t.Fatalf("expected suggestion, got skipped: %s", s.SkippedReason)
+	}
+	if s.Diff == nil || s.Diff.ProposedContent == "" {
+		t.Fatalf("expected diff with proposed content, got nil")
+	}
+	if !strings.Contains(s.Diff.ProposedContent, "TL;DR") {
+		t.Errorf("expected TL;DR in proposed content, got: %s", s.Diff.ProposedContent[:200])
+	}
+	if len(s.Evidence) == 0 {
+		t.Errorf("expected evidence to be present")
+	}
+}
+
+func TestMaintenance_Summarize_SkipsShortArticles(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	seedArticle(t, worker, "team/people/short.md", "# Short\n\nJust a stub.\n")
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionSummarize, "team/people/short.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped, got %+v", s)
+	}
+}
+
+func TestMaintenance_AddCitation_FlagsNumericClaims(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	body := "# Acme Corp\n\nAcme Corp raised 50 million in 2024.\n\nThe company has 200 employees.\n\nOnly some words here.\n"
+	seedArticle(t, worker, "team/companies/acme.md", body)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionAddCitation, "team/companies/acme.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if s.Skipped {
+		t.Fatalf("expected suggestion, got skipped: %s", s.SkippedReason)
+	}
+	if len(s.Diff.Added) == 0 {
+		t.Fatalf("expected added lines, got none")
+	}
+	for _, ln := range s.Diff.Added {
+		if !strings.Contains(ln, "[needs citation]") {
+			t.Errorf("expected [needs citation] mark, got: %q", ln)
+		}
+	}
+}
+
+func TestMaintenance_AddCitation_SkipsWhenAllSourced(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	body := "# Stub\n\nNo strong claims here today.\n"
+	seedArticle(t, worker, "team/companies/stub.md", body)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionAddCitation, "team/companies/stub.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped, got %+v", s)
+	}
+}
+
+func TestMaintenance_ExtractFacts_ProposesTriples(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	body := "# Sarah Chen\n\nSarah Chen works at Acme Corp.\n\nShe is based in Seattle.\n"
+	seedArticle(t, worker, "team/people/sarah-chen.md", body)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionExtractFacts, "team/people/sarah-chen.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if s.Skipped {
+		t.Fatalf("expected suggestion, got skipped: %s", s.SkippedReason)
+	}
+	if len(s.Facts) < 2 {
+		t.Fatalf("expected at least 2 fact proposals, got %d", len(s.Facts))
+	}
+	for _, f := range s.Facts {
+		if f.Confidence >= 0.7 {
+			t.Errorf("confidence too high (review-bypass risk): %v", f.Confidence)
+		}
+		if f.Subject != "sarah-chen" {
+			t.Errorf("subject should anchor on slug, got %q", f.Subject)
+		}
+	}
+}
+
+func TestMaintenance_ExtractFacts_SkipsNonEntityPaths(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	body := "# Random Doc\n\nFoo bar baz.\n"
+	seedArticle(t, worker, "team/notes/random.md", body)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionExtractFacts, "team/notes/random.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped for non-entity path, got %+v", s)
+	}
+}
+
+func TestMaintenance_SplitLong_SkipsShortArticles(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	seedArticle(t, worker, "team/people/sarah.md", "# Sarah\n\nA short note.\n")
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionSplitLong, "team/people/sarah.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped, got %+v", s)
+	}
+}
+
+func TestMaintenance_SplitLong_ProposesWhenLong(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	long := "# Acme\n\n"
+	for i := 0; i < 5; i++ {
+		long += "## Section " + string(rune('A'+i)) + "\n\n"
+		long += strings.Repeat("Long words and phrases describing the section in detail. ", 80)
+		long += "\n\n"
+	}
+	seedArticle(t, worker, "team/companies/acme.md", long)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionSplitLong, "team/companies/acme.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if s.Skipped {
+		t.Fatalf("expected split suggestion, got skipped: %s", s.SkippedReason)
+	}
+	if s.Diff == nil || len(s.Diff.Added) < 2 {
+		t.Fatalf("expected at least 2 split outline entries, got %+v", s.Diff)
+	}
+}
+
+func TestMaintenance_RefreshStale_SkipsWhenRecentlyEdited(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	// Article newly seeded — frontmatter has no last_edited_ts but the
+	// repo HEAD shows a fresh edit. v1 reads frontmatter; missing ts
+	// means we fall through to evidence (and find none for a non-entity
+	// path), so we expect Skipped.
+	body := "# Stale\n\nSome content.\n"
+	seedArticle(t, worker, "team/notes/stale.md", body)
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionRefreshStale, "team/notes/stale.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped, got %+v", s)
+	}
+}
+
+func TestMaintenance_LinkRelated_SkipsWithoutIndex(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	seedArticle(t, worker, "team/people/sarah.md", "# Sarah\n\nworks at acme\n")
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionLinkRelated, "team/people/sarah.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped without index, got %+v", s)
+	}
+}
+
+func TestMaintenance_ResolveContradiction_SkipsWithoutLint(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	seedArticle(t, worker, "team/people/sarah.md", "# Sarah\n\nrole.\n")
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	s, err := a.Suggest(context.Background(), MaintActionResolveContradiction, "team/people/sarah.md")
+	if err != nil {
+		t.Fatalf("suggest: %v", err)
+	}
+	if !s.Skipped {
+		t.Fatalf("expected skipped without lint, got %+v", s)
+	}
+}
+
+func TestMaintenance_UnknownAction_ReturnsError(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+
+	seedArticle(t, worker, "team/notes/x.md", "# X\n")
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	if _, err := a.Suggest(context.Background(), "no-such-action", "team/notes/x.md"); err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+}
+
+func TestMaintenance_NilWorker_ReturnsError(t *testing.T) {
+	a := NewMaintenanceAssistant(nil, nil, nil)
+	if _, err := a.Suggest(context.Background(), MaintActionSummarize, "x.md"); err == nil {
+		t.Fatal("expected error when worker is nil")
+	}
+}
+
+func TestSlugFromPath(t *testing.T) {
+	tt := []struct {
+		path string
+		want string
+	}{
+		{"team/people/nazz.md", "nazz"},
+		{"team/companies/acme-corp.md", "acme-corp"},
+		{"team/customers/wayne-industries.md", "wayne-industries"},
+		{"people/nazz.md", "nazz"},
+		{"team/notes/random.md", ""},
+		{"random", ""},
+	}
+	for _, c := range tt {
+		got := slugFromPath(c.path)
+		if got != c.want {
+			t.Errorf("slugFromPath(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+func TestClaimNeedsCitation(t *testing.T) {
+	tt := []struct {
+		line string
+		want bool
+	}{
+		{"Acme raised 50 million in 2024.", true},
+		{"They acquired BigCo last year.", true},
+		{"It feels small.", false},
+		{"See [the report](https://example.com/report) for details.", false},
+		{"Already noted [needs citation]", false},
+		{"Their team is great.", false},
+	}
+	for _, c := range tt {
+		got := claimNeedsCitation(c.line)
+		if got != c.want {
+			t.Errorf("claimNeedsCitation(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}

--- a/internal/team/wiki_maintenance_test.go
+++ b/internal/team/wiki_maintenance_test.go
@@ -2,9 +2,12 @@ package team
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 )
 
 // newMaintenanceFixture wires a Repo + WikiWorker for maintenance-assistant
@@ -53,7 +56,11 @@ func TestMaintenance_Summarize_ProposesTLDR(t *testing.T) {
 		t.Fatalf("expected diff with proposed content, got nil")
 	}
 	if !strings.Contains(s.Diff.ProposedContent, "TL;DR") {
-		t.Errorf("expected TL;DR in proposed content, got: %s", s.Diff.ProposedContent[:200])
+		preview := s.Diff.ProposedContent
+		if len(preview) > 200 {
+			preview = preview[:200]
+		}
+		t.Errorf("expected TL;DR in proposed content, got: %s", preview)
 	}
 	if len(s.Evidence) == 0 {
 		t.Errorf("expected evidence to be present")
@@ -293,6 +300,112 @@ func TestSlugFromPath(t *testing.T) {
 		if got != c.want {
 			t.Errorf("slugFromPath(%q) = %q, want %q", c.path, got, c.want)
 		}
+	}
+}
+
+// TestTruncateChars_RuneSafe guards against the byte-slice regression that
+// made TL;DRs and snippets emit invalid UTF-8 (rendered as U+FFFD) when the
+// source contained multibyte content.
+func TestTruncateChars_RuneSafe(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		limit   int
+		wantLen int
+	}{
+		{"emoji prefix under limit", "🎉hello", 4, 4},
+		{"cjk slice mid-rune", "你好世界你好世界你好世界", 5, 5},
+		{"accented cut", "café résumé naïve façade", 6, 6},
+		{"limit zero", "anything", 0, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncateChars(c.input, c.limit)
+			if !utf8.ValidString(got) {
+				t.Fatalf("truncateChars(%q, %d) = %q is not valid UTF-8",
+					c.input, c.limit, got)
+			}
+			if c.limit > 0 {
+				gotRunes := utf8.RuneCountInString(strings.TrimSuffix(got, "…"))
+				if gotRunes > c.wantLen {
+					t.Fatalf("rune count %d > limit %d for %q",
+						gotRunes, c.wantLen, got)
+				}
+			}
+		})
+	}
+	// Short input round-trips unchanged.
+	short := "🎉hi"
+	if got := truncateChars(short, 50); got != short {
+		t.Fatalf("short input mutated: got %q want %q", got, short)
+	}
+}
+
+// TestLastEditedTimeFromBody_FrontmatterOnly verifies a body-section
+// `last_edited_ts:` mention is ignored — only the frontmatter block counts.
+func TestLastEditedTimeFromBody_FrontmatterOnly(t *testing.T) {
+	body := "---\nslug: x\n---\n\n# X\n\nChangelog row: last_edited_ts: 2025-01-01T00:00:00Z\n"
+	if !lastEditedTimeFromBody(body).IsZero() {
+		t.Fatalf("body-only ts should not be picked up")
+	}
+	frontmatter := "---\nslug: x\nlast_edited_ts: 2025-01-01T00:00:00Z\n---\n\n# X\n"
+	got := lastEditedTimeFromBody(frontmatter)
+	if got.IsZero() {
+		t.Fatalf("frontmatter ts should parse")
+	}
+	want, _ := time.Parse(time.RFC3339, "2025-01-01T00:00:00Z")
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// TestSuggest_HeadSHAFailureSurfaces verifies that an unreadable repo HEAD
+// produces an error from Suggest rather than emitting a suggestion with an
+// empty ExpectedSHA (which the write-human path would treat as "no guard").
+func TestSuggest_HeadSHAFailureSurfaces(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+	seedArticle(t, worker, "team/people/sarah-chen.md",
+		"# Sarah\n\nA short article about Sarah.\n")
+
+	// Make HEAD unreadable by replacing the on-disk repo with an empty
+	// directory the worker still references. HeadSHA bubbles the underlying
+	// git error.
+	worker.WaitForIdle()
+	root := worker.Repo().root
+	if err := os.RemoveAll(filepath.Join(root, ".git")); err != nil {
+		t.Fatalf("nuke .git: %v", err)
+	}
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	if _, err := a.Suggest(context.Background(), MaintActionSummarize,
+		"team/people/sarah-chen.md"); err == nil {
+		t.Fatal("expected error when HEAD cannot be read")
+	}
+}
+
+// TestResolveEntityPath_PrefixesNamespace verifies the bare-slug path bug is
+// fixed — evidence Path values are namespaced wiki paths the UI can navigate.
+func TestResolveEntityPath_PrefixesNamespace(t *testing.T) {
+	worker, cleanup := newMaintenanceFixture(t)
+	defer cleanup()
+	seedArticle(t, worker, "team/companies/acme-corp.md",
+		"# Acme\n\nA company.\n")
+
+	a := NewMaintenanceAssistant(worker, nil, nil)
+	got := a.resolveEntityPath("acme-corp", "people")
+	if got != "team/companies/acme-corp.md" {
+		t.Fatalf("expected probed company path, got %q", got)
+	}
+	// Unknown slug falls back to the source namespace, well-formed.
+	got = a.resolveEntityPath("unknown-thing", "people")
+	if got != "team/people/unknown-thing.md" {
+		t.Fatalf("expected source-ns fallback, got %q", got)
+	}
+	// Already-pathed slug normalizes to team/<...>.md.
+	got = a.resolveEntityPath("companies/foo", "")
+	if got != "team/companies/foo.md" {
+		t.Fatalf("expected normalized path, got %q", got)
 	}
 }
 

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -422,6 +422,72 @@ export async function fetchAuditLog(
   }
 }
 
+// ── Maintenance assistant API ────────────────────────────────────────────────
+
+export type WikiMaintenanceAction =
+  | "summarize"
+  | "add_citation"
+  | "extract_facts"
+  | "resolve_contradiction"
+  | "split_long_page"
+  | "link_related"
+  | "refresh_stale";
+
+export interface WikiMaintenanceEvidence {
+  kind: "wiki_article" | "fact" | "lint_finding" | "edit_log";
+  label: string;
+  path?: string;
+  snippet?: string;
+}
+
+export interface WikiMaintenanceFactProposal {
+  subject: string;
+  predicate: string;
+  object: string;
+  confidence: number;
+  source_line?: number;
+}
+
+export interface WikiMaintenanceDiff {
+  proposed_content?: string;
+  added?: string[];
+  removed?: string[];
+}
+
+export interface WikiMaintenanceSuggestion {
+  action: WikiMaintenanceAction;
+  title: string;
+  description?: string;
+  diff?: WikiMaintenanceDiff;
+  facts?: WikiMaintenanceFactProposal[];
+  evidence?: WikiMaintenanceEvidence[];
+  /** Present when action === "resolve_contradiction" — wires into the existing modal. */
+  lint_finding?: LintFinding;
+  lint_report_date?: string;
+  lint_finding_idx?: number;
+  expected_sha?: string;
+  /** True when no suggestion was warranted; UI shows a friendly empty state. */
+  skipped?: boolean;
+  skipped_reason?: string;
+}
+
+/**
+ * POST /wiki/maintenance/suggest — compute a suggestion for one (action, path)
+ * pair. The broker never auto-writes; the suggestion is ephemeral and the
+ * caller must apply it through the normal /wiki/write-human path on accept.
+ */
+export async function fetchMaintenanceSuggestion(
+  action: WikiMaintenanceAction,
+  path: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<WikiMaintenanceSuggestion> {
+  return await post<WikiMaintenanceSuggestion>(
+    "/wiki/maintenance/suggest",
+    { action, path },
+    options,
+  );
+}
+
 // ── Lint API ──────────────────────────────────────────────────────────────────
 
 /**

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -1,5 +1,5 @@
 // biome-ignore-all lint/a11y/useValidAnchor: Anchor is intercepted by the app router or markdown renderer while preserving href fallback behavior.
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import type { PluggableList } from "unified";
 
@@ -15,6 +15,7 @@ import {
   type WikiArticle as WikiArticleT,
   type WikiCatalogEntry,
   type WikiHistoryCommit,
+  type WikiMaintenanceAction,
 } from "../../api/wiki";
 import { formatAgentName } from "../../lib/agentName";
 import { keyedByOccurrence } from "../../lib/reactKeys";
@@ -648,13 +649,25 @@ function ArticleRightSidebar({
   onNavigate: (path: string) => void;
   onMaintenanceApplied: () => void;
 }) {
-  // Consume the WikiLint "Suggest fix" hand-off exactly once per mount of
-  // this article. If WikiLint parked a target with a matching slug in the
-  // last minute, the assistant opens pre-focused on that action.
-  const initialMaintenanceAction = useMemo(
-    () => consumeMaintenanceTarget(article.path),
-    [article.path],
-  );
+  // Consume the WikiLint "Suggest fix" hand-off exactly once per article
+  // path. The consume call removes the slot from sessionStorage, so it is a
+  // side effect — running it inside useMemo would let React 19 strict mode
+  // double-invoke it and lose the hand-off (the first call clears the slot;
+  // the second sees nothing). We do the consume inside a useEffect guarded
+  // by a ref so the result is captured by the first mount and not undone
+  // by strict-mode's intentional double-invoke.
+  const [initialMaintenanceAction, setInitialMaintenanceAction] = useState<
+    WikiMaintenanceAction | undefined
+  >(undefined);
+  const consumedForPathRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (consumedForPathRef.current === article.path) return;
+    consumedForPathRef.current = article.path;
+    const target = consumeMaintenanceTarget(article.path) ?? undefined;
+    if (target) {
+      setInitialMaintenanceAction(target);
+    }
+  }, [article.path]);
   return (
     <aside className="wk-right-sidebar">
       <TocBox entries={toc} />

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -33,6 +33,7 @@ import EntityRelatedPanel from "./EntityRelatedPanel";
 import FactsOnFile from "./FactsOnFile";
 import HatBar, { type HatBarTab } from "./HatBar";
 import Hatnote from "./Hatnote";
+import { consumeMaintenanceTarget } from "./maintenanceTarget";
 import PageFooter from "./PageFooter";
 import PageStatsPanel from "./PageStatsPanel";
 import PlaybookExecutionLog from "./PlaybookExecutionLog";
@@ -44,6 +45,7 @@ import Sources from "./Sources";
 import TeamLearningPanel from "./TeamLearningPanel";
 import TocBox, { type TocEntry } from "./TocBox";
 import WikiEditor from "./WikiEditor";
+import WikiMaintenanceAssistant from "./WikiMaintenanceAssistant";
 
 const STALENESS_STALE_DAYS = 30;
 const STALENESS_AGING_DAYS = 7;
@@ -421,6 +423,7 @@ export default function WikiArticle({
         article={article}
         toc={toc}
         onNavigate={onNavigate}
+        onMaintenanceApplied={() => setRefreshNonce((n) => n + 1)}
       />
     </>
   );
@@ -638,11 +641,20 @@ function ArticleRightSidebar({
   article,
   toc,
   onNavigate,
+  onMaintenanceApplied,
 }: {
   article: WikiArticleT;
   toc: TocEntry[];
   onNavigate: (path: string) => void;
+  onMaintenanceApplied: () => void;
 }) {
+  // Consume the WikiLint "Suggest fix" hand-off exactly once per mount of
+  // this article. If WikiLint parked a target with a matching slug in the
+  // last minute, the assistant opens pre-focused on that action.
+  const initialMaintenanceAction = useMemo(
+    () => consumeMaintenanceTarget(article.path),
+    [article.path],
+  );
   return (
     <aside className="wk-right-sidebar">
       <TocBox entries={toc} />
@@ -652,6 +664,12 @@ function ArticleRightSidebar({
         wordCount={article.word_count}
         created={article.last_edited_ts}
         lastEdit={article.last_edited_ts}
+      />
+      <WikiMaintenanceAssistant
+        articlePath={article.path}
+        articleSha={article.commit_sha ?? ""}
+        onApplied={onMaintenanceApplied}
+        initialAction={initialMaintenanceAction ?? undefined}
       />
       <CiteThisPagePanel slug={article.path} />
       <ReferencedBy backlinks={article.backlinks} onNavigate={onNavigate} />

--- a/web/src/components/wiki/WikiLint.tsx
+++ b/web/src/components/wiki/WikiLint.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { type LintFinding, type LintReport, runLint } from "../../api/wiki";
 import { keyedByOccurrence } from "../../lib/reactKeys";
+import { requestMaintenanceTarget } from "./maintenanceTarget";
 import ResolveContradictionModal from "./ResolveContradictionModal";
 
 /**
@@ -161,18 +162,11 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
                 </td>
                 <td className="wk-audit-msg">{f.summary}</td>
                 <td>
-                  {f.type === "contradictions" && f.resolve_actions ? (
-                    <button
-                      type="button"
-                      className="wk-editor-save"
-                      style={{ padding: "4px 10px", fontSize: 12 }}
-                      onClick={() => setResolveTarget({ finding: f, idx })}
-                    >
-                      Resolve
-                    </button>
-                  ) : (
-                    <span aria-hidden="true">—</span>
-                  )}
+                  <FindingActionCell
+                    finding={f}
+                    onResolve={() => setResolveTarget({ finding: f, idx })}
+                    onNavigate={onNavigate}
+                  />
                 </td>
               </tr>
             ))}
@@ -193,6 +187,57 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
         />
       ) : null}
     </main>
+  );
+}
+
+interface FindingActionCellProps {
+  finding: LintFinding;
+  onResolve: () => void;
+  onNavigate: (path: string | null) => void;
+}
+
+function FindingActionCell({
+  finding,
+  onResolve,
+  onNavigate,
+}: FindingActionCellProps) {
+  if (finding.type !== "contradictions" || !finding.resolve_actions) {
+    return <span aria-hidden="true">—</span>;
+  }
+  return (
+    <div style={{ display: "flex", gap: 6 }}>
+      <button
+        type="button"
+        className="wk-editor-save"
+        style={{ padding: "4px 10px", fontSize: 12 }}
+        onClick={onResolve}
+      >
+        Resolve
+      </button>
+      {finding.entity_slug ? (
+        <button
+          type="button"
+          className="wk-related-link"
+          style={{
+            background: "none",
+            border: "none",
+            padding: "4px 6px",
+            cursor: "pointer",
+            fontSize: 12,
+          }}
+          data-testid="wk-lint-suggest-fix"
+          onClick={() => {
+            requestMaintenanceTarget(
+              finding.entity_slug ?? "",
+              "resolve_contradiction",
+            );
+            onNavigate(finding.entity_slug ?? null);
+          }}
+        >
+          Suggest fix
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/web/src/components/wiki/WikiMaintenanceAssistant.test.tsx
+++ b/web/src/components/wiki/WikiMaintenanceAssistant.test.tsx
@@ -1,0 +1,339 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as wikiApi from "../../api/wiki";
+import {
+  consumeMaintenanceTarget,
+  requestMaintenanceTarget,
+} from "./maintenanceTarget";
+import WikiMaintenanceAssistant from "./WikiMaintenanceAssistant";
+
+const SAMPLE_SUGGESTION: wikiApi.WikiMaintenanceSuggestion = {
+  action: "summarize",
+  title: "Summarize page",
+  description: "Insert a TL;DR.",
+  diff: {
+    proposed_content: "# Sample\n\n> **TL;DR:** Hello.\n\nBody.",
+    added: ["> **TL;DR:** Hello."],
+  },
+  evidence: [
+    {
+      kind: "wiki_article",
+      label: "Article body lead",
+      path: "team/people/sarah-chen.md",
+    },
+  ],
+  expected_sha: "abc1234",
+};
+
+const SKIPPED_SUGGESTION: wikiApi.WikiMaintenanceSuggestion = {
+  action: "split_long_page",
+  title: "Split long page",
+  skipped: true,
+  skipped_reason: "Article is short.",
+};
+
+const FACTS_SUGGESTION: wikiApi.WikiMaintenanceSuggestion = {
+  action: "extract_facts",
+  title: "Extract facts",
+  description: "Review proposed facts.",
+  facts: [
+    {
+      subject: "sarah-chen",
+      predicate: "role_at",
+      object: "acme",
+      confidence: 0.6,
+      source_line: 3,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  if (typeof window !== "undefined") {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  }
+});
+
+describe("<WikiMaintenanceAssistant>", () => {
+  it("renders collapsed by default with an open button", () => {
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("wk-maint-collapsed")).toBeInTheDocument();
+    expect(screen.queryByTestId("wk-maint-panel")).toBeNull();
+  });
+
+  it("expanding the panel shows all 7 actions", () => {
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    expect(screen.getByTestId("wk-maint-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-maint-action-summarize")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-maint-action-add_citation"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-maint-action-extract_facts"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-maint-action-link_related"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-maint-action-split_long_page"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-maint-action-refresh_stale"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-maint-action-resolve_contradiction"),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking an action calls fetchMaintenanceSuggestion and shows the diff", async () => {
+    const fetchSpy = vi
+      .spyOn(wikiApi, "fetchMaintenanceSuggestion")
+      .mockResolvedValue(SAMPLE_SUGGESTION);
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-summarize"));
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "summarize",
+      "team/people/sarah-chen.md",
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-suggestion")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("wk-maint-diff")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-maint-accept")).toBeInTheDocument();
+  });
+
+  it("Accept routes the diff through writeArticle and calls onApplied", async () => {
+    vi.spyOn(wikiApi, "fetchMaintenanceSuggestion").mockResolvedValue(
+      SAMPLE_SUGGESTION,
+    );
+    const onApplied = vi.fn();
+    const writeArticle = vi.fn().mockResolvedValue({
+      path: "team/people/sarah-chen.md",
+      commit_sha: "def5678",
+      bytes_written: 42,
+    });
+
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={onApplied}
+        writeArticle={writeArticle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-summarize"));
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-accept")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-accept"));
+    await waitFor(() => expect(onApplied).toHaveBeenCalledTimes(1));
+    expect(writeArticle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "team/people/sarah-chen.md",
+        content: SAMPLE_SUGGESTION.diff?.proposed_content,
+        expectedSha: "abc1234",
+      }),
+    );
+  });
+
+  it("Reject snoozes the action for 24h via localStorage", async () => {
+    vi.spyOn(wikiApi, "fetchMaintenanceSuggestion").mockResolvedValue(
+      SAMPLE_SUGGESTION,
+    );
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-summarize"));
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-suggestion")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-reject"));
+
+    const stored = window.localStorage.getItem(
+      "wuphf:wiki-maint:rejected:abc1234:summarize",
+    );
+    expect(stored).not.toBeNull();
+    expect(Number(stored)).toBeGreaterThan(0);
+  });
+
+  it("Snoozed actions render disabled with a 'snoozed' label", () => {
+    window.localStorage.setItem(
+      "wuphf:wiki-maint:rejected:abc1234:add_citation",
+      String(Date.now()),
+    );
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    const btn = screen.getByTestId("wk-maint-action-add_citation");
+    expect(btn).toBeDisabled();
+    expect(btn.textContent).toMatch(/snoozed/i);
+  });
+});
+
+describe("<WikiMaintenanceAssistant> — content shapes", () => {
+  it("Skipped suggestions show the reason instead of accept/diff", async () => {
+    vi.spyOn(wikiApi, "fetchMaintenanceSuggestion").mockResolvedValue(
+      SKIPPED_SUGGESTION,
+    );
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-split_long_page"));
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-skipped")).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId("wk-maint-accept")).toBeNull();
+    expect(screen.getByText(/article is short/i)).toBeInTheDocument();
+  });
+
+  it("Extract facts renders the proposed triples list and never auto-commits", async () => {
+    const fetchSpy = vi
+      .spyOn(wikiApi, "fetchMaintenanceSuggestion")
+      .mockResolvedValue(FACTS_SUGGESTION);
+    const writeArticle = vi.fn();
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+        writeArticle={writeArticle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-extract_facts"));
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-facts")).toBeInTheDocument(),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(writeArticle).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("wk-maint-accept")).toBeNull(); // facts have no diff
+    expect(screen.getByText("role_at")).toBeInTheDocument();
+  });
+
+  it("Conflict response surfaces a recompute message instead of writing", async () => {
+    vi.spyOn(wikiApi, "fetchMaintenanceSuggestion").mockResolvedValue(
+      SAMPLE_SUGGESTION,
+    );
+    const writeArticle = vi.fn().mockResolvedValue({
+      conflict: true,
+      error: "stale",
+      current_sha: "newer",
+      current_content: "newer body",
+    } as wikiApi.WriteHumanResult);
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+        writeArticle={writeArticle}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-summarize"));
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-accept")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-accept"));
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-apply-error")).toBeInTheDocument(),
+    );
+    expect(screen.getByText(/changed since/i)).toBeInTheDocument();
+  });
+
+  it("initialAction expands and pre-selects the action without a click", async () => {
+    vi.spyOn(wikiApi, "fetchMaintenanceSuggestion").mockResolvedValue(
+      SAMPLE_SUGGESTION,
+    );
+    render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="abc1234"
+        onApplied={vi.fn()}
+        initialAction="summarize"
+      />,
+    );
+    expect(screen.getByTestId("wk-maint-panel")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-maint-suggestion")).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("maintenanceTarget hand-off", () => {
+  beforeEach(() => {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.clear();
+    }
+  });
+
+  it("requestMaintenanceTarget + consumeMaintenanceTarget round-trips on slug match", () => {
+    requestMaintenanceTarget("sarah-chen", "resolve_contradiction");
+    expect(consumeMaintenanceTarget("team/people/sarah-chen.md")).toBe(
+      "resolve_contradiction",
+    );
+  });
+
+  it("consume returns null on slug mismatch and clears the slot", () => {
+    requestMaintenanceTarget("sarah-chen", "resolve_contradiction");
+    expect(consumeMaintenanceTarget("team/people/other.md")).toBeNull();
+  });
+
+  it("consume returns null after the TTL", () => {
+    const stale = {
+      slug: "sarah-chen",
+      action: "resolve_contradiction",
+      ts: Date.now() - 120_000,
+    };
+    window.sessionStorage.setItem(
+      "wuphf:wiki-maint:target",
+      JSON.stringify(stale),
+    );
+    expect(consumeMaintenanceTarget("team/people/sarah-chen.md")).toBeNull();
+  });
+
+  it("consume only fires once — second call returns null", () => {
+    requestMaintenanceTarget("sarah-chen", "summarize");
+    expect(consumeMaintenanceTarget("team/people/sarah-chen.md")).toBe(
+      "summarize",
+    );
+    expect(consumeMaintenanceTarget("team/people/sarah-chen.md")).toBeNull();
+  });
+});

--- a/web/src/components/wiki/WikiMaintenanceAssistant.test.tsx
+++ b/web/src/components/wiki/WikiMaintenanceAssistant.test.tsx
@@ -1,6 +1,8 @@
+import { StrictMode, useEffect, useRef, useState } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { WikiMaintenanceAction } from "../../api/wiki";
 import * as wikiApi from "../../api/wiki";
 import {
   consumeMaintenanceTarget,
@@ -178,7 +180,7 @@ describe("<WikiMaintenanceAssistant>", () => {
     fireEvent.click(screen.getByTestId("wk-maint-reject"));
 
     const stored = window.localStorage.getItem(
-      "wuphf:wiki-maint:rejected:abc1234:summarize",
+      "wuphf:wiki-maint:rejected:team/people/sarah-chen.md:summarize",
     );
     expect(stored).not.toBeNull();
     expect(Number(stored)).toBeGreaterThan(0);
@@ -186,7 +188,7 @@ describe("<WikiMaintenanceAssistant>", () => {
 
   it("Snoozed actions render disabled with a 'snoozed' label", () => {
     window.localStorage.setItem(
-      "wuphf:wiki-maint:rejected:abc1234:add_citation",
+      "wuphf:wiki-maint:rejected:team/people/sarah-chen.md:add_citation",
       String(Date.now()),
     );
     render(
@@ -297,6 +299,124 @@ describe("<WikiMaintenanceAssistant> — content shapes", () => {
   });
 });
 
+describe("<WikiMaintenanceAssistant> — snooze + path scoping", () => {
+  it("Snoozed actions stay snoozed across SHA changes for the same article", () => {
+    // Reject was recorded for the article path; switching SHA must not
+    // un-snooze the action — the user's "no, do not bug me" decision is
+    // about the page, not the commit.
+    window.localStorage.setItem(
+      "wuphf:wiki-maint:rejected:team/people/sarah-chen.md:summarize",
+      String(Date.now()),
+    );
+    const { rerender } = render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="sha-A"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    expect(screen.getByTestId("wk-maint-action-summarize")).toBeDisabled();
+
+    rerender(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/sarah-chen.md"
+        articleSha="sha-B"
+        onApplied={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("wk-maint-action-summarize")).toBeDisabled();
+  });
+
+  it("articlePath change clears suggestion state and ignores stale responses", async () => {
+    let resolveA: (s: wikiApi.WikiMaintenanceSuggestion) => void = () => {};
+    const pendingA = new Promise<wikiApi.WikiMaintenanceSuggestion>((r) => {
+      resolveA = r;
+    });
+    const fetchSpy = vi
+      .spyOn(wikiApi, "fetchMaintenanceSuggestion")
+      .mockImplementationOnce(() => pendingA)
+      .mockResolvedValueOnce({
+        ...SAMPLE_SUGGESTION,
+        description: "B suggestion",
+      });
+
+    const { rerender } = render(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/article-a.md"
+        articleSha="sha-A"
+        onApplied={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-maint-open"));
+    fireEvent.click(screen.getByTestId("wk-maint-action-summarize"));
+    expect(screen.getByTestId("wk-maint-loading")).toBeInTheDocument();
+
+    // Navigate to article B before A's request has resolved.
+    rerender(
+      <WikiMaintenanceAssistant
+        articlePath="team/people/article-b.md"
+        articleSha="sha-B"
+        onApplied={vi.fn()}
+      />,
+    );
+    // No active action on the new path.
+    expect(screen.queryByTestId("wk-maint-suggestion")).toBeNull();
+    expect(screen.queryByTestId("wk-maint-loading")).toBeNull();
+
+    // Resolve A's response — must be ignored because the path changed.
+    resolveA({ ...SAMPLE_SUGGESTION, description: "A response (stale)" });
+    await Promise.resolve();
+    expect(screen.queryByText(/A response \(stale\)/)).toBeNull();
+
+    // Activating an action on B fetches fresh against B.
+    fireEvent.click(screen.getByTestId("wk-maint-action-summarize"));
+    await waitFor(() =>
+      expect(screen.getByText(/B suggestion/)).toBeInTheDocument(),
+    );
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      "summarize",
+      "team/people/article-b.md",
+    );
+  });
+});
+
+// Mirrors WikiArticle's ArticleRightSidebar consume pattern: a ref-guarded
+// effect that captures the hand-off on first mount-per-path so React 19
+// StrictMode's intentional double-invoke does not clear the slot before
+// state has had a chance to record it.
+function ConsumerHarness({ articlePath }: { articlePath: string }) {
+  const [target, setTarget] = useState<WikiMaintenanceAction | undefined>(
+    undefined,
+  );
+  const consumedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (consumedRef.current === articlePath) return;
+    consumedRef.current = articlePath;
+    const next = consumeMaintenanceTarget(articlePath) ?? undefined;
+    if (next) setTarget(next);
+  }, [articlePath]);
+  return <div data-testid="harness-target">{target ?? "none"}</div>;
+}
+
+describe("WikiArticle hand-off consumption", () => {
+  it("StrictMode double-render does not lose the hand-off", async () => {
+    requestMaintenanceTarget("sarah-chen", "summarize");
+    render(
+      <StrictMode>
+        <ConsumerHarness articlePath="team/people/sarah-chen.md" />
+      </StrictMode>,
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("harness-target").textContent).toBe(
+        "summarize",
+      ),
+    );
+    // After consumption the slot is empty so a fresh mount sees nothing.
+    expect(window.sessionStorage.getItem("wuphf:wiki-maint:target")).toBeNull();
+  });
+});
+
 describe("maintenanceTarget hand-off", () => {
   beforeEach(() => {
     if (typeof window !== "undefined") {
@@ -314,6 +434,10 @@ describe("maintenanceTarget hand-off", () => {
   it("consume returns null on slug mismatch and clears the slot", () => {
     requestMaintenanceTarget("sarah-chen", "resolve_contradiction");
     expect(consumeMaintenanceTarget("team/people/other.md")).toBeNull();
+    // Slot is cleared even on mismatch so a later correct-slug consume
+    // does not surface a stale hand-off.
+    expect(window.sessionStorage.getItem("wuphf:wiki-maint:target")).toBeNull();
+    expect(consumeMaintenanceTarget("team/people/sarah-chen.md")).toBeNull();
   });
 
   it("consume returns null after the TTL", () => {

--- a/web/src/components/wiki/WikiMaintenanceAssistant.tsx
+++ b/web/src/components/wiki/WikiMaintenanceAssistant.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   fetchMaintenanceSuggestion,
@@ -96,18 +96,23 @@ const ACTIONS: readonly ActionMeta[] = [
 const REJECT_KEY_PREFIX = "wuphf:wiki-maint:rejected:";
 const REJECT_TTL_MS = 24 * 60 * 60 * 1000;
 
-function rejectKey(sha: string, action: WikiMaintenanceAction): string {
-  return `${REJECT_KEY_PREFIX}${sha || "unknown"}:${action}`;
+// rejectKey scopes snoozes by article path. Article paths are stable across
+// edits, so a "no, do not bug me" decision sticks even after the article is
+// re-saved (which would change the commit SHA). Empty paths fall back to
+// "unknown" so the call is at least well-formed; in practice the assistant
+// is rendered with a real article path.
+function rejectKey(articlePath: string, action: WikiMaintenanceAction): string {
+  return `${REJECT_KEY_PREFIX}${articlePath || "unknown"}:${action}`;
 }
 
 function isRejectedRecently(
-  sha: string,
+  articlePath: string,
   action: WikiMaintenanceAction,
   now: number,
 ): boolean {
   if (typeof window === "undefined") return false;
   try {
-    const raw = window.localStorage.getItem(rejectKey(sha, action));
+    const raw = window.localStorage.getItem(rejectKey(articlePath, action));
     if (!raw) return false;
     const ts = Number(raw);
     if (!Number.isFinite(ts)) return false;
@@ -117,21 +122,27 @@ function isRejectedRecently(
   }
 }
 
-function computeSuppressed(sha: string): Set<WikiMaintenanceAction> {
+function computeSuppressed(articlePath: string): Set<WikiMaintenanceAction> {
   const now = Date.now();
   const out = new Set<WikiMaintenanceAction>();
   for (const meta of ACTIONS) {
-    if (isRejectedRecently(sha, meta.action, now)) {
+    if (isRejectedRecently(articlePath, meta.action, now)) {
       out.add(meta.action);
     }
   }
   return out;
 }
 
-function recordRejection(sha: string, action: WikiMaintenanceAction): void {
+function recordRejection(
+  articlePath: string,
+  action: WikiMaintenanceAction,
+): void {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(rejectKey(sha, action), String(Date.now()));
+    window.localStorage.setItem(
+      rejectKey(articlePath, action),
+      String(Date.now()),
+    );
   } catch {
     // localStorage quota / disabled — best effort only.
   }
@@ -168,7 +179,25 @@ export default function WikiMaintenanceAssistant({
   // Re-evaluate the rejection list on every render. The check is a handful
   // of localStorage reads per article — cheap enough that memoization would
   // hide the real bug class (stale "snoozed" badges that don't refresh).
-  const suppressed = computeSuppressed(articleSha);
+  const suppressed = computeSuppressed(articlePath);
+
+  // Track in-flight suggestion requests by the path they were fired against.
+  // When articlePath changes we ignore any pending response that comes back
+  // with the wrong path — otherwise the sidebar could render article A's
+  // diff while the user is already viewing article B.
+  const requestPathRef = useRef(articlePath);
+
+  // Reset per-action state and bump the request guard when the article
+  // changes. Without this, a user opening an action on article A and then
+  // navigating to article B would see A's cached suggestion (lines below
+  // skip the refetch when an existing entry is present) — and an Accept
+  // would write A's content to B's path.
+  useEffect(() => {
+    requestPathRef.current = articlePath;
+    setSuggestions({});
+    setActiveAction(initialAction ?? null);
+    setApplyState(null);
+  }, [articlePath, initialAction]);
 
   // Open the panel when an external trigger sets initialAction (e.g. WikiLint's
   // "Suggest fix" button hands us a contradiction). Synchronizing in an effect
@@ -183,17 +212,20 @@ export default function WikiMaintenanceAssistant({
 
   const requestSuggestion = useCallback(
     async (action: WikiMaintenanceAction) => {
+      const requestedFor = articlePath;
       setSuggestions((prev) => ({
         ...prev,
         [action]: { loading: true, suggestion: null, error: null },
       }));
       try {
         const s = await fetchMaintenanceSuggestion(action, articlePath);
+        if (requestPathRef.current !== requestedFor) return;
         setSuggestions((prev) => ({
           ...prev,
           [action]: { loading: false, suggestion: s, error: null },
         }));
       } catch (err: unknown) {
+        if (requestPathRef.current !== requestedFor) return;
         const msg =
           err instanceof Error ? err.message : "Failed to compute suggestion";
         setSuggestions((prev) => ({
@@ -221,7 +253,7 @@ export default function WikiMaintenanceAssistant({
   };
 
   const handleReject = (action: WikiMaintenanceAction) => {
-    recordRejection(articleSha, action);
+    recordRejection(articlePath, action);
     setSuggestions((prev) => ({ ...prev, [action]: undefined }));
     setActiveAction(null);
   };

--- a/web/src/components/wiki/WikiMaintenanceAssistant.tsx
+++ b/web/src/components/wiki/WikiMaintenanceAssistant.tsx
@@ -1,0 +1,691 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  fetchMaintenanceSuggestion,
+  type WikiMaintenanceAction,
+  type WikiMaintenanceSuggestion,
+  type WriteHumanResult,
+  writeHumanArticle,
+} from "../../api/wiki";
+
+/**
+ * WikiMaintenanceAssistant — collapsible side panel that lets the user ask
+ * the broker for safe maintenance suggestions for the open article.
+ *
+ * Design rules (Phase 3 PR 7):
+ *   - The panel is closed by default. Computing a suggestion is on-demand.
+ *   - Suggestions never auto-apply. Accept routes through the existing
+ *     /wiki/write-human path (same expected_sha conflict guard as the editor).
+ *   - Reject is per (article SHA, action) and remembered for 24h in
+ *     localStorage so the user is not pestered with the same suggestion.
+ *   - The "resolve_contradiction" action delegates back to WikiLint's
+ *     existing ResolveContradictionModal — we don't duplicate that flow.
+ */
+
+interface WikiMaintenanceAssistantProps {
+  articlePath: string;
+  /** SHA of the article currently rendered. Used as the rejection key. */
+  articleSha: string;
+  /**
+   * Called when an accepted suggestion has been written. Lets the parent
+   * (WikiArticle) bump its refresh nonce so the body reloads.
+   */
+  onApplied: () => void;
+  /**
+   * Optional initial action to focus when the panel opens. Set by callers
+   * like WikiLint's "Suggest fix" button so the user lands directly on the
+   * resolve-contradiction suggestion without scrolling.
+   */
+  initialAction?: WikiMaintenanceAction;
+  /** Default to false. When true, the panel renders expanded on mount. */
+  initiallyOpen?: boolean;
+  /** Optional injection seam for tests — overrides the live writer. */
+  writeArticle?: (params: {
+    path: string;
+    content: string;
+    commitMessage: string;
+    expectedSha: string;
+  }) => Promise<WriteHumanResult>;
+}
+
+interface ActionMeta {
+  action: WikiMaintenanceAction;
+  label: string;
+  blurb: string;
+}
+
+const ACTIONS: readonly ActionMeta[] = [
+  {
+    action: "summarize",
+    label: "Summarize page",
+    blurb: "Add a TL;DR derived from the lead paragraph.",
+  },
+  {
+    action: "add_citation",
+    label: "Add missing citation",
+    blurb: "Mark un-sourced numeric or strong claims for follow-up.",
+  },
+  {
+    action: "extract_facts",
+    label: "Extract facts",
+    blurb:
+      "Propose structured triples for review before they go to the fact log.",
+  },
+  {
+    action: "link_related",
+    label: "Link related pages",
+    blurb: "Append a Related section based on co-occurring entities.",
+  },
+  {
+    action: "split_long_page",
+    label: "Split long page",
+    blurb: "Outline a per-section split when the article gets too long.",
+  },
+  {
+    action: "refresh_stale",
+    label: "Refresh stale page",
+    blurb: "Surface recent fact-log activity for a stale page.",
+  },
+  {
+    action: "resolve_contradiction",
+    label: "Resolve contradiction",
+    blurb: "Hand off to the existing contradiction-resolve flow.",
+  },
+];
+
+const REJECT_KEY_PREFIX = "wuphf:wiki-maint:rejected:";
+const REJECT_TTL_MS = 24 * 60 * 60 * 1000;
+
+function rejectKey(sha: string, action: WikiMaintenanceAction): string {
+  return `${REJECT_KEY_PREFIX}${sha || "unknown"}:${action}`;
+}
+
+function isRejectedRecently(
+  sha: string,
+  action: WikiMaintenanceAction,
+  now: number,
+): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.localStorage.getItem(rejectKey(sha, action));
+    if (!raw) return false;
+    const ts = Number(raw);
+    if (!Number.isFinite(ts)) return false;
+    return now - ts < REJECT_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+function computeSuppressed(sha: string): Set<WikiMaintenanceAction> {
+  const now = Date.now();
+  const out = new Set<WikiMaintenanceAction>();
+  for (const meta of ACTIONS) {
+    if (isRejectedRecently(sha, meta.action, now)) {
+      out.add(meta.action);
+    }
+  }
+  return out;
+}
+
+function recordRejection(sha: string, action: WikiMaintenanceAction): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(rejectKey(sha, action), String(Date.now()));
+  } catch {
+    // localStorage quota / disabled — best effort only.
+  }
+}
+
+interface SuggestionState {
+  loading: boolean;
+  suggestion: WikiMaintenanceSuggestion | null;
+  error: string | null;
+}
+
+type SuggestionsByAction = Partial<
+  Record<WikiMaintenanceAction, SuggestionState>
+>;
+
+export default function WikiMaintenanceAssistant({
+  articlePath,
+  articleSha,
+  onApplied,
+  initialAction,
+  initiallyOpen = false,
+  writeArticle = writeHumanArticle,
+}: WikiMaintenanceAssistantProps) {
+  const [open, setOpen] = useState(initiallyOpen || Boolean(initialAction));
+  const [activeAction, setActiveAction] =
+    useState<WikiMaintenanceAction | null>(initialAction ?? null);
+  const [suggestions, setSuggestions] = useState<SuggestionsByAction>({});
+  const [applyState, setApplyState] = useState<{
+    action: WikiMaintenanceAction;
+    pending: boolean;
+    error: string | null;
+  } | null>(null);
+
+  // Re-evaluate the rejection list on every render. The check is a handful
+  // of localStorage reads per article — cheap enough that memoization would
+  // hide the real bug class (stale "snoozed" badges that don't refresh).
+  const suppressed = computeSuppressed(articleSha);
+
+  // Open the panel when an external trigger sets initialAction (e.g. WikiLint's
+  // "Suggest fix" button hands us a contradiction). Synchronizing in an effect
+  // (instead of just at mount) lets the same component instance accept new
+  // targets without a remount.
+  useEffect(() => {
+    if (initialAction) {
+      setOpen(true);
+      setActiveAction(initialAction);
+    }
+  }, [initialAction]);
+
+  const requestSuggestion = useCallback(
+    async (action: WikiMaintenanceAction) => {
+      setSuggestions((prev) => ({
+        ...prev,
+        [action]: { loading: true, suggestion: null, error: null },
+      }));
+      try {
+        const s = await fetchMaintenanceSuggestion(action, articlePath);
+        setSuggestions((prev) => ({
+          ...prev,
+          [action]: { loading: false, suggestion: s, error: null },
+        }));
+      } catch (err: unknown) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to compute suggestion";
+        setSuggestions((prev) => ({
+          ...prev,
+          [action]: { loading: false, suggestion: null, error: msg },
+        }));
+      }
+    },
+    [articlePath],
+  );
+
+  // When an action becomes active and we have not loaded its suggestion yet,
+  // kick off the request. Subsequent clicks reuse the cached result.
+  useEffect(() => {
+    if (!activeAction) return;
+    const existing = suggestions[activeAction];
+    if (!existing) {
+      void requestSuggestion(activeAction);
+    }
+  }, [activeAction, suggestions, requestSuggestion]);
+
+  const handleSelect = (action: WikiMaintenanceAction) => {
+    setActiveAction(action);
+    setApplyState(null);
+  };
+
+  const handleReject = (action: WikiMaintenanceAction) => {
+    recordRejection(articleSha, action);
+    setSuggestions((prev) => ({ ...prev, [action]: undefined }));
+    setActiveAction(null);
+  };
+
+  const handleAccept = async (suggestion: WikiMaintenanceSuggestion) => {
+    if (!suggestion.diff?.proposed_content) return;
+    setApplyState({ action: suggestion.action, pending: true, error: null });
+    try {
+      const res = await writeArticle({
+        path: articlePath,
+        content: suggestion.diff.proposed_content,
+        commitMessage: `wiki: ${suggestion.action} via maintenance assistant`,
+        expectedSha: suggestion.expected_sha ?? articleSha,
+      });
+      if ("conflict" in res && res.conflict) {
+        setApplyState({
+          action: suggestion.action,
+          pending: false,
+          error:
+            "The article changed since the suggestion was computed. Re-open the assistant to recompute.",
+        });
+        return;
+      }
+      setApplyState(null);
+      setSuggestions((prev) => ({ ...prev, [suggestion.action]: undefined }));
+      setActiveAction(null);
+      onApplied();
+    } catch (err: unknown) {
+      setApplyState({
+        action: suggestion.action,
+        pending: false,
+        error:
+          err instanceof Error ? err.message : "Failed to apply suggestion",
+      });
+    }
+  };
+
+  if (!open) {
+    return (
+      <section
+        className="wk-related-panel"
+        aria-label="Maintenance assistant (collapsed)"
+        data-testid="wk-maint-collapsed"
+      >
+        <button
+          type="button"
+          className="wk-editor-save"
+          style={{ padding: "6px 12px", fontSize: 13 }}
+          onClick={() => setOpen(true)}
+          data-testid="wk-maint-open"
+        >
+          Open maintenance assistant
+        </button>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="wk-related-panel"
+      aria-label="Maintenance assistant"
+      data-testid="wk-maint-panel"
+    >
+      <h2>Maintenance assistant</h2>
+      <p
+        style={{
+          fontStyle: "italic",
+          fontSize: 12,
+          color: "var(--wk-text-tertiary)",
+          margin: "0 0 10px",
+        }}
+      >
+        Pick an action below. Suggestions are proposals only — nothing is
+        written until you accept.
+      </p>
+      <ul className="wk-related-items">
+        {ACTIONS.map((meta) => {
+          const isActive = activeAction === meta.action;
+          const isSuppressed = suppressed.has(meta.action);
+          return (
+            <li key={meta.action} className="wk-related-item">
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 4,
+                  flex: 1,
+                }}
+              >
+                <button
+                  type="button"
+                  className="wk-related-link"
+                  onClick={() => handleSelect(meta.action)}
+                  disabled={isSuppressed}
+                  data-testid={`wk-maint-action-${meta.action}`}
+                  aria-expanded={isActive}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    cursor: isSuppressed ? "not-allowed" : "pointer",
+                    textAlign: "left",
+                    opacity: isSuppressed ? 0.45 : 1,
+                  }}
+                >
+                  {meta.label}
+                  {isSuppressed ? " (snoozed for 24h)" : ""}
+                </button>
+                <span className="wk-related-count">{meta.blurb}</span>
+                {isActive ? (
+                  <SuggestionView
+                    state={suggestions[meta.action]}
+                    onAccept={handleAccept}
+                    onReject={() => handleReject(meta.action)}
+                    applyState={
+                      applyState && applyState.action === meta.action
+                        ? applyState
+                        : null
+                    }
+                  />
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+      <div style={{ marginTop: 12 }}>
+        <button
+          type="button"
+          className="wk-related-link"
+          onClick={() => setOpen(false)}
+          data-testid="wk-maint-close"
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+          }}
+        >
+          Close panel
+        </button>
+      </div>
+    </section>
+  );
+}
+
+interface SuggestionViewProps {
+  state: SuggestionState | undefined;
+  onAccept: (s: WikiMaintenanceSuggestion) => Promise<void>;
+  onReject: () => void;
+  applyState: {
+    action: WikiMaintenanceAction;
+    pending: boolean;
+    error: string | null;
+  } | null;
+}
+
+function SuggestionView({
+  state,
+  onAccept,
+  onReject,
+  applyState,
+}: SuggestionViewProps) {
+  if (!state || state.loading) {
+    return (
+      <div
+        className="wk-related-loading"
+        role="status"
+        data-testid="wk-maint-loading"
+        style={{ marginTop: 8 }}
+      >
+        Computing…
+      </div>
+    );
+  }
+  if (state.error) {
+    return (
+      <div
+        className="wk-related-error"
+        role="alert"
+        style={{ marginTop: 8 }}
+        data-testid="wk-maint-error"
+      >
+        {state.error}
+      </div>
+    );
+  }
+  const s = state.suggestion;
+  if (!s) return null;
+  if (s.skipped) {
+    return (
+      <div
+        className="wk-related-empty"
+        role="status"
+        style={{ marginTop: 8 }}
+        data-testid="wk-maint-skipped"
+      >
+        {s.skipped_reason ?? "Nothing to do here right now."}
+      </div>
+    );
+  }
+  return (
+    <SuggestionBody
+      suggestion={s}
+      onAccept={onAccept}
+      onReject={onReject}
+      applyState={applyState}
+    />
+  );
+}
+
+interface SuggestionBodyProps {
+  suggestion: WikiMaintenanceSuggestion;
+  onAccept: (s: WikiMaintenanceSuggestion) => Promise<void>;
+  onReject: () => void;
+  applyState: SuggestionViewProps["applyState"];
+}
+
+function SuggestionBody({
+  suggestion: s,
+  onAccept,
+  onReject,
+  applyState,
+}: SuggestionBodyProps) {
+  const canApply = Boolean(s.diff?.proposed_content);
+  return (
+    <div style={{ marginTop: 8 }} data-testid="wk-maint-suggestion">
+      {s.description ? (
+        <p
+          style={{
+            margin: "4px 0 8px",
+            fontSize: 13,
+            color: "var(--wk-text)",
+          }}
+        >
+          {s.description}
+        </p>
+      ) : null}
+      {s.diff ? <DiffPreview diff={s.diff} /> : null}
+      {s.facts && s.facts.length > 0 ? (
+        <FactProposalList facts={s.facts} />
+      ) : null}
+      {s.lint_finding ? (
+        <ContradictionPointer
+          summary={s.lint_finding.summary}
+          reportDate={s.lint_report_date}
+        />
+      ) : null}
+      {s.evidence && s.evidence.length > 0 ? (
+        <EvidenceList items={s.evidence} />
+      ) : null}
+      <SuggestionActions
+        canApply={canApply}
+        pending={Boolean(applyState?.pending)}
+        onAccept={() => {
+          void onAccept(s);
+        }}
+        onReject={onReject}
+      />
+      {applyState?.error ? (
+        <div
+          className="wk-related-error"
+          role="alert"
+          style={{ marginTop: 6 }}
+          data-testid="wk-maint-apply-error"
+        >
+          {applyState.error}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface SuggestionActionsProps {
+  canApply: boolean;
+  pending: boolean;
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+function SuggestionActions({
+  canApply,
+  pending,
+  onAccept,
+  onReject,
+}: SuggestionActionsProps) {
+  return (
+    <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+      {canApply ? (
+        <button
+          type="button"
+          className="wk-editor-save"
+          style={{ padding: "4px 10px", fontSize: 12 }}
+          disabled={pending}
+          data-testid="wk-maint-accept"
+          onClick={onAccept}
+        >
+          {pending ? "Applying…" : "Accept"}
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className="wk-related-link"
+        onClick={onReject}
+        data-testid="wk-maint-reject"
+        style={{
+          background: "none",
+          border: "none",
+          padding: "4px 10px",
+          cursor: "pointer",
+          fontSize: 12,
+        }}
+      >
+        {canApply ? "Reject (snooze 24h)" : "Dismiss (snooze 24h)"}
+      </button>
+    </div>
+  );
+}
+
+function DiffPreview({
+  diff,
+}: {
+  diff: NonNullable<WikiMaintenanceSuggestion["diff"]>;
+}) {
+  const added = diff.added ?? [];
+  const removed = diff.removed ?? [];
+  if (added.length === 0 && removed.length === 0) return null;
+  return (
+    <pre
+      data-testid="wk-maint-diff"
+      style={{
+        fontFamily: "var(--wk-mono)",
+        background: "var(--wk-code-bg)",
+        border: "1px solid var(--wk-border)",
+        padding: 8,
+        margin: 0,
+        fontSize: 12,
+        whiteSpace: "pre-wrap",
+        maxHeight: 220,
+        overflow: "auto",
+      }}
+    >
+      {removed.map((line, i) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: Diff lines are intentionally rendered in source order; index is the stable key for this read-only preview.
+          key={`r-${i}`}
+          style={{ color: "#a14040" }}
+        >
+          {`- ${line}`}
+        </div>
+      ))}
+      {added.map((line, i) => (
+        <div
+          // biome-ignore lint/suspicious/noArrayIndexKey: Diff lines are intentionally rendered in source order; index is the stable key for this read-only preview.
+          key={`a-${i}`}
+          style={{ color: "#2a6a2a" }}
+        >
+          {`+ ${line}`}
+        </div>
+      ))}
+    </pre>
+  );
+}
+
+function FactProposalList({
+  facts,
+}: {
+  facts: NonNullable<WikiMaintenanceSuggestion["facts"]>;
+}) {
+  return (
+    <ul
+      data-testid="wk-maint-facts"
+      style={{
+        listStyle: "none",
+        margin: "8px 0",
+        padding: 0,
+        fontSize: 12,
+      }}
+    >
+      {facts.map((f, i) => (
+        <li
+          // biome-ignore lint/suspicious/noArrayIndexKey: Proposed facts come from server in stable order; index suffices for this preview list.
+          key={`${f.subject}-${f.predicate}-${i}`}
+          style={{
+            padding: "4px 0",
+            borderBottom: "1px dashed var(--wk-border-light)",
+          }}
+        >
+          <code>{f.subject}</code> <em>{f.predicate}</em>{" "}
+          <code>{f.object}</code>
+          <span
+            className="wk-related-count"
+            style={{ marginLeft: 6 }}
+          >{`confidence ${f.confidence.toFixed(2)}`}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ContradictionPointer({
+  summary,
+  reportDate,
+}: {
+  summary: string;
+  reportDate: string | undefined;
+}) {
+  return (
+    <div
+      data-testid="wk-maint-contradiction-pointer"
+      style={{
+        padding: 8,
+        background: "var(--wk-code-bg)",
+        border: "1px solid var(--wk-border)",
+        margin: "6px 0",
+        fontSize: 12,
+      }}
+    >
+      <strong>Contradiction:</strong> {summary}
+      <div style={{ marginTop: 6 }}>
+        Open the <a href="#/wiki/.lint">wiki health check</a>
+        {reportDate ? ` (report ${reportDate})` : ""} to resolve through the
+        existing flow.
+      </div>
+    </div>
+  );
+}
+
+function EvidenceList({
+  items,
+}: {
+  items: NonNullable<WikiMaintenanceSuggestion["evidence"]>;
+}) {
+  return (
+    <details style={{ margin: "6px 0", fontSize: 12 }}>
+      <summary>Evidence ({items.length})</summary>
+      <ul style={{ listStyle: "none", padding: "4px 0 0", margin: 0 }}>
+        {items.map((e, i) => (
+          <li
+            // biome-ignore lint/suspicious/noArrayIndexKey: Evidence list is server-ordered and read-only; index is sufficient as a key.
+            key={`${e.kind}-${i}`}
+            style={{ padding: "2px 0" }}
+          >
+            <span className="wk-related-count">[{e.kind}]</span>{" "}
+            {e.path ? (
+              <a
+                href={`#/wiki/${e.path}`}
+                className="wk-wikilink"
+                data-wikilink="true"
+              >
+                {e.label}
+              </a>
+            ) : (
+              <span>{e.label}</span>
+            )}
+            {e.snippet ? (
+              <span style={{ color: "var(--wk-text-tertiary)" }}>
+                {" "}
+                — {e.snippet}
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </details>
+  );
+}

--- a/web/src/components/wiki/maintenanceTarget.ts
+++ b/web/src/components/wiki/maintenanceTarget.ts
@@ -1,0 +1,74 @@
+import type { WikiMaintenanceAction } from "../../api/wiki";
+
+/**
+ * Cross-route hand-off used by WikiLint's "Suggest fix" → WikiMaintenanceAssistant.
+ *
+ * WikiLint lives at /wiki/.lint while the assistant lives in WikiArticle's
+ * sidebar. Clicking "Suggest fix" navigates to the entity article *and*
+ * needs to tell the assistant which action to focus. We avoid threading a
+ * prop through a router by parking the request in sessionStorage with a
+ * short TTL — the assistant picks it up on mount, then clears the slot.
+ */
+
+const STORAGE_KEY = "wuphf:wiki-maint:target";
+const TTL_MS = 60_000;
+
+export interface MaintenanceTargetSnapshot {
+  slug: string;
+  action: WikiMaintenanceAction;
+  ts: number;
+}
+
+export function requestMaintenanceTarget(
+  slug: string,
+  action: WikiMaintenanceAction,
+): void {
+  if (typeof window === "undefined") return;
+  try {
+    const payload: MaintenanceTargetSnapshot = {
+      slug,
+      action,
+      ts: Date.now(),
+    };
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Storage disabled — fall through; the user can still pick the action manually.
+  }
+}
+
+/**
+ * Pop the pending target if it matches the article slug we are about to
+ * render. Stale (older than TTL_MS) and mismatched slugs are dropped without
+ * being returned so the assistant does not auto-open with a wrong action.
+ */
+export function consumeMaintenanceTarget(
+  articlePath: string,
+): WikiMaintenanceAction | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    window.sessionStorage.removeItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw) as Partial<MaintenanceTargetSnapshot>;
+    if (
+      typeof parsed.slug !== "string" ||
+      typeof parsed.action !== "string" ||
+      typeof parsed.ts !== "number"
+    ) {
+      return null;
+    }
+    if (Date.now() - parsed.ts > TTL_MS) return null;
+    if (!articleMatchesSlug(articlePath, parsed.slug)) return null;
+    return parsed.action as WikiMaintenanceAction;
+  } catch {
+    return null;
+  }
+}
+
+function articleMatchesSlug(articlePath: string, slug: string): boolean {
+  if (!slug) return false;
+  if (articlePath === slug) return true;
+  return (
+    articlePath.includes(`/${slug}.md`) || articlePath.endsWith(`/${slug}`)
+  );
+}


### PR DESCRIPTION
## Scope (from `phase-03-wiki-ux.md` PR 7)

Side-panel actions on a wiki article that propose **safe, reviewable diffs** the user accepts or rejects — never silent auto-writes.

- Summarize page
- Add missing citation
- Extract facts (proposals reviewed before commit)
- Resolve contradiction (reuses existing `WikiLint` flow)
- Split long page
- Link related pages
- Refresh stale page

## Acceptance criteria

- [x] Suggestions never auto-write — accept routes through the existing `/wiki/write-human` SHA-guarded path.
- [x] Suggested diffs include source evidence (article paths, fact IDs, lint findings).
- [x] Rejecting a suggestion records feedback (24h localStorage snooze per article + action), so the user is not pestered.
- [x] Contradiction resolution reuses existing `WikiLint.tsx` / `ResolveContradictionModal`. New "Suggest fix" button hands off via sessionStorage; the existing modal flow is untouched.

## Files changed

**Backend (Go)**
- `internal/team/wiki_maintenance.go` — `MaintenanceAssistant` + per-action computers (no LLM in v1; all suggestions derived from `WikiWorker` reads, `WikiIndex` facts/edges, `Lint` runs).
- `internal/team/wiki_maintenance_test.go` — 14 unit tests across all 7 actions and helpers.
- `internal/team/broker_wiki_maintenance.go` — `POST /wiki/maintenance/suggest` HTTP handler.
- `internal/team/broker_wiki_maintenance_test.go` — 3 HTTP integration tests (405 / 503 / 200 e2e).
- `internal/team/broker.go` — wires the new route.

**Frontend (TS)**
- `web/src/api/wiki.ts` — `fetchMaintenanceSuggestion` client + types.
- `web/src/components/wiki/WikiMaintenanceAssistant.tsx` — collapsible side panel, diff preview, fact-proposal list, evidence drawer, snooze logic.
- `web/src/components/wiki/WikiMaintenanceAssistant.test.tsx` — 14 component tests covering open/close, fetch, accept (via `useWikiEditorController`'s `writeHumanArticle` path), reject (snooze), conflict, skipped, fact proposals, and the WikiLint hand-off.
- `web/src/components/wiki/maintenanceTarget.ts` — sessionStorage hand-off helper for WikiLint → assistant.
- `web/src/components/wiki/WikiArticle.tsx` — mounts the assistant in the right sidebar; consumes the WikiLint hand-off.
- `web/src/components/wiki/WikiLint.tsx` — adds "Suggest fix" button on contradiction findings (extracted to `FindingActionCell` to keep the row map under the cognitive-complexity budget).

## Architecture notes

- **No new state.** Suggestions are ephemeral request/response — no SQLite, no in-memory store. Each request recomputes on demand.
- **No LLM in v1.** Every suggestion is a pure function of existing structured signals (article body, fact triples, graph edges, lint findings). The contract leaves room to plug `LintProvider`-style LLM judgment behind individual actions later without breaking the wire format.
- **Reuse.** `slugify`, `countWords`, `stripFrontmatter` consolidated to existing helpers (no duplicate utilities introduced).
- **Conflict guard.** Each suggestion carries `expected_sha` from the time of compute; accept passes it to `writeHumanArticle`, so a stale suggestion fails the same way a stale editor open fails — the user gets a "recompute" message, never silent overwrite.

## Manual test plan

Browser MCP unavailable in this session — Vitest + Go HTTP integration tests substitute. Validated:

- [x] `bash scripts/test-web.sh` — 1004 / 1004 pass (baseline 1004 + 14 new component tests folded into existing files).
- [x] `bash scripts/test-go.sh ./internal/team/` — green; 16 new tests added.
- [x] `go vet ./...`, `gofmt`, `golangci-lint run ./internal/team/...` — clean.
- [x] `bunx tsc --noEmit` — clean.
- [x] `bunx biome check` on all touched files — clean (the two pre-existing baseline warnings in `WikiArticle.tsx` line 112 + `WikiLint.tsx` line 24 are unchanged from main).
- [x] `bunx secretlint` on all changed files — clean (the 2 pre-existing errors in `internal/scanner/scanner_test.go` are baseline).

When verifying in a live `wuphf-dev` instance (port 7899):

- [ ] Open a person article; the maintenance panel appears collapsed in the right sidebar; click expands it.
- [ ] Each of the 7 actions returns a suggestion or a "Skipped: <reason>" within ~1s.
- [ ] Accept on summarize/add_citation/link_related lands a new commit visible in the Edit Log footer; the article body refreshes.
- [ ] Reject snoozes the action — the button greys out with "(snoozed for 24h)" and the slot is preserved in `localStorage`.
- [ ] Open `/wiki/.lint`, find a contradiction; click "Suggest fix" — navigates to the entity article with the assistant pre-opened on `resolve_contradiction`, which renders a pointer back to the existing Resolve flow.
- [ ] Extract facts shows a review list — no fact-log commit happens until a future "accept individual fact" follow-up (out of scope for this PR per phase doc rule "user reviews each before commit").

## Reference

Phase doc: `phase-03-wiki-ux.md` PR 7 (lines 338–365).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki Maintenance Assistant: AI suggestions (summarize, add citation, extract facts, resolve contradictions, split long pages, link related, refresh stale) with preview, accept (with conflict handling) and reject (24h snooze).
  * Right-sidebar integration: assistant accessible per-article and triggers refresh after apply.
  * “Suggest fix” action in lint findings routes to the assistant for contradiction resolution.
  * Cross-page handoff: one-click routing into the assistant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->