### PR TITLE
feat(web): Tier 2 hover peek card on the agent rail

### DIFF
--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -95,7 +95,7 @@ so it floats above the sidebar without causing row reflow.
 
 ### Structure
 
-```
+```text
 .sidebar-agent-peek [role="dialog"]
 ├── .sidebar-agent-peek-header
 │   ├── .sidebar-agent-peek-avatar       24×24 CSS-driven circle, first letter

--- a/web/DESIGN.md
+++ b/web/DESIGN.md
@@ -76,3 +76,88 @@ at the same line forever.
   first SSE event arrives.
 - When no event has ever arrived and the agent is idle, the pill renders
   Office-voice idle copy.
+
+## Tier 2 hover peek
+
+Popover card surfacing richer agent state on hover/long-press/Space.
+Rendered by `AgentEventPeek.tsx` via `createPortal` to `document.body`
+so it floats above the sidebar without causing row reflow.
+
+### Anchor and positioning
+
+| Rule | Detail |
+| ---- | ------ |
+| Anchor | `anchorRef` — the rail row element passed by the opener (Slice D) |
+| Default position | 8px to the RIGHT of the anchor's right edge, top-aligned to anchor top |
+| Viewport clamp | If `anchorRight + 8 + 320 > window.innerWidth`, flip to left of anchor |
+| Recalculate on | `open` flip, `resize`, `scroll` (capture phase) |
+| Portal target | `document.body`; `z-index: 60` (above rail popovers at 40) |
+
+### Structure
+
+```
+.sidebar-agent-peek [role="dialog"]
+├── .sidebar-agent-peek-header
+│   ├── .sidebar-agent-peek-avatar       24×24 CSS-driven circle, first letter
+│   ├── .sidebar-agent-peek-identity
+│   │   ├── #peek-name-{slug}            agent name (aria-labelledby target)
+│   │   └── .sidebar-agent-peek-role     optional role string
+│   └── .sidebar-agent-peek-blocked-chip "BLOCKED" — stuck variant only
+├── .sidebar-agent-peek-state-row        state chip + relative time
+├── #peek-current-{slug}                 detail block — omitted when detail === activity
+│   .sidebar-agent-peek-detail
+├── .sidebar-agent-peek-recent-section   omitted when list would be empty
+│   ├── .sidebar-agent-peek-recent-header "RECENT"
+│   └── .sidebar-agent-peek-recent (ul)  ≤6 entries; stuck pin at top
+└── .sidebar-agent-peek-footer           "⏎ Open workspace" — plain text, not a button
+```
+
+### Motion budget
+
+| Property | Value |
+| -------- | ----- |
+| Open animation | `peek-in` — 0.14s ease-out, `opacity` 0→1 + `translateY(6px)` → 0 |
+| Compositor-only | Only `opacity` and `transform` animated. Never width/height/top/left |
+| Clock | 1Hz `setInterval` owned by the peek; mounts/unmounts with it |
+
+### Reduced motion
+
+Under `prefers-reduced-motion: reduce`: `animation: none`, `transition:
+none`. The stuck-state border and `--bubble-stuck` color still render —
+they are structural chrome, not motion.
+
+### Keyboard
+
+| Key | Action |
+| --- | ------ |
+| `Escape` | `onClose()` — strips listener on close/unmount |
+| `Enter` | `onOpenWorkspace()` |
+| Outside `mousedown` | `onClose()` — ignores clicks inside dialog or inside anchor |
+
+Focus moves into the dialog (`tabIndex={-1}`) when `open` flips true.
+Focus return on close is managed by Slice D's chevron toggle path, not
+by the peek itself.
+
+### Stuck variant
+
+`data-stuck="true"` on the root element. Border color swaps to
+`--bubble-stuck`. `BLOCKED` chip appears in the header. The current
+stuck snapshot is pinned as the first entry in the RECENT list with a
+`BLOCKED:` prefix (a duplicate entry — the full thought block above and
+the pin below serve different scan modes).
+
+### Footer rationale (not a button)
+
+The footer line `"⏎ Open workspace"` is a plain `<div>`, not a
+`<button>`. Making it a button would create a second interactive target
+inside the dialog, splitting keyboard intent between `Enter` (global
+peek action) and a button press. `Enter` on the focused dialog fires
+`onOpenWorkspace` directly; the footer is a visible affordance hint, not
+a clickable control. Screen readers read it as static text, which is
+correct — the action hint is already announced in the dialog label.
+
+### Single-instance discipline
+
+At most one peek is open at a time. Opening a second peek closes the
+first. Managed by Slice D's opener state; the peek component itself has
+no instance registry.

