### PR TITLE
feat(team): team_notebook_review MCP + /notebook/review-candidates endpoint (PR 4)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -466,6 +466,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/notebook/catalog", b.requireAuth(b.handleNotebookCatalog))
 	mux.HandleFunc("/notebook/search", b.requireAuth(b.handleNotebookSearch))
 	mux.HandleFunc("/notebook/promote", b.requireAuth(b.handleNotebookPromote))
+	mux.HandleFunc("/notebook/review-candidates", b.requireAuth(b.handleNotebookReviewCandidates))
 	mux.HandleFunc("/review/list", b.requireAuth(b.handleReviewList))
 	mux.HandleFunc("/review/", b.requireAuth(b.handleReviewSubpath))
 	mux.HandleFunc("/entity/fact", b.requireAuth(b.handleEntityFact))

--- a/internal/team/broker_notebook_review.go
+++ b/internal/team/broker_notebook_review.go
@@ -1,0 +1,186 @@
+package team
+
+// broker_notebook_review.go is PR 4 of the notebook-wiki-promise design.
+//
+// It exposes the demand-index ranking surface to the MCP layer so the CEO
+// agent can call team_notebook_review and see which notebook entries the
+// rest of the team is implicitly asking for. PR 3 already records the
+// signals; this file just hands them out and accepts CEO-flag writes.
+//
+// Lock discipline:
+//   - Handlers never touch b.mu. They read b.demandIndex under that index's
+//     own mutex (via TopCandidates / Record) and snippet bytes via the
+//     wiki worker (its own locking). No re-entry into broker state.
+//   - When b.demandIndex is nil (e.g. PR 4 lands without PR 3 wiring on a
+//     reverted branch), the endpoint returns 503 instead of crashing.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// notebookReviewCandidatesDefaultN is the default page size when the caller
+// does not pass ?n=. 20 matches the spec's TopCandidates(20) ceiling and
+// stays well under the MCP tool's response budget.
+const notebookReviewCandidatesDefaultN = 20
+
+// notebookReviewCandidatesMaxN bounds the caller-supplied n to keep the
+// response small. 100 is generous; anything above is almost certainly a
+// misuse of the endpoint.
+const notebookReviewCandidatesMaxN = 100
+
+// notebookReviewFlagRequest is the POST body shape used to record CEO flag
+// signals. EntryPaths is the only required field; Actor falls back to the
+// X-WUPHF-Agent header when omitted.
+type notebookReviewFlagRequest struct {
+	EntryPaths []string `json:"entry_paths"`
+	Actor      string   `json:"actor,omitempty"`
+}
+
+// handleNotebookReviewCandidates serves both:
+//
+//	GET  /notebook/review-candidates[?n=N]   → []DemandCandidate ranked
+//	POST /notebook/review-candidates         → record DemandSignalCEOReviewFlag
+//
+// The endpoint is forward-compat: a broker without PR 3's demandIndex wired
+// returns 503 with a stable error string, so the MCP tool can degrade
+// gracefully without crashing the office.
+func (b *Broker) handleNotebookReviewCandidates(w http.ResponseWriter, r *http.Request) {
+	idx := b.demandIndex
+	if idx == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "demand index not active"})
+		return
+	}
+	switch r.Method {
+	case http.MethodGet:
+		b.serveNotebookReviewCandidatesGET(w, r, idx)
+	case http.MethodPost:
+		b.serveNotebookReviewCandidatesPOST(w, r, idx)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (b *Broker) serveNotebookReviewCandidatesGET(w http.ResponseWriter, r *http.Request, idx *NotebookDemandIndex) {
+	n := notebookReviewCandidatesDefaultN
+	if raw := strings.TrimSpace(r.URL.Query().Get("n")); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil || v <= 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "n must be a positive integer"})
+			return
+		}
+		if v > notebookReviewCandidatesMaxN {
+			v = notebookReviewCandidatesMaxN
+		}
+		n = v
+	}
+	candidates := idx.TopCandidates(n)
+	if candidates == nil {
+		candidates = []DemandCandidate{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"candidates": candidates,
+		"threshold":  idx.Threshold(),
+		"window":     idx.WindowDays(),
+	})
+}
+
+func (b *Broker) serveNotebookReviewCandidatesPOST(w http.ResponseWriter, r *http.Request, idx *NotebookDemandIndex) {
+	var req notebookReviewFlagRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body: " + err.Error()})
+		return
+	}
+	paths := dedupeNonEmpty(req.EntryPaths)
+	if len(paths) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "entry_paths is required"})
+		return
+	}
+	actor := strings.TrimSpace(req.Actor)
+	if actor == "" {
+		actor = strings.TrimSpace(r.Header.Get(agentRateLimitHeader))
+	}
+	if actor == "" {
+		actor = "ceo"
+	}
+	now := time.Now().UTC()
+	recorded := make([]string, 0, len(paths))
+	skipped := make([]map[string]string, 0)
+	for _, path := range paths {
+		owner, ok := ownerSlugFromNotebookPath(path)
+		if !ok {
+			skipped = append(skipped, map[string]string{"path": path, "reason": "owner slug not extractable from path"})
+			continue
+		}
+		evt := PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    owner,
+			SearcherSlug: actor,
+			Signal:       DemandSignalCEOReviewFlag,
+			RecordedAt:   now,
+		}
+		if err := idx.Record(evt); err != nil {
+			if errors.Is(err, ErrPromotionDemandInvalid) {
+				skipped = append(skipped, map[string]string{"path": path, "reason": err.Error()})
+				continue
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("record %s: %v", path, err)})
+			return
+		}
+		recorded = append(recorded, path)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"recorded": recorded,
+		"skipped":  skipped,
+	})
+}
+
+// ownerSlugFromNotebookPath extracts the owner agent slug from a path of the
+// form "agents/{slug}/notebook/{file}". Returns (slug, true) only when the
+// shape matches; (zero, false) otherwise so the caller can skip malformed
+// entries without recording a junk event.
+func ownerSlugFromNotebookPath(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", false
+	}
+	parts := strings.SplitN(path, "/", 4)
+	if len(parts) < 3 {
+		return "", false
+	}
+	if parts[0] != "agents" || parts[2] != "notebook" {
+		return "", false
+	}
+	slug := strings.TrimSpace(parts[1])
+	if slug == "" {
+		return "", false
+	}
+	return slug, true
+}
+
+// dedupeNonEmpty trims whitespace, drops empties, and removes duplicates
+// while preserving input order. Tiny helper kept local to this file; the
+// few other slice-of-string dedupes in the broker have their own loops.
+func dedupeNonEmpty(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		v := strings.TrimSpace(it)
+		if v == "" {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/team/broker_notebook_review_test.go
+++ b/internal/team/broker_notebook_review_test.go
@@ -1,0 +1,304 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newReviewCandidatesTestServer wires the same broker surface as the
+// promotion-demand integration test, but only exposes /notebook/review-candidates
+// so the GET/POST contract is exercised in isolation.
+func newReviewCandidatesTestServer(t *testing.T, withIndex bool) (*httptest.Server, *Broker, *NotebookDemandIndex, func()) {
+	t.Helper()
+	b := newTestBroker(t)
+	var idx *NotebookDemandIndex
+	if withIndex {
+		demandPath := filepath.Join(t.TempDir(), "events.jsonl")
+		var err error
+		idx, err = NewNotebookDemandIndex(demandPath)
+		if err != nil {
+			t.Fatalf("NewNotebookDemandIndex: %v", err)
+		}
+		b.mu.Lock()
+		b.demandIndex = idx
+		b.mu.Unlock()
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/notebook/review-candidates", b.requireAuth(b.handleNotebookReviewCandidates))
+	srv := httptest.NewServer(mux)
+	return srv, b, idx, srv.Close
+}
+
+func reviewGet(t *testing.T, srv *httptest.Server, token, query string) (*http.Response, []byte) {
+	t.Helper()
+	url := srv.URL + "/notebook/review-candidates"
+	if query != "" {
+		url += "?" + query
+	}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	return res, body
+}
+
+func reviewPost(t *testing.T, srv *httptest.Server, token, agent string, payload any) (*http.Response, []byte) {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/notebook/review-candidates", bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	if agent != "" {
+		req.Header.Set("X-WUPHF-Agent", agent)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	return res, body
+}
+
+func TestNotebookReviewCandidates_GET_NoIndex_503(t *testing.T) {
+	srv, b, _, cleanup := newReviewCandidatesTestServer(t, false)
+	defer cleanup()
+	res, body := reviewGet(t, srv, b.Token(), "")
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", res.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "demand index not active") {
+		t.Fatalf("expected 'demand index not active' in body, got %s", body)
+	}
+}
+
+func TestNotebookReviewCandidates_GET_EmptyIndex(t *testing.T) {
+	srv, b, _, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+	res, body := reviewGet(t, srv, b.Token(), "")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", res.StatusCode, body)
+	}
+	var resp struct {
+		Candidates []DemandCandidate `json:"candidates"`
+		Threshold  float64           `json:"threshold"`
+		Window     int               `json:"window"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(resp.Candidates) != 0 {
+		t.Fatalf("candidates = %v, want []", resp.Candidates)
+	}
+	if resp.Threshold <= 0 {
+		t.Fatalf("threshold should be positive, got %v", resp.Threshold)
+	}
+	if resp.Window <= 0 {
+		t.Fatalf("window should be positive, got %v", resp.Window)
+	}
+}
+
+func TestNotebookReviewCandidates_GET_RankedByScore(t *testing.T) {
+	srv, b, idx, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
+
+	// pm entry: 2 distinct cross-agent searches → score 2.0
+	mustRecord(t, idx, PromotionDemandEvent{
+		EntryPath: "agents/pm/notebook/retro.md", OwnerSlug: "pm",
+		SearcherSlug: "eng", Signal: DemandSignalCrossAgentSearch, RecordedAt: now,
+	})
+	mustRecord(t, idx, PromotionDemandEvent{
+		EntryPath: "agents/pm/notebook/retro.md", OwnerSlug: "pm",
+		SearcherSlug: "design", Signal: DemandSignalCrossAgentSearch, RecordedAt: now,
+	})
+	// eng entry: one channel-context-ask → score 2.0 (tied with pm) but
+	// alphabetic tiebreak puts agents/eng/... first.
+	mustRecord(t, idx, PromotionDemandEvent{
+		EntryPath: "agents/eng/notebook/auth.md", OwnerSlug: "eng",
+		SearcherSlug: "pm", Signal: DemandSignalChannelContextAsk, RecordedAt: now,
+	})
+
+	res, body := reviewGet(t, srv, b.Token(), "n=5")
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", res.StatusCode, body)
+	}
+	var resp struct {
+		Candidates []DemandCandidate `json:"candidates"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v; body=%s", err, body)
+	}
+	if len(resp.Candidates) != 2 {
+		t.Fatalf("len(candidates) = %d, want 2; got %+v", len(resp.Candidates), resp.Candidates)
+	}
+	// Both at score 2.0; alphabetic tiebreak in TopCandidates puts eng first.
+	if resp.Candidates[0].EntryPath != "agents/eng/notebook/auth.md" {
+		t.Fatalf("candidates[0] = %q, want eng/auth.md", resp.Candidates[0].EntryPath)
+	}
+	if resp.Candidates[1].EntryPath != "agents/pm/notebook/retro.md" {
+		t.Fatalf("candidates[1] = %q, want pm/retro.md", resp.Candidates[1].EntryPath)
+	}
+}
+
+func TestNotebookReviewCandidates_GET_BadN(t *testing.T) {
+	srv, b, _, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+	res, body := reviewGet(t, srv, b.Token(), "n=not-a-number")
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%s", res.StatusCode, body)
+	}
+}
+
+func TestNotebookReviewCandidates_POST_RecordsCEOFlag(t *testing.T) {
+	srv, b, idx, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+
+	res, body := reviewPost(t, srv, b.Token(), "ceo", map[string]any{
+		"entry_paths": []string{"agents/pm/notebook/retro.md"},
+	})
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", res.StatusCode, body)
+	}
+	var resp struct {
+		Recorded []string            `json:"recorded"`
+		Skipped  []map[string]string `json:"skipped"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Recorded) != 1 {
+		t.Fatalf("recorded = %v, want 1 path", resp.Recorded)
+	}
+	if got := idx.Score("agents/pm/notebook/retro.md"); got != 1.5 {
+		t.Fatalf("score = %v, want 1.5 (single CEO flag)", got)
+	}
+}
+
+func TestNotebookReviewCandidates_POST_DedupeSameDay(t *testing.T) {
+	srv, b, idx, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+
+	payload := map[string]any{
+		"entry_paths": []string{"agents/pm/notebook/retro.md"},
+	}
+	for i := 0; i < 3; i++ {
+		res, body := reviewPost(t, srv, b.Token(), "ceo", payload)
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("attempt %d status = %d; body=%s", i, res.StatusCode, body)
+		}
+	}
+	if got := idx.Score("agents/pm/notebook/retro.md"); got != 1.5 {
+		t.Fatalf("score = %v after 3 same-day flags, want 1.5 (deduped)", got)
+	}
+}
+
+func TestNotebookReviewCandidates_POST_BadPath(t *testing.T) {
+	srv, b, _, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+	res, body := reviewPost(t, srv, b.Token(), "ceo", map[string]any{
+		"entry_paths": []string{"team/already-promoted.md", "agents/pm/notebook/ok.md"},
+	})
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; body=%s", res.StatusCode, body)
+	}
+	var resp struct {
+		Recorded []string            `json:"recorded"`
+		Skipped  []map[string]string `json:"skipped"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Recorded) != 1 || resp.Recorded[0] != "agents/pm/notebook/ok.md" {
+		t.Fatalf("recorded = %v, want one valid path", resp.Recorded)
+	}
+	if len(resp.Skipped) != 1 || resp.Skipped[0]["path"] != "team/already-promoted.md" {
+		t.Fatalf("skipped = %v, want one entry for malformed path", resp.Skipped)
+	}
+}
+
+func TestNotebookReviewCandidates_POST_EmptyBody(t *testing.T) {
+	srv, b, _, cleanup := newReviewCandidatesTestServer(t, true)
+	defer cleanup()
+	res, body := reviewPost(t, srv, b.Token(), "ceo", map[string]any{
+		"entry_paths": []string{},
+	})
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d; body=%s", res.StatusCode, body)
+	}
+}
+
+func TestNotebookReviewCandidates_POST_NoIndex_503(t *testing.T) {
+	srv, b, _, cleanup := newReviewCandidatesTestServer(t, false)
+	defer cleanup()
+	res, body := reviewPost(t, srv, b.Token(), "ceo", map[string]any{
+		"entry_paths": []string{"agents/pm/notebook/retro.md"},
+	})
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", res.StatusCode, body)
+	}
+}
+
+func TestNotebookReviewCandidates_OwnerSlugExtraction(t *testing.T) {
+	cases := []struct {
+		path   string
+		want   string
+		wantOK bool
+	}{
+		{"agents/pm/notebook/retro.md", "pm", true},
+		{"agents/eng/notebook/sub/dir/file.md", "eng", true},
+		{"team/already-promoted.md", "", false},
+		{"agents/pm/wiki/x.md", "", false},
+		{"", "", false},
+		{"agents//notebook/x.md", "", false},
+		{"agents/pm", "", false},
+	}
+	for _, c := range cases {
+		got, ok := ownerSlugFromNotebookPath(c.path)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("ownerSlugFromNotebookPath(%q) = (%q, %v); want (%q, %v)",
+				c.path, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+// mustRecord is a tiny helper used by review-candidates tests; the
+// existing promotion_demand tests have their own assertion patterns and
+// we keep these self-contained.
+func mustRecord(t *testing.T, idx *NotebookDemandIndex, evt PromotionDemandEvent) {
+	t.Helper()
+	if err := idx.Record(evt); err != nil {
+		t.Fatalf("Record(%+v): %v", evt, err)
+	}
+	// Wait for the in-memory bucket to reflect the write before tests
+	// query it. Record is synchronous so this is a fast no-op, but the
+	// helper isolates tests from any future async re-implementation.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = idx.WaitForCondition(ctx, func() bool {
+		return idx.Score(evt.EntryPath) != 0
+	})
+}

--- a/internal/team/promotion_demand.go
+++ b/internal/team/promotion_demand.go
@@ -108,6 +108,13 @@ func signalWeight(s PromotionDemandSignal) float64 {
 	return 0
 }
 
+// PromotionDemandSignalLabel is the exported alias of signalLabel. PR 4
+// (teammcp.team_notebook_review) needs the rendered label string for the
+// CEO-facing JSON, and the teammcp package can't see unexported helpers.
+func PromotionDemandSignalLabel(s PromotionDemandSignal) string {
+	return signalLabel(s)
+}
+
 // signalLabel renders a PromotionDemandSignal as a stable string for snapshot
 // comparisons and rationale strings.
 func signalLabel(s PromotionDemandSignal) string {

--- a/internal/teammcp/notebook_review_tool.go
+++ b/internal/teammcp/notebook_review_tool.go
@@ -1,0 +1,318 @@
+package teammcp
+
+// notebook_review_tool.go is PR 4 of the notebook-wiki-promise design.
+//
+// team_notebook_review is a CEO-only MCP tool: it surfaces ranked promotion
+// candidates from the broker's NotebookDemandIndex and (optionally) records
+// CEO review flags so the CEO's attention itself becomes a demand signal.
+//
+// Why the broker round-trip: the index lives in the broker process. The MCP
+// server runs in a separate stdio process. So the tool calls
+// /notebook/review-candidates rather than reaching into the index directly.
+//
+// Forward-compat: the broker endpoint returns 503 when its demandIndex is
+// nil (e.g. PR 4 lands without PR 3 wiring on a reverted branch). The tool
+// translates that into a friendly "no promotion candidates yet" message
+// instead of bubbling a raw HTTP error to the CEO agent.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// notebookReviewSnippetMax bounds the snippet returned per candidate. Spec:
+// "first 200 chars". We measure runes (not bytes) so multibyte characters
+// don't get split mid-codepoint.
+const notebookReviewSnippetMax = 200
+
+// notebookReviewDefaultLimit matches the broker's default n. Bounded
+// independently so the CEO agent can request a tighter list without the
+// broker default leaking in.
+const notebookReviewDefaultLimit = 20
+
+// registerNotebookReviewTool attaches the CEO-only team_notebook_review tool
+// to the MCP server. Caller (configureServerTools) is responsible for the
+// CEO gate; this function does not re-check the role.
+func registerNotebookReviewTool(server *mcp.Server) {
+	mcp.AddTool(server, readOnlyTool(
+		"team_notebook_review",
+		"CEO-only. List the top promotion candidates across every agent's notebook shelf, ranked by demand score (cross-agent searches, channel context-asks, prior CEO flags). Each row carries a path, owner slug, score, top demand signal, a 200-char snippet, and a /reviews?path=... link. Optional flag arg: pass an array of notebook entry paths to record a CEO review demand signal (weight 1.5) for each — useful when an entry is interesting but not yet promotion-ready. Same path flagged 3x in a day still counts as 1.5, not 4.5.",
+	), handleTeamNotebookReview)
+}
+
+// TeamNotebookReviewArgs is the contract for team_notebook_review.
+type TeamNotebookReviewArgs struct {
+	Limit int      `json:"limit,omitempty" jsonschema:"Maximum candidates to return. Default 20, max 100."`
+	Flag  []string `json:"flag,omitempty" jsonschema:"Optional list of notebook entry paths (agents/{slug}/notebook/{file}.md) to flag as worth reviewing. Each flag records a CEO review demand signal (weight 1.5) — same path multiple times in one day collapses to weight 1.5, not 4.5."`
+}
+
+// notebookReviewResult is the per-candidate row returned to the CEO agent.
+// Field tags are stable wire format consumed by the agent prompt; renaming
+// any of them breaks downstream rationale strings.
+type notebookReviewResult struct {
+	Path       string  `json:"path"`
+	OwnerSlug  string  `json:"owner_slug"`
+	Score      float64 `json:"score"`
+	TopSignal  string  `json:"top_signal"`
+	Snippet    string  `json:"snippet"`
+	PromoteURL string  `json:"promote_url"`
+}
+
+// notebookReviewResponse wraps the tool's full payload. We always return a
+// flagged-paths echo so the CEO agent can confirm the flag side-effect ran.
+type notebookReviewResponse struct {
+	Candidates []notebookReviewResult `json:"candidates"`
+	Flagged    []string               `json:"flagged,omitempty"`
+	Skipped    []map[string]string    `json:"skipped,omitempty"`
+	Threshold  float64                `json:"threshold,omitempty"`
+	Window     int                    `json:"window_days,omitempty"`
+	Message    string                 `json:"message,omitempty"`
+}
+
+// brokerReviewCandidatesGET is the GET-side payload returned by
+// /notebook/review-candidates. Mirrors the JSON shape produced by the
+// broker handler.
+type brokerReviewCandidatesGET struct {
+	Candidates []team.DemandCandidate `json:"candidates"`
+	Threshold  float64                `json:"threshold"`
+	Window     int                    `json:"window"`
+}
+
+// brokerReviewCandidatesPOST is the POST-side payload echo for flag writes.
+type brokerReviewCandidatesPOST struct {
+	Recorded []string            `json:"recorded"`
+	Skipped  []map[string]string `json:"skipped"`
+}
+
+// handleTeamNotebookReview implements the team_notebook_review MCP tool.
+//
+// Behaviour:
+//  1. If args.Flag is non-empty, POST those paths to the broker so they
+//     record DemandSignalCEOReviewFlag. POST happens first so the flag's
+//     score contribution is visible in the very same call's GET ranking.
+//  2. GET /notebook/review-candidates?n=limit. On 503, return a clean
+//     "demand index not yet populated" message instead of a tool error.
+//  3. For each returned DemandCandidate, fetch a snippet via /notebook/read
+//     (best-effort — a missing file does not fail the tool, it just yields
+//     an empty snippet).
+//  4. Sort the result by score descending and return.
+func handleTeamNotebookReview(ctx context.Context, _ *mcp.CallToolRequest, args TeamNotebookReviewArgs) (*mcp.CallToolResult, any, error) {
+	limit := args.Limit
+	if limit <= 0 {
+		limit = notebookReviewDefaultLimit
+	}
+
+	resp := notebookReviewResponse{
+		Candidates: []notebookReviewResult{},
+	}
+
+	// 1. Flag side-effect first so the score updates feed the GET.
+	if flagPaths := dedupeNonEmptyStrings(args.Flag); len(flagPaths) > 0 {
+		var flagOut brokerReviewCandidatesPOST
+		err := brokerPostJSON(ctx, "/notebook/review-candidates", map[string]any{
+			"entry_paths": flagPaths,
+		}, &flagOut)
+		if err != nil {
+			// 503 from broker: index not active. Don't fail — just surface
+			// the message and skip the GET (which would also 503).
+			if isBrokerDemandIndexInactive(err) {
+				resp.Message = "Demand index is not yet active on this broker; no candidates and no flags recorded."
+				return marshalNotebookReviewResponse(resp), nil, nil
+			}
+			return toolError(fmt.Errorf("flag CEO review entries: %w", err)), nil, nil
+		}
+		resp.Flagged = flagOut.Recorded
+		resp.Skipped = flagOut.Skipped
+	}
+
+	// 2. Fetch ranked candidates.
+	var candidates brokerReviewCandidatesGET
+	q := url.Values{}
+	q.Set("n", fmt.Sprintf("%d", limit))
+	err := brokerGetJSON(ctx, "/notebook/review-candidates?"+q.Encode(), &candidates)
+	if err != nil {
+		if isBrokerDemandIndexInactive(err) {
+			resp.Message = "Demand index is not yet active on this broker; no promotion candidates yet."
+			return marshalNotebookReviewResponse(resp), nil, nil
+		}
+		return toolError(fmt.Errorf("list review candidates: %w", err)), nil, nil
+	}
+	resp.Threshold = candidates.Threshold
+	resp.Window = candidates.Window
+
+	if len(candidates.Candidates) == 0 {
+		resp.Message = "No promotion candidates yet — agents have not searched each other's notebooks above the threshold."
+		return marshalNotebookReviewResponse(resp), nil, nil
+	}
+
+	// 3. Hydrate snippets. Best-effort; broker GET /notebook/read returns
+	// text/plain on success and a JSON error otherwise. We only swallow the
+	// error — the rest of the tool result is still useful.
+	out := make([]notebookReviewResult, 0, len(candidates.Candidates))
+	for _, c := range candidates.Candidates {
+		row := notebookReviewResult{
+			Path:       c.EntryPath,
+			OwnerSlug:  c.OwnerSlug,
+			Score:      c.Score,
+			TopSignal:  team.PromotionDemandSignalLabel(c.TopSignal),
+			PromoteURL: promoteURLFor(c.EntryPath),
+		}
+		row.Snippet = fetchNotebookSnippet(ctx, c.EntryPath, c.OwnerSlug)
+		out = append(out, row)
+	}
+	// Broker already sorts by score desc, but we re-sort defensively in
+	// case a future broker change relaxes that contract.
+	sortByScoreDesc(out)
+	resp.Candidates = out
+	return marshalNotebookReviewResponse(resp), nil, nil
+}
+
+// fetchNotebookSnippet pulls the first chunk of an entry's text from the
+// broker. The broker handler returns text/plain on success, so we use
+// brokerGetRaw and trim. On any error (404, 503, etc) we return "" — a
+// missing snippet should not break the ranking surface.
+func fetchNotebookSnippet(ctx context.Context, path, slug string) string {
+	if strings.TrimSpace(path) == "" {
+		return ""
+	}
+	q := url.Values{}
+	q.Set("path", path)
+	if slug != "" {
+		q.Set("slug", slug)
+	}
+	body, err := brokerGetRaw(ctx, "/notebook/read?"+q.Encode())
+	if err != nil {
+		return ""
+	}
+	return truncateOnWordBoundary(string(body), notebookReviewSnippetMax)
+}
+
+// truncateOnWordBoundary returns up to max runes of s, preferring to cut at
+// the last whitespace character within the window so words aren't sliced in
+// half. Falls back to a hard rune cut when no whitespace exists in the
+// window. Always strips a trailing fence/code marker fragment.
+func truncateOnWordBoundary(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if max <= 0 || s == "" {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return collapseWhitespace(string(runes))
+	}
+	window := runes[:max]
+	// Walk backward from the end of the window for the last whitespace.
+	cut := -1
+	for i := len(window) - 1; i >= 0; i-- {
+		if isSpaceRune(window[i]) {
+			cut = i
+			break
+		}
+	}
+	if cut <= 0 {
+		// No whitespace in the window — hard rune cut.
+		return collapseWhitespace(string(window)) + "…"
+	}
+	return collapseWhitespace(string(window[:cut])) + "…"
+}
+
+func isSpaceRune(r rune) bool {
+	return r == ' ' || r == '\n' || r == '\t' || r == '\r'
+}
+
+// collapseWhitespace replaces runs of whitespace with single spaces so the
+// snippet renders cleanly in the agent prompt regardless of the source
+// markdown's line breaks.
+func collapseWhitespace(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	for _, r := range s {
+		if isSpaceRune(r) {
+			if !prevSpace {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+			continue
+		}
+		b.WriteRune(r)
+		prevSpace = false
+	}
+	return strings.TrimSpace(b.String())
+}
+
+// promoteURLFor builds the deep-link the CEO agent passes to the human so
+// they can land on the existing /reviews Kanban filtered to this entry.
+// PR 4 deliberately does not add a new web surface — this URL points at
+// the surface that already exists.
+func promoteURLFor(entryPath string) string {
+	q := url.Values{}
+	q.Set("path", entryPath)
+	return "/reviews?" + q.Encode()
+}
+
+// sortByScoreDesc orders results by Score descending, breaking ties on Path
+// ascending so the output is deterministic for snapshot tests.
+func sortByScoreDesc(rows []notebookReviewResult) {
+	for i := 1; i < len(rows); i++ {
+		for j := i; j > 0; j-- {
+			a, b := rows[j-1], rows[j]
+			if a.Score < b.Score || (a.Score == b.Score && a.Path > b.Path) {
+				rows[j-1], rows[j] = b, a
+				continue
+			}
+			break
+		}
+	}
+}
+
+// dedupeNonEmptyStrings is the teammcp-side analog of the broker helper.
+// Lives here (not in server_helpers.go) because no other tool currently
+// dedupes string args; if a second consumer arrives we'll lift it.
+func dedupeNonEmptyStrings(items []string) []string {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]string, 0, len(items))
+	for _, raw := range items {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// isBrokerDemandIndexInactive matches the stable error string the broker
+// returns when b.demandIndex is nil. Match on substring rather than parsing
+// the JSON body because brokerGetJSON wraps the body into a single error.
+func isBrokerDemandIndexInactive(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "503") && strings.Contains(msg, "demand index not active")
+}
+
+// marshalNotebookReviewResponse is a tiny helper that serialises the tool
+// payload and wraps it in a successful CallToolResult.
+func marshalNotebookReviewResponse(resp notebookReviewResponse) *mcp.CallToolResult {
+	if resp.Candidates == nil {
+		resp.Candidates = []notebookReviewResult{}
+	}
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return toolError(fmt.Errorf("marshal review response: %w", err))
+	}
+	return textResult(string(payload))
+}

--- a/internal/teammcp/notebook_review_tool_test.go
+++ b/internal/teammcp/notebook_review_tool_test.go
@@ -1,0 +1,428 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// reviewToolStubBroker mounts the two endpoints the team_notebook_review
+// tool consumes. The handler may be supplied per-test to override behaviour
+// (503, errors, etc).
+type reviewToolStubBroker struct {
+	mu              sync.Mutex
+	getCalls        int
+	postCalls       int
+	postBodies      []string
+	getN            []string
+	candidatesGET   func(w http.ResponseWriter, r *http.Request)
+	candidatesPOST  func(w http.ResponseWriter, r *http.Request)
+	notebookReadGET func(w http.ResponseWriter, r *http.Request)
+}
+
+func newReviewToolStubBroker(t *testing.T, b *reviewToolStubBroker) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/notebook/review-candidates":
+			switch r.Method {
+			case http.MethodGet:
+				b.mu.Lock()
+				b.getCalls++
+				b.getN = append(b.getN, r.URL.Query().Get("n"))
+				b.mu.Unlock()
+				if b.candidatesGET != nil {
+					b.candidatesGET(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"candidates": []map[string]any{},
+					"threshold":  3.0,
+					"window":     7,
+				})
+			case http.MethodPost:
+				body, _ := io.ReadAll(r.Body)
+				b.mu.Lock()
+				b.postCalls++
+				b.postBodies = append(b.postBodies, string(body))
+				b.mu.Unlock()
+				if b.candidatesPOST != nil {
+					b.candidatesPOST(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"recorded": []string{},
+					"skipped":  []map[string]string{},
+				})
+			default:
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			}
+		case "/notebook/read":
+			if b.notebookReadGET != nil {
+				b.notebookReadGET(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			_, _ = w.Write([]byte("# default snippet\nbody body body"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func setBrokerEnv(t *testing.T, url string) {
+	t.Helper()
+	t.Setenv("WUPHF_TEAM_BROKER_URL", url)
+	t.Setenv("WUPHF_BROKER_TOKEN", "test-token")
+	t.Setenv("WUPHF_BROKER_TOKEN_FILE", "/dev/null")
+}
+
+func TestNotebookReviewTool_ReturnsRankedCandidates(t *testing.T) {
+	stub := &reviewToolStubBroker{
+		candidatesGET: func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"candidates": []map[string]any{
+					{
+						"entry_path": "agents/eng/notebook/auth.md",
+						"owner_slug": "eng",
+						"score":      2.0,
+						"top_signal": 1, // DemandSignalChannelContextAsk
+					},
+					{
+						"entry_path": "agents/pm/notebook/retro.md",
+						"owner_slug": "pm",
+						"score":      3.0,
+						"top_signal": 0, // DemandSignalCrossAgentSearch
+					},
+				},
+				"threshold": 3.0,
+				"window":    7,
+			})
+		},
+		notebookReadGET: func(w http.ResponseWriter, r *http.Request) {
+			path := r.URL.Query().Get("path")
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			_, _ = w.Write([]byte("snippet for " + path))
+		},
+	}
+	srv := newReviewToolStubBroker(t, stub)
+	setBrokerEnv(t, srv.URL)
+
+	res, _, err := handleTeamNotebookReview(context.Background(), nil, TeamNotebookReviewArgs{Limit: 5})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	payload := toolErrorText(res)
+	var resp notebookReviewResponse
+	if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+		t.Fatalf("unmarshal: %v; payload=%s", err, payload)
+	}
+	if len(resp.Candidates) != 2 {
+		t.Fatalf("candidates len = %d; payload=%s", len(resp.Candidates), payload)
+	}
+	// Sorted by score desc — pm(3.0) before eng(2.0).
+	if resp.Candidates[0].Path != "agents/pm/notebook/retro.md" {
+		t.Fatalf("candidates[0].Path = %q, want pm/retro.md", resp.Candidates[0].Path)
+	}
+	if resp.Candidates[0].TopSignal != "cross_agent_search" {
+		t.Fatalf("candidates[0].TopSignal = %q, want cross_agent_search", resp.Candidates[0].TopSignal)
+	}
+	if !strings.Contains(resp.Candidates[0].Snippet, "snippet for agents/pm/notebook/retro.md") {
+		t.Fatalf("snippet missing for pm: %q", resp.Candidates[0].Snippet)
+	}
+	if resp.Candidates[0].PromoteURL != "/reviews?path=agents%2Fpm%2Fnotebook%2Fretro.md" {
+		t.Fatalf("promote_url = %q", resp.Candidates[0].PromoteURL)
+	}
+	if resp.Threshold != 3.0 || resp.Window != 7 {
+		t.Fatalf("threshold/window = %v/%v", resp.Threshold, resp.Window)
+	}
+	if stub.getCalls != 1 {
+		t.Fatalf("getCalls = %d, want 1", stub.getCalls)
+	}
+	if stub.postCalls != 0 {
+		t.Fatalf("postCalls = %d, want 0 (no flag)", stub.postCalls)
+	}
+	if got := stub.getN[0]; got != "5" {
+		t.Fatalf("GET n = %q, want 5", got)
+	}
+}
+
+func TestNotebookReviewTool_EmptyCandidates_FriendlyMessage(t *testing.T) {
+	stub := &reviewToolStubBroker{}
+	srv := newReviewToolStubBroker(t, stub)
+	setBrokerEnv(t, srv.URL)
+
+	res, _, err := handleTeamNotebookReview(context.Background(), nil, TeamNotebookReviewArgs{})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	var resp notebookReviewResponse
+	if err := json.Unmarshal([]byte(toolErrorText(res)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Candidates) != 0 {
+		t.Fatalf("candidates = %v, want empty", resp.Candidates)
+	}
+	if !strings.Contains(resp.Message, "No promotion candidates yet") {
+		t.Fatalf("message = %q, want friendly empty message", resp.Message)
+	}
+}
+
+func TestNotebookReviewTool_503_DegradesGracefully(t *testing.T) {
+	stub := &reviewToolStubBroker{
+		candidatesGET: func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "demand index not active"})
+		},
+	}
+	srv := newReviewToolStubBroker(t, stub)
+	setBrokerEnv(t, srv.URL)
+
+	res, _, err := handleTeamNotebookReview(context.Background(), nil, TeamNotebookReviewArgs{})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("expected success, got tool error: %s", toolErrorText(res))
+	}
+	var resp notebookReviewResponse
+	if err := json.Unmarshal([]byte(toolErrorText(res)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(resp.Message, "not yet active") {
+		t.Fatalf("message = %q, want degradation message", resp.Message)
+	}
+}
+
+func TestNotebookReviewTool_FlagPostsCEOSignal(t *testing.T) {
+	stub := &reviewToolStubBroker{
+		candidatesPOST: func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"recorded": []string{"agents/pm/notebook/retro.md"},
+				"skipped":  []map[string]string{},
+			})
+		},
+	}
+	srv := newReviewToolStubBroker(t, stub)
+	setBrokerEnv(t, srv.URL)
+
+	res, _, err := handleTeamNotebookReview(context.Background(), nil, TeamNotebookReviewArgs{
+		Flag: []string{"agents/pm/notebook/retro.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	if stub.postCalls != 1 {
+		t.Fatalf("postCalls = %d, want 1", stub.postCalls)
+	}
+	if !strings.Contains(stub.postBodies[0], "\"entry_paths\":[\"agents/pm/notebook/retro.md\"]") {
+		t.Fatalf("post body did not include entry_paths: %s", stub.postBodies[0])
+	}
+	var resp notebookReviewResponse
+	if err := json.Unmarshal([]byte(toolErrorText(res)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !slices.Contains(resp.Flagged, "agents/pm/notebook/retro.md") {
+		t.Fatalf("flagged = %v, want pm/retro.md", resp.Flagged)
+	}
+}
+
+func TestNotebookReviewTool_Flag503_DegradesGracefully(t *testing.T) {
+	stub := &reviewToolStubBroker{
+		candidatesPOST: func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "demand index not active"})
+		},
+	}
+	srv := newReviewToolStubBroker(t, stub)
+	setBrokerEnv(t, srv.URL)
+
+	res, _, err := handleTeamNotebookReview(context.Background(), nil, TeamNotebookReviewArgs{
+		Flag: []string{"agents/pm/notebook/retro.md"},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	if stub.getCalls != 0 {
+		t.Fatalf("getCalls = %d after 503 flag, want 0 (skipped)", stub.getCalls)
+	}
+	var resp notebookReviewResponse
+	if err := json.Unmarshal([]byte(toolErrorText(res)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !strings.Contains(resp.Message, "not yet active") {
+		t.Fatalf("message = %q, want degradation", resp.Message)
+	}
+}
+
+func TestNotebookReviewTool_DedupesAndTrimsFlag(t *testing.T) {
+	stub := &reviewToolStubBroker{
+		candidatesPOST: func(w http.ResponseWriter, r *http.Request) {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"recorded": []string{"agents/pm/notebook/retro.md"},
+				"skipped":  []map[string]string{},
+			})
+		},
+	}
+	srv := newReviewToolStubBroker(t, stub)
+	setBrokerEnv(t, srv.URL)
+
+	_, _, err := handleTeamNotebookReview(context.Background(), nil, TeamNotebookReviewArgs{
+		Flag: []string{"agents/pm/notebook/retro.md", "  agents/pm/notebook/retro.md  ", "", "  "},
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if stub.postCalls != 1 {
+		t.Fatalf("postCalls = %d, want 1 after dedupe", stub.postCalls)
+	}
+	body := stub.postBodies[0]
+	// Only one unique path should be present.
+	if strings.Count(body, "agents/pm/notebook/retro.md") != 1 {
+		t.Fatalf("expected exactly one occurrence of dedupe path in body: %s", body)
+	}
+}
+
+func TestNotebookReviewTool_RegisteredOnlyForCEO(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "markdown")
+	cases := []struct {
+		name     string
+		channel  string
+		oneOnOne bool
+		slug     string
+		want     bool
+	}{
+		{"office non-lead", "general", false, "workflow-architect", false},
+		{"dm non-lead", "dm-eng", true, "workflow-architect", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := listRegisteredToolsWithSlug(t, tc.slug, tc.channel, tc.oneOnOne)
+			has := slices.Contains(names, "team_notebook_review")
+			if has != tc.want {
+				t.Errorf("present = %v; want %v; tools=%v", has, tc.want, names)
+			}
+		})
+	}
+}
+
+func TestNotebookReviewTool_RegisteredForCEOInOfficeAndDM(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "markdown")
+	cases := []struct {
+		name     string
+		channel  string
+		oneOnOne bool
+		slug     string
+	}{
+		{"office ceo", "general", false, "ceo"},
+		{"dm ceo", "dm-ceo", true, "ceo"},
+		{"office empty-slug lead", "general", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			names := listRegisteredToolsWithSlug(t, tc.slug, tc.channel, tc.oneOnOne)
+			if !slices.Contains(names, "team_notebook_review") {
+				t.Errorf("expected team_notebook_review for ceo; got %v", names)
+			}
+		})
+	}
+}
+
+func TestTruncateOnWordBoundary(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"empty", "", 200, ""},
+		{"short", "hello world", 200, "hello world"},
+		{"trims at word boundary", "the quick brown fox jumps", 14, "the quick…"},
+		{"hard cut without spaces", "abcdefghij", 5, "abcde…"},
+		{"collapses internal whitespace", "line one\n\nline two", 200, "line one line two"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncateOnWordBoundary(c.in, c.max)
+			if got != c.want {
+				t.Errorf("got %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSortByScoreDesc(t *testing.T) {
+	rows := []notebookReviewResult{
+		{Path: "a", Score: 1.0},
+		{Path: "c", Score: 3.0},
+		{Path: "b", Score: 3.0},
+		{Path: "d", Score: 2.0},
+	}
+	sortByScoreDesc(rows)
+	want := []string{"b", "c", "d", "a"} // tie-break: path asc within score desc
+	for i, w := range want {
+		if rows[i].Path != w {
+			t.Errorf("rows[%d].Path = %q, want %q (full=%v)", i, rows[i].Path, w, rows)
+		}
+	}
+}
+
+// listRegisteredToolsWithSlug is the variable-slug analog of
+// listRegisteredTools (which hardcodes "workflow-architect"). PR 4's CEO
+// gate cannot be exercised through the existing helper, so we build a
+// parallel one here. The pattern mirrors server_backend_switch_test.go.
+func listRegisteredToolsWithSlug(t *testing.T, slug, channel string, oneOnOne bool) []string {
+	t.Helper()
+	ctx := context.Background()
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "wuphf-team-test", Version: "0.1.0"}, nil)
+	configureServerTools(server, slug, channel, oneOnOne)
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	defer serverSession.Wait()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "client", Version: "0.1.0"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer func() { _ = clientSession.Close() }()
+
+	tools, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+	names := make([]string, 0, len(tools.Tools))
+	for _, tool := range tools.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -160,6 +160,13 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"Return the canonical runtime snapshot for this direct session, including tasks, pending human requests, recovery summary, and runtime capabilities.",
 		), handleTeamRuntimeState)
 
