### PR TITLE
feat(team): promotion_demand event + notebook_demand_index for cross-agent signals (PR 3)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -103,6 +103,7 @@ type Broker struct {
 	wikiInitErr             error
 	autoNotebookWriter      *AutoNotebookWriter
 	humanWikiWriter         *HumanWikiIntentWriter
+	demandIndex             *NotebookDemandIndex
 	wikiIndex               *WikiIndex
 	wikiExtractor           *Extractor
 	wikiDLQ                 *DLQ

--- a/internal/team/broker_notebook.go
+++ b/internal/team/broker_notebook.go
@@ -460,6 +460,29 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
 		return
 	}
+	// PR 3 (notebook-wiki-promise): cross-agent search hits feed the demand
+	// index. Searcher slug comes from the standard X-WUPHF-Agent header (the
+	// MCP server sets this on every outbound call). Per-owner hit slices are
+	// kept separate so a slug=all search records one demand event per
+	// (entry, owner) pair, not one aggregate.
+	searcherSlug := strings.TrimSpace(r.Header.Get(agentRateLimitHeader))
+	hitsByOwner := map[string][]string{}
+	recordOwnerHit := func(ownerSlug string, slugHits []WikiSearchHit) {
+		if ownerSlug == "" || len(slugHits) == 0 {
+			return
+		}
+		seen := map[string]struct{}{}
+		paths := hitsByOwner[ownerSlug]
+		for _, h := range slugHits {
+			if _, dup := seen[h.Path]; dup {
+				continue
+			}
+			seen[h.Path] = struct{}{}
+			paths = append(paths, h.Path)
+		}
+		hitsByOwner[ownerSlug] = paths
+	}
+
 	var hits []WikiSearchHit
 	if strings.EqualFold(slug, "all") {
 		searchSlugs, err := b.notebookSearchSlugs(worker)
@@ -477,6 +500,7 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 				return
 			}
