### PR TITLE
feat(team): channel-intent classifier records cross-agent demand signals (PR 5)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -104,6 +104,7 @@ type Broker struct {
 	autoNotebookWriter      *AutoNotebookWriter
 	humanWikiWriter         *HumanWikiIntentWriter
 	demandIndex             *NotebookDemandIndex
+	channelIntentDispatcher *ChannelIntentDispatcher
 	wikiIndex               *WikiIndex
 	wikiExtractor           *Extractor
 	wikiDLQ                 *DLQ
@@ -616,6 +617,7 @@ func (b *Broker) Stop() {
 	compressor := b.wikiCompressor
 	autoWriter := b.autoNotebookWriter
 	humanWikiWriter := b.humanWikiWriter
+	channelIntent := b.channelIntentDispatcher
 	b.mu.Unlock()
 	if synth != nil {
 		synth.Stop()
@@ -634,6 +636,9 @@ func (b *Broker) Stop() {
 	}
 	if humanWikiWriter != nil {
 		humanWikiWriter.Stop(2 * time.Second)
+	}
+	if channelIntent != nil {
+		channelIntent.Stop(2 * time.Second)
 	}
 }
 

--- a/internal/team/broker_channel_intent_test.go
+++ b/internal/team/broker_channel_intent_test.go
@@ -1,0 +1,234 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// brokerWithChannelIntentDispatcher wires a real WikiWorker on a temp git
+// repo plus a NotebookDemandIndex and a ChannelIntentDispatcher. Mirrors
+// the brokerWithHumanWikiWriter pattern used by PR 2's integration test.
+//
+// Cleanup must stop the dispatcher BEFORE cancelling the wiki worker's
+// context so the goroutine drains cleanly without races.
+func brokerWithChannelIntentDispatcher(t *testing.T) (*Broker, *Repo, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("repo init: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	demandPath := filepath.Join(t.TempDir(), "events.jsonl")
+	idx, err := NewNotebookDemandIndex(demandPath)
+	if err != nil {
+		t.Fatalf("NewNotebookDemandIndex: %v", err)
+	}
+
+	dispatcher := NewChannelIntentDispatcher(b)
+	dispatcher.Start(ctx)
+
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.demandIndex = idx
+	b.channelIntentDispatcher = dispatcher
+	b.mu.Unlock()
+
+	return b, repo, func() {
+		dispatcher.Stop(2 * time.Second)
+		cancel()
+		<-worker.Done()
+	}
+}
+
+// writeNotebookEntryDirect populates a notebook entry by going through the
+// wiki worker's NotebookWrite path. The integration test needs a real entry
+// on disk for NotebookSearch to find.
+func writeNotebookEntryDirect(t *testing.T, b *Broker, slug, path, content string) {
+	t.Helper()
+	worker := b.WikiWorker()
+	if worker == nil {
+		t.Fatalf("wiki worker not wired")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, _, err := worker.NotebookWrite(ctx, slug, path, content, "create", "test entry"); err != nil {
+		t.Fatalf("NotebookWrite slug=%s path=%s: %v", slug, path, err)
+	}
+}
+
+// TestChannelIntent_ContextAskRecordsDemand drives the end-to-end flow:
+// human posts "who has context on X", an agent's notebook has an entry that
+// matches X, and the dispatcher records a DemandSignalChannelContextAsk
+// for the matched (path, owner) pair.
+func TestChannelIntent_ContextAskRecordsDemand(t *testing.T) {
+	b, _, teardown := brokerWithChannelIntentDispatcher(t)
+	defer teardown()
+
+	notebookPath := "agents/pm/notebook/2026-05-06-icp.md"
+	writeNotebookEntryDirect(t, b, "pm", notebookPath,
+		"# our ICP\n\nfounders running 3+ AI agents are the wedge.\n")
+
+	if _, err := b.PostMessage("human", "general",
+		"who has context on our ICP", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	// Wait for the dispatcher to process the message and the demand index
+	// to record at least one event for the matched path.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := b.channelIntentDispatcher.WaitForCondition(ctx, func() bool {
+		return b.channelIntentDispatcher.Counters().DemandFired >= 1
+	}); err != nil {
+		t.Fatalf("expected DemandFired >= 1 (counters=%+v): %v",
+			b.channelIntentDispatcher.Counters(), err)
+	}
+
+	// Demand index should reflect the channel-context-ask weight (2.0).
+	if got := b.demandIndex.Score(notebookPath); got < 2.0 {
+		t.Fatalf("demand score for %q = %v, want >= 2.0", notebookPath, got)
+	}
+
+	// Counters: one classified, at least one search, and at least one hit.
+	c := b.channelIntentDispatcher.Counters()
+	if c.Classified < 1 {
+		t.Fatalf("expected Classified >= 1, got %d (counters=%+v)", c.Classified, c)
+	}
+	if c.Searched < 1 {
+		t.Fatalf("expected Searched >= 1, got %d (counters=%+v)", c.Searched, c)
+	}
+	if c.HitsFound < 1 {
+		t.Fatalf("expected HitsFound >= 1, got %d (counters=%+v)", c.HitsFound, c)
+	}
+}
+
+// TestChannelIntent_NoHitsNoDemand asserts that a context-ask which finds
+// nothing in any notebook records ZERO demand events. The classifier still
+// matched (Classified increments), but with no notebook entries to point
+// at, the demand index stays empty.
+func TestChannelIntent_NoHitsNoDemand(t *testing.T) {
+	b, _, teardown := brokerWithChannelIntentDispatcher(t)
+	defer teardown()
+
+	if _, err := b.PostMessage("human", "general",
+		"who has context on the unrelated billing migration", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	// Wait for classification to happen — the dispatcher must have
+	// processed the message to a terminal state. Searched will increment
+	// even on an empty corpus (NotebookSearchAll runs over zero slugs but
+	// is still a "we searched" event).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := b.channelIntentDispatcher.WaitForCondition(ctx, func() bool {
+		return b.channelIntentDispatcher.Counters().Classified >= 1
+	}); err != nil {
+		t.Fatalf("classifier never fired (counters=%+v): %v",
+			b.channelIntentDispatcher.Counters(), err)
+	}
+	// And wait for the search to complete so we can assert on hits.
+	if err := b.channelIntentDispatcher.WaitForCondition(ctx, func() bool {
+		return b.channelIntentDispatcher.Counters().Searched >= 1
+	}); err != nil {
+		t.Fatalf("search never ran (counters=%+v): %v",
+			b.channelIntentDispatcher.Counters(), err)
+	}
+
+	c := b.channelIntentDispatcher.Counters()
+	if c.HitsFound != 0 {
+		t.Fatalf("expected HitsFound=0 with no matching entries, got %d", c.HitsFound)
+	}
+	if c.DemandFired != 0 {
+		t.Fatalf("expected DemandFired=0 with no matching entries, got %d", c.DemandFired)
+	}
+}
+
+// TestChannelIntent_NonQuestionMessageSkipped exercises the question-form
+// guard: a statement-form message ("I have context on X") must NOT trigger
+// the search/record path.
+func TestChannelIntent_NonQuestionMessageSkipped(t *testing.T) {
+	b, _, teardown := brokerWithChannelIntentDispatcher(t)
+	defer teardown()
+
+	// First post a non-question message: must NOT classify.
+	if _, err := b.PostMessage("human", "general",
+		"I have context on the billing migration", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	// Then a sentinel question that DOES classify, used as a drain barrier.
+	if _, err := b.PostMessage("human", "general",
+		"who has context on the billing migration", nil, ""); err != nil {
+		t.Fatalf("PostMessage sentinel: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := b.channelIntentDispatcher.WaitForCondition(ctx, func() bool {
+		return b.channelIntentDispatcher.Counters().Classified >= 1
+	}); err != nil {
+		t.Fatalf("sentinel never classified (counters=%+v): %v",
+			b.channelIntentDispatcher.Counters(), err)
+	}
+
+	c := b.channelIntentDispatcher.Counters()
+	// Two messages were enqueued; exactly one classified (the sentinel)
+	// and exactly one was skipped (the statement-form first message).
+	if c.Enqueued != 2 {
+		t.Fatalf("expected Enqueued=2, got %d (counters=%+v)", c.Enqueued, c)
+	}
+	if c.Classified != 1 {
+		t.Fatalf("expected Classified=1 (sentinel only), got %d (counters=%+v)", c.Classified, c)
+	}
+	if c.Skipped != 1 {
+		t.Fatalf("expected Skipped=1 (statement form), got %d (counters=%+v)", c.Skipped, c)
+	}
+}
+
+// TestChannelIntent_AgentSenderAlsoTriggers verifies the hook fires for
+// agent senders as well as humans: a roster agent posting "who has context
+// on X" must trigger classification and demand recording the same way a
+// human does. The classifier inside the dispatcher is what filters; the
+// hook itself does NOT pre-filter on sender role.
+//
+// This guards against a regression where a future change accidentally
+// routes the dispatcher only on isHumanMessageSender, losing agent-to-agent
+// context-asks.
+func TestChannelIntent_AgentSenderAlsoTriggers(t *testing.T) {
+	b, _, teardown := brokerWithChannelIntentDispatcher(t)
+	defer teardown()
+
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'; cannot exercise agent-sender path")
+	}
+
+	// Plant a notebook entry on the PM's shelf for the agent to ask about.
+	notebookPath := "agents/pm/notebook/2026-05-06-onboarding.md"
+	writeNotebookEntryDirect(t, b, "pm", notebookPath,
+		"# onboarding gotchas\n\nthe bun version pin is required.\n")
+
+	if _, err := b.PostMessage("ceo", "general",
+		"who has context on onboarding gotchas", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := b.channelIntentDispatcher.WaitForCondition(ctx, func() bool {
+		return b.channelIntentDispatcher.Counters().DemandFired >= 1
+	}); err != nil {
+		t.Fatalf("agent-sender context-ask did not fire demand (counters=%+v): %v",
+			b.channelIntentDispatcher.Counters(), err)
+	}
+	if got := b.demandIndex.Score(notebookPath); got < 2.0 {
+		t.Fatalf("demand score = %v, want >= 2.0", got)
+	}
+}

--- a/internal/team/broker_messages.go
+++ b/internal/team/broker_messages.go
@@ -262,6 +262,12 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	if b.humanWikiWriter != nil && isHumanMessageSender(msg.From) {
 		b.humanWikiWriter.Handle(msg)
 	}
+	// PR 5: channel intent classifier. Fires for ALL senders (human OR
+	// agent) — context-asks happen in any channel message form. The
+	// classifier's question-form filter, evaluated inside the dispatcher
+	// goroutine, restricts the actual demand recording to genuine
+	// interrogative phrases. Handle is a non-blocking enqueue.
+	b.dispatchChannelIntentAsync(msg)
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
@@ -488,6 +494,13 @@ func (b *Broker) PostMessage(from, channel, content string, tagged []string, rep
 	// goroutine never re-enters b.mu, so calling it under the lock is safe.
 	if b.humanWikiWriter != nil && isHumanMessageSender(msg.From) {
 		b.humanWikiWriter.Handle(msg)
+	}
+	// PR 5: channel intent dispatcher fires for ALL senders. Same lock
+	// invariants as PR 2's Handle: the dispatcher's queue-send is non-
+	// blocking and its goroutine never re-enters b.mu, so calling it
+	// under b.mu is safe.
+	if b.channelIntentDispatcher != nil {
+		b.channelIntentDispatcher.Handle(msg)
 	}
 	return msg, nil
 }

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -124,6 +124,16 @@ func (b *Broker) initWikiWorker() {
 		demandIdx = nil
 	}
 
+	// PR 5 (notebook-wiki-promise): channel intent dispatcher classifies
+	// question-form context-asks ("who has context on …") and feeds
+	// cross-agent notebook hits into the demand index as
+	// DemandSignalChannelContextAsk events. Dispatcher is started here so
+	// the goroutine is alive before the first PostMessage hook can fire.
+	// The optional reply path is OFF by default; toggle with
+	// WUPHF_CHANNEL_INTENT_REPLY=true.
+	channelIntent := NewChannelIntentDispatcher(b)
+	channelIntent.Start(lifecycleCtx)
+
 	b.mu.Lock()
 	b.wikiWorker = worker
 	b.wikiIndex = idx
@@ -133,6 +143,7 @@ func (b *Broker) initWikiWorker() {
 	b.autoNotebookWriter = autoWriter
 	b.humanWikiWriter = humanWiki
 	b.demandIndex = demandIdx
+	b.channelIntentDispatcher = channelIntent
 	b.mu.Unlock()
 	// Init succeeded; clear any cached failure so future calls don't surface
 	// stale errors from a previous attempt.

--- a/internal/team/channel_intent_classifier.go
+++ b/internal/team/channel_intent_classifier.go
@@ -1,0 +1,682 @@
+package team
+
+// channel_intent_classifier.go is PR 5 of the notebook-wiki-promise design
+// (~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md).
+//
+// It classifies channel messages that are asking for prior team context
+// ("who has context on X", "does anyone know what we decided about Y",
+// "what do we have on Z") and, on a hit, searches every agent's notebook
+// shelf for the topic. Each cross-agent hit feeds PR 3's NotebookDemandIndex
+// with a DemandSignalChannelContextAsk event (weight 2.0).
+//
+// Lock discipline (mirrors PR 1 auto_notebook_writer.go and PR 2
+// human_wiki_intent.go):
+//   - Handle() is called from broker_messages.go AFTER b.mu.Unlock(). It is a
+//     non-blocking enqueue — never re-enters b.mu.
+//   - The classifier (regex match + topic extraction) is pure CPU and runs
+//     INSIDE the dispatcher goroutine, not at the hook site. The hot path is
+//     a single channel send.
+//   - The dispatcher goroutine calls only:
+//       * client.NotebookSearchAll(query)   // file I/O, no b.mu
+//       * client.RecordDemandSignal(evt)    // idx.mu only
+//       * (optional) client.PostSystemMessage — gated OFF by default in PR 5.
+//     It NEVER acquires b.mu.
+//
+// Shutdown race (same as PR 1/PR 2): close stopCh, never the queue, so a
+// concurrent Handle() past the running.Load() check cannot panic on
+// send-to-closed-chan.
+
+import (
+	"context"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// channelIntentKind tags which family of phrase matched. Currently only one
+// kind exists (context_ask); the type is kept open so future intents (e.g.
+// "summarise X for me") can be added without churning the wire shape.
+type channelIntentKind string
+
+const (
+	// ChannelIntentContextAsk fires on question-form context-seeking phrases:
+	// "who has context on …", "does anyone know …", "what do we have on …".
+	ChannelIntentContextAsk channelIntentKind = "context_ask"
+)
+
+// channelIntentQueueSize mirrors PR 1/PR 2 — same enqueue cadence (one per
+// PostMessage), same drop-on-saturation safety net.
+const channelIntentQueueSize = 256
+
+// channelIntentSearchTimeout bounds a single NotebookSearchAll call so a
+// degenerate corpus or stuck git op cannot wedge the dispatcher goroutine.
+const channelIntentSearchTimeout = 10 * time.Second
+
+// channelIntentTopicMinTokens drops topic phrases shorter than this many
+// whitespace-delimited tokens. Without it, agent technical chatter like
+// "who has access" or "what we ship" produces 1- or 2-word topics that
+// match thousands of unrelated notebook lines.
+const channelIntentTopicMinTokens = 2
+
+// channelIntentTopicMaxLen caps the topic length used as a search query so
+// a runaway sentence does not turn into a multi-kilobyte regex search.
+const channelIntentTopicMaxLen = 120
+
+// envChannelIntentReply names the env var that toggles the optional system
+// reply post-summary. Default OFF for PR 5 — the spec leaves the wiring in
+// place but does not enable it. Set to "true" to opt in.
+const envChannelIntentReply = "WUPHF_CHANNEL_INTENT_REPLY"
+
+// channelIntentMatch is the classifier output. Topic is the noun phrase
+// after the question opener; it is used verbatim as the substring search
+// pattern across all notebook shelves.
+type channelIntentMatch struct {
+	Kind  channelIntentKind
+	Topic string
+}
+
+// channelIntentPattern pairs a kind with a question-form regex that captures
+// the topic in submatch 1. Order is significant: the first match wins.
+type channelIntentPattern struct {
+	Kind channelIntentKind
+	Re   *regexp.Regexp
+}
+
+// channelIntentPatterns is the locked classifier set. Each pattern anchors
+// at the start of the (trimmed, scrubbed) first line and requires an
+// interrogative form. Statements with the same verbs ("I have context …",
+// "we know …") do NOT match because the regex demands the question opener.
+//
+// Conservative by design: false positives flooding the demand index would
+// distort scoring across the team. PR 5b (deferred) will add an LLM-based
+// disambiguator if regex miss rate proves too high.
+var channelIntentPatterns = []channelIntentPattern{
+	// "who has (context|notes|docs|info|...) (on|about|for) X"
+	// "who wrote/owns/tracks (context|notes|...) (on|about) X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*who\s+(?:has|wrote|owns|tracks)\s+(?:any\s+|the\s+|some\s+)?(?:context|info(?:rmation)?|notes?|docs?|details?|history|background|knowledge)\s+(?:on|about|for|regarding|re)\s+(.+?)\??\s*$`)},
+	// "who knows about X" / "who remembers X" — bare verb + "about"; the
+	// topic noun is implicit ("knowledge"). Only fires when the verb
+	// directly governs "about" so "who knows the answer" does not match.
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*who\s+(?:knows|remembers|recalls)\s+(?:about|of|anything\s+about)\s+(.+?)\??\s*$`)},
+	// "does anyone (know|remember|recall) (about|what) X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*does\s+anyone\s+(?:know|remember|recall)\s+(?:about|of)\s+(.+?)\??\s*$`)},
+	// "does anyone know what we (decided|landed|did|did with) ... <topic>"
+	// — the "what we decided about" form pulls the topic from after the
+	// trailing preposition. Capture the tail and clean up "about|on|re"
+	// at the front of the match in cleanChannelIntentTopic.
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*does\s+anyone\s+(?:know|remember|recall)\s+what\s+we\s+(?:decided|landed|agreed|got|did|chose|picked)\s+(?:on|about|for|with|regarding|re)\s+(.+?)\??\s*$`)},
+	// "does anyone have (any|the|some) (context|notes|docs|info) (on|about) X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*does\s+anyone\s+have\s+(?:any\s+|the\s+|some\s+)?(?:context|info(?:rmation)?|notes?|docs?|details?|history|background)\s+(?:on|about|for|regarding|re)\s+(.+?)\??\s*$`)},
+	// "anyone know about X" (informal — drops "does")
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*anyone\s+(?:know|remember|recall)\s+(?:about|of)\s+(.+?)\??\s*$`)},
+	// "anyone have (context|notes|docs) on X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*anyone\s+have\s+(?:any\s+|the\s+|some\s+)?(?:context|info(?:rmation)?|notes?|docs?|details?|history|background)\s+(?:on|about|for|regarding|re)\s+(.+?)\??\s*$`)},
+	// "what (do|did|have) we (decide|land|agree) (on|about) X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*what\s+(?:do|did|have)\s+we\s+(?:decide(?:d)?|land(?:ed)?|agree(?:d)?|chose|pick(?:ed)?)\s+(?:on|about|for|with|regarding|re)\s+(.+?)\??\s*$`)},
+	// "what do we have on X" / "what do we know about X" / "what did we get on X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*what\s+(?:do\s+we|have\s+we|did\s+we)\s+(?:have|know|got)\s+(?:on|about|for|regarding|re)\s+(.+?)\??\s*$`)},
+	// "where can I find (info|context|docs) (on|about) X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*where\s+can\s+(?:i|we)\s+find\s+(?:any\s+|the\s+|some\s+)?(?:context|info(?:rmation)?|notes?|docs?|details?|history|background)\s+(?:on|about|for|regarding|re)\s+(.+?)\??\s*$`)},
+	// "do we have (notes|docs|context) on X"
+	{Kind: ChannelIntentContextAsk, Re: regexp.MustCompile(`(?i)^\s*(?:do|did)\s+we\s+have\s+(?:any\s+|the\s+|some\s+)?(?:context|info(?:rmation)?|notes?|docs?|details?|history|background|knowledge)\s+(?:on|about|for|regarding|re)\s+(.+?)\??\s*$`)},
+}
+
+// classifyChannelIntent inspects body and returns (match, true) when a
+// question-form context-ask matches. Otherwise (zero, false).
+//
+// Preprocessing:
+//   - Strip fenced code blocks (``` … ```) and inline backticks; intent
+//     phrases inside code do not count (mirrors PR 2's stripCodeFences).
+//   - Take the FIRST line only. A user pasting a long log followed by a
+//     question on line 30 should not flood the demand index.
+//   - Drop URLs from the first line so "who has context on https://…" does
+//     not treat the URL as the topic.
+//
+// Pure function: no locks, no I/O. Safe to call from any goroutine.
+func classifyChannelIntent(body string) (channelIntentMatch, bool) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" {
+		return channelIntentMatch{}, false
+	}
+
+	scrubbed := stripCodeFences(trimmed)
+	scrubbed = stripInlineCode(scrubbed)
+	scrubbed = strings.TrimSpace(scrubbed)
+	if scrubbed == "" {
+		return channelIntentMatch{}, false
+	}
+
+	firstLine := scrubbed
+	if idx := strings.IndexByte(scrubbed, '\n'); idx >= 0 {
+		firstLine = scrubbed[:idx]
+	}
+	firstLine = stripURLs(strings.TrimSpace(firstLine))
+	firstLine = strings.TrimSpace(firstLine)
+	if firstLine == "" {
+		return channelIntentMatch{}, false
+	}
+
+	// Question-form heuristic: line must end with "?" OR start with one of
+	// the recognised interrogative openers ("who", "does", "anyone",
+	// "what", "where", "do we", "did we"). This shape filter is what makes
+	// statements like "I have context on X" reliably miss.
+	if !looksLikeContextAskQuestion(firstLine) {
+		return channelIntentMatch{}, false
+	}
+
+	for _, pat := range channelIntentPatterns {
+		m := pat.Re.FindStringSubmatch(firstLine)
+		if m == nil {
+			continue
+		}
+		topic := ""
+		if len(m) >= 2 {
+			topic = strings.TrimSpace(m[1])
+		}
+		topic = cleanChannelIntentTopic(topic)
+		if !channelIntentTopicValid(topic) {
+			return channelIntentMatch{}, false
+		}
+		return channelIntentMatch{
+			Kind:  pat.Kind,
+			Topic: topic,
+		}, true
+	}
+	return channelIntentMatch{}, false
+}
+
+// channelIntentQuestionOpenerRe is a fast pre-filter: only lines whose first
+// word is one of the recognised interrogative openers reach the regex set.
+// This is the question-form gate that statements like "I have context on X"
+// must fail.
+var channelIntentQuestionOpenerRe = regexp.MustCompile(`(?i)^\s*(?:who|does|do|did|anyone|what|where)\b`)
+
+// looksLikeContextAskQuestion returns true when line is plausibly an
+// interrogative context-ask. The trailing "?" is NOT required — many users
+// drop it in chat — but the leading interrogative opener IS required.
+func looksLikeContextAskQuestion(line string) bool {
+	return channelIntentQuestionOpenerRe.MatchString(line)
+}
+
+// channelIntentURLRe strips http(s) URLs from the topic line. Email
+// addresses and bare hostnames are left in place — those are valid topic
+// fragments ("who has context on stripe.com integration").
+var channelIntentURLRe = regexp.MustCompile(`https?://\S+`)
+
+func stripURLs(s string) string {
+	return channelIntentURLRe.ReplaceAllString(s, " ")
+}
+
+// cleanChannelIntentTopic trims trailing punctuation and collapses
+// whitespace so the resulting search query is stable.
+func cleanChannelIntentTopic(topic string) string {
+	topic = strings.TrimSpace(topic)
+	if topic == "" {
+		return ""
+	}
+	// Drop a trailing question mark / period / exclamation that survived
+	// the regex.
+	topic = strings.TrimRight(topic, "?.!,;:")
+	topic = strings.TrimSpace(topic)
+	// Collapse runs of whitespace.
+	topic = strings.Join(strings.Fields(topic), " ")
+	if len(topic) > channelIntentTopicMaxLen {
+		// Cut at a UTF-8 boundary.
+		n := channelIntentTopicMaxLen
+		for n > 0 && (topic[n]&0xC0) == 0x80 {
+			n--
+		}
+		topic = strings.TrimSpace(topic[:n])
+	}
+	return topic
+}
+
+// channelIntentTopicValid enforces the minimum-tokens guard. Single-word
+// topics ("X") would match too broadly and feed the demand index with
+// spurious cross-agent signals.
+func channelIntentTopicValid(topic string) bool {
+	if topic == "" {
+		return false
+	}
+	tokens := strings.Fields(topic)
+	return len(tokens) >= channelIntentTopicMinTokens
+}
+
+// channelIntentBrokerClient is the slice of *Broker the dispatcher needs.
+// Kept as an interface so unit tests can substitute a fake without spinning
+// the real wiki worker / demand index / system message poster.
+type channelIntentBrokerClient interface {
+	// NotebookSearchAll runs a substring search across every notebook shelf
+	// (slug=all). Returns one merged hit slice plus a parallel slice of
+	// owner slugs aligned with hits — i.e. ownerSlugs[i] is the owner of
+	// hits[i]. Errors are logged by the caller; an error short-circuits
+	// the dispatch for one message without crashing the goroutine.
+	NotebookSearchAll(ctx context.Context, query string) (hits []WikiSearchHit, ownerSlugs []string, err error)
+	// RecordDemandSignal funnels a PromotionDemandEvent into the demand
+	// index. No-op when the index is nil.
+	RecordDemandSignal(evt PromotionDemandEvent) error
+	// PostSystemMessage is the optional reply path. Only invoked when
+	// envChannelIntentReply is "true".
+	PostSystemMessage(channel, content, kind string)
+}
+
+// ChannelIntentDispatcher ingests channel messages, classifies them, and
+// fires the demand-signal recording for cross-agent notebook hits.
+// Lifecycle mirrors AutoNotebookWriter: New → Start(ctx) → Stop(timeout).
+// Safe for concurrent Handle() callers.
+type ChannelIntentDispatcher struct {
+	client channelIntentBrokerClient
+	queue  chan channelMessage
+	// stopCh signals shutdown without closing w.queue. See PR 1's
+	// auto_notebook_writer for the rationale (close-vs-stopCh race).
+	stopCh chan struct{}
+
+	// progressMu + progressCond drive WaitForCondition for tests. Same
+	// pattern as AutoNotebookWriter / HumanWikiIntentWriter.
+	progressMu   sync.Mutex
+	progressCond *sync.Cond
+
+	running atomic.Bool
+	done    chan struct{}
+
+	// replyEnabled mirrors envChannelIntentReply at start time so the
+	// dispatcher's behaviour is locked once it begins. Defaults to false.
+	replyEnabled bool
+
+	// counters
+	enqueued     atomic.Int64
+	classified   atomic.Int64 // matched the regex
+	skipped      atomic.Int64 // no intent match
+	searched     atomic.Int64 // ran NotebookSearchAll at least once
+	hitsFound    atomic.Int64 // number of (path, owner) pairs recorded
+	demandFired  atomic.Int64 // RecordDemandSignal succeeded
+	searchFailed atomic.Int64
+	recordFailed atomic.Int64
+	queueSat     atomic.Int64
+	repliesSent  atomic.Int64
+}
+
+// ChannelIntentCounters is a thread-safe snapshot of the dispatcher's
+// observability counters.
+type ChannelIntentCounters struct {
+	Enqueued     int64
+	Classified   int64
+	Skipped      int64
+	Searched     int64
+	HitsFound    int64
+	DemandFired  int64
+	SearchFailed int64
+	RecordFailed int64
+	QueueSat     int64
+	RepliesSent  int64
+}
+
+// NewChannelIntentDispatcher constructs an idle dispatcher. nil client is
+// safe but disables the search + record path (counters still advance up to
+// classification).
+func NewChannelIntentDispatcher(client channelIntentBrokerClient) *ChannelIntentDispatcher {
+	d := &ChannelIntentDispatcher{
+		client: client,
+		queue:  make(chan channelMessage, channelIntentQueueSize),
+		stopCh: make(chan struct{}),
+		done:   make(chan struct{}),
+	}
+	d.progressCond = sync.NewCond(&d.progressMu)
+	d.replyEnabled = strings.EqualFold(strings.TrimSpace(os.Getenv(envChannelIntentReply)), "true")
+	return d
+}
+
+// Start launches the drain goroutine. Idempotent.
+func (d *ChannelIntentDispatcher) Start(ctx context.Context) {
+	if d == nil {
+		return
+	}
+	if d.running.Swap(true) {
+		return
+	}
+	go d.run(ctx)
+}
+
+// Stop signals the drain goroutine and waits up to timeout. Idempotent.
+// Mirrors AutoNotebookWriter.Stop — closes stopCh, never the queue, and
+// wakes any test goroutine parked on progressCond.
+func (d *ChannelIntentDispatcher) Stop(timeout time.Duration) {
+	if d == nil || !d.running.Swap(false) {
+		return
+	}
+	close(d.stopCh)
+	d.progressMu.Lock()
+	d.progressCond.Broadcast()
+	d.progressMu.Unlock()
+	if timeout <= 0 {
+		<-d.done
+		return
+	}
+	select {
+	case <-d.done:
+	case <-time.After(timeout):
+	}
+}
+
+// Handle is the broker-side ingress. Non-blocking enqueue. Drops with a
+// counter increment on saturation. The classifier is intentionally NOT
+// called here — it runs inside the dispatcher goroutine so the hot path
+// stays a single channel send.
+//
+// The hook fires for ALL senders (human or agent). The classifier's
+// question-form filter is what restricts demand recording to genuine
+// context-asks; sender role is not a useful pre-filter because agents can
+// also ask each other for context.
+func (d *ChannelIntentDispatcher) Handle(msg channelMessage) {
+	if d == nil || !d.running.Load() {
+		return
+	}
+	if strings.TrimSpace(msg.Content) == "" {
+		return
+	}
+	select {
+	case <-d.stopCh:
+		return
+	default:
+	}
+	select {
+	case <-d.stopCh:
+	case d.queue <- msg:
+		d.enqueued.Add(1)
+	default:
+		d.queueSat.Add(1)
+		log.Printf("channel_intent_dispatcher: queue saturated, dropping msg id=%s from=%s", msg.ID, msg.From)
+		d.signalProgress()
+	}
+}
+
+// signalProgress wakes any goroutine parked in WaitForCondition. Cheap.
+func (d *ChannelIntentDispatcher) signalProgress() {
+	d.progressMu.Lock()
+	d.progressCond.Broadcast()
+	d.progressMu.Unlock()
+}
+
+// WaitForCondition blocks until predicate returns true, ctx cancels, or the
+// dispatcher stops. Test-only.
+func (d *ChannelIntentDispatcher) WaitForCondition(ctx context.Context, predicate func() bool) error {
+	if d == nil {
+		return nil
+	}
+	if predicate() {
+		return nil
+	}
+	cancelWatcher := make(chan struct{})
+	defer close(cancelWatcher)
+	go func() {
+		select {
+		case <-ctx.Done():
+			d.progressMu.Lock()
+			d.progressCond.Broadcast()
+			d.progressMu.Unlock()
+		case <-cancelWatcher:
+		}
+	}()
+	d.progressMu.Lock()
+	defer d.progressMu.Unlock()
+	for !predicate() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !d.running.Load() {
+			if predicate() {
+				return nil
+			}
+			return ErrWorkerStopped
+		}
+		d.progressCond.Wait()
+	}
+	return nil
+}
+
+// Counters returns a thread-safe snapshot.
+func (d *ChannelIntentDispatcher) Counters() ChannelIntentCounters {
+	if d == nil {
+		return ChannelIntentCounters{}
+	}
+	return ChannelIntentCounters{
+		Enqueued:     d.enqueued.Load(),
+		Classified:   d.classified.Load(),
+		Skipped:      d.skipped.Load(),
+		Searched:     d.searched.Load(),
+		HitsFound:    d.hitsFound.Load(),
+		DemandFired:  d.demandFired.Load(),
+		SearchFailed: d.searchFailed.Load(),
+		RecordFailed: d.recordFailed.Load(),
+		QueueSat:     d.queueSat.Load(),
+		RepliesSent:  d.repliesSent.Load(),
+	}
+}
+
+func (d *ChannelIntentDispatcher) run(ctx context.Context) {
+	defer close(d.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-d.stopCh:
+			return
+		case msg := <-d.queue:
+			d.process(ctx, msg)
+		}
+	}
+}
+
+// process classifies one message and, on a match, performs the search +
+// demand-recording. Errors are logged + counter-incremented but never
+// surface to the caller — the dispatcher must stay alive across single
+// failures.
+func (d *ChannelIntentDispatcher) process(ctx context.Context, msg channelMessage) {
+	defer d.signalProgress()
+
+	match, ok := classifyChannelIntent(msg.Content)
+	if !ok {
+		d.skipped.Add(1)
+		return
+	}
+	d.classified.Add(1)
+
+	if d.client == nil {
+		// No client wired (test harness or partial init). We classified
+		// the intent but cannot search; bail before counting a search.
+		return
+	}
+
+	searchCtx, cancel := context.WithTimeout(ctx, channelIntentSearchTimeout)
+	defer cancel()
+
+	d.searched.Add(1)
+	hits, owners, err := d.client.NotebookSearchAll(searchCtx, match.Topic)
+	if err != nil {
+		d.searchFailed.Add(1)
+		log.Printf("channel_intent_dispatcher: NotebookSearchAll failed topic=%q: %v", match.Topic, err)
+		return
+	}
+	if len(hits) == 0 {
+		// Zero hits: classified an intent but no notebook entry answered.
+		// Do not record any demand event; the entry doesn't exist yet.
+		return
+	}
+
+	// Dedupe (entryPath, ownerSlug) pairs so a single search returning
+	// multiple line-level hits on the same file fires one demand event.
+	type pairKey struct {
+		path  string
+		owner string
+	}
+	seen := map[pairKey]struct{}{}
+	now := time.Now().UTC()
+	channel := strings.TrimSpace(msg.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	// SearcherSlug records the message author so the demand index can dedupe
+	// "same searcher same entry same day". For human senders this groups
+	// repeated questions from one person under one signal per day. For
+	// agent senders it does the same per agent.
+	searcher := strings.TrimSpace(msg.From)
+	if searcher == "" {
+		searcher = "channel"
+	}
+
+	for i, h := range hits {
+		owner := ""
+		if i < len(owners) {
+			owner = strings.TrimSpace(owners[i])
+		}
+		path := strings.TrimSpace(h.Path)
+		if path == "" || owner == "" {
+			continue
+		}
+		// Self-search guard: if the searcher is the same as the entry
+		// owner, this is the agent finding its own notebook. Not a
+		// cross-agent signal.
+		if owner == searcher {
+			continue
+		}
+		key := pairKey{path: path, owner: owner}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		evt := PromotionDemandEvent{
+			EntryPath:    path,
+			OwnerSlug:    owner,
+			SearcherSlug: searcher,
+			Signal:       DemandSignalChannelContextAsk,
+			RecordedAt:   now,
+		}
+		if err := d.client.RecordDemandSignal(evt); err != nil {
+			d.recordFailed.Add(1)
+			log.Printf("channel_intent_dispatcher: RecordDemandSignal failed path=%s: %v", path, err)
+			continue
+		}
+		d.hitsFound.Add(1)
+		d.demandFired.Add(1)
+	}
+
+	// Optional system reply path. OFF by default in PR 5; the env flag
+	// keeps the wiring discoverable for the demand-signals operator runbook
+	// without exposing the surface to users until the copy is reviewed.
+	if d.replyEnabled && d.client != nil && len(seen) > 0 && isHumanMessageSender(msg.From) {
+		summary := renderChannelIntentReply(match.Topic, hits, owners)
+		if summary != "" {
+			d.client.PostSystemMessage(channel, summary, "channel_intent_context")
+			d.repliesSent.Add(1)
+		}
+	}
+}
+
+// renderChannelIntentReply produces a short system-message summary for the
+// optional reply path. Format is intentionally terse: one line per hit,
+// owner-slug + path. The entry is not quoted in full — the demand index
+// is the durable record; the reply is just a pointer.
+func renderChannelIntentReply(topic string, hits []WikiSearchHit, owners []string) string {
+	if len(hits) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Found context on ")
+	b.WriteString(strings.TrimSpace(topic))
+	b.WriteString(":\n")
+	limit := len(hits)
+	if limit > 5 {
+		limit = 5
+	}
+	for i := 0; i < limit; i++ {
+		owner := ""
+		if i < len(owners) {
+			owner = strings.TrimSpace(owners[i])
+		}
+		if owner == "" {
+			owner = "agent"
+		}
+		b.WriteString("- @")
+		b.WriteString(owner)
+		b.WriteString(": ")
+		b.WriteString(hits[i].Path)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// dispatchChannelIntentAsync is the broker-side helper invoked from
+// handlePostMessage / PostMessage AFTER b.mu.Unlock(). nil-safe: a missing
+// dispatcher is a silent no-op so PR 5 can revert by clearing
+// b.channelIntentDispatcher without breaking message posting.
+//
+// Lock invariant: caller MUST NOT hold b.mu. The dispatcher's Handle is
+// non-blocking and its goroutine never re-enters b.mu.
+func (b *Broker) dispatchChannelIntentAsync(msg channelMessage) {
+	if b == nil {
+		return
+	}
+	d := b.channelIntentDispatcher
+	if d == nil {
+		return
+	}
+	d.Handle(msg)
+}
+
+// NotebookSearchAll runs a substring search across every notebook shelf
+// (slug=all) and returns the merged hits with a parallel slice of owner
+// slugs. This is the broker-side adapter for ChannelIntentDispatcher and
+// any future caller that needs the same cross-shelf rollup outside the
+// HTTP path.
+//
+// Lock invariant: this method does NOT acquire b.mu. It calls
+// notebookSearchSlugs (which itself calls b.OfficeMembers and so does
+// briefly take b.mu), then iterates worker.NotebookSearch — both are
+// safe to invoke from a goroutine.
+func (b *Broker) NotebookSearchAll(_ context.Context, query string) ([]WikiSearchHit, []string, error) {
+	if b == nil {
+		return nil, nil, nil
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		return nil, nil, nil
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil, nil
+	}
+	slugs, err := b.notebookSearchSlugs(worker)
+	if err != nil {
+		return nil, nil, err
+	}
+	var hits []WikiSearchHit
+	var owners []string
+	for _, slug := range slugs {
+		slugHits, err := worker.NotebookSearch(slug, query)
+		if err != nil {
+			// Skip per-slug failures rather than abort the whole sweep.
+			// A single corrupt shelf must not silence cross-agent demand.
+			log.Printf("channel_intent: NotebookSearch slug=%s failed: %v", slug, err)
+			continue
+		}
+		for _, h := range slugHits {
+			hits = append(hits, h)
+			owners = append(owners, slug)
+		}
+	}
+	return hits, owners, nil
+}
+
+// RecordDemandSignal funnels an event into the demand index. nil-safe:
+// when the index is not wired the call is a silent no-op so the dispatcher
+// can run on a partially-initialised broker without crashing.
+func (b *Broker) RecordDemandSignal(evt PromotionDemandEvent) error {
+	if b == nil || b.demandIndex == nil {
+		return nil
+	}
+	return b.demandIndex.Record(evt)
+}

--- a/internal/team/channel_intent_classifier_test.go
+++ b/internal/team/channel_intent_classifier_test.go
@@ -1,0 +1,264 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyChannelIntent_Matches covers the full set of supported
+// question-form context-ask patterns. Each row is a positive example: the
+// classifier must match and extract the topic phrase shown in want.
+func TestClassifyChannelIntent_Matches(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantKind  channelIntentKind
+		wantTopic string
+	}{
+		{
+			name:      "who has context on",
+			body:      "who has context on our onboarding flow",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "our onboarding flow",
+		},
+		{
+			name:      "who knows about (no question mark)",
+			body:      "who knows about the billing migration",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "the billing migration",
+		},
+		{
+			name:      "who has notes on with trailing question mark",
+			body:      "who has notes on the auth incident?",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "the auth incident",
+		},
+		{
+			name:      "does anyone know about",
+			body:      "does anyone know about our pricing experiments",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "our pricing experiments",
+		},
+		{
+			name:      "does anyone remember what we decided about",
+			body:      "does anyone remember what we decided about retro cadence",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "retro cadence",
+		},
+		{
+			name:      "anyone know about (informal)",
+			body:      "anyone know about the deployment gotchas",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "the deployment gotchas",
+		},
+		{
+			name:      "what do we have on",
+			body:      "what do we have on the API rate limits",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "the API rate limits",
+		},
+		{
+			name:      "what did we decide about",
+			body:      "what did we decide about feature flag naming",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "feature flag naming",
+		},
+		{
+			name:      "where can I find context on",
+			body:      "where can I find context on our launch checklist",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "our launch checklist",
+		},
+		{
+			name:      "do we have notes on",
+			body:      "do we have notes on the incident response runbook",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "the incident response runbook",
+		},
+		{
+			name:      "case-insensitive opener",
+			body:      "WHO HAS CONTEXT ON our ICP definition",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "our ICP definition",
+		},
+		{
+			name:      "leading whitespace tolerated",
+			body:      "   who has context on the founding story",
+			wantKind:  ChannelIntentContextAsk,
+			wantTopic: "the founding story",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classifyChannelIntent(tc.body)
+			if !ok {
+				t.Fatalf("expected match for %q, got none", tc.body)
+			}
+			if got.Kind != tc.wantKind {
+				t.Fatalf("kind = %q, want %q", got.Kind, tc.wantKind)
+			}
+			if got.Topic != tc.wantTopic {
+				t.Fatalf("topic = %q, want %q", got.Topic, tc.wantTopic)
+			}
+		})
+	}
+}
+
+// TestClassifyChannelIntent_NoMatch covers the negative cases: statement
+// form, agent technical chatter, code fences, URLs-as-topics, and topics
+// that are too short to be useful.
+func TestClassifyChannelIntent_NoMatch(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: ""},
+		{name: "whitespace only", body: "   \n\t  "},
+		{
+			name: "statement form first person",
+			body: "I have context on the onboarding flow",
+		},
+		{
+			name: "statement form we know",
+			body: "we know about the billing migration",
+		},
+		{
+			name: "statement form anyone can",
+			body: "anyone can see this",
+		},
+		{
+			name: "we have docs (statement)",
+			body: "we have good docs on the API rate limits",
+		},
+		{
+			name: "no topic — single token",
+			body: "who has context on X",
+		},
+		{
+			name: "code fence wrapping the question",
+			body: "```\nwho has context on our onboarding flow\n```",
+		},
+		{
+			name: "inline backtick wrapping the verb",
+			body: "`who has context on` our onboarding",
+		},
+		{
+			name: "URL stripped leaves no topic",
+			body: "who has context on https://example.com",
+		},
+		{
+			name: "bare 'remember' — historical, not a question",
+			body: "remember when we shipped the auth PR",
+		},
+		{
+			name: "agent technical output: who has access",
+			body: "who has access to the prod database",
+		},
+		{
+			name: "agent technical output: what is X",
+			body: "what is the current head sha",
+		},
+		{
+			name: "wrong opener",
+			body: "should we add notes on the launch checklist",
+		},
+		{
+			name: "question form but no recognised verb",
+			body: "who likes pizza on friday",
+		},
+		{
+			name: "question on later line, log first",
+			body: "ERROR: build failed at step 3\nstack trace blah\nwho has context on the build",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, ok := classifyChannelIntent(tc.body); ok {
+				t.Fatalf("expected no match for %q, got %+v", tc.body, got)
+			}
+		})
+	}
+}
+
+// TestClassifyChannelIntent_TopicCleanup verifies trailing punctuation is
+// dropped, whitespace is collapsed, and overlong topics are truncated.
+func TestClassifyChannelIntent_TopicCleanup(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantTopic string
+	}{
+		{
+			name:      "trailing question mark dropped",
+			body:      "who has context on our onboarding flow?",
+			wantTopic: "our onboarding flow",
+		},
+		{
+			name:      "trailing period dropped",
+			body:      "what do we know about the launch.",
+			wantTopic: "the launch",
+		},
+		{
+			name:      "internal whitespace collapsed",
+			body:      "who has context on    our   onboarding   flow",
+			wantTopic: "our onboarding flow",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := classifyChannelIntent(tc.body)
+			if !ok {
+				t.Fatalf("expected match for %q", tc.body)
+			}
+			if got.Topic != tc.wantTopic {
+				t.Fatalf("topic = %q, want %q", got.Topic, tc.wantTopic)
+			}
+		})
+	}
+}
+
+// TestClassifyChannelIntent_TopicLengthCap exercises channelIntentTopicMaxLen.
+// A topic longer than the cap is truncated; the result still passes the
+// minimum-tokens guard.
+func TestClassifyChannelIntent_TopicLengthCap(t *testing.T) {
+	long := strings.Repeat("alpha beta ", 30) // ~330 chars, far above the cap
+	body := "who has context on " + long
+	got, ok := classifyChannelIntent(body)
+	if !ok {
+		t.Fatalf("expected match")
+	}
+	if len(got.Topic) > channelIntentTopicMaxLen {
+		t.Fatalf("topic length = %d, want ≤ %d", len(got.Topic), channelIntentTopicMaxLen)
+	}
+	if len(strings.Fields(got.Topic)) < channelIntentTopicMinTokens {
+		t.Fatalf("truncated topic %q lost minimum tokens", got.Topic)
+	}
+}
+
+// TestRenderChannelIntentReply locks the optional reply format. Even though
+// the reply path is OFF by default in PR 5, the renderer is a pure function
+// and easy to pin so the format is reviewable independently.
+func TestRenderChannelIntentReply(t *testing.T) {
+	hits := []WikiSearchHit{
+		{Path: "agents/pm/notebook/2026-05-06-icp.md", Line: 1, Snippet: "..."},
+		{Path: "agents/eng/notebook/2026-05-05-onboarding.md", Line: 1, Snippet: "..."},
+	}
+	owners := []string{"pm", "eng"}
+	out := renderChannelIntentReply("our onboarding flow", hits, owners)
+	if !strings.Contains(out, "Found context on our onboarding flow") {
+		t.Fatalf("missing header: %q", out)
+	}
+	if !strings.Contains(out, "@pm") || !strings.Contains(out, "@eng") {
+		t.Fatalf("expected both owners cited: %q", out)
+	}
+	if !strings.Contains(out, "agents/pm/notebook/2026-05-06-icp.md") {
+		t.Fatalf("expected first path cited: %q", out)
+	}
+}
+
+// TestRenderChannelIntentReply_Empty returns "" when no hits.
+func TestRenderChannelIntentReply_Empty(t *testing.T) {
+	if got := renderChannelIntentReply("topic", nil, nil); got != "" {
+		t.Fatalf("expected empty reply, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

PR 5 of the notebook-wiki-promise series. Built on PR 3's `NotebookDemandIndex` (#692, merged).

New `ChannelIntentDispatcher` ingests every channel message, classifies question-form context-asks, runs a `slug=all` notebook search, and records `DemandSignalChannelContextAsk` (weight 2.0) per matched `(entry, owner)` pair.

**Recognized question forms:**
- "who has context on X"
- "does anyone know about X"
- "what do we have on X"
- "where can I find info on X"
- "anyone know what we decided about X"

Hook fires for ALL senders — humans and agents. Context-asks happen in both directions; the classifier's question-form regex is the filter, not sender role.

## Architecture

Mirrors PR 1's `AutoNotebookWriter` and PR 2's `HumanWikiIntentWriter`:

| Pattern | Why |
|---|---|
| Buffered queue (256), `stopCh` (never close queue) | Prevents send-to-closed-chan panic on shutdown race |
| Classifier inside dispatcher goroutine | Hook site stays sub-microsecond; PR 5b LLM upgrade fits without touching hot path |
| `sync.Cond` `WaitForCondition` | Tests gate on observable state without sleeping |
| `atomic.Int64` counters: matched, searched, hitsFound, queueSat | Queue-saturation observability |
| Drop-on-saturation | Same back-pressure pattern as PR 1/2 |

**Lock discipline:** `Handle` is non-blocking enqueue. Classifier + search + record run inside dispatcher goroutine, never re-entering `b.mu`.

**Conservative regex:** two-stage filter — fast `(?i)^\s*(who|does|do|did|anyone|what|where)\b` opener gate, then the per-pattern regex. Statement forms ("I have context on X", "we know about Y") never reach the regex set. Topic min-2-tokens guard + URL/code-fence stripping.

**New API:** `Broker.NotebookSearchAll(ctx, query)` wraps existing `slug=all` logic for non-HTTP callers. Returns parallel `hits` + `owners` slices so the dispatcher records one event per `(path, owner)` pair, mirroring PR 3's contract.

**Optional reply:** `PostSystemMessage` summary is wired but gated OFF behind `WUPHF_CHANNEL_INTENT_REPLY=true`. Renderer is pure-function unit-tested so the format is reviewable now.

## Tests

| File | Count | Coverage |
|---|---|---|
| `channel_intent_classifier_test.go` | 12 + 16 + 3 + 1 | 12 positive matches, 16 no-match (statements, code fences, URLs, agent technical chatter), 3 topic-cleanup, length cap |
| `broker_channel_intent_test.go` | 4 integration | ContextAskRecordsDemand (score ≥ 2.0), NoHitsNoDemand, NonQuestionMessageSkipped, AgentSenderAlsoTriggers |

Full `internal/team` race-on: **107s green**.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l internal/team/` empty
- [x] `go vet ./internal/team/...`
- [x] `golangci-lint run ./internal/team/...` 0 issues
- [x] `go test -count=1 -race -timeout 600s ./internal/team/`
- [x] `bash scripts/check-no-new-sleeps-in-tests.sh`
- [ ] **Manual:** post `"who has context on our onboarding flow?"` in #general; confirm `events.jsonl` gains a `channel_context_ask` entry per matched notebook hit.
- [ ] **Manual:** post `"i have context on the auth incident"` (statement form); confirm no events.

## Deferred
- **PR 5b:** LLM disambiguator on top of regex. Only execute if regex miss rate >25% on production traffic per spec.
- Default-on of `WUPHF_CHANNEL_INTENT_REPLY` — needs copy review.
- Wiring into `PostInboundSurfaceMessage` (Telegram inbound) — transport coupling out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)