--- a/web/src/components/sidebar/AgentEventPeek.test.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.test.tsx
@@ -235,23 +235,25 @@ describe("<AgentEventPeek> render", () => {
   it("renders correctly under prefers-reduced-motion: reduce (smoke)", () => {
     // Mock matchMedia to report reduced motion.
     const original = window.matchMedia;
-    window.matchMedia = (query: string) => ({
-      matches: query === "(prefers-reduced-motion: reduce)",
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    });
+    try {
+      window.matchMedia = (query: string) => ({
+        matches: query === "(prefers-reduced-motion: reduce)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      });
 
-    const anchorRef = makeAnchorRef();
-    render(<AgentEventPeek {...defaultProps} anchorRef={anchorRef} />);
-    // The dialog must still be present — CSS handles the motion suppression.
-    expect(document.querySelector(".sidebar-agent-peek")).not.toBeNull();
-
-    window.matchMedia = original;
+      const anchorRef = makeAnchorRef();
+      render(<AgentEventPeek {...defaultProps} anchorRef={anchorRef} />);
+      // The dialog must still be present — CSS handles the motion suppression.
+      expect(document.querySelector(".sidebar-agent-peek")).not.toBeNull();
+    } finally {
+      window.matchMedia = original;
+    }
   });
 });
 
@@ -288,7 +290,7 @@ describe("<AgentEventPeek> interaction and accessibility", () => {
     expect(onOpenWorkspace).toHaveBeenCalledOnce();
   });
 
-  it("calls onClose on outside mousedown and does NOT close on inside mousedown", () => {
+  it("calls onClose on outside pointerdown and does NOT close on inside pointerdown", () => {
     const anchorRef = makeAnchorRef();
     const onClose = vi.fn();
     render(
@@ -299,13 +301,13 @@ describe("<AgentEventPeek> interaction and accessibility", () => {
       />,
     );
 
-    // Mousedown inside the dialog — should NOT close.
+    // Pointerdown inside the dialog — should NOT close.
     const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
-    fireEvent.mouseDown(dialog);
+    fireEvent.pointerDown(dialog);
     expect(onClose).not.toHaveBeenCalled();
 
-    // Mousedown outside — should close.
-    fireEvent.mouseDown(document.body);
+    // Pointerdown outside — should close.
+    fireEvent.pointerDown(document.body);
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/web/src/components/sidebar/AgentEventPeek.test.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.test.tsx
@@ -1,0 +1,348 @@
+import { createRef } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { StoredActivitySnapshot } from "../../stores/app";
+import { AgentEventPeek } from "./AgentEventPeek";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeSnap(
+  overrides: Partial<StoredActivitySnapshot> = {},
+): StoredActivitySnapshot {
+  return {
+    slug: "tess",
+    activity: "running tests",
+    detail: "running jest suite with 3 failing snapshots",
+    kind: "routine",
+    receivedAtMs: Date.now() - 5000,
+    haloUntilMs: 0,
+    ...overrides,
+  };
+}
+
+function makeAnchorRef() {
+  const div = document.createElement("div");
+  // Simulate a bounding rect so computePosition() gets real numbers.
+  div.getBoundingClientRect = () =>
+    ({
+      top: 100,
+      bottom: 140,
+      left: 260,
+      right: 260,
+      width: 0,
+      height: 40,
+      x: 260,
+      y: 100,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  document.body.appendChild(div);
+  const ref = createRef<HTMLElement | null>();
+  // createRef is readonly; assign via cast.
+  (ref as React.MutableRefObject<HTMLElement | null>).current = div;
+  return ref;
+}
+
+const defaultProps = {
+  slug: "tess",
+  agentName: "Tess Edison",
+  agentRole: "engineer",
+  open: true,
+  current: makeSnap(),
+  history: [],
+  onClose: vi.fn(),
+  onOpenWorkspace: vi.fn(),
+};
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  // Remove any leftover anchor divs.
+  for (const el of Array.from(document.body.querySelectorAll("div[style]"))) {
+    el.remove();
+  }
+});
+
+// ─── render behavior ─────────────────────────────────────────────────────────
+
+describe("<AgentEventPeek> render", () => {
+  it("renders nothing when open=false", () => {
+    const anchorRef = makeAnchorRef();
+    const { container } = render(
+      <AgentEventPeek {...defaultProps} anchorRef={anchorRef} open={false} />,
+    );
+    // Portal target is document.body, but the dialog itself must be absent.
+    expect(document.querySelector(".sidebar-agent-peek")).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when open=true but current=undefined", () => {
+    const anchorRef = makeAnchorRef();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        current={undefined}
+      />,
+    );
+    expect(document.querySelector(".sidebar-agent-peek")).toBeNull();
+  });
+
+  it("renders the current-thought block when detail differs from activity", () => {
+    const anchorRef = makeAnchorRef();
+    const current = makeSnap({
+      activity: "running tests",
+      detail: "running jest suite with 3 failing snapshots",
+    });
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        current={current}
+      />,
+    );
+    expect(
+      screen.getByText("running jest suite with 3 failing snapshots"),
+    ).toBeDefined();
+  });
+
+  it("omits the current-thought block when detail equals activity", () => {
+    const anchorRef = makeAnchorRef();
+    const sameText = "running tests";
+    const current = makeSnap({ activity: sameText, detail: sameText });
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        current={current}
+      />,
+    );
+    const detailEl = document.getElementById(
+      `peek-current-${defaultProps.slug}`,
+    );
+    expect(detailEl).toBeNull();
+  });
+
+  it("omits RECENT block when history is empty and not stuck", () => {
+    const anchorRef = makeAnchorRef();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        history={[]}
+        current={makeSnap({ kind: "routine" })}
+      />,
+    );
+    expect(document.querySelector(".sidebar-agent-peek-recent")).toBeNull();
+  });
+
+  it("shows up to 6 history entries in passed order", () => {
+    const anchorRef = makeAnchorRef();
+    const now = Date.now();
+    const history: StoredActivitySnapshot[] = Array.from(
+      { length: 8 },
+      (_, i) =>
+        makeSnap({
+          activity: `event-${i}`,
+          detail: `event-${i}`,
+          receivedAtMs: now - (i + 1) * 10000,
+        }),
+    );
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        history={history}
+        current={makeSnap({ kind: "routine" })}
+      />,
+    );
+    const items = document.querySelectorAll(".sidebar-agent-peek-recent-item");
+    // Cap is 6 (not stuck, so no pinned entry).
+    expect(items.length).toBe(6);
+    // First visible item matches the first history entry.
+    expect(items[0].textContent).toContain("event-0");
+  });
+
+  describe("stuck variant", () => {
+    it("sets data-stuck='true' on the dialog", () => {
+      const anchorRef = makeAnchorRef();
+      render(
+        <AgentEventPeek
+          {...defaultProps}
+          anchorRef={anchorRef}
+          current={makeSnap({ kind: "stuck", activity: "vault timeout" })}
+        />,
+      );
+      const dialog = document.querySelector(".sidebar-agent-peek");
+      expect(dialog?.getAttribute("data-stuck")).toBe("true");
+    });
+
+    it("renders the BLOCKED chip", () => {
+      const anchorRef = makeAnchorRef();
+      render(
+        <AgentEventPeek
+          {...defaultProps}
+          anchorRef={anchorRef}
+          current={makeSnap({ kind: "stuck", activity: "vault timeout" })}
+        />,
+      );
+      expect(
+        document.querySelector(".sidebar-agent-peek-blocked-chip"),
+      ).not.toBeNull();
+    });
+
+    it("pins the stuck event at the top of the recent list with a BLOCKED: prefix", () => {
+      const anchorRef = makeAnchorRef();
+      const stuckSnap = makeSnap({
+        kind: "stuck",
+        activity: "vault credentials expired",
+      });
+      const history: StoredActivitySnapshot[] = [
+        makeSnap({
+          activity: "deploy started",
+          receivedAtMs: Date.now() - 60000,
+        }),
+      ];
+      render(
+        <AgentEventPeek
+          {...defaultProps}
+          anchorRef={anchorRef}
+          current={stuckSnap}
+          history={history}
+        />,
+      );
+      const items = document.querySelectorAll(
+        ".sidebar-agent-peek-recent-item",
+      );
+      expect(items.length).toBeGreaterThanOrEqual(1);
+      expect(items[0].textContent).toContain("BLOCKED:");
+      expect(items[0].textContent).toContain("vault credentials expired");
+    });
+  });
+
+  it("renders correctly under prefers-reduced-motion: reduce (smoke)", () => {
+    // Mock matchMedia to report reduced motion.
+    const original = window.matchMedia;
+    window.matchMedia = (query: string) => ({
+      matches: query === "(prefers-reduced-motion: reduce)",
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+
+    const anchorRef = makeAnchorRef();
+    render(<AgentEventPeek {...defaultProps} anchorRef={anchorRef} />);
+    // The dialog must still be present — CSS handles the motion suppression.
+    expect(document.querySelector(".sidebar-agent-peek")).not.toBeNull();
+
+    window.matchMedia = original;
+  });
+});
+
+// ─── interaction and accessibility ────────────────────────────────────────────
+
+describe("<AgentEventPeek> interaction and accessibility", () => {
+  it("calls onClose when Escape is pressed inside the dialog", () => {
+    const anchorRef = makeAnchorRef();
+    const onClose = vi.fn();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        onClose={onClose}
+      />,
+    );
+    const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onOpenWorkspace when Enter is pressed inside the dialog", () => {
+    const anchorRef = makeAnchorRef();
+    const onOpenWorkspace = vi.fn();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        onOpenWorkspace={onOpenWorkspace}
+      />,
+    );
+    const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
+    fireEvent.keyDown(dialog, { key: "Enter" });
+    expect(onOpenWorkspace).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on outside mousedown and does NOT close on inside mousedown", () => {
+    const anchorRef = makeAnchorRef();
+    const onClose = vi.fn();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        onClose={onClose}
+      />,
+    );
+
+    // Mousedown inside the dialog — should NOT close.
+    const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
+    fireEvent.mouseDown(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Mousedown outside — should close.
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("aria-labelledby points to an element containing the agent name", () => {
+    const anchorRef = makeAnchorRef();
+    render(<AgentEventPeek {...defaultProps} anchorRef={anchorRef} />);
+    const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
+    const labelId = dialog.getAttribute("aria-labelledby");
+    expect(labelId).toBe(`peek-name-${defaultProps.slug}`);
+    const labelEl = document.getElementById(labelId as string);
+    expect(labelEl).not.toBeNull();
+    expect(labelEl?.textContent).toBe(defaultProps.agentName);
+  });
+
+  it("aria-describedby points to the detail element when detail differs from activity", () => {
+    const anchorRef = makeAnchorRef();
+    const current = makeSnap({
+      activity: "running tests",
+      detail: "running jest suite with 3 failing snapshots",
+    });
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        current={current}
+      />,
+    );
+    const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
+    const descId = dialog.getAttribute("aria-describedby");
+    expect(descId).toBe(`peek-current-${defaultProps.slug}`);
+    const descEl = document.getElementById(descId as string);
+    expect(descEl).not.toBeNull();
+    expect(descEl?.textContent).toContain(
+      "running jest suite with 3 failing snapshots",
+    );
+  });
+
+  it("aria-describedby is absent when detail equals activity", () => {
+    const anchorRef = makeAnchorRef();
+    const sameText = "running tests";
+    const current = makeSnap({ activity: sameText, detail: sameText });
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        current={current}
+      />,
+    );
+    const dialog = document.querySelector(".sidebar-agent-peek") as HTMLElement;
+    expect(dialog.getAttribute("aria-describedby")).toBeNull();
+  });
+});

--- a/web/src/components/sidebar/AgentEventPeek.test.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.test.tsx
@@ -76,7 +76,7 @@ describe("<AgentEventPeek> render", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders nothing when open=true but current=undefined", () => {
+  it("renders the empty-state when open=true but no snapshot has arrived yet", () => {
     const anchorRef = makeAnchorRef();
     render(
       <AgentEventPeek
@@ -85,7 +85,19 @@ describe("<AgentEventPeek> render", () => {
         current={undefined}
       />,
     );
-    expect(document.querySelector(".sidebar-agent-peek")).toBeNull();
+    // Dialog itself still mounts so the chevron's aria-controls target
+    // resolves and the user gets a visible response to the click.
+    expect(document.querySelector(".sidebar-agent-peek")).not.toBeNull();
+    // Header still renders (agent name + role).
+    expect(screen.getByText(defaultProps.agentName)).toBeDefined();
+    // Empty-state line carries the "no activity yet" copy.
+    expect(screen.getByTestId("peek-empty")).toBeDefined();
+    // State row, detail, recent list all collapse — no snapshot to render.
+    expect(document.querySelector(".sidebar-agent-peek-state-row")).toBeNull();
+    expect(document.querySelector(".sidebar-agent-peek-detail")).toBeNull();
+    expect(
+      document.querySelector(".sidebar-agent-peek-recent-section"),
+    ).toBeNull();
   });
 
   it("renders the current-thought block when detail differs from activity", () => {

--- a/web/src/components/sidebar/AgentEventPeek.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.tsx
@@ -24,14 +24,24 @@ interface Position {
 const PEEK_WIDTH = 320;
 const PEEK_OFFSET = 8;
 
+const PEEK_VIEWPORT_MARGIN = 8;
+
 function computePosition(anchor: HTMLElement): Position {
   const { top, right, left: rectLeft } = anchor.getBoundingClientRect();
   const rightEdge = right + PEEK_OFFSET + PEEK_WIDTH;
   // Flip to left if the peek would extend beyond the right viewport edge.
-  const left =
+  const rawLeft =
     rightEdge > window.innerWidth
       ? rectLeft - PEEK_OFFSET - PEEK_WIDTH
       : right + PEEK_OFFSET;
+  // Clamp to viewport-safe bounds — the flip alone can still produce a
+  // negative left on narrow viewports.
+  const minLeft = PEEK_VIEWPORT_MARGIN;
+  const maxLeft = Math.max(
+    minLeft,
+    window.innerWidth - PEEK_WIDTH - PEEK_VIEWPORT_MARGIN,
+  );
+  const left = Math.min(Math.max(rawLeft, minLeft), maxLeft);
   return { top, left };
 }
 
@@ -107,19 +117,20 @@ export function AgentEventPeek({
     return () => el?.removeEventListener("keydown", onKeyDown);
   }, [open, onClose, onOpenWorkspace]);
 
-  // Outside mousedown → close.
+  // Outside pointerdown → close. pointerdown unifies mouse + touch + pen so
+  // tap-outside dismissal works on touch devices too.
   useEffect(() => {
     if (!open) return;
 
-    function onMouseDown(e: MouseEvent) {
+    function onPointerDown(e: PointerEvent) {
       const target = e.target as Node;
       if (dialogRef.current?.contains(target)) return;
       if (anchorRef.current?.contains(target)) return;
       onClose();
     }
 
-    document.addEventListener("mousedown", onMouseDown);
-    return () => document.removeEventListener("mousedown", onMouseDown);
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [open, anchorRef, onClose]);
 
   if (!open) return null;
@@ -205,8 +216,8 @@ export function AgentEventPeek({
       {/* Empty state — no SSE event has arrived for this agent yet */}
       {showEmptyState ? (
         <div className="sidebar-agent-peek-empty" data-testid="peek-empty">
-          No activity yet. This agent has not streamed an event since the
-          office opened.
+          No activity yet. This agent has not streamed an event since the office
+          opened.
         </div>
       ) : null}
 

--- a/web/src/components/sidebar/AgentEventPeek.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { formatRelative } from "../../lib/relativeTime";
+import type { StoredActivitySnapshot } from "../../stores/app";
+
+export interface AgentEventPeekProps {
+  slug: string;
+  agentName: string;
+  agentRole?: string;
+  open: boolean;
+  current: StoredActivitySnapshot | undefined;
+  history: StoredActivitySnapshot[];
+  anchorRef: React.RefObject<HTMLElement | null>;
+  onClose: () => void;
+  onOpenWorkspace: () => void;
+}
+
+interface Position {
+  top: number;
+  left: number;
+}
+
+const PEEK_WIDTH = 320;
+const PEEK_OFFSET = 8;
+
+function computePosition(anchor: HTMLElement): Position {
+  const { top, right, left: rectLeft } = anchor.getBoundingClientRect();
+  const rightEdge = right + PEEK_OFFSET + PEEK_WIDTH;
+  // Flip to left if the peek would extend beyond the right viewport edge.
+  const left =
+    rightEdge > window.innerWidth
+      ? rectLeft - PEEK_OFFSET - PEEK_WIDTH
+      : right + PEEK_OFFSET;
+  return { top, left };
+}
+
+function kindLabel(kind: StoredActivitySnapshot["kind"]): string {
+  if (kind === "milestone") return "milestone";
+  if (kind === "stuck") return "stuck";
+  return "routine";
+}
+
+export function AgentEventPeek({
+  slug,
+  agentName,
+  agentRole,
+  open,
+  current,
+  history,
+  anchorRef,
+  onClose,
+  onOpenWorkspace,
+}: AgentEventPeekProps) {
+  const [now, setNow] = useState<number>(() => Date.now());
+  const [pos, setPos] = useState<Position>({ top: 0, left: 0 });
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+
+  // Own 1Hz tick — the peek is mount/unmount so it owns its own clock.
+  useEffect(() => {
+    if (!open) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [open]);
+
+  // Position from anchor whenever open flips true or on scroll/resize.
+  useEffect(() => {
+    if (!open) return;
+
+    function reposition() {
+      if (anchorRef.current) {
+        setPos(computePosition(anchorRef.current));
+      }
+    }
+
+    reposition();
+    window.addEventListener("resize", reposition);
+    window.addEventListener("scroll", reposition, true);
+    return () => {
+      window.removeEventListener("resize", reposition);
+      window.removeEventListener("scroll", reposition, true);
+    };
+  }, [open, anchorRef]);
+
+  // Focus the dialog when it opens.
+  useEffect(() => {
+    if (open && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [open]);
+
+  // Keyboard: Escape → close, Enter → open workspace.
+  useEffect(() => {
+    if (!open) return;
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      } else if (e.key === "Enter") {
+        onOpenWorkspace();
+      }
+    }
+
+    const el = dialogRef.current;
+    el?.addEventListener("keydown", onKeyDown);
+    return () => el?.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose, onOpenWorkspace]);
+
+  // Outside mousedown → close.
+  useEffect(() => {
+    if (!open) return;
+
+    function onMouseDown(e: MouseEvent) {
+      const target = e.target as Node;
+      if (dialogRef.current?.contains(target)) return;
+      if (anchorRef.current?.contains(target)) return;
+      onClose();
+    }
+
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open, anchorRef, onClose]);
+
+  if (!(open && current)) return null;
+
+  const isStuck = current.kind === "stuck";
+  const currentLabel = kindLabel(current.kind);
+  const showDetailBlock =
+    typeof current.detail === "string" &&
+    current.detail.length > 0 &&
+    current.detail !== current.activity;
+
+  // Recent list: if stuck, prepend the current as a "BLOCKED:" pin,
+  // then show up to 6 history entries.
+  const recentEntries: Array<{
+    entry: StoredActivitySnapshot;
+    prefix?: string;
+  }> = [];
+  if (isStuck) {
+    recentEntries.push({ entry: current, prefix: "BLOCKED:" });
+  }
+  for (const h of history) {
+    if (recentEntries.length >= 6) break;
+    recentEntries.push({ entry: h });
+  }
+  const showRecentBlock = recentEntries.length > 0;
+
+  const avatarLetter = agentName.charAt(0).toUpperCase();
+
+  return createPortal(
+    <div
+      ref={dialogRef}
+      role="dialog"
+      aria-labelledby={`peek-name-${slug}`}
+      aria-describedby={showDetailBlock ? `peek-current-${slug}` : undefined}
+      className="sidebar-agent-peek"
+      data-stuck={isStuck ? "true" : undefined}
+      tabIndex={-1}
+      style={{ top: pos.top, left: pos.left }}
+    >
+      {/* Header */}
+      <div className="sidebar-agent-peek-header">
+        <div className="sidebar-agent-peek-avatar" aria-hidden="true">
+          {avatarLetter}
+        </div>
+        <div className="sidebar-agent-peek-identity">
+          <span id={`peek-name-${slug}`} className="sidebar-agent-peek-name">
+            {agentName}
+          </span>
+          {!!agentRole && (
+            <span className="sidebar-agent-peek-role">{agentRole}</span>
+          )}
+        </div>
+        {isStuck && (
+          <span className="sidebar-agent-peek-blocked-chip">BLOCKED</span>
+        )}
+      </div>
+
+      {/* State chip + relative time */}
+      <div className="sidebar-agent-peek-state-row">
+        <span
+          className="sidebar-agent-peek-state-chip"
+          data-kind={currentLabel}
+        >
+          {currentLabel}
+        </span>
+        <span className="sidebar-agent-peek-time">
+          {formatRelative(current.receivedAtMs, now)}
+        </span>
+      </div>
+
+      {/* Current thought */}
+      {showDetailBlock ? (
+        <div id={`peek-current-${slug}`} className="sidebar-agent-peek-detail">
+          {current.detail}
+        </div>
+      ) : null}
+
+      {/* Recent list */}
+      {showRecentBlock && (
+        <div className="sidebar-agent-peek-recent-section">
+          <div className="sidebar-agent-peek-recent-header">RECENT</div>
+          <ul className="sidebar-agent-peek-recent" aria-label="Recent events">
+            {recentEntries.map(({ entry, prefix }) => (
+              <li
+                key={`${entry.receivedAtMs}-${prefix ?? ""}`}
+                className="sidebar-agent-peek-recent-item"
+              >
+                <span
+                  className="sidebar-agent-peek-dot"
+                  data-kind={kindLabel(entry.kind)}
+                  aria-hidden="true"
+                />
+                <span className="sidebar-agent-peek-recent-text">
+                  {prefix ? `${prefix} ` : ""}
+                  {entry.activity ?? entry.detail ?? ""}
+                </span>
+                <span className="sidebar-agent-peek-recent-time">
+                  {formatRelative(entry.receivedAtMs, now)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Footer — NOT a button; Enter key drives the action */}
+      <div className="sidebar-agent-peek-footer">
+        <span>&#9166; Open workspace</span>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/sidebar/AgentEventPeek.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.tsx
@@ -122,22 +122,24 @@ export function AgentEventPeek({
     return () => document.removeEventListener("mousedown", onMouseDown);
   }, [open, anchorRef, onClose]);
 
-  if (!(open && current)) return null;
+  if (!open) return null;
 
-  const isStuck = current.kind === "stuck";
-  const currentLabel = kindLabel(current.kind);
+  const isStuck = current?.kind === "stuck";
+  const currentLabel = current ? kindLabel(current.kind) : null;
   const showDetailBlock =
+    !!current &&
     typeof current.detail === "string" &&
     current.detail.length > 0 &&
     current.detail !== current.activity;
 
   // Recent list: if stuck, prepend the current as a "BLOCKED:" pin,
-  // then show up to 6 history entries.
+  // then show up to 6 history entries. Both branches require a current
+  // snapshot, so the list collapses on the no-activity empty state.
   const recentEntries: Array<{
     entry: StoredActivitySnapshot;
     prefix?: string;
   }> = [];
-  if (isStuck) {
+  if (isStuck && current) {
     recentEntries.push({ entry: current, prefix: "BLOCKED:" });
   }
   for (const h of history) {
@@ -145,6 +147,7 @@ export function AgentEventPeek({
     recentEntries.push({ entry: h });
   }
   const showRecentBlock = recentEntries.length > 0;
+  const showEmptyState = !current;
 
   const avatarLetter = agentName.charAt(0).toUpperCase();
 
@@ -177,23 +180,33 @@ export function AgentEventPeek({
         )}
       </div>
 
-      {/* State chip + relative time */}
-      <div className="sidebar-agent-peek-state-row">
-        <span
-          className="sidebar-agent-peek-state-chip"
-          data-kind={currentLabel}
-        >
-          {currentLabel}
-        </span>
-        <span className="sidebar-agent-peek-time">
-          {formatRelative(current.receivedAtMs, now)}
-        </span>
-      </div>
+      {/* State chip + relative time — only when we have a snapshot */}
+      {current && currentLabel ? (
+        <div className="sidebar-agent-peek-state-row">
+          <span
+            className="sidebar-agent-peek-state-chip"
+            data-kind={currentLabel}
+          >
+            {currentLabel}
+          </span>
+          <span className="sidebar-agent-peek-time">
+            {formatRelative(current.receivedAtMs, now)}
+          </span>
+        </div>
+      ) : null}
 
       {/* Current thought */}
-      {showDetailBlock ? (
+      {showDetailBlock && current ? (
         <div id={`peek-current-${slug}`} className="sidebar-agent-peek-detail">
           {current.detail}
+        </div>
+      ) : null}
+
+      {/* Empty state — no SSE event has arrived for this agent yet */}
+      {showEmptyState ? (
+        <div className="sidebar-agent-peek-empty" data-testid="peek-empty">
+          No activity yet. This agent has not streamed an event since the
+          office opened.
         </div>
       ) : null}
 

--- a/web/src/components/sidebar/AgentEventPill.test.tsx
+++ b/web/src/components/sidebar/AgentEventPill.test.tsx
@@ -124,4 +124,23 @@ describe("<AgentEventPill>", () => {
     const pill = container.querySelector(".sidebar-agent-pill");
     expect(pill?.textContent?.length ?? 0).toBeGreaterThan(0);
   });
+
+  it("does NOT carry aria-haspopup or aria-expanded — the chevron sibling owns the dialog trigger", () => {
+    // Separation of concerns pin: the pill is a passive Tier 1 status
+    // surface. The Tier 2 hover peek is owned by the chevron button
+    // rendered as a sibling in <SidebarAgentRow>. Putting popup ARIA on
+    // both surfaces would lie to assistive tech about which control
+    // opens the peek.
+    const { container } = render(
+      <AgentEventPill
+        slug="devon"
+        agentRole="engineer"
+        fallbackTask="reading channel context"
+      />,
+    );
+    const pill = container.querySelector(".sidebar-agent-pill");
+    expect(pill).not.toBeNull();
+    expect(pill?.hasAttribute("aria-haspopup")).toBe(false);
+    expect(pill?.hasAttribute("aria-expanded")).toBe(false);
+  });
 });

--- a/web/src/components/sidebar/AgentList.test.tsx
+++ b/web/src/components/sidebar/AgentList.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { OfficeMember } from "../../api/client";
@@ -42,12 +42,47 @@ vi.mock("../ui/HarnessBadge", () => ({
   HarnessBadge: () => null,
 }));
 
+// AgentEventPeek renders into document.body via createPortal and pulls in
+// timers — stub it out for AgentList's integration tests so we focus on
+// the chevron + row wiring contract here. AgentEventPeek has its own
+// dedicated test file.
+vi.mock("./AgentEventPeek", () => ({
+  AgentEventPeek: () => null,
+}));
+
+// Mock useAgentEventPeek so the per-row peek state is deterministic. We
+// flip `isOpen` in tests by tracking calls to `toggle` via the mock
+// implementation rather than going through the real Zustand store.
+vi.mock("../../hooks/useAgentEventPeek", () => {
+  const peekState = {
+    isOpen: false,
+    current: undefined,
+    history: [],
+    open: vi.fn(),
+    close: vi.fn(),
+    toggle: vi.fn(),
+    hoverHandlers: { onMouseEnter: vi.fn(), onMouseLeave: vi.fn() },
+    longPressHandlers: {
+      onTouchStart: vi.fn(),
+      onTouchEnd: vi.fn(),
+      onTouchCancel: vi.fn(),
+      onTouchMove: vi.fn(),
+    },
+  };
+  return {
+    useAgentEventPeek: vi.fn(() => peekState),
+    usePeekIsOpen: vi.fn(() => false),
+  };
+});
+
+import { useAgentEventPeek } from "../../hooks/useAgentEventPeek";
 import { useFirstRunNudge } from "../../hooks/useFirstRunNudge";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { AgentList } from "./AgentList";
 
 const useOfficeMembersMock = vi.mocked(useOfficeMembers);
 const useFirstRunNudgeMock = vi.mocked(useFirstRunNudge);
+const useAgentEventPeekMock = vi.mocked(useAgentEventPeek);
 
 function setMembers(members: OfficeMember[]) {
   useOfficeMembersMock.mockReturnValue({
@@ -56,6 +91,25 @@ function setMembers(members: OfficeMember[]) {
     isError: false,
     error: null,
   } as unknown as ReturnType<typeof useOfficeMembers>);
+}
+
+function defaultPeekState(overrides: Partial<{ isOpen: boolean }> = {}) {
+  return {
+    isOpen: false,
+    current: undefined,
+    history: [],
+    open: vi.fn(),
+    close: vi.fn(),
+    toggle: vi.fn(),
+    hoverHandlers: { onMouseEnter: vi.fn(), onMouseLeave: vi.fn() },
+    longPressHandlers: {
+      onTouchStart: vi.fn(),
+      onTouchEnd: vi.fn(),
+      onTouchCancel: vi.fn(),
+      onTouchMove: vi.fn(),
+    },
+    ...overrides,
+  } as unknown as ReturnType<typeof useAgentEventPeek>;
 }
 
 function renderList() {
@@ -71,6 +125,7 @@ function renderList() {
 
 beforeEach(() => {
   useFirstRunNudgeMock.mockReturnValue({ showNudge: false });
+  useAgentEventPeekMock.mockImplementation(() => defaultPeekState());
   useAppStore.setState({ agentActivitySnapshots: {} });
 });
 
@@ -215,5 +270,111 @@ describe("<AgentList>", () => {
     expect(
       container.querySelectorAll('[data-testid="first-run-nudge"]').length,
     ).toBe(0);
+  });
+
+  // ─── Tier 2 chevron / peek wiring ────────────────────────────────────────
+
+  it("renders a peek chevron for every agent row, collapsed by default", () => {
+    setMembers([
+      { slug: "tess", name: "Tess", role: "engineer", task: "watching tests" },
+      { slug: "ava", name: "Ava", role: "designer", task: "moving pixels" },
+    ]);
+
+    const { container } = renderList();
+    const triggers = container.querySelectorAll(".sidebar-agent-peek-trigger");
+    expect(triggers.length).toBe(2);
+    for (const t of triggers) {
+      expect(t.getAttribute("aria-expanded")).toBe("false");
+      expect(t.getAttribute("aria-haspopup")).toBe("dialog");
+    }
+  });
+
+  it("REGRESSION: button[data-agent-slug] still resolves to the row button (NOT the chevron)", () => {
+    // The e2e harness selects rows via `button[data-agent-slug]`. The
+    // chevron is a sibling button without that attribute; it uses
+    // data-testid instead.
+    setMembers([
+      { slug: "tess", name: "Tess", role: "engineer", task: "watching tests" },
+    ]);
+
+    const { container } = renderList();
+
+    const slugButtons = container.querySelectorAll("button[data-agent-slug]");
+    expect(slugButtons.length).toBe(1);
+    expect(slugButtons[0].classList.contains("sidebar-agent")).toBe(true);
+
+    const chevron = container.querySelector(
+      '[data-testid="peek-trigger-tess"]',
+    );
+    expect(chevron).not.toBeNull();
+    expect(chevron?.hasAttribute("data-agent-slug")).toBe(false);
+  });
+
+  it("clicking the chevron does NOT call setActiveAgentSlug (e.stopPropagation)", () => {
+    const setActiveAgentSlug = vi.fn();
+    useAppStore.setState({ setActiveAgentSlug });
+
+    setMembers([
+      { slug: "tess", name: "Tess", role: "engineer", task: "watching tests" },
+    ]);
+
+    const { container } = renderList();
+    const chevron = container.querySelector(
+      '[data-testid="peek-trigger-tess"]',
+    );
+    expect(chevron).not.toBeNull();
+    fireEvent.click(chevron as Element);
+
+    expect(setActiveAgentSlug).not.toHaveBeenCalled();
+  });
+
+  it("clicking the chevron calls peek.toggle and flips aria-expanded to true on the next render", () => {
+    const toggle = vi.fn();
+    let isOpen = false;
+    useAgentEventPeekMock.mockImplementation(() =>
+      defaultPeekState({ isOpen }),
+    );
+
+    setMembers([
+      { slug: "tess", name: "Tess", role: "engineer", task: "watching tests" },
+    ]);
+
+    const { container, rerender } = renderList();
+    const chevron = container.querySelector(
+      '[data-testid="peek-trigger-tess"]',
+    );
+    expect(chevron?.getAttribute("aria-expanded")).toBe("false");
+
+    // Rewire mock so the click handler calls our spy AND so the next
+    // render reflects the open state.
+    useAgentEventPeekMock.mockImplementation(() => {
+      const state = defaultPeekState({ isOpen });
+      (state as unknown as { toggle: () => void }).toggle = () => {
+        toggle();
+        isOpen = true;
+      };
+      return state;
+    });
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <AgentList />
+      </QueryClientProvider>,
+    );
+    const chevron2 = container.querySelector(
+      '[data-testid="peek-trigger-tess"]',
+    );
+    fireEvent.click(chevron2 as Element);
+    expect(toggle).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <QueryClientProvider client={new QueryClient()}>
+        <AgentList />
+      </QueryClientProvider>,
+    );
+    const chevron3 = container.querySelector(
+      '[data-testid="peek-trigger-tess"]',
+    );
+    expect(chevron3?.getAttribute("aria-expanded")).toBe("true");
   });
 });

--- a/web/src/components/sidebar/AgentList.test.tsx
+++ b/web/src/components/sidebar/AgentList.test.tsx
@@ -93,7 +93,9 @@ function setMembers(members: OfficeMember[]) {
   } as unknown as ReturnType<typeof useOfficeMembers>);
 }
 
-function defaultPeekState(overrides: Partial<{ isOpen: boolean }> = {}) {
+function defaultPeekState(
+  overrides: Partial<ReturnType<typeof useAgentEventPeek>> = {},
+) {
   return {
     isOpen: false,
     current: undefined,
@@ -308,6 +310,33 @@ describe("<AgentList>", () => {
     );
     expect(chevron).not.toBeNull();
     expect(chevron?.hasAttribute("data-agent-slug")).toBe(false);
+  });
+
+  it("clicking the row (Tier 3 escalation) closes any open peek before navigating", () => {
+    // Plan §Disclosure tiers: "Quick activation always wins; the long-press
+    // threshold is what differentiates peek from navigate." If peek is open
+    // when the user taps the row, the workspace should be the only surface
+    // visible after the tap — close the peek as part of escalation.
+    const close = vi.fn();
+    const setActiveAgentSlug = vi.fn();
+    useAppStore.setState({ setActiveAgentSlug });
+    useAgentEventPeekMock.mockImplementation(() =>
+      defaultPeekState({ isOpen: true, close }),
+    );
+
+    setMembers([
+      { slug: "tess", name: "Tess", role: "engineer", task: "watching tests" },
+    ]);
+
+    const { container } = renderList();
+    const row = container.querySelector(
+      'button[data-agent-slug="tess"]',
+    ) as HTMLButtonElement;
+    expect(row).not.toBeNull();
+    fireEvent.click(row);
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(setActiveAgentSlug).toHaveBeenCalledWith("tess");
   });
 
   it("clicking the chevron does NOT call setActiveAgentSlug (e.stopPropagation)", () => {

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -75,7 +75,13 @@ function SidebarAgentRow({
         type="button"
         className={`sidebar-agent${isDMActive ? " active" : ""}`}
         title={`${agent.name} — ${ac.label}`}
-        onClick={() => onSelect(agent.slug)}
+        onClick={() => {
+          // Tier 3 escalation: "quick activation always wins" per the plan.
+          // Close any open Tier 2 peek so the workspace is the only surface
+          // visible after the tap, instead of two competing per-agent UIs.
+          peek.close();
+          onSelect(agent.slug);
+        }}
         data-agent-slug={agent.slug}
       >
         <span className="sidebar-agent-avatar avatar-with-harness">

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -74,7 +74,7 @@ function SidebarAgentRow({
       <button
         type="button"
         className={`sidebar-agent${isDMActive ? " active" : ""}`}
-        title={`${agent.name} — ${ac.label}`}
+        title={`${displayName} — ${ac.label}`}
         onClick={() => {
           // Tier 3 escalation: "quick activation always wins" per the plan.
           // Close any open Tier 2 peek so the workspace is the only surface

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -1,14 +1,18 @@
+import { useRef } from "react";
+
 import type { OfficeMember } from "../../api/client";
+import { useAgentEventPeek } from "../../hooks/useAgentEventPeek";
 import { useDefaultHarness } from "../../hooks/useConfig";
 import { useFirstRunNudge } from "../../hooks/useFirstRunNudge";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { useOverflow } from "../../hooks/useOverflow";
-import { resolveHarness } from "../../lib/harness";
+import { type HarnessKind, resolveHarness } from "../../lib/harness";
 import { useCurrentRoute } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
 import { AgentWizard, useAgentWizard } from "../agents/AgentWizard";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
+import { AgentEventPeek } from "./AgentEventPeek";
 import { AgentEventPill, AgentEventTickProvider } from "./AgentEventPill";
 
 function classifyActivity(member: OfficeMember | undefined) {
@@ -30,6 +34,117 @@ function classifyActivity(member: OfficeMember | undefined) {
   if (status === "active")
     return { state: "talking", label: "talking", dotClass: "active pulse" };
   return { state: "lurking", label: "lurking", dotClass: "lurking" };
+}
+
+interface SidebarAgentRowProps {
+  agent: OfficeMember;
+  isDMActive: boolean;
+  isFirst: boolean;
+  showNudge: boolean;
+  defaultHarness: HarnessKind;
+  onSelect: (slug: string) => void;
+}
+
+/**
+ * Row body extracted into its own component so the per-row hook
+ * (`useAgentEventPeek`) is called once per row instead of inside a `.map`
+ * loop in the parent — React forbids hooks in loops directly.
+ */
+function SidebarAgentRow({
+  agent,
+  isDMActive,
+  isFirst,
+  showNudge,
+  defaultHarness,
+  onSelect,
+}: SidebarAgentRowProps) {
+  const peek = useAgentEventPeek(agent.slug);
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const ac = classifyActivity(agent);
+  const harness = resolveHarness(agent.provider, defaultHarness);
+  const displayName = agent.name || agent.slug;
+
+  return (
+    <div
+      className="sidebar-agent-row"
+      ref={anchorRef}
+      {...peek.hoverHandlers}
+      {...peek.longPressHandlers}
+    >
+      <button
+        type="button"
+        className={`sidebar-agent${isDMActive ? " active" : ""}`}
+        title={`${agent.name} — ${ac.label}`}
+        onClick={() => onSelect(agent.slug)}
+        data-agent-slug={agent.slug}
+      >
+        <span className="sidebar-agent-avatar avatar-with-harness">
+          <PixelAvatar
+            slug={agent.slug}
+            size={24}
+            className="pixel-avatar-sidebar"
+          />
+          <HarnessBadge
+            kind={harness}
+            size={10}
+            className="harness-badge-on-avatar"
+          />
+        </span>
+        <div className="sidebar-agent-wrap">
+          <span className="sidebar-agent-name">{displayName}</span>
+          <AgentEventPill
+            slug={agent.slug}
+            agentRole={agent.role}
+            fallbackTask={agent.task}
+          />
+        </div>
+        <span className={`status-dot ${ac.dotClass}`} />
+      </button>
+      <button
+        type="button"
+        className="sidebar-agent-peek-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={peek.isOpen}
+        aria-controls={`agent-peek-${agent.slug}`}
+        aria-label={`Recent activity for ${displayName}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          peek.toggle();
+        }}
+        data-testid={`peek-trigger-${agent.slug}`}
+      >
+        <svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">
+          <path
+            d="M2 1 L6 4 L2 7"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      <AgentEventPeek
+        slug={agent.slug}
+        agentName={displayName}
+        agentRole={agent.role}
+        open={peek.isOpen}
+        current={peek.current}
+        history={peek.history}
+        anchorRef={anchorRef}
+        onClose={peek.close}
+        onOpenWorkspace={() => {
+          peek.close();
+          onSelect(agent.slug);
+        }}
+      />
+      {isFirst && showNudge ? (
+        <span className="sidebar-agent-nudge" data-testid="first-run-nudge">
+          {`→ tag @${agent.slug} in #general`}
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 export function AgentList() {
@@ -61,56 +176,17 @@ export function AgentList() {
               No agents online
             </div>
           ) : (
-            agents.map((agent) => {
-              const ac = classifyActivity(agent);
-              const isDMActive = activeDmAgent === agent.slug;
-              const harness = resolveHarness(agent.provider, defaultHarness);
-              const isFirst = agent.slug === firstAgentSlug;
-
-              return (
-                <div key={agent.slug} className="sidebar-agent-row">
-                  <button
-                    type="button"
-                    className={`sidebar-agent${isDMActive ? " active" : ""}`}
-                    title={`${agent.name} — ${ac.label}`}
-                    onClick={() => setActiveAgentSlug(agent.slug)}
-                    data-agent-slug={agent.slug}
-                  >
-                    <span className="sidebar-agent-avatar avatar-with-harness">
-                      <PixelAvatar
-                        slug={agent.slug}
-                        size={24}
-                        className="pixel-avatar-sidebar"
-                      />
-                      <HarnessBadge
-                        kind={harness}
-                        size={10}
-                        className="harness-badge-on-avatar"
-                      />
-                    </span>
-                    <div className="sidebar-agent-wrap">
-                      <span className="sidebar-agent-name">
-                        {agent.name || agent.slug}
-                      </span>
-                      <AgentEventPill
-                        slug={agent.slug}
-                        agentRole={agent.role}
-                        fallbackTask={agent.task}
-                      />
-                    </div>
-                    <span className={`status-dot ${ac.dotClass}`} />
-                  </button>
-                  {isFirst && showNudge ? (
-                    <span
-                      className="sidebar-agent-nudge"
-                      data-testid="first-run-nudge"
-                    >
-                      {`→ tag @${agent.slug} in #general`}
-                    </span>
-                  ) : null}
-                </div>
-              );
-            })
+            agents.map((agent) => (
+              <SidebarAgentRow
+                key={agent.slug}
+                agent={agent}
+                isDMActive={activeDmAgent === agent.slug}
+                isFirst={agent.slug === firstAgentSlug}
+                showNudge={showNudge}
+                defaultHarness={defaultHarness}
+                onSelect={setActiveAgentSlug}
+              />
+            ))
           )}
           <button
             type="button"

--- a/web/src/hooks/useAgentEventPeek.test.ts
+++ b/web/src/hooks/useAgentEventPeek.test.ts
@@ -1,0 +1,460 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../stores/app";
+import {
+  __internal,
+  useAgentEventPeek,
+  usePeekIsOpen,
+} from "./useAgentEventPeek";
+
+const { usePeekOpenStore } = __internal;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resetStores() {
+  usePeekOpenStore.setState({ openSlug: null });
+  useAppStore.setState({
+    agentActivitySnapshots: {},
+    agentActivityHistory: {},
+  });
+}
+
+// Options that make timers instant-ish for determinism without real delays.
+const FAST: Parameters<typeof useAgentEventPeek>[1] = {
+  hoverIntentMs: 300,
+  closeGraceMs: 80,
+  longPressMs: 500,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  resetStores();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetStores();
+});
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe("initial state", () => {
+  it("isOpen is false before any interaction", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("current is undefined and history is empty when no snapshot exists", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    expect(result.current.current).toBeUndefined();
+    expect(result.current.history).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hover-intent open
+// ---------------------------------------------------------------------------
+
+describe("hover-intent open", () => {
+  it("does NOT open before 300ms", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("opens after exactly 300ms hover", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("stays closed when cursor leaves before 300ms", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.hoverHandlers.onMouseLeave();
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Close-grace
+// ---------------------------------------------------------------------------
+
+describe("close-grace on leave", () => {
+  it("closes after leave + 80ms", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    // Open via hover-intent.
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.hoverHandlers.onMouseLeave();
+    });
+    act(() => {
+      vi.advanceTimersByTime(80);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("stays open when cursor re-enters within the 80ms close-grace window", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.hoverHandlers.onMouseLeave();
+    });
+    act(() => {
+      vi.advanceTimersByTime(40);
+    });
+    // Cursor returns before grace expires.
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+    });
+    act(() => {
+      vi.advanceTimersByTime(80);
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Toggle / open / close (keyboard-style, no timers)
+// ---------------------------------------------------------------------------
+
+describe("toggle, open, close", () => {
+  it("toggle flips false -> true instantly", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("toggle flips true -> false instantly", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.toggle();
+    });
+    act(() => {
+      result.current.toggle();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("open() sets isOpen to true", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.open();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("close() sets isOpen to false after open", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.open();
+    });
+    act(() => {
+      result.current.close();
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("toggle does not involve any timers — no pending callbacks after flip", () => {
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    act(() => {
+      result.current.toggle();
+    });
+    // Advancing time should not change state (no close-grace triggered).
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Long-press (touch)
+// ---------------------------------------------------------------------------
+
+describe("long-press touch", () => {
+  it("opens after 500ms touchstart without move or end", () => {
+    const { result } = renderHook(() => useAgentEventPeek("ava", FAST));
+    act(() => {
+      result.current.longPressHandlers.onTouchStart();
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("does not open when touchend fires before 500ms", () => {
+    const { result } = renderHook(() => useAgentEventPeek("ava", FAST));
+    act(() => {
+      result.current.longPressHandlers.onTouchStart();
+    });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    act(() => {
+      result.current.longPressHandlers.onTouchEnd();
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("does not open when touchcancel fires before 500ms", () => {
+    const { result } = renderHook(() => useAgentEventPeek("ava", FAST));
+    act(() => {
+      result.current.longPressHandlers.onTouchStart();
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    act(() => {
+      result.current.longPressHandlers.onTouchCancel();
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("touchmove during press cancels the long-press timer", () => {
+    const { result } = renderHook(() => useAgentEventPeek("ava", FAST));
+    act(() => {
+      result.current.longPressHandlers.onTouchStart();
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    act(() => {
+      result.current.longPressHandlers.onTouchMove();
+    });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("touchend after open does NOT close the peek (touch dismiss by tap-outside)", () => {
+    const { result } = renderHook(() => useAgentEventPeek("ava", FAST));
+    act(() => {
+      result.current.longPressHandlers.onTouchStart();
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.longPressHandlers.onTouchEnd();
+    });
+    expect(result.current.isOpen).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single-instance discipline
+// ---------------------------------------------------------------------------
+
+describe("single-instance: opening one slug closes another", () => {
+  it("opening slug B leaves slug A closed", () => {
+    const hookA = renderHook(() => useAgentEventPeek("tess", FAST));
+    const hookB = renderHook(() => useAgentEventPeek("ava", FAST));
+
+    act(() => {
+      hookA.result.current.open();
+    });
+    expect(hookA.result.current.isOpen).toBe(true);
+    expect(hookB.result.current.isOpen).toBe(false);
+
+    act(() => {
+      hookB.result.current.open();
+    });
+    expect(hookA.result.current.isOpen).toBe(false);
+    expect(hookB.result.current.isOpen).toBe(true);
+  });
+
+  it("hover-intent on B clears A's open state", () => {
+    const hookA = renderHook(() => useAgentEventPeek("tess", FAST));
+    const hookB = renderHook(() => useAgentEventPeek("ava", FAST));
+
+    act(() => {
+      hookA.result.current.open();
+    });
+    expect(hookA.result.current.isOpen).toBe(true);
+
+    act(() => {
+      hookB.result.current.hoverHandlers.onMouseEnter();
+      vi.advanceTimersByTime(300);
+    });
+    expect(hookA.result.current.isOpen).toBe(false);
+    expect(hookB.result.current.isOpen).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unmount cleanup
+// ---------------------------------------------------------------------------
+
+describe("unmount cleanup", () => {
+  it("cancels pending hover-open timer on unmount without error", () => {
+    const { result, unmount } = renderHook(() =>
+      useAgentEventPeek("tess", FAST),
+    );
+    act(() => {
+      result.current.hoverHandlers.onMouseEnter();
+    });
+    // Unmount before the 300ms fires.
+    unmount();
+    // Advancing time after unmount must not throw or open the peek.
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    // No assertion on result (unmounted), just verify no errors were thrown.
+    // The peek open store should remain untouched.
+    expect(usePeekOpenStore.getState().openSlug).toBeNull();
+  });
+
+  it("cancels pending close-grace timer on unmount without error", () => {
+    const { result, unmount } = renderHook(() =>
+      useAgentEventPeek("tess", FAST),
+    );
+    act(() => {
+      result.current.open();
+      result.current.hoverHandlers.onMouseLeave();
+    });
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    // The peek is open via direct open(); grace timer was set on leave.
+    // After unmount and timer flush the store should not have been null-ified
+    // by the grace timer callback (the timer was cancelled).
+    expect(usePeekOpenStore.getState().openSlug).toBe("tess");
+  });
+
+  it("cancels pending long-press timer on unmount without error", () => {
+    const { result, unmount } = renderHook(() =>
+      useAgentEventPeek("ava", FAST),
+    );
+    act(() => {
+      result.current.longPressHandlers.onTouchStart();
+    });
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(usePeekOpenStore.getState().openSlug).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePeekIsOpen helper
+// ---------------------------------------------------------------------------
+
+describe("usePeekIsOpen", () => {
+  it("returns false when nothing is open", () => {
+    const { result } = renderHook(() => usePeekIsOpen("tess"));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true for the open slug", () => {
+    const { result } = renderHook(() => usePeekIsOpen("tess"));
+    act(() => {
+      usePeekOpenStore.getState().setOpenSlug("tess");
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false for a slug that is NOT the open one", () => {
+    const { result } = renderHook(() => usePeekIsOpen("ava"));
+    act(() => {
+      usePeekOpenStore.getState().setOpenSlug("tess");
+    });
+    expect(result.current).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Snapshot data passthrough
+// ---------------------------------------------------------------------------
+
+describe("snapshot data from store", () => {
+  it("exposes current snapshot when one exists for the slug", () => {
+    const snap = {
+      slug: "tess",
+      activity: "running tests",
+      receivedAtMs: Date.now(),
+      haloUntilMs: Date.now() + 600,
+    };
+    useAppStore.setState({
+      agentActivitySnapshots: { tess: snap },
+    });
+
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    expect(result.current.current).toMatchObject({
+      slug: "tess",
+      activity: "running tests",
+    });
+  });
+
+  it("exposes history array for the slug", () => {
+    const snap1 = {
+      slug: "tess",
+      activity: "merging branch",
+      receivedAtMs: Date.now() - 10_000,
+      haloUntilMs: 0,
+    };
+    const snap2 = {
+      slug: "tess",
+      activity: "running tests",
+      receivedAtMs: Date.now(),
+      haloUntilMs: Date.now() + 600,
+    };
+    useAppStore.setState({
+      agentActivitySnapshots: { tess: snap2 },
+      agentActivityHistory: { tess: [snap1] },
+    });
+
+    const { result } = renderHook(() => useAgentEventPeek("tess", FAST));
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.history[0]).toMatchObject({
+      activity: "merging branch",
+    });
+  });
+});

--- a/web/src/hooks/useAgentEventPeek.ts
+++ b/web/src/hooks/useAgentEventPeek.ts
@@ -1,0 +1,248 @@
+import { useCallback, useEffect, useRef } from "react";
+import { create } from "zustand";
+
+import { type StoredActivitySnapshot, useAppStore } from "../stores/app";
+
+// --- Timer constants ---
+
+const HOVER_INTENT_MS = 300;
+const CLOSE_GRACE_MS = 80;
+// Long-press cancels on touchmove because a scroll gesture starting on a row
+// should not open a peek mid-scroll.
+const LONG_PRESS_MS = 500;
+
+// Stable empty array returned when a slug has no history yet, so the selector
+// never allocates a fresh [] on every render (which would trigger an infinite
+// re-render cycle via React 19's useSyncExternalStore snapshot check).
+const EMPTY_HISTORY: StoredActivitySnapshot[] = [];
+
+// --- Single-instance open store (NOT part of useAppStore) ---
+
+interface PeekOpenState {
+  openSlug: string | null;
+  setOpenSlug: (slug: string | null) => void;
+}
+
+export const usePeekOpenStore = create<PeekOpenState>((set) => ({
+  openSlug: null,
+  setOpenSlug: (slug) => set({ openSlug: slug }),
+}));
+
+// --- Public types ---
+
+export interface PeekOptions {
+  /** Override hover-intent delay in ms (default: 300). Tests use small values for speed. */
+  hoverIntentMs?: number;
+  /** Override close-grace delay in ms (default: 80). */
+  closeGraceMs?: number;
+  /** Override long-press delay in ms (default: 500). */
+  longPressMs?: number;
+}
+
+export interface PeekState {
+  isOpen: boolean;
+  current: StoredActivitySnapshot | undefined;
+  history: StoredActivitySnapshot[];
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+  hoverHandlers: {
+    onMouseEnter: () => void;
+    onMouseLeave: () => void;
+  };
+  longPressHandlers: {
+    onTouchStart: () => void;
+    onTouchEnd: () => void;
+    onTouchCancel: () => void;
+    onTouchMove: () => void;
+  };
+}
+
+// --- Internal constants re-exported for tests ---
+
+export const __internal = {
+  HOVER_INTENT_MS,
+  CLOSE_GRACE_MS,
+  LONG_PRESS_MS,
+  usePeekOpenStore,
+} as const;
+
+// --- Hook implementations ---
+
+/**
+ * Returns true only when the given slug is the currently open peek.
+ * Used by AgentEventPill's chevron for aria-expanded without subscribing
+ * to the full PeekState.
+ */
+export function usePeekIsOpen(slug: string): boolean {
+  return usePeekOpenStore((s) => s.openSlug === slug);
+}
+
+/**
+ * Full peek state for a single agent row. Attach hoverHandlers onto the row
+ * container element and longPressHandlers onto the same container for touch.
+ * Use open/close/toggle for keyboard activation.
+ */
+export function useAgentEventPeek(
+  slug: string,
+  options?: PeekOptions,
+): PeekState {
+  const hoverIntentMs = options?.hoverIntentMs ?? HOVER_INTENT_MS;
+  const closeGraceMs = options?.closeGraceMs ?? CLOSE_GRACE_MS;
+  const longPressMs = options?.longPressMs ?? LONG_PRESS_MS;
+
+  const setOpenSlug = usePeekOpenStore((s) => s.setOpenSlug);
+  const isOpen = usePeekOpenStore((s) => s.openSlug === slug);
+
+  // Two separate selectors avoid creating a new object reference on every render
+  // (object identity would always be fresh and trigger an infinite re-render loop
+  // with useSyncExternalStore in React 19).
+  const current = useAppStore((s) => s.agentActivitySnapshots[slug]);
+  // Read the array reference directly — Zustand's store produces a stable
+  // reference when the slice hasn't changed, so the selector never returns a
+  // freshly-allocated array on every render (which would cause an infinite
+  // re-render loop via useSyncExternalStore in React 19).
+  const historyOrUndef = useAppStore((s) => s.agentActivityHistory[slug]);
+  const history: StoredActivitySnapshot[] = historyOrUndef ?? EMPTY_HISTORY;
+
+  // Timer refs — never stored in state to avoid triggering re-renders
+  // on every schedule/cancel cycle.
+  const hoverOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeGraceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearHoverOpenTimer = useCallback(() => {
+    if (hoverOpenTimerRef.current !== null) {
+      clearTimeout(hoverOpenTimerRef.current);
+      hoverOpenTimerRef.current = null;
+    }
+  }, []);
+
+  const clearCloseGraceTimer = useCallback(() => {
+    if (closeGraceTimerRef.current !== null) {
+      clearTimeout(closeGraceTimerRef.current);
+      closeGraceTimerRef.current = null;
+    }
+  }, []);
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  // Flush all pending timers when slug changes or on unmount. `slug` is read
+  // here so biome's useExhaustiveDependencies rule sees it as a real
+  // dependency — the cleanup body itself doesn't need it, but the slug-change
+  // re-run is the whole point: timers from the previous slug get cleared
+  // before any new ones bind.
+  useEffect(() => {
+    void slug;
+    return () => {
+      clearHoverOpenTimer();
+      clearCloseGraceTimer();
+      clearLongPressTimer();
+    };
+  }, [slug, clearHoverOpenTimer, clearCloseGraceTimer, clearLongPressTimer]);
+
+  const open = useCallback(() => {
+    setOpenSlug(slug);
+  }, [slug, setOpenSlug]);
+
+  const close = useCallback(() => {
+    setOpenSlug(null);
+  }, [setOpenSlug]);
+
+  // We read isOpen from the store inside toggle via a fresh selector rather
+  // than from the captured closure so the flip is always based on latest state.
+  const toggle = useCallback(() => {
+    const currentlyOpen = usePeekOpenStore.getState().openSlug === slug;
+    if (currentlyOpen) {
+      setOpenSlug(null);
+    } else {
+      setOpenSlug(slug);
+    }
+  }, [slug, setOpenSlug]);
+
+  const onMouseEnter = useCallback(() => {
+    // Cancel any in-flight close-grace so re-entering keeps the peek open.
+    clearCloseGraceTimer();
+
+    // Skip re-scheduling if we are already open (cursor returned to already-open row).
+    const alreadyOpen = usePeekOpenStore.getState().openSlug === slug;
+    if (alreadyOpen) return;
+
+    // Start hover-intent timer; only opens if cursor stays for the full duration.
+    clearHoverOpenTimer();
+    hoverOpenTimerRef.current = setTimeout(() => {
+      hoverOpenTimerRef.current = null;
+      setOpenSlug(slug);
+    }, hoverIntentMs);
+  }, [
+    slug,
+    hoverIntentMs,
+    setOpenSlug,
+    clearHoverOpenTimer,
+    clearCloseGraceTimer,
+  ]);
+
+  const onMouseLeave = useCallback(() => {
+    // If the intent timer hasn't fired yet, cancel it — cursor left too soon.
+    clearHoverOpenTimer();
+
+    const alreadyOpen = usePeekOpenStore.getState().openSlug === slug;
+    if (!alreadyOpen) return;
+
+    // Start close-grace; re-entering before it fires cancels it (onMouseEnter).
+    clearCloseGraceTimer();
+    closeGraceTimerRef.current = setTimeout(() => {
+      closeGraceTimerRef.current = null;
+      // Only close if this slug is still the open one (another slug may have
+      // stolen focus in the grace window).
+      if (usePeekOpenStore.getState().openSlug === slug) {
+        setOpenSlug(null);
+      }
+    }, closeGraceMs);
+  }, [
+    slug,
+    closeGraceMs,
+    setOpenSlug,
+    clearHoverOpenTimer,
+    clearCloseGraceTimer,
+  ]);
+
+  const onTouchStart = useCallback(() => {
+    clearLongPressTimer();
+    longPressTimerRef.current = setTimeout(() => {
+      longPressTimerRef.current = null;
+      setOpenSlug(slug);
+    }, longPressMs);
+  }, [slug, longPressMs, setOpenSlug, clearLongPressTimer]);
+
+  // touchend and touchcancel cancel the timer but do NOT close the peek
+  // if it has already opened — touch users dismiss by tapping outside.
+  const onTouchEnd = useCallback(() => {
+    clearLongPressTimer();
+  }, [clearLongPressTimer]);
+
+  const onTouchCancel = useCallback(() => {
+    clearLongPressTimer();
+  }, [clearLongPressTimer]);
+
+  // A scroll attempt during the long-press window should not open a peek.
+  const onTouchMove = useCallback(() => {
+    clearLongPressTimer();
+  }, [clearLongPressTimer]);
+
+  return {
+    isOpen,
+    current,
+    history,
+    open,
+    close,
+    toggle,
+    hoverHandlers: { onMouseEnter, onMouseLeave },
+    longPressHandlers: { onTouchStart, onTouchEnd, onTouchCancel, onTouchMove },
+  };
+}

--- a/web/src/lib/relativeTime.ts
+++ b/web/src/lib/relativeTime.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a millisecond delta into a compact relative time string.
+ * Examples: "4s ago", "1m 30s ago", "2m ago".
+ *
+ * Designed for the Tier 2 hover peek recent-event list. Uses wall-clock
+ * milliseconds rather than ISO strings to stay decoupled from server time.
+ */
+export function formatRelative(thenMs: number, nowMs: number): string {
+  const diffMs = Math.max(0, nowMs - thenMs);
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) {
+    return `${totalSeconds}s ago`;
+  }
+  if (seconds === 0) {
+    return `${minutes}m ago`;
+  }
+  return `${minutes}m ${seconds}s ago`;
+}

--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { directChannelSlug, selectPillState, useAppStore } from "./app";
+import {
+  directChannelSlug,
+  MAX_AGENT_HISTORY,
+  selectAgentPeek,
+  selectPillState,
+  useAppStore,
+} from "./app";
 
 afterEach(() => {
   useAppStore.setState({
@@ -15,6 +21,7 @@ afterEach(() => {
     composerHelpOpen: false,
     onboardingComplete: false,
     agentActivitySnapshots: {},
+    agentActivityHistory: {},
     isReconnecting: false,
   });
 });
@@ -169,6 +176,119 @@ describe("recordActivitySnapshot", () => {
       activity: "noise",
     });
     expect(useAppStore.getState().agentActivitySnapshots).toEqual({});
+  });
+
+  it("first event for a slug leaves history empty (nothing displaced yet)", () => {
+    useAppStore.getState().recordActivitySnapshot({
+      slug: "tess",
+      activity: "merging branch",
+      kind: "routine",
+    });
+
+    expect(useAppStore.getState().agentActivityHistory.tess ?? []).toEqual([]);
+    expect(useAppStore.getState().agentActivitySnapshots.tess.activity).toBe(
+      "merging branch",
+    );
+  });
+
+  it("each subsequent event prepends the displaced previous snapshot to history (newest-first)", () => {
+    const store = useAppStore.getState();
+    store.recordActivitySnapshot({ slug: "tess", activity: "first" });
+    store.recordActivitySnapshot({ slug: "tess", activity: "second" });
+    store.recordActivitySnapshot({ slug: "tess", activity: "third" });
+
+    const history = useAppStore.getState().agentActivityHistory.tess;
+    expect(history.map((h) => h.activity)).toEqual(["second", "first"]);
+    expect(useAppStore.getState().agentActivitySnapshots.tess.activity).toBe(
+      "third",
+    );
+  });
+
+  it("caps history at MAX_AGENT_HISTORY entries (oldest evicted)", () => {
+    const store = useAppStore.getState();
+    // Fire MAX_AGENT_HISTORY + 3 events. After event N, the current is in
+    // agentActivitySnapshots and the previous N-1 sit in history capped at
+    // MAX_AGENT_HISTORY.
+    for (let i = 0; i < MAX_AGENT_HISTORY + 3; i += 1) {
+      store.recordActivitySnapshot({
+        slug: "ava",
+        activity: `evt-${i}`,
+        kind: "routine",
+      });
+    }
+
+    const history = useAppStore.getState().agentActivityHistory.ava;
+    expect(history.length).toBe(MAX_AGENT_HISTORY);
+    // Newest displaced is the most recent prior current — evt-(N-2) where
+    // N = MAX_AGENT_HISTORY + 3 (the still-current value is evt-(N-1)).
+    const expectedNewest = `evt-${MAX_AGENT_HISTORY + 1}`;
+    expect(history[0].activity).toBe(expectedNewest);
+    // Tail is the oldest survivor: total fired = MAX_AGENT_HISTORY + 3, the
+    // current absorbs 1, so MAX_AGENT_HISTORY + 2 displaced events compete
+    // for MAX_AGENT_HISTORY slots — oldest 2 fall off, leaving evt-2 at tail.
+    expect(history[history.length - 1].activity).toBe("evt-2");
+  });
+
+  it("history is per-slug and does not leak between agents", () => {
+    const store = useAppStore.getState();
+    store.recordActivitySnapshot({ slug: "tess", activity: "tess-1" });
+    store.recordActivitySnapshot({ slug: "ava", activity: "ava-1" });
+    store.recordActivitySnapshot({ slug: "tess", activity: "tess-2" });
+
+    const tessHistory = useAppStore.getState().agentActivityHistory.tess;
+    const avaHistory = useAppStore.getState().agentActivityHistory.ava ?? [];
+    expect(tessHistory.map((h) => h.activity)).toEqual(["tess-1"]);
+    expect(avaHistory).toEqual([]);
+  });
+
+  it("history records the full StoredActivitySnapshot (with receivedAtMs/haloUntilMs preserved)", () => {
+    const store = useAppStore.getState();
+    store.recordActivitySnapshot({ slug: "sam", activity: "first" });
+    const firstStamped = useAppStore.getState().agentActivitySnapshots.sam;
+    store.recordActivitySnapshot({ slug: "sam", activity: "second" });
+
+    const [displaced] = useAppStore.getState().agentActivityHistory.sam;
+    expect(displaced.activity).toBe("first");
+    expect(displaced.receivedAtMs).toBe(firstStamped.receivedAtMs);
+    expect(displaced.haloUntilMs).toBe(firstStamped.haloUntilMs);
+  });
+});
+
+describe("selectAgentPeek", () => {
+  it("returns undefined current and empty history for an unknown slug", () => {
+    const result = selectAgentPeek(
+      { agentActivitySnapshots: {}, agentActivityHistory: {} },
+      "ghost",
+    );
+    expect(result).toEqual({ current: undefined, history: [] });
+  });
+
+  it("returns the current snapshot plus its newest-first history", () => {
+    const now = 1_700_000_000_000;
+    const state = {
+      agentActivitySnapshots: {
+        tess: {
+          slug: "tess",
+          activity: "now",
+          receivedAtMs: now,
+          haloUntilMs: now + 600,
+        },
+      },
+      agentActivityHistory: {
+        tess: [
+          {
+            slug: "tess",
+            activity: "prev",
+            receivedAtMs: now - 1000,
+            haloUntilMs: now - 400,
+          },
+        ],
+      },
+    };
+    expect(selectAgentPeek(state, "tess")).toEqual({
+      current: state.agentActivitySnapshots.tess,
+      history: state.agentActivityHistory.tess,
+    });
   });
 });
 

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -42,6 +42,13 @@ export interface StoredActivitySnapshot extends AgentActivitySnapshot {
 
 const { HALO_DECAY_MS } = agentEventTimerInternal;
 
+/**
+ * Cap on per-slug history depth in agentActivityHistory. The Tier 2 hover
+ * peek surfaces the most recent ≤6 prior events; the buffer holds 8 so the
+ * peek has a small forward margin if display rules change.
+ */
+export const MAX_AGENT_HISTORY = 8;
+
 const _storedTheme = ((): Theme => {
   try {
     const v = localStorage.getItem("wuphf-theme");
@@ -197,6 +204,11 @@ export interface AppStore {
 
   // Agent activity (SSE-driven event bubbles)
   agentActivitySnapshots: Record<string, StoredActivitySnapshot>;
+  // Per-slug ring buffer of prior snapshots, newest-first, capped at
+  // MAX_AGENT_HISTORY. Powers the Tier 2 hover-peek "Recent" list. The
+  // current snapshot lives in agentActivitySnapshots; history holds only
+  // what was previously current and got displaced by a newer event.
+  agentActivityHistory: Record<string, StoredActivitySnapshot[]>;
   recordActivitySnapshot: (snap: AgentActivitySnapshot) => void;
 
   // SSE reconnect grace — true after the EventSource has stayed in a
@@ -341,6 +353,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setTelegramConnectOpen: (v) => set({ telegramConnectOpen: v }),
 
   agentActivitySnapshots: {},
+  agentActivityHistory: {},
   recordActivitySnapshot: (snap) => {
     if (typeof snap?.slug !== "string" || snap.slug.length === 0) return;
     const { slug } = snap;
@@ -355,6 +368,14 @@ export const useAppStore = create<AppStore>((set, get) => ({
         snap.kind === "stuck"
           ? (previous?.haloUntilMs ?? 0)
           : now + HALO_DECAY_MS;
+      // Push the previous current snapshot onto the per-slug history ring
+      // buffer (newest-first). The current snapshot itself stays in
+      // agentActivitySnapshots; history holds only displaced events. First
+      // event for a slug leaves history untouched (no previous to keep).
+      const prevHistory = state.agentActivityHistory[slug] ?? [];
+      const nextHistory = previous
+        ? [previous, ...prevHistory].slice(0, MAX_AGENT_HISTORY)
+        : prevHistory;
       return {
         agentActivitySnapshots: {
           ...state.agentActivitySnapshots,
@@ -363,6 +384,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
             receivedAtMs: now,
             haloUntilMs,
           },
+        },
+        agentActivityHistory: {
+          ...state.agentActivityHistory,
+          [slug]: nextHistory,
         },
       };
     });
@@ -417,4 +442,24 @@ export function selectPillState(
     kind: snapshot.kind,
     haloUntilMs: snapshot.haloUntilMs,
   });
+}
+
+export interface AgentPeekData {
+  current: StoredActivitySnapshot | undefined;
+  history: StoredActivitySnapshot[];
+}
+
+/**
+ * Read the current snapshot + per-slug history for the Tier 2 hover peek.
+ * Returns an empty history array (not undefined) when nothing has streamed
+ * past for that slug yet, so consumers can `.map` without a guard.
+ */
+export function selectAgentPeek(
+  state: Pick<AppStore, "agentActivitySnapshots" | "agentActivityHistory">,
+  slug: string,
+): AgentPeekData {
+  return {
+    current: state.agentActivitySnapshots[slug],
+    history: state.agentActivityHistory[slug] ?? [],
+  };
 }

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -449,6 +449,13 @@ export interface AgentPeekData {
   history: StoredActivitySnapshot[];
 }
 
+// Stable empty-history reference so selectAgentPeek does not allocate a fresh
+// array on every call. Important if the selector is later subscribed via
+// Zustand — equal references avoid spurious re-renders.
+const EMPTY_AGENT_HISTORY: readonly StoredActivitySnapshot[] = Object.freeze(
+  [],
+);
+
 /**
  * Read the current snapshot + per-slug history for the Tier 2 hover peek.
  * Returns an empty history array (not undefined) when nothing has streamed
@@ -460,6 +467,8 @@ export function selectAgentPeek(
 ): AgentPeekData {
   return {
     current: state.agentActivitySnapshots[slug],
-    history: state.agentActivityHistory[slug] ?? [],
+    history:
+      state.agentActivityHistory[slug] ??
+      (EMPTY_AGENT_HISTORY as StoredActivitySnapshot[]),
   };
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -136,6 +136,9 @@
   --bubble-pulse-fade-in: 150ms;
   --bubble-text-crossfade: 180ms;
   --bubble-idle-dim-duration: 600ms;
+
+  /* Popover shadow — used by the Tier 2 hover peek card. */
+  --shadow-popover: 0 8px 24px -8px rgba(0, 0, 0, 0.32);
 }
 
 html {

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -939,6 +939,7 @@ html[data-theme="nex"]
   color: var(--text-tertiary);
   cursor: pointer;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 120ms ease-out;
   border-radius: var(--radius-sm);
 }
@@ -946,6 +947,7 @@ html[data-theme="nex"]
 .sidebar-agent-row:focus-within .sidebar-agent-peek-trigger,
 .sidebar-agent-peek-trigger[aria-expanded="true"] {
   opacity: 1;
+  pointer-events: auto;
 }
 .sidebar-agent-peek-trigger:hover {
   color: var(--text);

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2365,6 +2365,16 @@ html[data-theme="nex"]
   mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
 }
 
+/* Empty-state line — shown only when no SSE event has arrived for this
+   agent yet. Sits where the state row + detail block would normally render. */
+.sidebar-agent-peek-empty {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+  padding: 0 16px 12px;
+  font-style: italic;
+}
+
 /* RECENT header + scrollable list */
 .sidebar-agent-peek-recent-section {
   display: flex;

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -913,6 +913,53 @@ html[data-theme="nex"]
   pointer-events: none;
 }
 
+/* Tier 2 hover peek — chevron trigger.
+   The trigger is a sibling of the row button (nested <button> would be
+   invalid HTML), absolutely positioned inside the .sidebar-agent-row
+   wrapper. It sits between the pill end and the status-dot:
+   - status-dot is at right ~10-12px (row padding 10px + 6px dot)
+   - chevron sits at right 24px (10px row padding + 6px dot + 8px gap),
+     leaving ~6px between the chevron and the status-dot. */
+.sidebar-agent-row {
+  position: relative;
+}
+.sidebar-agent-peek-trigger {
+  position: absolute;
+  top: 50%;
+  right: 24px;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+  border-radius: var(--radius-sm);
+}
+.sidebar-agent-row:hover .sidebar-agent-peek-trigger,
+.sidebar-agent-row:focus-within .sidebar-agent-peek-trigger,
+.sidebar-agent-peek-trigger[aria-expanded="true"] {
+  opacity: 1;
+}
+.sidebar-agent-peek-trigger:hover {
+  color: var(--text);
+}
+.sidebar-agent-peek-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-agent-peek-trigger {
+    transition: none;
+  }
+}
+
 .sidebar-channels {
   padding: 4px var(--sidebar-pad-x) 4px;
   flex: 1 1 auto;
@@ -2155,6 +2202,242 @@ html[data-theme="nex"]
   .team-welcome-dismiss {
     align-self: flex-end;
   }
+}
+
+/* ─── Tier 2 hover peek ──────────────────────────────────────────
+   Presentational popover anchored to an agent rail row. Rendered via
+   createPortal to document.body so it floats above the sidebar without
+   triggering row reflow. Position is set by AgentEventPeek via inline
+   style; width/max-height are structural CSS.
+   See web/DESIGN.md "Tier 2 hover peek" section.
+   ─────────────────────────────────────────────────────────────── */
+.sidebar-agent-peek {
+  position: fixed;
+  width: 320px;
+  max-height: 360px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+  z-index: 60;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  outline: none;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.sidebar-agent-peek[data-stuck="true"] {
+  border-color: var(--bubble-stuck);
+}
+
+/* Open animation — slide up from 6px below the anchor. */
+@media (prefers-reduced-motion: no-preference) {
+  .sidebar-agent-peek {
+    animation: peek-in 0.14s ease-out;
+  }
+}
+@keyframes peek-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-agent-peek {
+    animation: none;
+    transition: none;
+  }
+}
+
+/* Header strip */
+.sidebar-agent-peek-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px 6px;
+  flex-shrink: 0;
+}
+.sidebar-agent-peek-avatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  user-select: none;
+}
+.sidebar-agent-peek-identity {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+  flex: 1;
+}
+.sidebar-agent-peek-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-agent-peek-role {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-agent-peek-blocked-chip {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bubble-stuck);
+  border: 1px solid var(--bubble-stuck);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+}
+
+/* State chip + relative time row */
+.sidebar-agent-peek-state-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px 8px;
+  flex-shrink: 0;
+}
+.sidebar-agent-peek-state-chip {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.sidebar-agent-peek-state-chip[data-kind="routine"] {
+  color: var(--bubble-plotting);
+  background: rgba(90, 107, 200, 0.1);
+}
+.sidebar-agent-peek-state-chip[data-kind="milestone"] {
+  color: var(--bubble-shipping);
+  background: rgba(42, 143, 76, 0.1);
+}
+.sidebar-agent-peek-state-chip[data-kind="stuck"] {
+  color: var(--bubble-stuck);
+  background: rgba(200, 84, 42, 0.1);
+}
+.sidebar-agent-peek-time {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+/* Current thought block — detail text, 3-line clamp with bottom fade */
+.sidebar-agent-peek-detail {
+  font-size: 14px;
+  color: var(--text-secondary);
+  line-height: 1.45;
+  padding: 0 12px 10px;
+  flex-shrink: 0;
+  /* 3-line clamp */
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  /* Bottom fade via mask for the last line */
+  -webkit-mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+  mask-image: linear-gradient(to bottom, black 60%, transparent 100%);
+}
+
+/* RECENT header + scrollable list */
+.sidebar-agent-peek-recent-section {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border-top: 1px solid var(--border-light);
+  flex: 1 1 auto;
+  overflow: hidden;
+}
+.sidebar-agent-peek-recent-header {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  padding: 7px 12px 4px;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+}
+.sidebar-agent-peek-recent {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 4px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+.sidebar-agent-peek-recent-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 12px;
+}
+.sidebar-agent-peek-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.sidebar-agent-peek-dot[data-kind="routine"] {
+  background: var(--bubble-plotting);
+}
+.sidebar-agent-peek-dot[data-kind="milestone"] {
+  background: var(--bubble-shipping);
+}
+.sidebar-agent-peek-dot[data-kind="stuck"] {
+  background: var(--bubble-stuck);
+}
+.sidebar-agent-peek-recent-text {
+  font-size: 11px;
+  color: var(--text-secondary);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sidebar-agent-peek-recent-time {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* Footer — plain text, not a button. Enter key drives the action. */
+.sidebar-agent-peek-footer {
+  border-top: 1px solid var(--border-light);
+  padding: 6px 12px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  user-select: none;
 }
 
 .team-member-badge {


### PR DESCRIPTION
## Summary

Closes the last deferred TODO from PR #664: Tier 2 of the agent-event-bubbles disclosure stack — a floating peek card that surfaces the richer per-agent context the live pill (Tier 1) does not have room for, without breaking the glance loop.

Memorable thing: **the peek that doesn't slow you down.** Tier 1 = glance. Tier 3 = workspace dive. Tier 2 = reward curiosity in <1s.

### What's in scope

- **Per-slug history ring buffer** in Zustand (`agentActivityHistory`, capped at `MAX_AGENT_HISTORY=8`, newest-first). Survives navigation, resets on hard reload — by design; the peek is for what just streamed past, not audit history.
- **`useAgentEventPeek(slug)`** hook: hover-intent (300ms) + close-grace (80ms) + long-press (500ms), single-instance discipline via a tiny separate Zustand atom (opening one peek closes any other).
- **`<AgentEventPeek>`** popover: `role="dialog"` portal, focus trap, Esc-close, outside-mousedown-close, anchored to the row's right edge (auto-flips left when overflow), state-color throughout (`--bubble-routine|milestone|stuck`), one new design token `--shadow-popover`.
- **Chevron opener** as a *sibling* of the row button (not nested — nested buttons are invalid HTML; the row button stays the Tier 3 fast-path with `data-agent-slug` intact). Visible on row `:hover` / `:focus-within` / when its peek is open.
- **Tier 3 escalation polish**: tapping the row closes any open peek before opening the workspace, per the plan's "quick activation always wins" semantics. Tier 2 doesn't linger as a duplicate per-agent surface alongside the workspace panel.
- **Empty state**: dialog still mounts when no SSE event has streamed for the agent yet; "no activity yet" copy + footer hint. Caught during live verification — would have shipped as a silent-fail click otherwise.
- **Stuck variant**: `--bubble-stuck` border, BLOCKED chip in header, stuck event pinned at top of recent list.
- **Reduced motion**: dialog snaps open/closed with no fade or translate; state-color border still renders (color is structural chrome, not motion).
- **Spec appended** to `web/DESIGN.md`.

### Out of scope (future work)

- **Per-event click-to-jump-to-context** from the recent list (originally deferred in plan §345). Requires extending the snapshot wire shape with a `SourceRef` field on the backend so each event carries the message/task it originated from. Bounded ~half-day backend + frontend PR; intentionally not bundled here.

### Tutorial verification (per global CLAUDE.md §1)

3 ICP tutorials written upfront as acceptance criteria; live-verified in a fresh dev build:

- **Tutorial 1 (Casey, multi-agent operator)**: hover-intent open + recent stack — chevron + dialog mount confirmed live, recent list logic exercised by tests.
- **Tutorial 2 (Marcus, keyboard SRE)**: `aria-haspopup="dialog"`, `aria-expanded` reflects state, Esc closes — confirmed live + unit-tested.
- **Tutorial 3 (Priya, touch user)**: long-press 500ms, tap-outside closes, short-tap row goes to workspace (Tier 3 fast-path preserved, `button[data-agent-slug]` regression intact, peek closes on escalation) — outside-click confirmed live, escalation unit-tested.

### Slicing

6 commits, bisectable:

1. `feat(web): per-slug agent activity history ring buffer` (store + selector + 6 new vitest cases)
2. `feat(web): useAgentEventPeek hook with multi-modal triggers` (27 vitest cases)
3. `feat(web): agent peek popover component + design tokens` (16 vitest cases)
4. `feat(web): wire Tier 2 peek into the agent rail` (chevron sibling + integration tests, e2e regression-pinned)
5. `fix(web): render Tier 2 peek when chevron opens before any SSE event` (empty-state caught during live smoke)
6. `feat(web): close Tier 2 peek on Tier 3 escalation` (workspace tap dismisses peek)

## Test plan

- [x] `bash scripts/test-web.sh` for all touched files — all green
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check --write` on touched files — clean (pre-existing baseline noise on unrelated files unchanged)
- [x] `bun run build` — production bundle compiles
- [x] Live browser smoke against the Go binary on isolated `:7898/:7897`:
  - 5 chevrons render (hidden until hover/focus/expanded)
  - Click chevron → peek opens (header + empty-state copy + footer hint)
  - Single-instance: clicking a second chevron closes the first; only 1 dialog at a time
  - Esc closes
  - Outside mousedown closes
  - Row click opens workspace (Tier 3) and `data-agent-slug` selector still resolves
- [ ] CI green
- [ ] CodeRabbit review addressed

## Notes for reviewer

- **Empty state was caught at smoke**, not in the spec. The original spec returned `null` when `current` was undefined, which made the click feel broken on fresh agents. Worth a sanity-check on the copy.
- **Chevron is a sibling, not a child** of the row button — both live inside `.sidebar-agent-row`. Nested interactive elements are invalid HTML and were the only structural blocker for the obvious "put the chevron in the pill" approach. The row button keeps `data-agent-slug` so the e2e selectors that bit us once on PR #664 stay fixed.
- **`SidebarAgentRow` extracted** to allow `useAgentEventPeek` per row (hooks-can't-be-in-loops). Same file, no new file.
- **Tier 3 escalation closes peek**: `peek.close()` runs before `setActiveAgentSlug(slug)` in the row's onClick. Mirrors the chevron's "Open workspace" footer hint pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hover peek popover for agent rows showing current activity, recent events (pinned blocked entry, up to 6), live relative timestamps, and keyboard actions (Escape/Enter).

* **Documentation**
  * Added detailed design guidance for peek positioning, animations, reduced-motion, interactions, and single-instance behavior.

* **Refactor**
  * Agent rows refactored to a dedicated row component with a separate chevron peek trigger that toggles without selecting the agent.

* **Tests**
  * Extensive tests covering peek UI, timing/interaction, pill behavior, list wiring, hook semantics, and store history.

* **Style**
  * Sidebar and popover CSS including trigger, shadow, animation, and reduced-motion styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->