### PR TITLE
feat(team): restore in-character cross-agent banter and chime-ins

### DIFF
--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -1987,13 +1987,19 @@ func TestResponseInstructionForTargetDMChannelRespondsHelpfully(t *testing.T) {
 		t.Errorf("DM instruction should indicate direct message, got %q", dmInstr)
 	}
 
-	// Non-DM without @tag — should still stay quiet (existing behavior preserved)
+	// Non-DM without @tag — should invite an in-character chime-in, not the
+	// strict DM "messaging you directly" treatment. The agent is woken because
+	// the topic brushes their domain; the prompt asks for a short alive reply
+	// when they have one, and to skip otherwise.
 	channelInstr := l.responseInstructionForTarget(channelMessage{
 		From:    "you",
 		Channel: "general",
 	}, "engineering")
-	if !strings.Contains(channelInstr, "Stay quiet") {
-		t.Errorf("non-DM untagged should stay quiet, got %q", channelInstr)
+	if strings.Contains(channelInstr, "messaging you directly") {
+		t.Errorf("non-DM should not get DM-direct guidance, got %q", channelInstr)
+	}
+	if !strings.Contains(channelInstr, "in-character") || !strings.Contains(channelInstr, "Skip the turn only if") {
+		t.Errorf("non-DM untagged should get chime-in-with-personality default, got %q", channelInstr)
 	}
 
 	// DM with agent slug mismatch — wrong agent should not get DM instruction

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -361,7 +361,7 @@ func (b *notificationContextBuilder) RelevantTaskForTarget(msg channelMessage, s
 
 // ResponseInstructionForTarget returns the per-agent guidance string
 // appended to a notification. Branches: lead-from-human, lead-from-
-// specialist, DM, tagged, owns-matching-task, default-stay-quiet.
+// specialist, DM, tagged, owns-matching-task, default-domain-chime-in.
 func (b *notificationContextBuilder) ResponseInstructionForTarget(msg channelMessage, slug string) string {
 	lead := b.targeter.LeadSlug()
 	if slug == lead {

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -388,7 +388,7 @@ func (b *notificationContextBuilder) ResponseInstructionForTarget(msg channelMes
 		}
 		return fmt.Sprintf("You are @%s. You already own matching work. Reply only with concrete progress or a blocker; do not re-triage the thread.", slug)
 	}
-	return fmt.Sprintf("You are @%s. Stay quiet unless you are directly tagged, you own the active work, or you can unblock it. Prefer not to reply.", slug)
+	return fmt.Sprintf("You are @%s. You were woken because the thread brushes your domain. If you have a sharp in-character take, a push-back from your expertise, a quick observation, or a one-line crack that adds energy, drop it — short. Office banter and half-joke riffs are how real teams stumble into ideas, so don't suppress yours when something genuine lands. Skip the turn only if you truly have nothing to add; do not reply just to acknowledge.", slug)
 }
 
 // BuildMessageWorkPacket returns the work packet a notified agent receives

--- a/internal/team/notification_context_test.go
+++ b/internal/team/notification_context_test.go
@@ -406,11 +406,11 @@ func TestNotificationContext_ResponseInstruction_TaggedTriggersTaggedGuidance(t 
 	}
 }
 
-func TestNotificationContext_ResponseInstruction_UntaggedNonOwnerStaysQuiet(t *testing.T) {
+func TestNotificationContext_ResponseInstruction_UntaggedNonOwnerInvitedToChimeIn(t *testing.T) {
 	b := newTestNotifyContextBuilder(t)
 	got := b.ResponseInstructionForTarget(channelMessage{Channel: "general"}, "eng")
-	if !strings.Contains(got, "Stay quiet") {
-		t.Errorf("expected stay-quiet default for untagged non-owner; got %q", got)
+	if !strings.Contains(got, "in-character") || !strings.Contains(got, "Skip the turn only if") {
+		t.Errorf("expected chime-in-with-personality default for untagged non-owner; got %q", got)
 	}
 }
 

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -166,8 +166,7 @@ func (p *promptBuilder) Build(slug string) string {
 			sb.WriteString("\n")
 		}
 		sb.WriteString("Tagged agents are expected to respond.\n\n")
-		sb.WriteString("== OFFICE VIBE ==\n")
-		sb.WriteString("This is a real team. Agents learn from each other the same way humans do — through short, in-character banter, half-joke push-back, and dropped observations between teammates. Don't suppress that. Real ideas usually fall out of riffing, not out of formal rounds. Keep replies short and alive; skip filler and pure acknowledgements.\n\n")
+		sb.WriteString(officeVibeBlock())
 		if p.isFocusMode() {
 			sb.WriteString("== DELEGATION MODE ==\n")
 			sb.WriteString("You are the routing hub. Specialists only act when you or the human explicitly @tag them.\n")
@@ -295,8 +294,8 @@ func (p *promptBuilder) Build(slug string) string {
 			sb.WriteString("\n")
 		}
 		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
-		sb.WriteString("\n== OFFICE VIBE ==\n")
-		sb.WriteString("This is a real team. Agents learn from each other the same way humans do — through short, in-character banter, half-joke push-back, and dropped observations between teammates. Don't suppress that. Real ideas usually fall out of riffing, not out of formal rounds. Keep replies short and alive; skip filler and pure acknowledgements.\n\n")
+		sb.WriteString("\n")
+		sb.WriteString(officeVibeBlock())
 		if p.isFocusMode() {
 			sb.WriteString("== DELEGATION MODE ==\n")
 			sb.WriteString("Delegation mode is enabled.\n")
@@ -435,6 +434,11 @@ func clipPromptText(s string, max int) string {
 		return s[:max]
 	}
 	return strings.TrimSpace(s[:max-1]) + "…"
+}
+
+func officeVibeBlock() string {
+	return "== OFFICE VIBE ==\n" +
+		"This is a real team. Agents learn from each other the same way humans do — through short, in-character banter, half-joke push-back, and dropped observations between teammates. Don't suppress that. Real ideas usually fall out of riffing, not out of formal rounds. Keep replies short and alive; skip filler and pure acknowledgements.\n\n"
 }
 
 func headlessSandboxNote() string {

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -166,12 +166,14 @@ func (p *promptBuilder) Build(slug string) string {
 			sb.WriteString("\n")
 		}
 		sb.WriteString("Tagged agents are expected to respond.\n\n")
+		sb.WriteString("== OFFICE VIBE ==\n")
+		sb.WriteString("This is a real team. Agents learn from each other the same way humans do — through short, in-character banter, half-joke push-back, and dropped observations between teammates. Don't suppress that. Real ideas usually fall out of riffing, not out of formal rounds. Keep replies short and alive; skip filler and pure acknowledgements.\n\n")
 		if p.isFocusMode() {
 			sb.WriteString("== DELEGATION MODE ==\n")
 			sb.WriteString("You are the routing hub. Specialists only act when you or the human explicitly @tag them.\n")
 			sb.WriteString("- Route and hold: dispatch work to the right specialist and WAIT. Never do their work while they are working.\n")
 			sb.WriteString("- Don't re-trigger: a [STATUS] or any reply from a specialist means they are working. When they finish, only respond if coordination is still needed — if the task is done and the human already has what they need, stay quiet.\n")
-			sb.WriteString("- Specialists report up, not sideways: keep them out of cross-agent chatter. Coordinate through you.\n")
+			sb.WriteString("- Specialists report up to you on work, but a quick in-character reaction, push-back, or half-joke riff between teammates is fine — that's how a real office stumbles into ideas. Just keep full debates and re-routing coordinated through you.\n")
 			sb.WriteString("- After you delegate, ask a blocking question, or post the current synthesis, END THE TURN. Do not stay active waiting for teammates; a new pushed notification will wake you when something changes.\n\n")
 		}
 		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
@@ -185,8 +187,8 @@ func (p *promptBuilder) Build(slug string) string {
 		}
 		sb.WriteString("2. The pushed notification is authoritative — it contains thread context, task state, and agent activity. Respond directly from it. Do NOT call team_poll or team_tasks unless the notification explicitly says context is missing. Every unnecessary tool call burns tokens without adding value.\n")
 		sb.WriteString("3. When routing a simple human @tagged request that should resolve in one reply, tag the specialist in your message and do NOT also create a team_task for the same work. For any multi-step build, cross-functional initiative, or work likely to need another round, you MUST create explicit team_task records for each owned lane before you send the kickoff so specialists wake up from durable task state. When those task records already exist, do NOT also tag the same specialists in the kickoff unless you need extra commentary outside the owned task.\n")
-		sb.WriteString("4. Tag only the specialists who should weigh in. Unowned background chatter is a bug.\n")
-		sb.WriteString("5. Keep specialists in their lane and mostly offstage. You make the FINAL decision.\n")
+		sb.WriteString("4. Tag the specialists who should weigh in. Don't tag everyone for everything — but don't be paranoid about a little cross-agent banter either: a sharp half-joke between teammates is how a real office stumbles into ideas. Suppress only filler and acknowledgement noise.\n")
+		sb.WriteString("5. Keep specialists in their lane on execution. You make the FINAL decision. A quick in-character reaction from them on someone else's lane is fine; full re-routing or scope debates run through you.\n")
 		sb.WriteString("6. Check team_requests before asking the human anything new\n")
 		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for cancelable clarifications, and team_request for blocking decisions\n")
 		if markdownMemory {
@@ -293,11 +295,13 @@ func (p *promptBuilder) Build(slug string) string {
 			sb.WriteString("\n")
 		}
 		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
+		sb.WriteString("\n== OFFICE VIBE ==\n")
+		sb.WriteString("This is a real team. Agents learn from each other the same way humans do — through short, in-character banter, half-joke push-back, and dropped observations between teammates. Don't suppress that. Real ideas usually fall out of riffing, not out of formal rounds. Keep replies short and alive; skip filler and pure acknowledgements.\n\n")
 		if p.isFocusMode() {
 			sb.WriteString("== DELEGATION MODE ==\n")
 			sb.WriteString("Delegation mode is enabled.\n")
 			sb.WriteString("- You take work directly from the human only when they explicitly tag you, or from @ceo when delegated.\n")
-			sb.WriteString("- Do not debate with other specialists in the channel.\n")
+			sb.WriteString("- A quick in-character reaction, joke, or sharp push-back to a teammate is welcome — that's the office talking. Don't open full debates or re-route work yourself; let @ceo coordinate that.\n")
 			sb.WriteString("- Do the work, then report completion, blockers, or handoff notes back to @ceo.\n")
 			sb.WriteString("- If another specialist should get involved, tell @ceo instead of routing it yourself.\n")
 			sb.WriteString("- After you report completion, a blocker, or a handoff, END THE TURN. Do not keep researching or wait for acknowledgements in the same run.\n\n")
@@ -305,7 +309,7 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
 		sb.WriteString("YOUR ROLE AS SPECIALIST:\n")
 		sb.WriteString("1. The pushed notification is authoritative — it contains thread context and task state. Respond directly from it. Do NOT call team_poll or team_tasks unless context is genuinely missing. Every unnecessary tool call burns tokens without adding value. Just do the work.\n")
-		sb.WriteString("2. Stay in your lane. Speak only when tagged, owning a task, blocked, or adding real delta that others haven't covered. Don't jump in just because a topic matches your domain.\n")
+		sb.WriteString("2. Stay in your lane on execution. But you're a real teammate, not a silent worker: when a thread brushes your domain and you've got a sharp take, push-back, observation, or a quick in-character crack that adds energy or sparks a better idea, drop it. Real offices solve problems through half-joke banter. The line you don't cross: filler, restating what's been said, or grabbing someone else's work.\n")
 		sb.WriteString("3. Push back when you disagree — explain why using your expertise\n")
 		sb.WriteString("4. Check team_requests before asking the human anything new\n")
 		sb.WriteString("5. For completion or recommendations, use human_message. For cancelable clarifications, use human_interview with options. For blocking human decisions, use team_request with kind `approval`, `confirm`, or `choice`.\n")


### PR DESCRIPTION
The agent collaboration originally felt alive: agents riffed with each
other, cracked jokes in-character, and that informal banter is where
cross-agent learning and better ideas tended to fall out — same way real
humans brainstorm in an office. Over time the prompt and notification
guidance hardened around silence: every wake-up tail ended with "stay
quiet, prefer not to reply", lead/specialist rules called any
unowned cross-agent reply a bug, and focus mode explicitly forbade
specialist-to-specialist chatter. Agents kept paying the wake-up token
cost, then spent those tokens deciding not to participate.

This change keeps the wake-up gating exactly as is (collaborative-mode
score threshold, focus-mode CEO-only routing, mute/disable rules), and
loosens only the per-target response instructions and a handful of
prompt rules so woken agents are explicitly invited to chime in with
personality when they have a real take, push-back, or one-line reaction.
Filler, acknowledgements, scope debates, and re-routing other agents'
work remain off-limits.

Specifically:

- notification_context.go: untagged-non-owner default flips from
  "Stay quiet … prefer not to reply" to a chime-in-with-personality
  instruction that names office banter as a signal source and asks the
  agent to skip the turn only when it genuinely has nothing to add.
- prompt_builder.go: lead and specialist prompts gain a short
  "OFFICE VIBE" block calling out cross-agent learning through
  half-joke push-back; specialist rule 2 now permits sharp in-character
  takes outside owned tasks; focus-mode "no cross-agent chatter" softens
  to "quick in-character reaction welcome, full debates run through
  CEO"; lead's "unowned background chatter is a bug" rewrites to allow
  banter while still suppressing filler.
- Tests updated: notification_context_test.go and launcher_test.go
  now assert the new chime-in default instead of "Stay quiet".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Untagged team members are now invited to contribute to conversations instead of remaining quiet
  * Leadership notification prompts now use a proactive, domain-relevant chime-in instead of quiet guidance
  * Office team dynamics messaging has been expanded and consolidated for consistent tone
  * Delegation mode guidance clarified; role-specific messaging for leaders and specialists refined

* **Tests**
  * Updated and added tests to validate the new untagged chime-in behavior and notification guidance changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->