### PR TITLE
Implement human-priority message queue with preemption

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -32,6 +32,11 @@ const (
 	defaultMaxErrorRetries = 3
 )
 
+// humanInterruptDirective is injected as a system entry when a human message
+// preempts the agent's prior task. It tells the model to absorb the human
+// message before doing anything else.
+const humanInterruptDirective = "A human just sent you a message. Stop and absorb it before continuing any prior task. Decide which is appropriate: (a) abandon the prior task and address the human directly, (b) give a brief status update if they are asking what you're doing, or (c) acknowledge and queue their request for after the current task. Human messages take priority over agent-to-agent follow-ups."
+
 // EventHandler is a callback for agent loop events.
 type EventHandler func(args ...any)
 
@@ -410,8 +415,23 @@ func (l *AgentLoop) buildContext() error {
 		})
 	}
 
-	// Drain follow-up message and append as user entry.
-	if msg, ok := l.queues.DrainFollowUp(slug); ok {
+	// Human messages take priority over agent-originated follow-ups: a person
+	// who interjects while the agent is mid-task should be absorbed first, and
+	// the agent decides whether to stop, give a status update, or queue the
+	// prior task for later.
+	if msg, ok := l.queues.DrainHuman(slug); ok {
+		l.state.CurrentTask = msg
+		l.state.TaskID = nextTaskID(slug)
+		l.lastCompactionAt = 0
+		l.appendSession(SessionEntry{
+			Type:    "system",
+			Content: humanInterruptDirective,
+		})
+		l.appendSession(SessionEntry{
+			Type:    "user",
+			Content: "[HUMAN] " + msg,
+		})
+	} else if msg, ok := l.queues.DrainFollowUp(slug); ok {
 		l.state.CurrentTask = msg
 		l.state.TaskID = nextTaskID(slug)
 		l.lastCompactionAt = 0

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -211,6 +211,83 @@ func TestSteerInjectsSystemMessage(t *testing.T) {
 	}
 }
 
+func TestBuildContextDrainsHumanBeforeFollowUp(t *testing.T) {
+	loop, _ := newTestLoop(t, mockStreamFn("ack"))
+
+	// Simulate a busy agent already working on an agent-originated follow-up
+	// when a human chimes in. The human message should preempt: the next
+	// build_context tick must absorb the human, not the queued follow-up.
+	loop.queues.FollowUp("test-agent", "previously queued agent task")
+	loop.queues.Human("test-agent", "wait, what are you doing?")
+	loop.Start()
+
+	if err := loop.Tick(); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+
+	state := loop.GetState()
+	if got := state.CurrentTask; got != "wait, what are you doing?" {
+		t.Errorf("CurrentTask = %q, want the human message", got)
+	}
+
+	entries, err := loop.sessions.GetHistory(state.SessionID, 0, "")
+	if err != nil {
+		t.Fatalf("get history: %v", err)
+	}
+
+	var sawDirective, sawHuman, sawFollowUp bool
+	for _, e := range entries {
+		switch {
+		case e.Type == "system" && e.Content == humanInterruptDirective:
+			sawDirective = true
+		case e.Type == "user" && e.Content == "[HUMAN] wait, what are you doing?":
+			sawHuman = true
+		case e.Type == "user" && e.Content == "previously queued agent task":
+			sawFollowUp = true
+		}
+	}
+	if !sawDirective {
+		t.Error("expected absorb-first system directive in session")
+	}
+	if !sawHuman {
+		t.Error("expected [HUMAN]-prefixed user entry in session")
+	}
+	if sawFollowUp {
+		t.Error("queued follow-up must stay queued, not be drained alongside the human")
+	}
+
+	if !loop.queues.HasFollowUp("test-agent") {
+		t.Error("follow-up queue should still hold the deferred agent task")
+	}
+}
+
+func TestHumanMessageInterruptsBusyLoop(t *testing.T) {
+	loop, _ := newTestLoop(t, mockStreamFn("ack"))
+	// Force the loop into a busy phase with a registered cancelFunc, mirroring
+	// what streamLLM sets up. We don't need a real LLM call — just need to
+	// verify Interrupt fires and clears the cancelFunc.
+	loop.Start()
+
+	_, cancel := context.WithCancel(context.Background())
+	loop.mu.Lock()
+	loop.cancelFunc = cancel
+	loop.setPhase(PhaseStreamLLM)
+	loop.mu.Unlock()
+
+	if !loop.IsBusy() {
+		t.Fatal("loop should be busy after entering PhaseStreamLLM")
+	}
+	if !loop.Interrupt() {
+		t.Fatal("Interrupt should report success when a cancelFunc is set")
+	}
+	loop.mu.Lock()
+	cancelStillSet := loop.cancelFunc != nil
+	loop.mu.Unlock()
+	if cancelStillSet {
+		t.Error("Interrupt must clear cancelFunc")
+	}
+}
+
 func TestSteerOnlyMessageSurvivesFirstTick(t *testing.T) {
 	loop, _ := newTestLoop(t, mockStreamFn("ack"))
 	loop.queues.Steer("test-agent", "do the urgent thing")

--- a/internal/agent/queues.go
+++ b/internal/agent/queues.go
@@ -2,10 +2,19 @@ package agent
 
 import "sync"
 
-// MessageQueues manages per-agent steer and follow-up message queues.
+// MessageQueues manages per-agent message queues.
+//
+// Three queues are maintained per agent:
+//
+//   - steerQueues:    system-level course corrections (e.g. team-lead delegations)
+//   - humanQueues:    high-priority messages from a real person; drained before
+//     follow-ups so the agent absorbs human input before resuming
+//     any prior agent-originated task
+//   - followUpQueues: ordinary agent-to-agent follow-ups
 type MessageQueues struct {
 	mu             sync.Mutex
 	steerQueues    map[string][]string
+	humanQueues    map[string][]string
 	followUpQueues map[string][]string
 }
 
@@ -13,6 +22,7 @@ type MessageQueues struct {
 func NewMessageQueues() *MessageQueues {
 	return &MessageQueues{
 		steerQueues:    make(map[string][]string),
+		humanQueues:    make(map[string][]string),
 		followUpQueues: make(map[string][]string),
 	}
 }
@@ -22,6 +32,15 @@ func (q *MessageQueues) Steer(agentSlug, message string) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.steerQueues[agentSlug] = append(q.steerQueues[agentSlug], message)
+}
+
+// Human enqueues a human-priority message for the given agent. Drained before
+// follow-ups so a person's input is absorbed before the agent resumes any
+// prior agent-originated task.
+func (q *MessageQueues) Human(agentSlug, message string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.humanQueues[agentSlug] = append(q.humanQueues[agentSlug], message)
 }
 
 // FollowUp enqueues a follow-up message for the given agent.
@@ -42,6 +61,20 @@ func (q *MessageQueues) DrainSteer(agentSlug string) (string, bool) {
 	}
 	msg := msgs[0]
 	q.steerQueues[agentSlug] = msgs[1:]
+	return msg, true
+}
+
+// DrainHuman removes and returns the front human-priority message for the agent.
+// Returns ("", false) if the queue is empty.
+func (q *MessageQueues) DrainHuman(agentSlug string) (string, bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	msgs := q.humanQueues[agentSlug]
+	if len(msgs) == 0 {
+		return "", false
+	}
+	msg := msgs[0]
+	q.humanQueues[agentSlug] = msgs[1:]
 	return msg, true
 }
 
@@ -66,6 +99,13 @@ func (q *MessageQueues) HasSteer(agentSlug string) bool {
 	return len(q.steerQueues[agentSlug]) > 0
 }
 
+// HasHuman reports whether the agent has any human-priority messages queued.
+func (q *MessageQueues) HasHuman(agentSlug string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.humanQueues[agentSlug]) > 0
+}
+
 // HasFollowUp reports whether the agent has any follow-up messages queued.
 func (q *MessageQueues) HasFollowUp(agentSlug string) bool {
 	q.mu.Lock()
@@ -73,7 +113,8 @@ func (q *MessageQueues) HasFollowUp(agentSlug string) bool {
 	return len(q.followUpQueues[agentSlug]) > 0
 }
 
-// HasMessages reports whether the agent has any queued messages (steer or follow-up).
+// HasMessages reports whether the agent has any queued messages (steer, human,
+// or follow-up).
 func (q *MessageQueues) HasMessages(agentSlug string) bool {
-	return q.HasSteer(agentSlug) || q.HasFollowUp(agentSlug)
+	return q.HasSteer(agentSlug) || q.HasHuman(agentSlug) || q.HasFollowUp(agentSlug)
 }

--- a/internal/agent/queues_test.go
+++ b/internal/agent/queues_test.go
@@ -57,6 +57,45 @@ func TestQueues_HasMessages(t *testing.T) {
 	if !q.HasMessages("agent1") {
 		t.Error("expected HasMessages true after FollowUp")
 	}
+	q.DrainFollowUp("agent1")
+	q.Human("agent1", "hi")
+	if !q.HasMessages("agent1") {
+		t.Error("expected HasMessages true after Human")
+	}
+	if !q.HasHuman("agent1") {
+		t.Error("expected HasHuman true after Human")
+	}
+	q.DrainHuman("agent1")
+	if q.HasMessages("agent1") {
+		t.Error("expected no messages after draining human queue")
+	}
+}
+
+func TestQueues_HumanFIFOIndependentOfFollowUp(t *testing.T) {
+	q := NewMessageQueues()
+	q.FollowUp("agent1", "follow1")
+	q.Human("agent1", "human1")
+	q.FollowUp("agent1", "follow2")
+	q.Human("agent1", "human2")
+
+	// Human queue drains in arrival order, separate from follow-up.
+	if msg, ok := q.DrainHuman("agent1"); !ok || msg != "human1" {
+		t.Errorf("DrainHuman #1 = (%q, %v), want (\"human1\", true)", msg, ok)
+	}
+	if msg, ok := q.DrainHuman("agent1"); !ok || msg != "human2" {
+		t.Errorf("DrainHuman #2 = (%q, %v), want (\"human2\", true)", msg, ok)
+	}
+	if _, ok := q.DrainHuman("agent1"); ok {
+		t.Error("expected DrainHuman empty after both drains")
+	}
+
+	// Follow-up queue is untouched by Human draining.
+	if msg, ok := q.DrainFollowUp("agent1"); !ok || msg != "follow1" {
+		t.Errorf("DrainFollowUp #1 = (%q, %v), want (\"follow1\", true)", msg, ok)
+	}
+	if msg, ok := q.DrainFollowUp("agent1"); !ok || msg != "follow2" {
+		t.Errorf("DrainFollowUp #2 = (%q, %v), want (\"follow2\", true)", msg, ok)
+	}
 }
 
 func TestQueues_ConcurrentSteerDrain(t *testing.T) {

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -300,6 +300,27 @@ func (s *AgentService) FollowUp(slug, message string) error {
 	return nil
 }
 
+// HumanMessage pushes a high-priority message from a real person into the
+// agent's queue. It always interrupts any in-flight LLM or tool work so the
+// agent absorbs the human's message before resuming any prior agent-originated
+// task. Use this for chat (channel or DM) messages, whether the agent was
+// tagged or not — the human takes priority over agent-to-agent follow-ups.
+func (s *AgentService) HumanMessage(slug, message string) error {
+	s.mu.Lock()
+	ma, err := s.requireAgent(slug)
+	if err != nil {
+		s.mu.Unlock()
+		return err
+	}
+	s.queues.Human(slug, message)
+	s.mu.Unlock()
+	if ma.Loop.IsBusy() {
+		ma.Loop.Interrupt()
+	}
+	s.EnsureRunning(slug)
+	return nil
+}
+
 // EnsureRunning starts an idempotent worker that drives the agent loop immediately.
 // The worker exits as soon as the agent is idle and has no queued messages.
 func (s *AgentService) EnsureRunning(slug string) {

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -188,6 +188,45 @@ func TestFollowUpMessageDelivery(t *testing.T) {
 	}
 }
 
+func TestHumanMessageDelivery(t *testing.T) {
+	dir := t.TempDir()
+	sessions := NewSessionStoreAt(dir)
+	queues := NewMessageQueues()
+	tools := NewToolRegistry()
+
+	svc := NewAgentService(
+		WithToolRegistry(tools),
+		WithSessionStore(sessions),
+		WithQueues(queues),
+	)
+
+	cfg := AgentConfig{
+		Slug: "human-test",
+		Name: "Human Test",
+	}
+	svc.Create(cfg)
+
+	if err := svc.HumanMessage("human-test", "are you stuck?"); err != nil {
+		t.Fatalf("HumanMessage: %v", err)
+	}
+
+	if !queues.HasHuman("human-test") {
+		t.Error("expected human message in human-priority queue")
+	}
+	if queues.HasFollowUp("human-test") {
+		t.Error("human message must not leak into follow-up queue")
+	}
+
+	msg, ok := queues.DrainHuman("human-test")
+	if !ok || msg != "are you stuck?" {
+		t.Errorf("DrainHuman = (%q, %v), want (\"are you stuck?\", true)", msg, ok)
+	}
+
+	if err := svc.HumanMessage("nope", "x"); err == nil {
+		t.Error("expected error for nonexistent agent")
+	}
+}
+
 func TestSubscribeUnsubscribe(t *testing.T) {
 	dir := t.TempDir()
 	sessions := NewSessionStoreAt(dir)

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -116,6 +116,12 @@ type headlessCodexTurn struct {
 	TaskID     string
 	Attempts   int
 	EnqueuedAt time.Time
+	// FromHuman marks turns originating from a real person's chat message
+	// (channel post or DM, tagged or not). Human-originated turns bypass
+	// the lead queue-hold, the lead queue cap, the same-task dedup drop,
+	// and the staleness/min-age preemption floors so the agent absorbs
+	// the human input before resuming any prior agent-originated work.
+	FromHuman bool
 }
 
 type headlessCodexActiveTurn struct {

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -64,9 +64,13 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 		l.headless.workers = make(map[string]bool)
 	}
 	urgentLeadTurn := l.headlessLeadTurnNeedsImmediateWakeLocked(slug, turn.TaskID)
+	humanPriority := turn.FromHuman
 	if turn.TaskID != "" {
 		if active := l.headless.active[slug]; active != nil && strings.TrimSpace(active.Turn.TaskID) == turn.TaskID {
-			if !(slug == l.targeter().LeadSlug() && urgentLeadTurn) && turn.Attempts <= active.Turn.Attempts {
+			// Human turns bypass the same-task drop: a person sending a
+			// follow-up message during an in-flight turn must always be
+			// absorbed, never silently coalesced into the existing work.
+			if !humanPriority && !(slug == l.targeter().LeadSlug() && urgentLeadTurn) && turn.Attempts <= active.Turn.Attempts {
 				l.headless.mu.Unlock()
 				if slug == l.targeter().LeadSlug() {
 					appendHeadlessCodexLog(slug, "queue-drop: lead already handling same task")
@@ -76,21 +80,25 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 				return
 			}
 		}
-		if pending := l.replaceDuplicateTaskTurnLocked(slug, turn); pending {
-			if !l.headless.workers[slug] {
-				l.headless.workers[slug] = true
-				startWorker = true
+		// Skip the same-task replace for human turns: each human message is
+		// distinct content and must not stomp on a previously-queued one.
+		if !humanPriority {
+			if pending := l.replaceDuplicateTaskTurnLocked(slug, turn); pending {
+				if !l.headless.workers[slug] {
+					l.headless.workers[slug] = true
+					startWorker = true
+				}
+				l.headless.mu.Unlock()
+				if slug == l.targeter().LeadSlug() {
+					appendHeadlessCodexLog(slug, "queue-replace: refreshed pending lead turn for same task")
+				} else {
+					appendHeadlessCodexLog(slug, "queue-replace: refreshed pending turn for same task")
+				}
+				if startWorker {
+					l.spawnHeadlessWorker(slug)
+				}
+				return
 			}
-			l.headless.mu.Unlock()
-			if slug == l.targeter().LeadSlug() {
-				appendHeadlessCodexLog(slug, "queue-replace: refreshed pending lead turn for same task")
-			} else {
-				appendHeadlessCodexLog(slug, "queue-replace: refreshed pending turn for same task")
-			}
-			if startWorker {
-				l.spawnHeadlessWorker(slug)
-			}
-			return
 		}
 	}
 	// For the lead (CEO) agent, suppress the notification if any other specialist
@@ -98,7 +106,11 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	// parallel work is done — not when one specialist finishes while others are
 	// still running. This eliminates the race condition where CEO fires after the
 	// first specialist completes and redundantly re-routes to still-running agents.
-	if slug == l.targeter().LeadSlug() && !urgentLeadTurn {
+	//
+	// Human turns bypass this hold: a person addressing the lead must be absorbed
+	// immediately even if specialists are still working — the lead can decide
+	// whether to stop, give a status update, or queue the request for later.
+	if slug == l.targeter().LeadSlug() && !urgentLeadTurn && !humanPriority {
 		for workerSlug, queue := range l.headless.queues {
 			if workerSlug == slug {
 				continue
@@ -125,17 +137,23 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	// For the lead (CEO) agent, cap the pending queue at 1 turn.
 	// Multiple rapid-fire notifications (agent completions, status pings) can
 	// stack up redundant CEO turns that each re-route the same task. One pending
-	// turn is enough to catch the latest state; extras are dropped.
+	// turn is enough to catch the latest state; extras are dropped — except for
+	// urgent task wakes and human-originated messages, which replace the pending
+	// turn so the freshest signal wins instead of being silently dropped.
 	const leadMaxPending = 1
 	if slug == l.targeter().LeadSlug() && len(l.headless.queues[slug]) >= leadMaxPending {
-		if urgentLeadTurn {
+		if urgentLeadTurn || humanPriority {
 			l.headless.queues[slug][len(l.headless.queues[slug])-1] = turn
 			if !l.headless.workers[slug] {
 				l.headless.workers[slug] = true
 				startWorker = true
 			}
 			l.headless.mu.Unlock()
-			appendHeadlessCodexLog(slug, "queue-replace: lead queue at cap, replacing pending turn with urgent task notification")
+			if humanPriority {
+				appendHeadlessCodexLog(slug, "queue-replace: lead queue at cap, replacing pending turn with human-priority message")
+			} else {
+				appendHeadlessCodexLog(slug, "queue-replace: lead queue at cap, replacing pending turn with urgent task notification")
+			}
 			if startWorker {
 				l.spawnHeadlessWorker(slug)
 			}
@@ -152,11 +170,17 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	}
 	if active := l.headless.active[slug]; active != nil && active.Cancel != nil {
 		age := time.Since(active.StartedAt)
-		// Two conditions must hold to preempt: past the configured staleness
-		// threshold AND past the minimum-turn-age floor. The floor breaks the
-		// tight cancel-loop pattern observed in prod (see doc on the constant).
-		if age >= headlessCodexMinTurnAgeBeforeCancel &&
-			age >= l.headlessCodexStaleCancelAfterForTurn(active.Turn) {
+		// Human turns preempt unconditionally. The staleness/min-age floors
+		// exist to break tight agent-to-agent cancel loops, but a real person
+		// chatting must never wait behind an in-flight turn. For non-human
+		// turns both floors must hold: past the configured staleness threshold
+		// AND past the minimum-turn-age floor.
+		switch {
+		case humanPriority:
+			cancel = active.Cancel
+			staleAge = age
+		case age >= headlessCodexMinTurnAgeBeforeCancel &&
+			age >= l.headlessCodexStaleCancelAfterForTurn(active.Turn):
 			cancel = active.Cancel
 			staleAge = age
 		}
@@ -164,8 +188,13 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	l.headless.mu.Unlock()
 
 	if cancel != nil {
-		appendHeadlessCodexLog(slug, fmt.Sprintf("stale-turn: cancelling active turn after %s to process queued work", staleAge.Round(time.Second)))
-		l.updateHeadlessProgress(slug, "active", "queued", "preempting stale work for newer request", headlessProgressMetrics{})
+		if humanPriority {
+			appendHeadlessCodexLog(slug, fmt.Sprintf("human-priority: cancelling active turn after %s so the agent absorbs the human message", staleAge.Round(time.Millisecond)))
+			l.updateHeadlessProgress(slug, "active", "queued", "preempting in-flight turn for human message", headlessProgressMetrics{})
+		} else {
+			appendHeadlessCodexLog(slug, fmt.Sprintf("stale-turn: cancelling active turn after %s to process queued work", staleAge.Round(time.Second)))
+			l.updateHeadlessProgress(slug, "active", "queued", "preempting stale work for newer request", headlessProgressMetrics{})
+		}
 		cancel()
 	}
 	if startWorker {

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1220,6 +1220,9 @@ func TestEnqueueHeadlessCodexTurnRecordHumanPreemptsActiveTurn(t *testing.T) {
 	if got := len(queue); got != 1 || queue[0].Prompt != "stop, what about the X bug?" {
 		t.Fatalf("expected human turn to be queued for the worker to pick up, got %#v", queue)
 	}
+	if !queue[0].FromHuman {
+		t.Error("expected FromHuman flag to survive the preemption path")
+	}
 }
 
 func TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast(t *testing.T) {

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1133,6 +1133,95 @@ func TestEnqueueHeadlessCodexTurnRecordAllowsRetryBehindActiveAgentTask(t *testi
 	}
 }
 
+func TestEnqueueHeadlessCodexTurnRecordHumanBypassesLeadQueueCap(t *testing.T) {
+	l := newHeadlessLauncherForTest(t)
+	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
+	l.headless.workers["ceo"] = true
+	// Lead queue is already at the cap (1 pending) with an agent-originated
+	// turn. Without the human bypass, a follow-up human chat would be dropped
+	// with "queue-drop: lead queue at cap" — the exact symptom reported.
+	l.headless.queues["ceo"] = []headlessCodexTurn{{
+		Prompt:     "agent-originated catchup",
+		EnqueuedAt: time.Now(),
+	}}
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{
+		Prompt:     "wait, what are you doing?",
+		FromHuman:  true,
+		EnqueuedAt: time.Now(),
+	})
+
+	queue := l.headless.queues["ceo"]
+	if got := len(queue); got != 1 {
+		t.Fatalf("expected human turn to replace pending lead turn (cap=1), got %d", got)
+	}
+	if got := queue[0].Prompt; got != "wait, what are you doing?" {
+		t.Fatalf("expected human turn at the head of the queue, got %q", got)
+	}
+	if !queue[0].FromHuman {
+		t.Error("expected FromHuman flag to be preserved on the queued turn")
+	}
+}
+
+func TestEnqueueHeadlessCodexTurnRecordHumanBypassesLeadQueueHold(t *testing.T) {
+	l := newHeadlessLauncherForTest(t)
+	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
+	// A specialist is still active. An agent-originated lead turn would be
+	// deferred via deferredLead; a human chat must skip the hold and queue
+	// immediately so the lead absorbs the message right away.
+	l.headless.active["eng"] = &headlessCodexActiveTurn{
+		Turn:      headlessCodexTurn{Prompt: "specialist still working"},
+		StartedAt: time.Now(),
+	}
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{
+		Prompt:     "are you still on this?",
+		FromHuman:  true,
+		EnqueuedAt: time.Now(),
+	})
+
+	if l.headless.deferredLead != nil {
+		t.Error("human turn must not be parked on deferredLead")
+	}
+	queue := l.headless.queues["ceo"]
+	if got := len(queue); got != 1 {
+		t.Fatalf("expected human turn to enqueue past the lead hold, got %d", got)
+	}
+	if got := queue[0].Prompt; got != "are you still on this?" {
+		t.Fatalf("expected human prompt at head of lead queue, got %q", got)
+	}
+}
+
+func TestEnqueueHeadlessCodexTurnRecordHumanPreemptsActiveTurn(t *testing.T) {
+	l := newHeadlessLauncherForTest(t)
+	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
+	l.headless.workers["eng"] = true
+
+	cancelled := false
+	// An active turn that is well below the staleness/min-age floors —
+	// without the human bypass, it would never be cancelled by a follow-up
+	// enqueue.
+	l.headless.active["eng"] = &headlessCodexActiveTurn{
+		Turn:      headlessCodexTurn{Prompt: "agent-originated work in progress"},
+		StartedAt: time.Now(),
+		Cancel:    func() { cancelled = true },
+	}
+
+	l.enqueueHeadlessCodexTurnRecord("eng", headlessCodexTurn{
+		Prompt:     "stop, what about the X bug?",
+		FromHuman:  true,
+		EnqueuedAt: time.Now(),
+	})
+
+	if !cancelled {
+		t.Fatal("expected human-priority turn to preempt the active turn regardless of staleness")
+	}
+	queue := l.headless.queues["eng"]
+	if got := len(queue); got != 1 || queue[0].Prompt != "stop, what about the X bug?" {
+		t.Fatalf("expected human turn to be queued for the worker to pick up, got %#v", queue)
+	}
+}
+
 func TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 

--- a/internal/team/notifier_delivery.go
+++ b/internal/team/notifier_delivery.go
@@ -230,21 +230,39 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 		channel = "general"
 	}
 	notification := ""
+	humanPrefix := ""
+	fromHuman := isHumanMessageSender(msg.From)
+	if fromHuman {
+		// Front-load a directive so the model treats the human chat as a
+		// preemption signal: absorb the message before resuming any prior
+		// task, then decide whether to abandon, give a status update, or
+		// queue the request for later. The same priority semantics are
+		// enforced in the queue (FromHuman bypasses the hold/cap and forces
+		// preemption) so the model and the dispatcher stay in agreement.
+		humanPrefix = "[HUMAN-PRIORITY] A real person just messaged you. Stop, absorb this message before continuing any prior task, then decide which is appropriate: (a) abandon the prior task and address the human directly, (b) give a brief status update if they are asking what you're doing, or (c) acknowledge and queue their request for after the current task. Human messages take priority over agent-to-agent follow-ups.\n---\n"
+	}
 	if l.isOneOnOne() {
 		notification = fmt.Sprintf(
-			"[New from @%s]: %s\n%s Reply using team_broadcast with my_slug \"%s\" and channel \"%s\" reply_to_id \"%s\". Once you have posted the needed reply, STOP and wait for the next pushed notification.",
-			msg.From, truncate(msg.Content, 1000), l.responseInstructionForTarget(msg, target.Slug), target.Slug, channel, msg.ID,
+			"%s[New from @%s]: %s\n%s Reply using team_broadcast with my_slug \"%s\" and channel \"%s\" reply_to_id \"%s\". Once you have posted the needed reply, STOP and wait for the next pushed notification.",
+			humanPrefix, msg.From, truncate(msg.Content, 1000), l.responseInstructionForTarget(msg, target.Slug), target.Slug, channel, msg.ID,
 		)
 	} else {
 		packet := l.buildMessageWorkPacket(msg, target.Slug)
 		notification = fmt.Sprintf(
-			"%s\n---\n[New from @%s]: %s\n%s This packet is your complete context — do NOT call team_poll or team_tasks. Just do the work and reply via team_broadcast with my_slug \"%s\", channel \"%s\", reply_to_id \"%s\". Once you have posted the needed update, STOP and wait for the next pushed notification.",
-			packet, msg.From, truncate(msg.Content, 1000), l.responseInstructionForTarget(msg, target.Slug), target.Slug, channel, msg.ID,
+			"%s%s\n---\n[New from @%s]: %s\n%s This packet is your complete context — do NOT call team_poll or team_tasks. Just do the work and reply via team_broadcast with my_slug \"%s\", channel \"%s\", reply_to_id \"%s\". Once you have posted the needed update, STOP and wait for the next pushed notification.",
+			humanPrefix, packet, msg.From, truncate(msg.Content, 1000), l.responseInstructionForTarget(msg, target.Slug), target.Slug, channel, msg.ID,
 		)
 	}
 
 	if l.targeter().ShouldUseHeadlessForTarget(target) {
-		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
+		prompt := headlessSandboxNote() + notification
+		l.enqueueHeadlessCodexTurnRecord(target.Slug, headlessCodexTurn{
+			Prompt:     prompt,
+			Channel:    channel,
+			TaskID:     headlessCodexTaskID(prompt),
+			FromHuman:  fromHuman,
+			EnqueuedAt: time.Now(),
+		})
 		return
 	}
 	l.paneDispatch().Enqueue(target.Slug, target.PaneTarget, notification)


### PR DESCRIPTION
## Summary

This change introduces a human-priority message queue system that ensures messages from real people are absorbed by agents before resuming any agent-originated tasks. Human messages bypass queue caps, deduplication, and staleness checks to guarantee immediate absorption and preemption of in-flight work.

## Key Changes

- **New human message queue**: Added `humanQueues` to `MessageQueues` with dedicated `Human()`, `DrainHuman()`, and `HasHuman()` methods that maintain a separate FIFO queue independent of follow-up messages.

- **Agent loop prioritization**: Modified `buildContext()` to drain human messages before follow-up messages, ensuring human input is absorbed first. When a human message is drained, a `humanInterruptDirective` system entry is injected to instruct the model to stop and address the human before continuing prior work.

- **Headless codex human bypass logic**: Enhanced `enqueueHeadlessCodexTurnRecord()` to recognize human-originated turns (`FromHuman` flag) and:
  - Skip same-task deduplication drops for human messages
  - Bypass the lead queue hold when other specialists are active
  - Replace pending lead turns when the queue is at capacity (instead of being dropped)
  - Preempt active turns unconditionally, regardless of staleness/min-age thresholds

- **Service-level human message API**: Added `HumanMessage()` method to `AgentService` that enqueues human messages and immediately interrupts any busy agent loop so the message is absorbed on the next tick.

- **Notification delivery integration**: Updated `sendChannelUpdate()` to mark messages from human senders with a `[HUMAN-PRIORITY]` prefix and inject the human interrupt directive, ensuring both the queue dispatcher and the LLM model treat human messages with the same priority semantics.

- **Comprehensive test coverage**: Added three new headless codex tests covering queue cap bypass, lead hold bypass, and active turn preemption; two agent loop tests verifying human message draining and loop interruption; and service-level tests confirming human message delivery.

## Implementation Details

- Human messages are identified via the `FromHuman` flag in `headlessCodexTurn` and the `isHumanMessageSender()` check in notification delivery.
- The `humanInterruptDirective` constant provides consistent guidance to the LLM model about human message priority.
- Human preemption of active turns is unconditional (no staleness/min-age floors), while agent-to-agent preemption still respects these thresholds to prevent tight cancel loops.
- The human queue is drained before follow-ups in `buildContext()`, ensuring the agent absorbs human input before resuming any prior agent-originated task.

https://claude.ai/code/session_01F7zPPkhq8fWNCy5XaBSNeb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-initiated messages now preempt running tasks and take priority over queued follow-ups for faster handling.
  * A public endpoint to submit high-priority human messages was added, ensuring urgent inputs are enqueued and processed immediately.
  * Notifications and delivery now include human-priority markers so urgent messages are treated with elevated precedence.

* **Tests**
  * Extensive tests added covering human-message queuing, priority preemption, queue independence, and headless delivery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->