+			recordOwnerHit(searchSlug, slugHits)
 			hits = append(hits, slugHits...)
 		}
 	} else {
@@ -489,6 +513,7 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
+		recordOwnerHit(slug, slugHits)
 		hits = slugHits
 	}
 	if taskID != "" {
@@ -515,6 +540,15 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"hits": hits})
+
+	// Fire-and-forget demand recording AFTER the response is written. This
+	// runs outside b.mu (the handler never acquired it). recordNotebookDemandAsync
+	// no-ops on missing index, empty slugs, or self-search.
+	if searcherSlug != "" {
+		for ownerSlug, paths := range hitsByOwner {
+			b.recordNotebookDemandAsync(ownerSlug, paths, searcherSlug)
+		}
+	}
 }
 
 func (b *Broker) notebookTaskExists(taskID string) bool {

--- a/internal/team/broker_promotion_demand_test.go
+++ b/internal/team/broker_promotion_demand_test.go
@@ -1,0 +1,233 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newPromotionDemandTestServer wires the same notebook surface as
+// newNotebookTestServer but additionally instantiates a NotebookDemandIndex
+// against a temp JSONL log. The broker's wiki worker is wired so
+// AutoEscalateDemandCandidates can verify entry existence.
+func newPromotionDemandTestServer(t *testing.T) (*httptest.Server, *Broker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	demandPath := filepath.Join(t.TempDir(), "events.jsonl")
+	idx, err := NewNotebookDemandIndex(demandPath)
+	if err != nil {
+		t.Fatalf("NewNotebookDemandIndex: %v", err)
+	}
+
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.demandIndex = idx
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/notebook/write", b.requireAuth(b.handleNotebookWrite))
+	mux.HandleFunc("/notebook/search", b.requireAuth(b.handleNotebookSearch))
+	srv := httptest.NewServer(mux)
+
+	return srv, b, func() {
+		srv.Close()
+		cancel()
+		worker.Stop()
+	}
+}
+
+func searchAs(t *testing.T, srv *httptest.Server, token, agent, ownerSlug, query string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/notebook/search?slug="+ownerSlug+"&q="+query, nil)
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if agent != "" {
+		req.Header.Set("X-WUPHF-Agent", agent)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("search status %d: %s", res.StatusCode, string(body))
+	}
+}
+
+func writeNotebookEntryHTTP(t *testing.T, srv *httptest.Server, token, slug, path, content string) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"slug":           slug,
+		"path":           path,
+		"content":        content,
+		"mode":           "create",
+		"commit_message": "test entry",
+	})
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/notebook/write", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(res.Body)
+		t.Fatalf("write status %d: %s", res.StatusCode, string(raw))
+	}
+}
+
+func waitForDemandScore(t *testing.T, idx *NotebookDemandIndex, path string, want float64) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := idx.WaitForCondition(ctx, func() bool {
+		return idx.Score(path) >= want
+	}); err != nil {
+		t.Fatalf("demand score for %q never reached %v (got %v): %v", path, want, idx.Score(path), err)
+	}
+}
+
+// TestBrokerPromotionDemand_CrossAgentSearchAccrues exercises the end-to-end
+// hook: agent A and agent C searching agent B's notebook each accrue a demand
+// event, score reaches 2.0 (cross-agent search weight 1.0 each).
+func TestBrokerPromotionDemand_CrossAgentSearchAccrues(t *testing.T) {
+	srv, b, teardown := newPromotionDemandTestServer(t)
+	defer teardown()
+	token := b.Token()
+
+	notebookPath := "agents/pm/notebook/2026-05-06-onboarding.md"
+	writeNotebookEntryHTTP(t, srv, token, "pm", notebookPath,
+		"# onboarding gotchas\n\nremember to set the bun version on first clone.\n")
+
+	// Agent A (eng) searches PM's shelf.
+	searchAs(t, srv, token, "eng", "pm", "onboarding")
+	// Agent C (design) searches PM's shelf for the same content.
+	searchAs(t, srv, token, "design", "pm", "onboarding")
+
+	idx := b.demandIndex
+	if idx == nil {
+		t.Fatalf("demand index not wired")
+	}
+	waitForDemandScore(t, idx, notebookPath, 2.0)
+
+	// Self-search by PM should NOT accrue.
+	searchAs(t, srv, token, "pm", "pm", "onboarding")
+	if got := idx.Score(notebookPath); got != 2.0 {
+		t.Fatalf("after self-search score = %v, want 2.0", got)
+	}
+
+	// Same searcher, same day → still 2.0 (deduped).
+	searchAs(t, srv, token, "eng", "pm", "onboarding")
+	if got := idx.Score(notebookPath); got != 2.0 {
+		t.Fatalf("after dup-day search score = %v, want 2.0", got)
+	}
+}
+
+// TestBrokerPromotionDemand_AutoEscalation drives the full pipeline to
+// threshold and asserts a promotion lands in ReviewLog.
+func TestBrokerPromotionDemand_AutoEscalation(t *testing.T) {
+	srv, b, teardown := newPromotionDemandTestServer(t)
+	defer teardown()
+	token := b.Token()
+
+	notebookPath := "agents/pm/notebook/2026-05-06-icp.md"
+	writeNotebookEntryHTTP(t, srv, token, "pm", notebookPath,
+		"# our ICP\n\nfounders running 3+ AI agents.\n")
+
+	// Two distinct agents searching → 2.0 (below 3.0 threshold).
+	searchAs(t, srv, token, "eng", "pm", "ICP")
+	searchAs(t, srv, token, "design", "pm", "ICP")
+
+	idx := b.demandIndex
+	waitForDemandScore(t, idx, notebookPath, 2.0)
+
+	// Add a CEO review flag (PR 4 will be doing this via an MCP tool; here
+	// we exercise the same Record API).
+	now := time.Now().UTC()
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    notebookPath,
+		OwnerSlug:    "pm",
+		SearcherSlug: "ceo",
+		Signal:       DemandSignalCEOReviewFlag,
+		RecordedAt:   now,
+	}); err != nil {
+		t.Fatalf("record CEO flag: %v", err)
+	}
+	// 2 cross-agent (1.0 each) + 1 CEO flag (1.5) = 3.5 → above default 3.0.
+	if got := idx.Score(notebookPath); got < 3.0 {
+		t.Fatalf("post-CEO score = %v, want ≥ 3.0", got)
+	}
+
+	// Wire a ReviewLog backed by the wiki repo so SubmitPromotion's path
+	// validators work the same way they would in production.
+	worker := b.WikiWorker()
+	if worker == nil {
+		t.Fatalf("wiki worker missing")
+	}
+	rl, err := NewReviewLog(ReviewLogPath(worker.Repo().Root()), nil, nil)
+	if err != nil {
+		t.Fatalf("review log: %v", err)
+	}
+	if err := idx.AutoEscalateDemandCandidates(context.Background(), rl, worker); err != nil {
+		t.Fatalf("escalate: %v", err)
+	}
+
+	reviews := rl.List("all")
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 escalated review, got %d", len(reviews))
+	}
+	if reviews[0].SourcePath != notebookPath {
+		t.Fatalf("review source_path = %q, want %q", reviews[0].SourcePath, notebookPath)
+	}
+
+	// Idempotency: re-running escalation does NOT duplicate.
+	if err := idx.AutoEscalateDemandCandidates(context.Background(), rl, worker); err != nil {
+		t.Fatalf("re-escalate: %v", err)
+	}
+	if got := len(rl.List("all")); got != 1 {
+		t.Fatalf("idempotent escalation produced %d reviews, want 1", got)
+	}
+}
+
+// TestBrokerPromotionDemand_NoIndexNoOp asserts that handleNotebookSearch
+// works (and returns 200) when the demand index is not wired. The PR must be
+// safe to revert by clearing b.demandIndex without breaking search.
+func TestBrokerPromotionDemand_NoIndexNoOp(t *testing.T) {
+	srv, b, teardown := newPromotionDemandTestServer(t)
+	defer teardown()
+	token := b.Token()
+
+	notebookPath := "agents/pm/notebook/entry.md"
+	writeNotebookEntryHTTP(t, srv, token, "pm", notebookPath, "# entry\n\nbody.\n")
+
+	// Clear the index — search must still succeed.
+	b.mu.Lock()
+	b.demandIndex = nil
+	b.mu.Unlock()
+
+	searchAs(t, srv, token, "eng", "pm", "entry")
+	// No assertion on score; we're testing absence of panic / 500.
+}

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"path/filepath"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/config"
@@ -111,6 +112,18 @@ func (b *Broker) initWikiWorker() {
 	humanWiki := NewHumanWikiIntentWriter(worker)
 	humanWiki.Start(lifecycleCtx)
 
+	// PR 3 (notebook-wiki-promise): demand index aggregates cross-agent
+	// notebook search hits and other demand signals (PRs 4 & 5) into a
+	// rolling-window score per entry. JSONL log lives under
+	// <wiki_root>/.promotion-demand/events.jsonl. A failed init is non-fatal:
+	// hooks no-op when the index is nil.
+	demandLogPath := filepath.Join(repo.Root(), ".promotion-demand", "events.jsonl")
+	demandIdx, demandErr := NewNotebookDemandIndex(demandLogPath)
+	if demandErr != nil {
+		log.Printf("wiki: promotion demand index init failed: %v", demandErr)
+		demandIdx = nil
+	}
+
 	b.mu.Lock()
 	b.wikiWorker = worker
 	b.wikiIndex = idx
@@ -119,6 +132,7 @@ func (b *Broker) initWikiWorker() {
 	b.readLog = NewReadLog(repo.Root())
 	b.autoNotebookWriter = autoWriter
 	b.humanWikiWriter = humanWiki
+	b.demandIndex = demandIdx
 	b.mu.Unlock()
 	// Init succeeded; clear any cached failure so future calls don't surface
 	// stale errors from a previous attempt.

--- a/internal/team/promotion_demand.go
+++ b/internal/team/promotion_demand.go
@@ -1,0 +1,695 @@
+package team
+
+// promotion_demand.go is PR 3 of the notebook-wiki-promise design
+// (~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md).
+//
+// It defines the cross-agent demand signal that drives auto-promotion of
+// notebook entries to the team wiki. When agent A searches agent B's notebook
+// shelf and gets a hit, the broker emits a PromotionDemandEvent. The
+// NotebookDemandIndex aggregates these events on a 7-day sliding window with
+// per-(entry, searcher, day) deduplication. Entries that breach the threshold
+// (default 3.0) are auto-escalated as pending ReviewLog promotions.
+//
+// Contract for PRs 4 and 5:
+//   - PR 4 (CEO ranking) records DemandSignalCEOReviewFlag (weight +1.5).
+//   - PR 5 (channel context-ask) records DemandSignalChannelContextAsk (+2.0).
+// Both call idx.Record(evt) with the appropriate Signal field. Weights live
+// in signalWeight() — never hardcoded inside Record.
+//
+// Lock discipline:
+//   - NotebookDemandIndex has its own idx.mu. Methods NEVER call b.mu.
+//   - The broker hook (recordNotebookDemandAsync) calls Record outside b.mu.
+//   - AutoEscalateDemandCandidates acquires idx.mu for reads, then calls
+//     ReviewLog.Submit (which has its own mutex). Never holds idx.mu while
+//     calling external code that might re-acquire idx.mu.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PromotionDemandSignal enumerates the wire-format demand signal kinds. New
+// signal types added by future PRs MUST extend this enum and the corresponding
+// signalWeight() mapping; do not invent ad-hoc weights at call sites.
+type PromotionDemandSignal int
+
+const (
+	// DemandSignalCrossAgentSearch fires when one agent searches another's
+	// notebook shelf and gets a hit. PR 3 wiring.
+	DemandSignalCrossAgentSearch PromotionDemandSignal = iota
+	// DemandSignalChannelContextAsk fires when a channel context-ask
+	// classifier matches and a notebook search returns hits. PR 5 wiring.
+	DemandSignalChannelContextAsk
+	// DemandSignalCEOReviewFlag fires when the CEO explicitly flags an
+	// entry via team_notebook_review. PR 4 wiring.
+	DemandSignalCEOReviewFlag
+	// DemandSignalRejectionCooldown applies a negative weight when a prior
+	// promotion attempt was rejected, suppressing re-escalation for the
+	// 7-day window default.
+	DemandSignalRejectionCooldown
+)
+
+// PromotionDemandEvent is the JSONL record persisted to
+// <wiki_root>/.promotion-demand/events.jsonl. Field tags are stable wire
+// format; renaming any field is a breaking change.
+type PromotionDemandEvent struct {
+	EntryPath    string                `json:"entry_path"`
+	OwnerSlug    string                `json:"owner_slug"`
+	SearcherSlug string                `json:"searcher_slug"`
+	Signal       PromotionDemandSignal `json:"signal"`
+	RecordedAt   time.Time             `json:"recorded_at"`
+}
+
+// DemandCandidate is the aggregated view of one entry's current rolling score
+// returned by TopCandidates.
+type DemandCandidate struct {
+	EntryPath string                `json:"entry_path"`
+	OwnerSlug string                `json:"owner_slug"`
+	Score     float64               `json:"score"`
+	TopSignal PromotionDemandSignal `json:"top_signal"`
+}
+
+// promotionDemandReader is the slice of WikiWorker (or fake in tests) that
+// AutoEscalateDemandCandidates needs to validate that a candidate path still
+// exists on disk before submitting it as a promotion. This avoids escalating
+// stale or hallucinated paths.
+type promotionDemandReader interface {
+	NotebookRead(path string) ([]byte, error)
+}
+
+// ErrPromotionDemandInvalid is returned by Record when the event is malformed.
+var ErrPromotionDemandInvalid = errors.New("promotion_demand: invalid event")
+
+// signalWeight maps signal kind → score weight. Single source of truth.
+// Add new signals here; do NOT scatter constants at call sites.
+func signalWeight(s PromotionDemandSignal) float64 {
+	switch s {
+	case DemandSignalCrossAgentSearch:
+		return 1.0
+	case DemandSignalChannelContextAsk:
+		return 2.0
+	case DemandSignalCEOReviewFlag:
+		return 1.5
+	case DemandSignalRejectionCooldown:
+		return -2.0
+	}
+	return 0
+}
+
+// signalLabel renders a PromotionDemandSignal as a stable string for snapshot
+// comparisons and rationale strings.
+func signalLabel(s PromotionDemandSignal) string {
+	switch s {
+	case DemandSignalCrossAgentSearch:
+		return "cross_agent_search"
+	case DemandSignalChannelContextAsk:
+		return "channel_context_ask"
+	case DemandSignalCEOReviewFlag:
+		return "ceo_review_flag"
+	case DemandSignalRejectionCooldown:
+		return "rejection_cooldown"
+	}
+	return "unknown"
+}
+
+// demandWindowDefaultDays is the rolling window over which events are summed.
+const demandWindowDefaultDays = 7
+
+// demandThresholdDefault is the minimum score that triggers auto-escalation.
+const demandThresholdDefault = 3.0
+
+// envDemandWindow names the env var that overrides the rolling-window size.
+const envDemandWindow = "WUPHF_PROMOTION_DEMAND_WINDOW_DAYS"
+
+// envDemandThreshold names the env var that overrides the auto-escalation
+// threshold.
+const envDemandThreshold = "WUPHF_PROMOTION_DEMAND_THRESHOLD"
+
+// demandRecordKey is the dedupe identity for an in-memory event: same searcher
+// hitting same entry on same UTC day collapses into one record.
+type demandRecordKey struct {
+	EntryPath    string
+	SearcherSlug string
+	Day          string // "YYYY-MM-DD" UTC
+	Signal       PromotionDemandSignal
+}
+
+// demandRecord stores one deduped event with its owner slug for later
+// score reconstruction (we need OwnerSlug when surfacing candidates).
+type demandRecord struct {
+	OwnerSlug  string
+	Signal     PromotionDemandSignal
+	RecordedAt time.Time
+}
+
+// NotebookDemandIndex aggregates PromotionDemandEvents into per-entry rolling
+// scores backed by an append-only JSONL log. All methods are safe for
+// concurrent callers.
+type NotebookDemandIndex struct {
+	logPath    string
+	windowDays int
+	threshold  float64
+
+	mu sync.Mutex
+	// events keyed by entry_path → dedupe-key → record. Two-level map keeps
+	// per-entry score computation O(events-for-entry) without scanning the
+	// global set.
+	events map[string]map[demandRecordKey]demandRecord
+	// escalated tracks entry paths that have already been submitted to the
+	// review log. Prevents AutoEscalateDemandCandidates from re-submitting
+	// the same path on every tick.
+	escalated map[string]struct{}
+	clock     func() time.Time
+
+	// progressCond signals tests that an event was recorded so they can
+	// wait deterministically without sleep loops. Same pattern as
+	// AutoNotebookWriter.
+	progressMu   sync.Mutex
+	progressCond *sync.Cond
+}
+
+// NewNotebookDemandIndex opens (or creates) the JSONL log at logPath, replays
+// existing events into the in-memory map, and returns a ready index. Window
+// and threshold honour env overrides; invalid env values fall back to the
+// defaults with a warn log.
+func NewNotebookDemandIndex(logPath string) (*NotebookDemandIndex, error) {
+	idx := &NotebookDemandIndex{
+		logPath:    logPath,
+		windowDays: resolveWindowDays(),
+		threshold:  resolveThreshold(),
+		events:     make(map[string]map[demandRecordKey]demandRecord),
+		escalated:  make(map[string]struct{}),
+		clock:      time.Now,
+	}
+	idx.progressCond = sync.NewCond(&idx.progressMu)
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		return nil, fmt.Errorf("promotion_demand: mkdir: %w", err)
+	}
+	if err := idx.replay(); err != nil {
+		return nil, err
+	}
+	return idx, nil
+}
+
+// SetClockForTest overrides the clock used for window-expiry checks. Test-only.
+func (idx *NotebookDemandIndex) SetClockForTest(clock func() time.Time) {
+	if idx == nil || clock == nil {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	idx.clock = clock
+}
+
+// Threshold returns the configured auto-escalation threshold. Useful for
+// observability surfaces.
+func (idx *NotebookDemandIndex) Threshold() float64 {
+	if idx == nil {
+		return demandThresholdDefault
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	return idx.threshold
+}
+
+// WindowDays returns the configured sliding-window length in days.
+func (idx *NotebookDemandIndex) WindowDays() int {
+	if idx == nil {
+		return demandWindowDefaultDays
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	return idx.windowDays
+}
+
+func resolveWindowDays() int {
+	raw := strings.TrimSpace(os.Getenv(envDemandWindow))
+	if raw == "" {
+		return demandWindowDefaultDays
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		log.Printf("promotion_demand: invalid %s=%q; using default %d", envDemandWindow, raw, demandWindowDefaultDays)
+		return demandWindowDefaultDays
+	}
+	return v
+}
+
+func resolveThreshold() float64 {
+	raw := strings.TrimSpace(os.Getenv(envDemandThreshold))
+	if raw == "" {
+		return demandThresholdDefault
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v <= 0 {
+		log.Printf("promotion_demand: invalid %s=%q; using default %g", envDemandThreshold, raw, demandThresholdDefault)
+		return demandThresholdDefault
+	}
+	return v
+}
+
+// truncateToDay returns the YYYY-MM-DD UTC string for the dedupe day bucket.
+func truncateToDay(t time.Time) string {
+	return t.UTC().Format("2006-01-02")
+}
+
+// Record persists a demand event (append to JSONL) and updates the in-memory
+// score map. Same-day duplicates from the same searcher on the same entry
+// collapse into one record.
+func (idx *NotebookDemandIndex) Record(evt PromotionDemandEvent) error {
+	if idx == nil {
+		return ErrPromotionDemandInvalid
+	}
+	if strings.TrimSpace(evt.EntryPath) == "" {
+		return fmt.Errorf("%w: entry_path is required", ErrPromotionDemandInvalid)
+	}
+	if strings.TrimSpace(evt.OwnerSlug) == "" {
+		return fmt.Errorf("%w: owner_slug is required", ErrPromotionDemandInvalid)
+	}
+	if evt.RecordedAt.IsZero() {
+		evt.RecordedAt = time.Now().UTC()
+	} else {
+		evt.RecordedAt = evt.RecordedAt.UTC()
+	}
+	key := demandRecordKey{
+		EntryPath:    evt.EntryPath,
+		SearcherSlug: evt.SearcherSlug,
+		Day:          truncateToDay(evt.RecordedAt),
+		Signal:       evt.Signal,
+	}
+
+	idx.mu.Lock()
+	bucket, ok := idx.events[evt.EntryPath]
+	if !ok {
+		bucket = make(map[demandRecordKey]demandRecord)
+		idx.events[evt.EntryPath] = bucket
+	}
+	if _, dup := bucket[key]; dup {
+		idx.mu.Unlock()
+		// Same searcher, same entry, same day, same signal → collapse.
+		// Signal progress so tests waiting on Record completion (even on a
+		// dup) make forward progress.
+		idx.signalProgress()
+		return nil
+	}
+	bucket[key] = demandRecord{
+		OwnerSlug:  evt.OwnerSlug,
+		Signal:     evt.Signal,
+		RecordedAt: evt.RecordedAt,
+	}
+	err := idx.appendLocked(evt)
+	idx.mu.Unlock()
+	idx.signalProgress()
+	return err
+}
+
+// signalProgress wakes any goroutine parked in WaitForCondition. Cheap.
+func (idx *NotebookDemandIndex) signalProgress() {
+	idx.progressMu.Lock()
+	idx.progressCond.Broadcast()
+	idx.progressMu.Unlock()
+}
+
+// WaitForCondition blocks until predicate returns true or ctx is cancelled.
+// Test-only helper modelled on AutoNotebookWriter.WaitForCondition.
+func (idx *NotebookDemandIndex) WaitForCondition(ctx context.Context, predicate func() bool) error {
+	if idx == nil {
+		return nil
+	}
+	if predicate() {
+		return nil
+	}
+	cancelWatcher := make(chan struct{})
+	defer close(cancelWatcher)
+	go func() {
+		select {
+		case <-ctx.Done():
+			idx.progressMu.Lock()
+			idx.progressCond.Broadcast()
+			idx.progressMu.Unlock()
+		case <-cancelWatcher:
+		}
+	}()
+	idx.progressMu.Lock()
+	defer idx.progressMu.Unlock()
+	for !predicate() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		idx.progressCond.Wait()
+	}
+	return nil
+}
+
+// Score returns the current rolling-window score for entryPath. Events older
+// than windowDays are excluded.
+func (idx *NotebookDemandIndex) Score(entryPath string) float64 {
+	if idx == nil {
+		return 0
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	return idx.scoreLocked(entryPath)
+}
+
+func (idx *NotebookDemandIndex) scoreLocked(entryPath string) float64 {
+	bucket, ok := idx.events[entryPath]
+	if !ok {
+		return 0
+	}
+	cutoff := idx.clock().UTC().Add(-time.Duration(idx.windowDays) * 24 * time.Hour)
+	var total float64
+	for _, rec := range bucket {
+		if rec.RecordedAt.Before(cutoff) {
+			continue
+		}
+		total += signalWeight(rec.Signal)
+	}
+	return total
+}
+
+// TopCandidates returns up to n candidates sorted by descending score. Entries
+// with zero or negative score are excluded.
+func (idx *NotebookDemandIndex) TopCandidates(n int) []DemandCandidate {
+	if idx == nil || n <= 0 {
+		return nil
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+	out := make([]DemandCandidate, 0, len(idx.events))
+	cutoff := idx.clock().UTC().Add(-time.Duration(idx.windowDays) * 24 * time.Hour)
+	for path, bucket := range idx.events {
+		var score float64
+		var topSignal PromotionDemandSignal
+		var topWeight float64
+		var owner string
+		for _, rec := range bucket {
+			if rec.RecordedAt.Before(cutoff) {
+				continue
+			}
+			w := signalWeight(rec.Signal)
+			score += w
+			if w > topWeight {
+				topWeight = w
+				topSignal = rec.Signal
+			}
+			if owner == "" {
+				owner = rec.OwnerSlug
+			}
+		}
+		if score <= 0 {
+			continue
+		}
+		out = append(out, DemandCandidate{
+			EntryPath: path,
+			OwnerSlug: owner,
+			Score:     score,
+			TopSignal: topSignal,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].EntryPath < out[j].EntryPath
+	})
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+// AutoEscalateDemandCandidates submits any entry whose rolling score has
+// breached the threshold to the review log as a new pending promotion.
+// Idempotent: an entry already escalated (in-memory tracker) is not
+// re-submitted, and entries whose path no longer exists on disk are skipped.
+func (idx *NotebookDemandIndex) AutoEscalateDemandCandidates(
+	ctx context.Context,
+	reviewLog *ReviewLog,
+	reader promotionDemandReader,
+) error {
+	if idx == nil || reviewLog == nil {
+		return nil
+	}
+	_ = ctx // reserved for future cancellation; current path is fast.
+
+	// Collect candidates above threshold under idx.mu, then release before
+	// calling out to ReviewLog (which acquires its own mutex). Never hold
+	// idx.mu across an external call.
+	idx.mu.Lock()
+	candidates := make([]DemandCandidate, 0, len(idx.events))
+	cutoff := idx.clock().UTC().Add(-time.Duration(idx.windowDays) * 24 * time.Hour)
+	for path, bucket := range idx.events {
+		if _, already := idx.escalated[path]; already {
+			continue
+		}
+		var score float64
+		var topSignal PromotionDemandSignal
+		var topWeight float64
+		var owner string
+		for _, rec := range bucket {
+			if rec.RecordedAt.Before(cutoff) {
+				continue
+			}
+			w := signalWeight(rec.Signal)
+			score += w
+			if w > topWeight {
+				topWeight = w
+				topSignal = rec.Signal
+			}
+			if owner == "" {
+				owner = rec.OwnerSlug
+			}
+		}
+		if score >= idx.threshold && owner != "" {
+			candidates = append(candidates, DemandCandidate{
+				EntryPath: path,
+				OwnerSlug: owner,
+				Score:     score,
+				TopSignal: topSignal,
+			})
+		}
+	}
+	threshold := idx.threshold
+	idx.mu.Unlock()
+
+	// Pre-check ReviewLog for any prior pending/in-review/changes-requested
+	// promotion on this source_path so we don't stack duplicates across
+	// process restarts (in-memory escalated map is empty after replay).
+	existing := pendingSourcePathSet(reviewLog)
+
+	for _, c := range candidates {
+		if _, dup := existing[c.EntryPath]; dup {
+			// Mark as escalated locally so we skip it next time without
+			// re-listing the review log.
+			idx.markEscalated(c.EntryPath)
+			continue
+		}
+		// Validate the entry path is still on disk before promoting. Stale
+		// or hallucinated paths get skipped, not submitted.
+		if reader != nil {
+			if _, err := reader.NotebookRead(c.EntryPath); err != nil {
+				log.Printf("promotion_demand: skipping missing entry %q: %v", c.EntryPath, err)
+				idx.markEscalated(c.EntryPath)
+				continue
+			}
+		}
+		targetPath := autoPromoteTargetPath(c.EntryPath)
+		rationale := fmt.Sprintf("auto-escalated by demand index: score=%.2f top_signal=%s threshold=%.2f",
+			c.Score, signalLabel(c.TopSignal), threshold)
+		_, err := reviewLog.SubmitPromotion(SubmitPromotionRequest{
+			SourceSlug: c.OwnerSlug,
+			SourcePath: c.EntryPath,
+			TargetPath: targetPath,
+			Rationale:  rationale,
+		})
+		if err != nil {
+			log.Printf("promotion_demand: SubmitPromotion failed for %q: %v", c.EntryPath, err)
+			continue
+		}
+		idx.markEscalated(c.EntryPath)
+	}
+	return nil
+}
+
+func (idx *NotebookDemandIndex) markEscalated(path string) {
+	idx.mu.Lock()
+	idx.escalated[path] = struct{}{}
+	idx.mu.Unlock()
+}
+
+// pendingSourcePathSet returns the set of source_paths currently held by the
+// ReviewLog in non-terminal state. Used to dedupe escalation across process
+// restarts where the in-memory escalated map is empty.
+func pendingSourcePathSet(rl *ReviewLog) map[string]struct{} {
+	out := map[string]struct{}{}
+	if rl == nil {
+		return out
+	}
+	for _, p := range rl.List("all") {
+		if p == nil {
+			continue
+		}
+		switch p.State {
+		case PromotionPending, PromotionInReview, PromotionChangesRequested, PromotionApproved:
+			out[p.SourcePath] = struct{}{}
+		}
+	}
+	return out
+}
+
+// autoPromoteTargetPath maps a notebook entry path to the proposed wiki team
+// path. Format: team/{date-stem}-from-{slug}.md where date-stem is the
+// notebook filename without extension. The reviewer can rename during approve;
+// this is the proposed default.
+func autoPromoteTargetPath(notebookPath string) string {
+	base := filepath.Base(notebookPath)
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	parts := strings.SplitN(notebookPath, "/", 4)
+	slug := "agent"
+	if len(parts) >= 2 && parts[0] == "agents" {
+		slug = parts[1]
+	}
+	return fmt.Sprintf("team/%s-from-%s.md", stem, slug)
+}
+
+// appendLocked persists one event to the JSONL log. Caller holds idx.mu.
+// The file is opened in append mode for each call — the broker is single-process
+// so per-call open/close is acceptable for the expected ≤50 events/day rate.
+func (idx *NotebookDemandIndex) appendLocked(evt PromotionDemandEvent) error {
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return fmt.Errorf("promotion_demand: marshal: %w", err)
+	}
+	f, err := os.OpenFile(idx.logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("promotion_demand: open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("promotion_demand: write: %w", err)
+	}
+	return nil
+}
+
+// replay rebuilds the in-memory score map from the JSONL log on startup.
+// Malformed lines are SKIPPED with a warn log so a single corrupted record
+// never costs the whole history. Events older than the window are dropped
+// at replay time — they will not contribute to scores anyway, and keeping
+// them in memory wastes bytes on a long-lived process.
+func (idx *NotebookDemandIndex) replay() error {
+	f, err := os.Open(idx.logPath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil // empty log; nothing to replay.
+		}
+		return fmt.Errorf("promotion_demand: open for replay: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	cutoff := idx.clock().UTC().Add(-time.Duration(idx.windowDays) * 24 * time.Hour)
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 4096), 1<<20)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var evt PromotionDemandEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			log.Printf("promotion_demand: skipping malformed line: %v", err)
+			continue
+		}
+		evt.RecordedAt = evt.RecordedAt.UTC()
+		if evt.RecordedAt.Before(cutoff) {
+			continue
+		}
+		key := demandRecordKey{
+			EntryPath:    evt.EntryPath,
+			SearcherSlug: evt.SearcherSlug,
+			Day:          truncateToDay(evt.RecordedAt),
+			Signal:       evt.Signal,
+		}
+		bucket, ok := idx.events[evt.EntryPath]
+		if !ok {
+			bucket = make(map[demandRecordKey]demandRecord)
+			idx.events[evt.EntryPath] = bucket
+		}
+		bucket[key] = demandRecord{
+			OwnerSlug:  evt.OwnerSlug,
+			Signal:     evt.Signal,
+			RecordedAt: evt.RecordedAt,
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("promotion_demand: replay scan: %w", err)
+	}
+	return nil
+}
+
+// recordNotebookDemandAsync is the broker-side helper invoked from
+// handleNotebookSearch. Non-blocking: dispatches one Record call per (path,
+// owner) pair on a small goroutine so the HTTP response is never delayed by
+// JSONL writes. Safe to call with a nil index — no-op.
+//
+// Lock invariant: caller MUST NOT hold b.mu. The goroutine never re-enters
+// b.mu and the index uses its own mutex.
+func (b *Broker) recordNotebookDemandAsync(ownerSlug string, hitPaths []string, searcherSlug string) {
+	if b == nil {
+		return
+	}
+	idx := b.demandIndex
+	if idx == nil || len(hitPaths) == 0 {
+		return
+	}
+	ownerSlug = strings.TrimSpace(ownerSlug)
+	searcherSlug = strings.TrimSpace(searcherSlug)
+	if ownerSlug == "" || searcherSlug == "" || ownerSlug == searcherSlug {
+		return
+	}
+	// Snapshot inputs so the caller's slice can be mutated without affecting
+	// the goroutine.
+	paths := make([]string, 0, len(hitPaths))
+	seen := map[string]struct{}{}
+	for _, p := range hitPaths {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		paths = append(paths, p)
+	}
+	if len(paths) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	go func() {
+		for _, path := range paths {
+			evt := PromotionDemandEvent{
+				EntryPath:    path,
+				OwnerSlug:    ownerSlug,
+				SearcherSlug: searcherSlug,
+				Signal:       DemandSignalCrossAgentSearch,
+				RecordedAt:   now,
+			}
+			if err := idx.Record(evt); err != nil {
+				log.Printf("promotion_demand: Record failed path=%s: %v", path, err)
+			}
+		}
+	}()
+}

--- a/internal/team/promotion_demand_test.go
+++ b/internal/team/promotion_demand_test.go
@@ -1,0 +1,473 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fakeAutoNotebookWriterClient implements autoNotebookWriterClient so the
+// AutoEscalateDemandCandidates path can validate entry existence via NotebookRead.
+type fakeAutoNotebookWriterClient struct {
+	existing map[string]string
+	readErr  error
+}
+
+func (f *fakeAutoNotebookWriterClient) NotebookWrite(_ context.Context, slug, path, content, mode, _ string) (string, int, error) {
+	_ = slug
+	_ = path
+	_ = content
+	_ = mode
+	return "deadbeef", 0, nil
+}
+
+// fakeNotebookReader exposes NotebookRead so AutoEscalateDemandCandidates can
+// verify the entry path exists before submitting it to ReviewLog.
+type fakeNotebookReader struct {
+	existing map[string]string
+	readErr  error
+}
+
+func (f *fakeNotebookReader) NotebookRead(path string) ([]byte, error) {
+	if f == nil {
+		return nil, os.ErrNotExist
+	}
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	body, ok := f.existing[path]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return []byte(body), nil
+}
+
+func newDemandIndex(t *testing.T) *NotebookDemandIndex {
+	t.Helper()
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+	idx, err := NewNotebookDemandIndex(logPath)
+	if err != nil {
+		t.Fatalf("NewNotebookDemandIndex: %v", err)
+	}
+	return idx
+}
+
+func TestSignalWeight_Mapping(t *testing.T) {
+	cases := []struct {
+		signal PromotionDemandSignal
+		want   float64
+	}{
+		{DemandSignalCrossAgentSearch, 1.0},
+		{DemandSignalChannelContextAsk, 2.0},
+		{DemandSignalCEOReviewFlag, 1.5},
+		{DemandSignalRejectionCooldown, -2.0},
+	}
+	for _, c := range cases {
+		if got := signalWeight(c.signal); got != c.want {
+			t.Fatalf("signalWeight(%d) = %v, want %v", c.signal, got, c.want)
+		}
+	}
+}
+
+func TestDemandScoring_CrossAgentSearch(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	path := "agents/pm/notebook/2026-05-06-retro.md"
+
+	// Two distinct agents searching the same entry → score = 2.0.
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now,
+	}); err != nil {
+		t.Fatalf("record 1: %v", err)
+	}
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "design",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("record 2: %v", err)
+	}
+	if got := idx.Score(path); got != 2.0 {
+		t.Fatalf("score after 2 distinct searchers = %v, want 2.0", got)
+	}
+
+	// Same agent re-searching same entry within 24h → still 2.0 (deduped).
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(2 * time.Hour),
+	}); err != nil {
+		t.Fatalf("record dup: %v", err)
+	}
+	if got := idx.Score(path); got != 2.0 {
+		t.Fatalf("score after same-day dup = %v, want 2.0", got)
+	}
+
+	// Third distinct agent → 3.0.
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "ops",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(3 * time.Hour),
+	}); err != nil {
+		t.Fatalf("record 3: %v", err)
+	}
+	if got := idx.Score(path); got != 3.0 {
+		t.Fatalf("score after 3 distinct searchers = %v, want 3.0", got)
+	}
+}
+
+func TestDemandScoring_DifferentDays(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	path := "agents/pm/notebook/entry.md"
+
+	// Same agent, different days → both events count.
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now,
+	}); err != nil {
+		t.Fatalf("day1: %v", err)
+	}
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(25 * time.Hour),
+	}); err != nil {
+		t.Fatalf("day2: %v", err)
+	}
+	if got := idx.Score(path); got != 2.0 {
+		t.Fatalf("score across 2 days = %v, want 2.0", got)
+	}
+}
+
+func TestDemandScoring_RejectionCooldown(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	path := "agents/pm/notebook/entry.md"
+
+	// Build score above threshold (3 distinct searchers).
+	for _, slug := range []string{"eng", "design", "ops"} {
+		if err := idx.Record(PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		}); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	if got := idx.Score(path); got != 3.0 {
+		t.Fatalf("pre-rejection score = %v, want 3.0", got)
+	}
+	// Add a rejection cooldown — score drops below threshold.
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "ceo",
+		Signal:       DemandSignalRejectionCooldown,
+		RecordedAt:   now,
+	}); err != nil {
+		t.Fatalf("rejection: %v", err)
+	}
+	if got := idx.Score(path); got != 1.0 {
+		t.Fatalf("post-rejection score = %v, want 1.0", got)
+	}
+}
+
+func TestDemandScoring_WindowExpiry(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	path := "agents/pm/notebook/old.md"
+
+	// Event 8 days ago → outside default 7d window.
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(-8 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("old: %v", err)
+	}
+	// Event 1 day ago → in window.
+	if err := idx.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "design",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(-24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("recent: %v", err)
+	}
+	idx.SetClockForTest(func() time.Time { return now })
+	if got := idx.Score(path); got != 1.0 {
+		t.Fatalf("score with window expiry = %v, want 1.0 (only recent event counts)", got)
+	}
+}
+
+func TestAutoEscalate_ThresholdBreach(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
+
+	path := "agents/pm/notebook/onboarding.md"
+	// 3 distinct searchers → score 3.0 hits threshold.
+	for _, slug := range []string{"eng", "design", "ops"} {
+		if err := idx.Record(PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		}); err != nil {
+			t.Fatalf("record: %v", err)
+		}
+	}
+
+	// Set up a real ReviewLog backed by t.TempDir().
+	rl, err := NewReviewLog(filepath.Join(t.TempDir(), "reviews.jsonl"), nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("review log: %v", err)
+	}
+
+	reader := &fakeNotebookReader{existing: map[string]string{
+		path: "# onboarding\n\ngotchas",
+	}}
+	if err := idx.AutoEscalateDemandCandidates(context.Background(), rl, reader); err != nil {
+		t.Fatalf("escalate: %v", err)
+	}
+	reviews := rl.List("all")
+	if len(reviews) != 1 {
+		t.Fatalf("expected 1 escalated review, got %d", len(reviews))
+	}
+	if reviews[0].SourcePath != path {
+		t.Fatalf("source path = %q, want %q", reviews[0].SourcePath, path)
+	}
+	if reviews[0].SourceSlug != "pm" {
+		t.Fatalf("source slug = %q, want pm", reviews[0].SourceSlug)
+	}
+}
+
+func TestAutoEscalate_Idempotent(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
+
+	path := "agents/pm/notebook/onboarding.md"
+	for _, slug := range []string{"eng", "design", "ops"} {
+		if err := idx.Record(PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		}); err != nil {
+			t.Fatalf("record: %v", err)
+		}
+	}
+
+	rl, err := NewReviewLog(filepath.Join(t.TempDir(), "reviews.jsonl"), nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("review log: %v", err)
+	}
+	reader := &fakeNotebookReader{existing: map[string]string{
+		path: "# onboarding\n\ngotchas",
+	}}
+	// First escalation creates a review.
+	if err := idx.AutoEscalateDemandCandidates(context.Background(), rl, reader); err != nil {
+		t.Fatalf("escalate1: %v", err)
+	}
+	// Second escalation should NOT create a duplicate.
+	if err := idx.AutoEscalateDemandCandidates(context.Background(), rl, reader); err != nil {
+		t.Fatalf("escalate2: %v", err)
+	}
+	reviews := rl.List("all")
+	if len(reviews) != 1 {
+		t.Fatalf("idempotent escalation produced %d reviews, want 1", len(reviews))
+	}
+}
+
+func TestAutoEscalate_MissingEntry(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
+
+	path := "agents/pm/notebook/nonexistent.md"
+	for _, slug := range []string{"eng", "design", "ops"} {
+		if err := idx.Record(PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		}); err != nil {
+			t.Fatalf("record: %v", err)
+		}
+	}
+	rl, err := NewReviewLog(filepath.Join(t.TempDir(), "reviews.jsonl"), nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("review log: %v", err)
+	}
+	// Reader returns ErrNotExist for everything → escalation must skip.
+	reader := &fakeNotebookReader{existing: map[string]string{}}
+	if err := idx.AutoEscalateDemandCandidates(context.Background(), rl, reader); err != nil {
+		t.Fatalf("escalate: %v", err)
+	}
+	if got := len(rl.List("all")); got != 0 {
+		t.Fatalf("missing entry produced %d reviews, want 0", got)
+	}
+}
+
+func TestNotebookDemandIndex_ReloadFromJSONL(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	path := "agents/pm/notebook/entry.md"
+
+	idx1, err := NewNotebookDemandIndex(logPath)
+	if err != nil {
+		t.Fatalf("init1: %v", err)
+	}
+	idx1.SetClockForTest(func() time.Time { return now })
+	for _, slug := range []string{"eng", "design"} {
+		if err := idx1.Record(PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		}); err != nil {
+			t.Fatalf("record: %v", err)
+		}
+	}
+	if got := idx1.Score(path); got != 2.0 {
+		t.Fatalf("idx1 score = %v, want 2.0", got)
+	}
+
+	// Reopen the index against the same JSONL — events must replay.
+	idx2, err := NewNotebookDemandIndex(logPath)
+	if err != nil {
+		t.Fatalf("init2: %v", err)
+	}
+	idx2.SetClockForTest(func() time.Time { return now })
+	if got := idx2.Score(path); got != 2.0 {
+		t.Fatalf("idx2 score after reload = %v, want 2.0", got)
+	}
+}
+
+func TestNotebookDemandIndex_ReloadDropsExpired(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "events.jsonl")
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	path := "agents/pm/notebook/entry.md"
+
+	idx1, err := NewNotebookDemandIndex(logPath)
+	if err != nil {
+		t.Fatalf("init1: %v", err)
+	}
+	idx1.SetClockForTest(func() time.Time { return now })
+	// Old event (10 days ago) gets persisted.
+	if err := idx1.Record(PromotionDemandEvent{
+		EntryPath:    path,
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now.Add(-10 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	// Reopen with current clock — event should be outside the 7d window.
+	idx2, err := NewNotebookDemandIndex(logPath)
+	if err != nil {
+		t.Fatalf("init2: %v", err)
+	}
+	idx2.SetClockForTest(func() time.Time { return now })
+	if got := idx2.Score(path); got != 0 {
+		t.Fatalf("expired event score = %v, want 0", got)
+	}
+}
+
+func TestTopCandidates_SortedDescending(t *testing.T) {
+	idx := newDemandIndex(t)
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
+
+	// path A: 3 hits
+	for _, slug := range []string{"eng", "design", "ops"} {
+		_ = idx.Record(PromotionDemandEvent{
+			EntryPath:    "agents/pm/notebook/a.md",
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		})
+	}
+	// path B: 1 hit
+	_ = idx.Record(PromotionDemandEvent{
+		EntryPath:    "agents/pm/notebook/b.md",
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   now,
+	})
+	// path C: 2 hits
+	for _, slug := range []string{"eng", "design"} {
+		_ = idx.Record(PromotionDemandEvent{
+			EntryPath:    "agents/pm/notebook/c.md",
+			OwnerSlug:    "pm",
+			SearcherSlug: slug,
+			Signal:       DemandSignalCrossAgentSearch,
+			RecordedAt:   now,
+		})
+	}
+	got := idx.TopCandidates(10)
+	if len(got) != 3 {
+		t.Fatalf("len = %d, want 3", len(got))
+	}
+	if got[0].EntryPath != "agents/pm/notebook/a.md" || got[0].Score != 3.0 {
+		t.Fatalf("top = %+v, want a.md / 3.0", got[0])
+	}
+	if got[1].EntryPath != "agents/pm/notebook/c.md" || got[1].Score != 2.0 {
+		t.Fatalf("mid = %+v, want c.md / 2.0", got[1])
+	}
+	if got[2].EntryPath != "agents/pm/notebook/b.md" || got[2].Score != 1.0 {
+		t.Fatalf("low = %+v, want b.md / 1.0", got[2])
+	}
+}
+
+func TestRecord_RejectsEmptyPath(t *testing.T) {
+	idx := newDemandIndex(t)
+	err := idx.Record(PromotionDemandEvent{
+		EntryPath:    "",
+		OwnerSlug:    "pm",
+		SearcherSlug: "eng",
+		Signal:       DemandSignalCrossAgentSearch,
+		RecordedAt:   time.Now(),
+	})
+	if err == nil {
+		t.Fatalf("expected error on empty entry_path")
+	}
+	if !errors.Is(err, ErrPromotionDemandInvalid) {
+		t.Fatalf("err = %v, want ErrPromotionDemandInvalid", err)
+	}
+}


### PR DESCRIPTION
## Summary

PR 3 of the [notebook-wiki-promise](#660) series. Defines the `promotion_demand` event contract and `NotebookDemandIndex` that **PR 4** (CEO ranking MCP) and **PR 5** (channel context-ask classifier) will both consume.

When agent A searches agent B's notebook shelf via `notebook_search` and gets a hit, the broker emits a `PromotionDemandEvent`. The index aggregates events on a 7-day sliding window with per-`(entry, searcher, day)` deduplication. Entries that breach the threshold (default 3.0) are auto-escalated as pending `ReviewLog` promotions.

## Architecture

| Concern | Decision |
|---|---|
| Signal weights | Single source of truth via `signalWeight()` helper. PRs 4/5 add new `PromotionDemandSignal` enum values without touching `Record`. Forward-compatible. |
| Lock discipline | `idx.mu` is fully separate from `b.mu`. Hook fires outside `b.mu` in its own goroutine. |
| Persistence | JSONL log at `<wiki_root>/.promotion-demand/events.jsonl` survives broker restart. Replay drops out-of-window events at startup. |
| Idempotent escalation | In-memory tracker plus `ReviewLog` source-path scan dedupe across process restarts. |
| Hallucination guard | Path-existence check via `NotebookRead` interface before escalation (forward-compat with PR 6 LLM sweeper). |
| Searcher slug | Read from `X-WUPHF-Agent` header (mirrors `handleReviewList`). No new query param. |
| `slug=all` semantics | One demand event per `(entry, owner)` pair, never aggregated. |
| Self-search | `slug == X-WUPHF-Agent` → no event recorded. |

## Env knobs

- `WUPHF_PROMOTION_DEMAND_WINDOW_DAYS` (default `7`)
- `WUPHF_PROMOTION_DEMAND_THRESHOLD` (default `3.0`)

## Tests

| File | Count | Coverage |
|---|---|---|
| `promotion_demand_test.go` | 12 unit | signal-weight mapping, cross-agent additive scoring, same-day dedup, different-day count, rejection cooldown, window expiry, threshold breach + escalation with real `ReviewLog`, idempotency across restarts, missing-entry skip, JSONL reload, `TopCandidates` ordering, empty-path rejection |
| `broker_promotion_demand_test.go` | 3 integration | cross-agent search via httptest server with `X-WUPHF-Agent` header (eng + design → 2.0; self-search no-op; same-day dedup), full pipeline to threshold + escalation, nil-index no-op (revert safety) |

Full `internal/team` race-on suite: **79.8s green**.

## Test plan
- [x] `go build ./...`
- [x] `go test -count=1 -race -timeout 600s ./internal/team/`
- [x] `gofmt -l internal/team/` empty
- [x] `go vet ./internal/team/...`
- [x] `golangci-lint run ./internal/team/...` 0 issues
- [x] `bash scripts/check-no-new-sleeps-in-tests.sh` clean
- [ ] **Manual:** two agents search a third agent's notebook → observe `events.jsonl` grow → third distinct searcher pushes the entry into `/reviews` as a pending promotion
- [ ] **Manual:** \`WUPHF_PROMOTION_DEMAND_THRESHOLD=2.0\` env override lowers escalation bar
- [ ] **Manual:** self-search (slug == X-WUPHF-Agent) does not accrue
- [ ] **Manual:** \`slug=all\` multi-owner search records one event per (entry, owner) pair

## Deferred
- Periodic broker tick that calls \`AutoEscalateDemandCandidates\` — lands with PR 6's adaptive cadence sweep.
- \`DemandSignalRejectionCooldown\` weight is wired and tested; the broker hook that records it lives in PR 4/5 reject paths.
- JSONL log compaction (spec defers past 100K lines; current rate ≤50/day).

## What's next
- PR 4: \`team_notebook_review\` MCP tool + ranking surface that consumes \`TopCandidates\`.
- PR 5: channel intent classifier that records \`DemandSignalChannelContextAsk\` via \`idx.Record\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)