### PR TITLE
feat(team): prompt-side reinforcement for notebook→wiki demand pipeline (PR 7)

### DIFF
--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -192,6 +192,8 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for cancelable clarifications, and team_request for blocking decisions\n")
 		if markdownMemory {
 			sb.WriteString("8. When you lock a durable decision, write it to your notebook first and submit notebook_promote if it should become canonical wiki knowledge\n")
+			sb.WriteString("8b. Use team_notebook_review to see which notebook entries have earned promotion demand from cross-agent searches and channel context-asks. The tool surfaces candidates ranked by multi-agent convergence — review and approve those with the highest demand rather than scanning shelves manually. Calling the tool is itself a demand signal, so use it when you are actually curating, not as background polling.\n")
+			sb.WriteString("8c. When another agent or the human explicitly asks you to preserve something for the team, OR when team_notebook_review surfaces an entry with high demand, call notebook_promote in the same turn before you claim it is stored. The reviewer model is the quality gate — the broker auto-writes; you curate.\n")
 		} else if noNex {
 			sb.WriteString("8. Summarize final decisions clearly in-channel\n")
 		} else {
@@ -329,6 +331,7 @@ func (p *promptBuilder) Build(slug string) string {
 		}
 		if markdownMemory {
 			sb.WriteString("12. Use wuphf_wiki_lookup, team_wiki_search, or notebook_search when prior knowledge matters. Store your own durable working notes with notebook_write and submit notebook_promote when they should become canonical.\n")
+			sb.WriteString("12b. When another agent or the human explicitly asks you to preserve something for the team, OR when your own scan reveals a notebook entry that is clearly high-demand (cross-agent searches converging on it, repeated context-asks), call notebook_promote in the same turn before you claim it is stored. The reviewer model is the quality gate — the broker auto-writes; you curate.\n")
 			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
 		} else if noNex {
 			sb.WriteString("12. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n")
@@ -354,7 +357,7 @@ func (p *promptBuilder) Build(slug string) string {
 func markdownKnowledgeToolBlock() string {
 	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
 		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
-		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves.\n" +
+		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves. Cross-agent searches (looking at another agent's shelf) are tracked as promotion-demand signals — if their entry answers your question, the promotion pipeline scores it higher and surfaces it for review, so actually search instead of guessing.\n" +
 		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +
 		"- team_learning_search: Search typed prior learnings before repeating substantial work. Prefer scoped search by playbook, file, task, or repo when available; treat source/trust/confidence as evidence quality.\n" +
 		"- team_learning_record: Record a durable typed learning only when it would save future work or prevent a repeat mistake. Use user-stated only when the human explicitly said it; otherwise choose observed, inferred, execution, synthesis, cross-agent, or cross-model with an honest confidence.\n" +

--- a/internal/team/prompt_builder_test.go
+++ b/internal/team/prompt_builder_test.go
@@ -333,6 +333,149 @@ func TestPromptBuilder_LeadIncludesActivePoliciesSorted(t *testing.T) {
 	}
 }
 
+func TestMarkdownKnowledgeToolBlock_HumanRememberAutoRoutingNote(t *testing.T) {
+	// PR 7 edit 1: the team_wiki_write description must warn agents that the
+	// broker auto-routes human "remember this" / "save to wiki" phrases so
+	// they do not duplicate the write. PR 2 originally added this copy; PR 7
+	// keeps it as a regression gate.
+	block := markdownKnowledgeToolBlock()
+	for _, want := range []string{
+		"remember this",
+		"save to wiki",
+		"do NOT re-route",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("markdownKnowledgeToolBlock missing human auto-routing fragment %q", want)
+		}
+	}
+}
+
+func TestMarkdownKnowledgeToolBlock_NotebookSearchDemandSignalNote(t *testing.T) {
+	// PR 7 edit 2: cross-agent notebook searches are demand signals.
+	block := markdownKnowledgeToolBlock()
+	for _, want := range []string{
+		"Cross-agent searches",
+		"promotion-demand",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("markdownKnowledgeToolBlock missing demand-signal fragment %q", want)
+		}
+	}
+}
+
+func TestPromptBuilder_CEORuleMentionsTeamNotebookReview(t *testing.T) {
+	// PR 7 edit 3: the CEO prompt must mention team_notebook_review and the
+	// "calling the tool is itself a demand signal" caveat.
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies:       func() []officePolicy { return nil },
+		nameFor:        func(slug string) string { return slug },
+		markdownMemory: true,
+	}
+	got := pb.Build("ceo")
+	for _, want := range []string{
+		"team_notebook_review",
+		"multi-agent convergence",
+		"demand signal",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("CEO prompt missing team_notebook_review fragment %q", want)
+		}
+	}
+}
+
+func TestPromptBuilder_NonCEOOmitsTeamNotebookReview(t *testing.T) {
+	// PR 7 edit 3 is CEO-only. Specialist prompts must not include
+	// team_notebook_review (it is not in their tool set).
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies:       func() []officePolicy { return nil },
+		nameFor:        func(slug string) string { return slug },
+		markdownMemory: true,
+	}
+	got := pb.Build("fe")
+	if strings.Contains(got, "team_notebook_review") {
+		t.Fatalf("specialist prompt must not mention team_notebook_review (CEO-only tool)")
+	}
+}
+
+func TestPromptBuilder_PromoteWhenAskedBehavior(t *testing.T) {
+	// PR 7 edit 4: both CEO and specialist prompts must tell agents to call
+	// notebook_promote in the same turn when explicitly asked.
+	mk := func(slug string) *promptBuilder {
+		return &promptBuilder{
+			isOneOnOne:  func() bool { return false },
+			isFocusMode: func() bool { return false },
+			packName:    func() string { return "WUPHF Office" },
+			leadSlug:    func() string { return "ceo" },
+			members: func() []officeMember {
+				return []officeMember{
+					{Slug: "ceo", Name: "CEO"},
+					{Slug: "fe", Name: "Frontend"},
+				}
+			},
+			policies:       func() []officePolicy { return nil },
+			nameFor:        func(s string) string { return s },
+			markdownMemory: true,
+		}
+	}
+	for _, slug := range []string{"ceo", "fe"} {
+		got := mk(slug).Build(slug)
+		if !strings.Contains(got, "notebook_promote in the same turn") {
+			t.Errorf("%s prompt missing promote-when-asked instruction", slug)
+		}
+		if !strings.Contains(got, "broker auto-writes; you curate") {
+			t.Errorf("%s prompt missing broker-curates framing", slug)
+		}
+	}
+}
+
+func TestPromptBuilder_RegressionNotebookPromoteStillPresent(t *testing.T) {
+	// Regression: existing notebook_promote guidance line must still appear
+	// in both the CEO rule 8 and the specialist rule 12.
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies:       func() []officePolicy { return nil },
+		nameFor:        func(slug string) string { return slug },
+		markdownMemory: true,
+	}
+	ceoPrompt := pb.Build("ceo")
+	if !strings.Contains(ceoPrompt, "submit notebook_promote if it should become canonical wiki knowledge") {
+		t.Fatalf("CEO prompt regression: original notebook_promote rule 8 missing")
+	}
+	fePrompt := pb.Build("fe")
+	if !strings.Contains(fePrompt, "submit notebook_promote when they should become canonical") {
+		t.Fatalf("specialist prompt regression: original notebook_promote rule 12 missing")
+	}
+}
+
 func TestPromptBuilder_DeterministicOrderingFromMembers(t *testing.T) {
 	// PLAN.md trap-adjacent: prompt cache hits depend on byte-identical
 	// output across runs. The promptBuilder must sort its own members


### PR DESCRIPTION
## Summary

PR 7 of the notebook-wiki-promise series. **Pure prompt copy edits** in `prompt_builder.go` that reinforce the behaviors PRs 2, 3, 4, and 5 introduce. No code paths, no goroutines, no locks.

Four targeted edits, all gated behind `markdownMemory==true`:

| # | Edit | Audience |
|---|---|---|
| 1 | Auto-routing caveat on `team_wiki_write` (covered by PR 2; pinned by regression test) | All |
| 2 | Demand-signal note on `notebook_search` — cross-agent searches surface higher-scored entries | All |
| 3 | CEO `team_notebook_review` rules `8b` + `8c` — multi-agent convergence ranking, calling the tool is itself a demand signal | CEO/lead only |
| 4 | Promote-when-asked specialist rule `12b` — call `notebook_promote` when asked OR when own scan reveals high-demand entry | All specialists |

## Tests

| Test | Pins |
|---|---|
| `TestMarkdownKnowledgeToolBlock_HumanRememberAutoRoutingNote` | PR 2 copy |
| `TestMarkdownKnowledgeToolBlock_NotebookSearchDemandSignalNote` | Edit 2 |
| `TestPromptBuilder_CEORuleMentionsTeamNotebookReview` | Edit 3 (positive) |
| `TestPromptBuilder_NonCEOOmitsTeamNotebookReview` | Edit 3 (negative — specialist must NOT see CEO rules) |
| `TestPromptBuilder_PromoteWhenAskedBehavior` | Edit 4 (CEO + specialist) |
| `TestPromptBuilder_RegressionNotebookPromoteStillPresent` | guards original rule 8 / rule 12 strings |

Full `internal/team` race-on: **203.7s green**.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/team/...`
- [x] `golangci-lint run ./internal/team/...` 0 issues
- [x] `go test -count=1 -race -timeout 600s ./internal/team/`

## Reversibility
Each edit is a reversible string addition. No callers, no schemas, no broker behavior touched. Revert PR 7 = revert exactly the four sentences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notebook review and promotion workflows to improve knowledge curation
  * Added new rules to identify and surface high-demand entries for team knowledge preservation
  * Improved cross-agent signal detection for better knowledge discoverability

* **Tests**
  * Significantly expanded test coverage for prompt-building behaviors and agent configurations
  * Added comprehensive validation tests for notebook curation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->