### PR TITLE
fix(share): wire role field onto humanSessionResponse

### DIFF
--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -103,6 +103,10 @@ type humanSessionResponse struct {
 	InviteID    string `json:"invite_id"`
 	HumanSlug   string `json:"human_slug"`
 	DisplayName string `json:"display_name"`
+	// Role is hardcoded to "member" so the joiner web client can branch on
+	// useSessionRole().role without a second roundtrip. The host placeholder
+	// returned from /humans/me uses the same field with value "host".
+	Role        string `json:"role"`
 	Device      string `json:"device,omitempty"`
 	CreatedAt   string `json:"created_at"`
 	ExpiresAt   string `json:"expires_at"`
@@ -526,6 +530,7 @@ func humanSessionToResponse(session humanSession) humanSessionResponse {
 		InviteID:    session.InviteID,
 		HumanSlug:   session.HumanSlug,
 		DisplayName: session.DisplayName,
+		Role:        "member",
 		Device:      session.Device,
 		CreatedAt:   session.CreatedAt,
 		ExpiresAt:   sessionExpiresAt(session).Format(time.RFC3339),

--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -106,12 +106,12 @@ type humanSessionResponse struct {
 	// Role is hardcoded to "member" so the joiner web client can branch on
 	// useSessionRole().role without a second roundtrip. The host placeholder
 	// returned from /humans/me uses the same field with value "host".
-	Role        string `json:"role"`
-	Device      string `json:"device,omitempty"`
-	CreatedAt   string `json:"created_at"`
-	ExpiresAt   string `json:"expires_at"`
-	RevokedAt   string `json:"revoked_at,omitempty"`
-	LastSeenAt  string `json:"last_seen_at,omitempty"`
+	Role       string `json:"role"`
+	Device     string `json:"device,omitempty"`
+	CreatedAt  string `json:"created_at"`
+	ExpiresAt  string `json:"expires_at"`
+	RevokedAt  string `json:"revoked_at,omitempty"`
+	LastSeenAt string `json:"last_seen_at,omitempty"`
 }
 
 type shareError struct {

--- a/internal/team/broker_human_share_test.go
+++ b/internal/team/broker_human_share_test.go
@@ -74,6 +74,12 @@ func TestHumanMeAcceptsSessionCookie(t *testing.T) {
 	if !bytes.Contains(rec.Body.Bytes(), []byte(`"display_name":"Mira"`)) {
 		t.Fatalf("me body missing Mira: %s", rec.Body.String())
 	}
+	// useSessionRole on the web client branches on human.role. Without this
+	// field the joiner welcome card and sidebar badge fall back to "unknown"
+	// and never render — the bug PR #661 shipped silently.
+	if !bytes.Contains(rec.Body.Bytes(), []byte(`"role":"member"`)) {
+		t.Fatalf("me body missing role:member, welcome card will not render: %s", rec.Body.String())
+	}
 }
 
 func TestHumanSessionsHostCanRevokeSession(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `Role string \`json:"role"\`` to `humanSessionResponse` struct
- `humanSessionToResponse` now sets `Role: "member"` for all joiner sessions
- The host placeholder on `/humans/me` already returns `role: "host"` separately

## Why

`useSessionRole()` on the joiner web client branches on `human.role` to render the welcome card and sidebar badge. The field was missing from the API response — silent fallback to `"unknown"` blocked both components. Regression shipped in PR #661 without a test.

## Test plan

- [x] `TestHumanMeAcceptsSessionCookie` — asserts `"role":"member"` in `/humans/me` response
- [x] All `TestHuman*` tests pass (`go test ./internal/team/ -run TestHuman`)
- [x] Smoke: joiner welcome card + sidebar badge render correctly after accepting invite (verified in gstack-browser, 2026-05-06: card showed "You're in. You joined Sam Sender's office as Maya." and sidebar badge "TEAM-MEMBER SESSION" appeared after Maya joined via the LAN invite URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)