+		// CEO-only: in 1:1 / DM mode the CEO can still call review to see
+		// the office's promotion candidates from a private chat. Same lead
+		// gate as the office and DM branches below.
+		if slug == "" || slug == "ceo" {
+			registerNotebookReviewTool(server)
+		}
+
 		if hasActionProvider() {
 			registerActionTools(server)
 		}
@@ -197,6 +204,9 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"Invoke a named team skill. When the human's request matches an available skill, call this BEFORE replying — do not freelance. Bumps the skill's usage, logs a skill_invocation to the channel, and returns the skill's canonical step-by-step content for you to follow.",
 		), handleTeamSkillRun)
 		registerSkillAuthoringTools(server)
+		if isLead {
+			registerNotebookReviewTool(server)
+		}
 		if hasActionProvider() {
 			registerActionTools(server)
 		}
@@ -335,6 +345,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"team_member",
 			"Create or remove an office-wide member. Only create new members when the human explicitly wants to expand the team.",
 		), handleTeamMember)
+		registerNotebookReviewTool(server)
 	}
 }
 


### PR DESCRIPTION
## Summary

PR 4 of the notebook-wiki-promise series. Built on top of [PR 3](#692)'s `NotebookDemandIndex`. Gives the CEO agent a ranked promotion-candidate view drawn from cross-agent demand signals — same data the auto-escalation path uses, but exposed as a deliberate inspection tool.

> **Stacked PR.** Currently shows PR 3's commit + PR 4's commit. After PR 3 lands on main, this branch will be rebased to a single PR 4 commit.

## Endpoints

\`\`\`
GET /notebook/review-candidates
  → { candidates: [...DemandCandidate], threshold, window }

POST /notebook/review-candidates
  body: { entry_paths: ["agents/X/notebook/Y.md", ...] }
  → records DemandSignalCEOReviewFlag (weight 1.5) for each path
\`\`\`

PR 3's `Record` dedupes per `(entry, day)`, so the same path flagged 3× in one day still produces +1.5, not +4.5.

## MCP tool

\`team_notebook_review\` — registered for `slug == "" || slug == "ceo"` in all three `configureServerTools` branches (1:1 / DM / office). Returns:

| Field | Source |
|---|---|
| path | DemandCandidate |
| owner_slug | DemandCandidate |
| score | DemandCandidate |
| top_signal | `PromotionDemandSignalLabel(...)` |
| snippet | `GET /notebook/read` (200-char truncated, word-boundary aware) |
| promote_url | `/reviews?path=...` deep link |

Optional `flag` param posts to the same endpoint to record `DemandSignalCEOReviewFlag` for a list of paths the CEO is "marking" without promoting.

## Forward-compat (revert safety)

- Broker handler returns `503 {"error":"demand index not active"}` when `b.demandIndex == nil`.
- MCP tool detects that exact error string and returns a clean "no promotion candidates yet" message instead of an MCP `IsError`.
- Verified by tests on both branches.

## Design notes

- **Endpoint shape** returns `{candidates, threshold, window}` instead of bare `[]DemandCandidate`. Strict superset; older callers ignore unknown fields. Saves the CEO agent a round-trip when it wants to know what bar an entry has to clear.
- **POST shares the path** instead of a separate `/notebook/review-flag` route. Keeps the tool to a single broker URL pair.
- **Snippet I/O via broker, not direct file read.** MCP server runs in a separate process from the broker. Routing through `/notebook/read` keeps the tool free of filesystem assumptions about the wiki root path.
- **No new web surface.** PR 4 deliberately does NOT add a `/reviews` page — the existing Kanban already reads from `ReviewLog`, which PR 3 already feeds.

## Tests

| File | Count | Coverage |
|---|---|---|
| `broker_notebook_review_test.go` | 10 broker | 503 nil-guard (both methods), GET ranking, bad-N, POST flag record, dedupe, bad-path skip, empty body, owner-slug extraction |
| `notebook_review_tool_test.go` | 10 MCP | ranked candidates, empty-state message, 503 graceful degrade (GET + POST), flag POST, dedupe trim, CEO gate (office + DM + oneOnOne), snippet truncate boundary, deterministic sort |

Full `internal/team` + `internal/teammcp` race-on suites: 94s + 6s, all green.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/team/... ./internal/teammcp/...`
- [x] `golangci-lint run ./internal/team/... ./internal/teammcp/...` 0 issues
- [x] `go test -count=1 -race -timeout 600s ./internal/team/ ./internal/teammcp/`
- [x] `bash scripts/check-no-new-sleeps-in-tests.sh`
- [ ] **Manual:** with `WUPHF_AGENT_SLUG=ceo`, call `team_notebook_review` from a fresh office. Confirm empty-state message renders.
- [ ] **Manual:** have agent A search agent B's notebook (cross-agent), then call `team_notebook_review` as CEO. Confirm B's entry appears with `top_signal=cross_agent_search`.
- [ ] **Manual:** call `team_notebook_review` with `flag=["agents/X/notebook/Y.md"]` 3× in one day. Confirm score climbs to 1.5, not 4.5.
- [ ] **Manual:** revert PR 3's `b.demandIndex` wiring locally, call `team_notebook_review`. Confirm tool returns the friendly "not yet active" message.

## Deferred
- Heuristic freshness/uniqueness re-ranking pass (spec marks optional). Trust broker score order until PR 5 ships and we see ranking signal in the wild.
- Per-actor rate limit on POST flag endpoint. Currently relies on broker-wide requireAuth limiter.
- Exporting `signalLabel` for ALL package consumers vs the targeted `PromotionDemandSignalLabel` wrapper added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CEOs and leads can now access a notebook review tool to view top promotion candidates, ranked by signals and scores.
  * Added ability to flag notebooks for review, recording CEO review signals that influence candidate ranking.
  * Review candidates display owner information, scoring details, key signals, and code snippets for context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->