### PR TITLE
feat(team): canonical HeadlessEvent envelope + SSE replay-end boundary

### DIFF
--- a/internal/team/broker_agent_stream_replay_test.go
+++ b/internal/team/broker_agent_stream_replay_test.go
@@ -1,0 +1,79 @@
+package team
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHandleAgentStreamEmitsReplayEndBoundary pins the contract that
+// handleAgentStream sends a named `event: replay-end` SSE entry between
+// the recent-history replay and the live subscription. The frontend
+// uses this boundary to flip its `phase` ref from "replay" to "live"
+// so terminal events (HeadlessEvent idle) emitted during the live
+// window can close the EventSource — but replayed terminal events
+// from the history buffer must not.
+//
+// We pre-seed the agent's stream buffer with a fake history line, hit
+// the SSE handler, and assert the response body order is:
+//
+//	data: <history-line>
+//	event: replay-end
+//	data: {}
+//	... (live messages or heartbeat)
+//
+// The exact heartbeat/live entries are out of scope — we only need to
+// see the boundary in the right place.
+func TestHandleAgentStreamEmitsReplayEndBoundary(t *testing.T) {
+	b := newTestBroker(t)
+	stream := b.AgentStream("ceo")
+
+	// Pre-seed history. PushTask appends to both the global history and
+	// the per-task slot; we use a task ID so the test exercises the
+	// task-scoped subscribeTaskWithRecent branch (the most common path
+	// in production today).
+	stream.PushTask("task-1", `{"type":"system","subtype":"init"}`+"\n")
+
+	srv := httptest.NewServer(b.requireAuth(b.handleAgentStream))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/agent-stream/ceo?task=task-1", nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	// Read just enough of the stream to see history → boundary → first
+	// live entry (or heartbeat). A small fixed-size buffer is enough;
+	// we cancel the context after to unblock the server goroutine.
+	buf := make([]byte, 4096)
+	n, _ := resp.Body.Read(buf)
+	got := string(buf[:n])
+	cancel()
+
+	historyIdx := strings.Index(got, `"type":"system"`)
+	boundaryIdx := strings.Index(got, "event: replay-end\ndata: {}\n\n")
+	if historyIdx < 0 {
+		t.Fatalf("history line not seen in stream: %q", got)
+	}
+	if boundaryIdx < 0 {
+		t.Fatalf("replay-end boundary not emitted: %q", got)
+	}
+	if boundaryIdx <= historyIdx {
+		t.Fatalf("replay-end boundary must come after history (history=%d, boundary=%d): %q", historyIdx, boundaryIdx, got)
+	}
+}

--- a/internal/team/broker_sse.go
+++ b/internal/team/broker_sse.go
@@ -412,7 +412,19 @@ func (b *Broker) handleAgentStream(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// If no history, send a connected event so the client knows the stream is live.
+	// Replay-end boundary marker. The frontend listens for this named SSE
+	// event to flip its `phase` ref from "replay" to "live" so behaviors
+	// keyed on parsed events (e.g. closing the EventSource on a HeadlessEvent
+	// idle) only fire for live entries — replayed idle from the history
+	// buffer must NOT silently kill the connection. Default `data:` lines
+	// (both history and live) continue to land on `onmessage` so existing
+	// consumers keep working without any code change.
+	if _, err := fmt.Fprintf(w, "event: replay-end\ndata: {}\n\n"); err != nil {
+		return
+	}
+	// If no history, also send a connected marker so the client knows the
+	// stream is live. Kept after the replay-end boundary so its ordering
+	// relative to real entries is unambiguous.
 	if len(history) == 0 {
 		if _, err := fmt.Fprintf(w, "data: [connected]\n\n"); err != nil {
 			return

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -206,6 +206,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			detail,
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
+		emitHeadlessTerminal(agentStream, HeadlessProviderClaude, slug, taskID, "", detail, metrics, claudeUsageToTokenUsage(result.Usage))
 		return fmt.Errorf("%w: %s", err, detail)
 	}
 	if parseErr != nil {
@@ -218,6 +219,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			parseErr.Error(),
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
+		emitHeadlessTerminal(agentStream, HeadlessProviderClaude, slug, taskID, "", parseErr.Error(), metrics, claudeUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 
@@ -236,6 +238,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	emitHeadlessTerminal(agentStream, HeadlessProviderClaude, slug, taskID, summary, "", metrics, claudeUsageToTokenUsage(result.Usage))
 	if l.broker != nil {
 		l.broker.RecordAgentUsage(slug, l.headlessClaudeModel(slug), result.Usage)
 	}
@@ -268,6 +271,18 @@ func (l *Launcher) headlessClaudeMaxTurns(slug string) string {
 		return "30"
 	}
 	return "15"
+}
+
+// claudeUsageToTokenUsage adapts the provider-level ClaudeUsage record
+// into the runner-agnostic envelope HeadlessEvent expects. Cost and
+// cache-token fields are dropped: the wire shape only carries
+// input/output for now, and adding more fields here would force a wire
+// change for every runner.
+func claudeUsageToTokenUsage(u provider.ClaudeUsage) *headlessTokenUsage {
+	if u.InputTokens == 0 && u.OutputTokens == 0 {
+		return nil
+	}
+	return &headlessTokenUsage{InputTokens: u.InputTokens, OutputTokens: u.OutputTokens}
 }
 
 func (l *Launcher) buildHeadlessClaudeEnv(slug string) []string {

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -213,6 +213,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			))
 			appendHeadlessCodexLog(slug, "stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
+			emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, "", detail, metrics, codexUsageToTokenUsage(result.Usage))
 			if isCodexAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -232,11 +233,13 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			durationMillis(startedAt, firstToolAt),
 			err.Error(),
 		))
+		emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, "", err.Error(), metrics, codexUsageToTokenUsage(result.Usage))
 		return err
 	}
 	if parseErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
+		emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, "", parseErr.Error(), metrics, codexUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 	metrics.TotalMs = time.Since(startedAt).Milliseconds()
@@ -254,6 +257,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, summary, "", metrics, codexUsageToTokenUsage(result.Usage))
 	if l.broker != nil && (result.Usage.InputTokens != 0 || result.Usage.OutputTokens != 0 || result.Usage.CacheReadTokens != 0 || result.Usage.CacheCreationTokens != 0 || result.Usage.CostUSD != 0) {
 		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
 	}
@@ -268,6 +272,16 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		}
 	}
 	return nil
+}
+
+// codexUsageToTokenUsage adapts the Codex provider's ClaudeUsage record
+// (yes — Codex shares the ClaudeUsage envelope) into the runner-agnostic
+// shape HeadlessEvent expects.
+func codexUsageToTokenUsage(u provider.ClaudeUsage) *headlessTokenUsage {
+	if u.InputTokens == 0 && u.OutputTokens == 0 {
+		return nil
+	}
+	return &headlessTokenUsage{InputTokens: u.InputTokens, OutputTokens: u.OutputTokens}
 }
 
 func (l *Launcher) headlessCodexNeedsDangerousBypass(slug string) bool {

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -1,0 +1,183 @@
+package team
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// HeadlessEvent is the canonical, provider-agnostic envelope for a single
+// progress signal emitted from a headless agent turn. All four runners
+// (Claude, Codex, Opencode, OpenAI-compatible) populate the same shape so
+// the web UI can render a normalized timeline regardless of which
+// provider is executing.
+//
+// Wire shape: emitted as one JSONL line on /agent-stream/{slug} with
+// `kind` set to "headless_event" so the frontend can branch on a single
+// discriminator without inspecting type-specific fields. The line lives
+// alongside the raw provider chunks the runner already tees into the
+// stream — additive for now so existing consumers keep working; future
+// slices may replace the raw tee once the typed channel is the system
+// of record.
+//
+// Field semantics:
+//
+//   - Kind: always "headless_event". Lets a JSON.parse-then-discriminate
+//     consumer skip provider-native events without a structural sniff.
+//   - Type: phase of the turn — "status", "text", "tool_use",
+//     "tool_result", "idle", "error". A2-MVP emits only "idle" and
+//     "error"; the remaining types are reserved so the wire shape does
+//     not churn when later slices wire up per-runner mappers for the
+//     intermediate phases.
+//   - Provider: "claude" | "codex" | "opencode" | "openai-compat".
+//   - Agent: the speaker slug (the agent the turn belongs to).
+//   - TurnID, TaskID, ParentID: correlation IDs. TurnID groups events
+//     from one ReadXxxJSONStream call. TaskID is the broker task the
+//     turn is servicing (already used for SSE scoping in /agent-stream
+//     ?task=). ParentID is reserved for nested tool/sub-agent calls.
+//   - ToolName, Detail: payload for tool_use / tool_result / error.
+//   - Text: payload for text events (and the human-readable summary
+//     for idle).
+//   - Status: "active" | "idle" | "error" — mirrors the activity
+//     snapshot status so a single event drives both the timeline and
+//     status-pill subscribers.
+//   - StartedAt: RFC3339 timestamp from the runner's clock so ordering
+//     survives reordering at the SSE boundary and replay timing is
+//     reconstructable.
+//   - Metrics: turn-level latency and token totals. Populated on idle.
+//   - RawType: the underlying provider event type for debug tooling.
+//     Empty for runner-synthesized events like idle.
+type HeadlessEvent struct {
+	Kind      string                `json:"kind"`
+	Type      string                `json:"type"`
+	Provider  string                `json:"provider,omitempty"`
+	Agent     string                `json:"agent,omitempty"`
+	TurnID    string                `json:"turn_id,omitempty"`
+	TaskID    string                `json:"task_id,omitempty"`
+	ParentID  string                `json:"parent_id,omitempty"`
+	ToolName  string                `json:"tool_name,omitempty"`
+	Text      string                `json:"text,omitempty"`
+	Detail    string                `json:"detail,omitempty"`
+	Status    string                `json:"status,omitempty"`
+	StartedAt string                `json:"started_at,omitempty"`
+	Metrics   *HeadlessEventMetrics `json:"metrics,omitempty"`
+	RawType   string                `json:"raw_type,omitempty"`
+}
+
+// HeadlessEventMetrics carries turn-level timing and token totals. All
+// values are optional; zero is treated as "not measured".
+type HeadlessEventMetrics struct {
+	TotalMs      int64 `json:"total_ms,omitempty"`
+	FirstEventMs int64 `json:"first_event_ms,omitempty"`
+	FirstTextMs  int64 `json:"first_text_ms,omitempty"`
+	FirstToolMs  int64 `json:"first_tool_ms,omitempty"`
+	InputTokens  int   `json:"input_tokens,omitempty"`
+	OutputTokens int   `json:"output_tokens,omitempty"`
+}
+
+// Constants for the discriminator and stable Type values. Wire-format
+// strings — keep in lockstep with the frontend's HeadlessEventView.
+const (
+	HeadlessEventKind = "headless_event"
+
+	HeadlessEventTypeStatus     = "status"
+	HeadlessEventTypeText       = "text"
+	HeadlessEventTypeToolUse    = "tool_use"
+	HeadlessEventTypeToolResult = "tool_result"
+	HeadlessEventTypeIdle       = "idle"
+	HeadlessEventTypeError      = "error"
+
+	HeadlessProviderClaude       = "claude"
+	HeadlessProviderCodex        = "codex"
+	HeadlessProviderOpencode     = "opencode"
+	HeadlessProviderOpenAICompat = "openai-compat"
+)
+
+// pushHeadlessEvent serializes event as a single JSON line and writes it
+// into stream's task-scoped buffer. Kind is forced to the canonical
+// discriminator and StartedAt defaults to now() so callers cannot forget
+// either. A nil stream is a no-op so callers do not need a guard around
+// every test path that constructs a runner without a broker.
+func pushHeadlessEvent(stream *agentStreamBuffer, event HeadlessEvent) {
+	if stream == nil {
+		return
+	}
+	event.Kind = HeadlessEventKind
+	if strings.TrimSpace(event.StartedAt) == "" {
+		event.StartedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	data, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+	// PushTask appends the line as-is; we add a trailing newline so the
+	// SSE serializer in handleAgentStream can keep its `data: %s\n\n`
+	// framing without special-casing event lines.
+	stream.PushTask(strings.TrimSpace(event.TaskID), string(data)+"\n")
+}
+
+// headlessProgressEventMetrics adapts the runner-side
+// headlessProgressMetrics into the wire-format HeadlessEventMetrics. The
+// runner's `-1` sentinel for "not measured" maps to JSON `omitempty`
+// zeros so the SSE payload stays compact and the frontend can treat
+// missing fields the same way it treats zero.
+func headlessProgressEventMetrics(m headlessProgressMetrics, usage *headlessTokenUsage) *HeadlessEventMetrics {
+	out := HeadlessEventMetrics{}
+	if m.TotalMs >= 0 {
+		out.TotalMs = m.TotalMs
+	}
+	if m.FirstEventMs >= 0 {
+		out.FirstEventMs = m.FirstEventMs
+	}
+	if m.FirstTextMs >= 0 {
+		out.FirstTextMs = m.FirstTextMs
+	}
+	if m.FirstToolMs >= 0 {
+		out.FirstToolMs = m.FirstToolMs
+	}
+	if usage != nil {
+		out.InputTokens = usage.InputTokens
+		out.OutputTokens = usage.OutputTokens
+	}
+	if out == (HeadlessEventMetrics{}) {
+		return nil
+	}
+	return &out
+}
+
+// headlessTokenUsage is a runner-agnostic shape for the optional token
+// totals attached to a terminal HeadlessEvent. Each runner already has a
+// provider-specific usage struct; this is the smallest envelope all four
+// can populate without leaking the provider type.
+type headlessTokenUsage struct {
+	InputTokens  int
+	OutputTokens int
+}
+
+// emitHeadlessTerminal pushes either an idle or error HeadlessEvent to
+// the agent stream at the end of a turn. Callers pass the same status
+// summary they fed to updateHeadlessProgress so the activity-pill text
+// and the timeline event stay aligned. Provider is the wire-format
+// constant (HeadlessProviderClaude, etc).
+func emitHeadlessTerminal(stream *agentStreamBuffer, provider, slug, taskID, summary, errDetail string, metrics headlessProgressMetrics, usage *headlessTokenUsage) {
+	if stream == nil {
+		return
+	}
+	event := HeadlessEvent{
+		Provider: provider,
+		Agent:    slug,
+		TaskID:   strings.TrimSpace(taskID),
+		Metrics:  headlessProgressEventMetrics(metrics, usage),
+	}
+	if strings.TrimSpace(errDetail) != "" {
+		event.Type = HeadlessEventTypeError
+		event.Status = "error"
+		event.Detail = errDetail
+		event.Text = errDetail
+	} else {
+		event.Type = HeadlessEventTypeIdle
+		event.Status = "idle"
+		event.Text = summary
+	}
+	pushHeadlessEvent(stream, event)
+}

--- a/internal/team/headless_event_test.go
+++ b/internal/team/headless_event_test.go
@@ -1,0 +1,141 @@
+package team
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPushHeadlessEventEncodesDiscriminatorAndPushes pins the wire shape
+// the frontend depends on: every emitted line carries kind:"headless_event"
+// (so the React StreamLineView's branch-by-discriminator can short-circuit
+// without inspecting type-specific fields), and the line lands in the
+// agentStream task buffer with the canonical JSON encoding.
+func TestPushHeadlessEventEncodesDiscriminatorAndPushes(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+
+	pushHeadlessEvent(stream, HeadlessEvent{
+		Type:     HeadlessEventTypeIdle,
+		Provider: HeadlessProviderClaude,
+		Agent:    "ceo",
+		TaskID:   "task-42",
+		Text:     "reply ready · ttft 120ms",
+		Status:   "idle",
+		Metrics: &HeadlessEventMetrics{
+			TotalMs:      1500,
+			FirstTextMs:  120,
+			InputTokens:  300,
+			OutputTokens: 200,
+		},
+	})
+
+	got := stream.recentTask("task-42")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 line in task buffer, got %d (%v)", len(got), got)
+	}
+	if !strings.HasSuffix(got[0], "\n") {
+		t.Fatalf("expected trailing newline so SSE framing stays intact, got %q", got[0])
+	}
+	var decoded HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(got[0], "\n")), &decoded); err != nil {
+		t.Fatalf("emitted line is not valid HeadlessEvent JSON: %v\nline=%q", err, got[0])
+	}
+	if decoded.Kind != HeadlessEventKind {
+		t.Fatalf("kind discriminator: want %q, got %q", HeadlessEventKind, decoded.Kind)
+	}
+	if decoded.Type != HeadlessEventTypeIdle {
+		t.Fatalf("type: want idle, got %q", decoded.Type)
+	}
+	if decoded.Provider != HeadlessProviderClaude || decoded.Agent != "ceo" {
+		t.Fatalf("provider/agent: %+v", decoded)
+	}
+	if decoded.StartedAt == "" {
+		t.Fatal("StartedAt must be populated by pushHeadlessEvent default")
+	}
+	if decoded.Metrics == nil || decoded.Metrics.TotalMs != 1500 || decoded.Metrics.InputTokens != 300 {
+		t.Fatalf("metrics not encoded faithfully: %+v", decoded.Metrics)
+	}
+}
+
+// TestPushHeadlessEventNilStreamIsSafe pins the no-op contract for
+// callers that construct a runner without a broker (every test of the
+// runners would otherwise need a guard at every emit site).
+func TestPushHeadlessEventNilStreamIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("pushHeadlessEvent on nil stream panicked: %v", r)
+		}
+	}()
+	pushHeadlessEvent(nil, HeadlessEvent{Type: HeadlessEventTypeIdle})
+}
+
+// TestEmitHeadlessTerminalIdleAndError exercises the runner-side helper
+// that all four headless runners call at their terminal exit points. The
+// idle path must encode status="idle" + the human-readable summary; the
+// error path must encode status="error" + the error detail. Both shapes
+// flow into the same wire envelope so a single React component can
+// render both.
+func TestEmitHeadlessTerminalIdleAndError(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+
+	metrics := headlessProgressMetrics{TotalMs: 800, FirstTextMs: 90}
+	emitHeadlessTerminal(stream, HeadlessProviderCodex, "eng", "task-7", "reply ready · ttft 90ms", "", metrics, &headlessTokenUsage{InputTokens: 100, OutputTokens: 60})
+	emitHeadlessTerminal(stream, HeadlessProviderCodex, "eng", "task-7", "", "auth: 401 unauthorized", metrics, nil)
+
+	lines := stream.recentTask("task-7")
+	if len(lines) != 2 {
+		t.Fatalf("expected idle + error, got %d lines: %v", len(lines), lines)
+	}
+	var idle HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &idle); err != nil {
+		t.Fatalf("idle decode: %v", err)
+	}
+	if idle.Type != HeadlessEventTypeIdle || idle.Status != "idle" {
+		t.Fatalf("idle envelope: %+v", idle)
+	}
+	if idle.Text == "" {
+		t.Fatal("idle Text must carry the latency summary")
+	}
+	if idle.Metrics == nil || idle.Metrics.InputTokens != 100 {
+		t.Fatalf("idle metrics: %+v", idle.Metrics)
+	}
+
+	var errEvt HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[1], "\n")), &errEvt); err != nil {
+		t.Fatalf("error decode: %v", err)
+	}
+	if errEvt.Type != HeadlessEventTypeError || errEvt.Status != "error" {
+		t.Fatalf("error envelope: %+v", errEvt)
+	}
+	if errEvt.Detail != "auth: 401 unauthorized" || errEvt.Text != "auth: 401 unauthorized" {
+		t.Fatalf("error detail/text: %+v", errEvt)
+	}
+}
+
+// TestHeadlessProgressEventMetricsDropsSentinels pins the "-1 means
+// not measured" sentinel handling. Sentinels must not leak onto the
+// wire as negative numbers — JSON omitempty zeros are how the frontend
+// distinguishes "absent" from a real measured zero.
+func TestHeadlessProgressEventMetricsDropsSentinels(t *testing.T) {
+	out := headlessProgressEventMetrics(headlessProgressMetrics{
+		TotalMs:      -1,
+		FirstEventMs: -1,
+		FirstTextMs:  -1,
+		FirstToolMs:  -1,
+	}, nil)
+	if out != nil {
+		t.Fatalf("all-sentinel metrics must produce nil envelope, got %+v", out)
+	}
+	out = headlessProgressEventMetrics(headlessProgressMetrics{
+		TotalMs: 1500, FirstEventMs: -1, FirstTextMs: 90, FirstToolMs: -1,
+	}, &headlessTokenUsage{InputTokens: 5})
+	if out == nil {
+		t.Fatal("partial metrics must produce envelope")
+	}
+	if out.TotalMs != 1500 || out.FirstTextMs != 90 || out.InputTokens != 5 {
+		t.Fatalf("populated fields wrong: %+v", out)
+	}
+	if out.FirstEventMs != 0 || out.FirstToolMs != 0 {
+		t.Fatalf("sentinel-marked fields must zero out, got %+v", out)
+	}
+}

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -182,6 +182,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	if err != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), metrics)
+		emitHeadlessTerminal(agentStream, HeadlessProviderOpenAICompat, slug, activeTaskID, "", err.Error(), metrics, claudeUsageToTokenUsage(turnUsage))
 		return err
 	}
 	if streamErr != "" {
@@ -192,6 +193,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 			iterationsUsed, streamErr,
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(streamErr, 180), metrics)
+		emitHeadlessTerminal(agentStream, HeadlessProviderOpenAICompat, slug, activeTaskID, "", streamErr, metrics, claudeUsageToTokenUsage(turnUsage))
 		// Post any partial output (e.g. the cap-hit marker the loop
 		// produced when maxIters tripped) before propagating the error,
 		// so the user sees something on-channel rather than a silent
@@ -231,6 +233,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	emitHeadlessTerminal(agentStream, HeadlessProviderOpenAICompat, slug, activeTaskID, summary, "", metrics, claudeUsageToTokenUsage(turnUsage))
 
 	state.flushLiveChat()
 	if text != "" && state.shouldPostFinalText() {

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -213,6 +213,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			))
 			appendHeadlessCodexLog(slug, "opencode_stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
+			emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, "", detail, metrics, nil)
 			if isOpencodeAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -231,11 +232,13 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			durationMillis(startedAt, firstTextAt),
 			err.Error(),
 		))
+		emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, "", err.Error(), metrics, nil)
 		return err
 	}
 	if scanErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(scanErr.Error(), 180), metrics)
+		emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, "", scanErr.Error(), metrics, nil)
 		return scanErr
 	}
 
@@ -256,6 +259,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, summary, "", metrics, nil)
 	relay.Flush()
 	if text != "" {
 		appendHeadlessCodexLog(slug, "opencode_result: "+text)

--- a/web/src/components/messages/StreamLineView.test.tsx
+++ b/web/src/components/messages/StreamLineView.test.tsx
@@ -105,6 +105,55 @@ describe("<StreamLineView>", () => {
     expect(screen.getByText(/permission denied/)).toBeInTheDocument();
   });
 
+  it("renders a HeadlessEvent idle envelope as an idle status card", () => {
+    // Pin the discriminator-first routing: when parsed.kind === "headless_event"
+    // the view must render the typed envelope and not fall through to the
+    // provider-native branches (assistant/mcp_tool_event/...).
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "idle",
+            provider: "claude",
+            agent: "ceo",
+            text: "reply ready · ttft 90ms",
+            status: "idle",
+            metrics: { total_ms: 1500, first_text_ms: 90 },
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    expect(screen.getByText("claude")).toBeInTheDocument();
+    expect(screen.getByText(/reply ready/)).toBeInTheDocument();
+  });
+
+  it("renders a HeadlessEvent error envelope with the failure detail", () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "error",
+            provider: "codex",
+            agent: "eng",
+            text: "auth: 401 unauthorized",
+            detail: "auth: 401 unauthorized",
+            status: "error",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("error")).toBeInTheDocument();
+    expect(screen.getByText("codex")).toBeInTheDocument();
+    expect(screen.getByText("auth: 401 unauthorized")).toBeInTheDocument();
+  });
+
   it("renders Codex completed message content arrays", () => {
     render(
       <StreamLineView

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -28,6 +28,14 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
     return <div className="stream-line stream-line-raw">{text}</div>;
   }
 
+  // HeadlessEvent envelope: provider-agnostic, runner-emitted typed
+  // event. Wire shape mirrors internal/team/headless_event.go's struct.
+  // Branch first so the discriminator wins over provider-native `type`
+  // routes below (e.g. `assistant`, `mcp_tool_event`).
+  if (parsed.kind === "headless_event") {
+    return <HeadlessEventView parsed={parsed} />;
+  }
+
   const evtType = typeof parsed.type === "string" ? parsed.type : "";
 
   // Skip noise events entirely
@@ -114,6 +122,58 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
 
   // Fallback: structured event with type/phase/agent + detail + extras
   return <GenericEventCard parsed={parsed} compact={compact} />;
+}
+
+// HeadlessEventView renders the typed HeadlessEvent envelope emitted by
+// each runner at terminal phases (idle / error). The wire shape comes
+// from internal/team/headless_event.go (HeadlessEvent struct). A2-MVP
+// only emits idle and error; the rendering branches keep the layout
+// minimal because future slices (text / tool_use / tool_result) will
+// reuse this component, and a maximalist v1 design would lock those
+// future variants into chrome that won't fit.
+function HeadlessEventView({ parsed }: { parsed: Record<string, unknown> }) {
+  const eventType = stringish(parsed.type);
+  const provider = stringish(parsed.provider);
+  const text = stringish(parsed.text);
+  const detail = stringish(parsed.detail);
+  const summary = (text || detail).trim();
+  const metrics =
+    parsed.metrics && typeof parsed.metrics === "object"
+      ? (parsed.metrics as Record<string, unknown>)
+      : null;
+
+  if (eventType === "idle") {
+    return (
+      <div className="stream-card stream-card-idle">
+        <div className="stream-card-header">
+          <span className="stream-card-phase stream-phase-idle">idle</span>
+          {provider && <span className="stream-card-agent">{provider}</span>}
+        </div>
+        {summary && <div className="stream-card-detail">{summary}</div>}
+        {metrics && (
+          <div className="stream-line-json">
+            <Value value={metrics} depth={0} compact={true} />
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (eventType === "error") {
+    return (
+      <div className="stream-card stream-card-error">
+        <div className="stream-card-header">
+          <span className="stream-card-phase stream-phase-error">error</span>
+          {provider && <span className="stream-card-agent">{provider}</span>}
+        </div>
+        {summary && <div className="cc-tool-error-text">{summary}</div>}
+      </div>
+    );
+  }
+
+  // Unknown HeadlessEvent type — fall back to the generic card so future
+  // variants render something useful before they earn a dedicated branch.
+  return <GenericEventCard parsed={parsed} compact={false} />;
 }
 
 function ClaudeAssistantEvent({

--- a/web/src/hooks/useAgentStream.test.ts
+++ b/web/src/hooks/useAgentStream.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   agentStreamURL,
   appendStreamLine,
   type StreamLine,
+  useAgentStream,
 } from "./useAgentStream";
 
 vi.mock("../api/client", () => ({
@@ -11,6 +13,59 @@ vi.mock("../api/client", () => ({
   // the agentStreamURL caller has to merge query strings safely.
   sseURL: (path: string) => `http://broker${path}?token=ABC`,
 }));
+
+// MockEventSource is a minimal EventSource stand-in that lets the test
+// push named events (replay-end) and onmessage entries directly. JSDOM
+// does not ship an EventSource implementation, and patching window
+// globals makes the tests robust to the hook's underlying EventSource
+// reference.
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+  onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+  onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+  closed = false;
+  private listeners = new Map<string, Set<(ev: MessageEvent) => unknown>>();
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(name: string, fn: (ev: MessageEvent) => unknown) {
+    let bucket = this.listeners.get(name);
+    if (!bucket) {
+      bucket = new Set();
+      this.listeners.set(name, bucket);
+    }
+    bucket.add(fn);
+  }
+
+  removeEventListener(name: string, fn: (ev: MessageEvent) => unknown) {
+    this.listeners.get(name)?.delete(fn);
+  }
+
+  dispatchData(data: string) {
+    if (this.onmessage)
+      this.onmessage.call(
+        this as unknown as EventSource,
+        new MessageEvent("message", { data }),
+      );
+  }
+
+  dispatchNamed(name: string, data: string) {
+    const bucket = this.listeners.get(name);
+    if (!bucket) return;
+    for (const fn of bucket) {
+      fn(new MessageEvent(name, { data }));
+    }
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
 
 describe("appendStreamLine", () => {
   it("starts a new raw line when the buffer is empty", () => {
@@ -137,5 +192,82 @@ describe("appendStreamLine", () => {
       if (usedId) nextId += 1;
     }
     expect(lines.length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("useAgentStream phase + idle behavior", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    (global as unknown as { EventSource: typeof MockEventSource }).EventSource =
+      MockEventSource;
+  });
+
+  afterEach(() => {
+    delete (global as unknown as { EventSource?: typeof MockEventSource })
+      .EventSource;
+  });
+
+  it("does NOT close the EventSource when an idle event arrives during replay", () => {
+    // Regression: pre-fix, the hook closed on any parsed.status === "idle"
+    // past the first counter tick — meaning a HeadlessEvent idle from the
+    // recent-history buffer would silently kill the live stream the moment
+    // the user opened the viewer for an agent that just went idle. With
+    // the replay-end boundary in place, the hook must hold the connection
+    // open until phase flips to "live".
+    const { result } = renderHook(() => useAgentStream("ceo"));
+    const [source] = MockEventSource.instances;
+    expect(source).toBeDefined();
+    if (!source) return;
+
+    // Replay phase: dispatch a HeadlessEvent idle through the history
+    // pipe. Phase ref is still "replay" (broker has not yet sent the
+    // boundary), so the hook must NOT close.
+    act(() => {
+      source.dispatchData(
+        JSON.stringify({
+          kind: "headless_event",
+          type: "idle",
+          status: "idle",
+          provider: "claude",
+        }),
+      );
+    });
+    expect(source.closed).toBe(false);
+    expect(result.current.lines.length).toBeGreaterThan(0);
+
+    // Cross the boundary into live, then a NEW idle. Now the hook
+    // must close — the live HeadlessEvent idle is the legitimate
+    // turn-end signal.
+    act(() => {
+      source.dispatchNamed("replay-end", "{}");
+      source.dispatchData(
+        JSON.stringify({
+          kind: "headless_event",
+          type: "idle",
+          status: "idle",
+          provider: "claude",
+        }),
+      );
+    });
+    expect(source.closed).toBe(true);
+  });
+
+  it("ignores non-headless_event JSON entries with a status field", () => {
+    // The agent stream carries multiple event shapes today (raw provider
+    // chunks, mcp_tool_event audit lines, pane-capture noise). Only the
+    // typed HeadlessEvent envelope is allowed to drive auto-close — a
+    // foreign JSON object that happens to carry status:"idle" must not.
+    renderHook(() => useAgentStream("ceo"));
+    const [source] = MockEventSource.instances;
+    expect(source).toBeDefined();
+    if (!source) return;
+
+    act(() => {
+      source.dispatchNamed("replay-end", "{}");
+      source.dispatchData(
+        JSON.stringify({ type: "result", status: "idle", note: "not us" }),
+      );
+    });
+    expect(source.closed).toBe(false);
   });
 });

--- a/web/src/hooks/useAgentStream.ts
+++ b/web/src/hooks/useAgentStream.ts
@@ -60,6 +60,14 @@ export function agentStreamURL(slug: string, taskId: string | null): string {
   return `${base}${sep}task=${encodeURIComponent(trimmed)}`;
 }
 
+// StreamPhase tracks whether the SSE source is still serving the recent-
+// history replay or has crossed into live entries. The broker sends a
+// named `event: replay-end` SSE entry between the two; any consumer
+// branching on parsed-event content (e.g. closing the source on idle)
+// must gate on phase === "live" so a replayed terminal event from the
+// history buffer cannot silently kill the live connection.
+export type StreamPhase = "replay" | "live";
+
 export function useAgentStream(
   slug: string | null,
   taskId: string | null = null,
@@ -68,12 +76,14 @@ export function useAgentStream(
   const [connected, setConnected] = useState(false);
   const counterRef = useRef(0);
   const linesRef = useRef<StreamLine[]>([]);
+  const phaseRef = useRef<StreamPhase>("replay");
   const sourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
     if (!slug) {
       linesRef.current = [];
       counterRef.current = 0;
+      phaseRef.current = "replay";
       setLines([]);
       setConnected(false);
       return;
@@ -81,6 +91,7 @@ export function useAgentStream(
 
     linesRef.current = [];
     counterRef.current = 0;
+    phaseRef.current = "replay";
     setLines([]);
 
     const url = agentStreamURL(slug, taskId);
@@ -88,6 +99,15 @@ export function useAgentStream(
     sourceRef.current = source;
 
     source.onopen = () => setConnected(true);
+
+    // The broker emits one `event: replay-end` after history catch-up.
+    // EventSource fires it on the named-event channel, not onmessage —
+    // keep this listener even when the body is empty so the phase ref
+    // flips before the first live entry arrives.
+    const replayEndListener = () => {
+      phaseRef.current = "live";
+    };
+    source.addEventListener("replay-end", replayEndListener);
 
     source.onmessage = (e) => {
       let parsed: Record<string, unknown> | undefined;
@@ -114,8 +134,21 @@ export function useAgentStream(
       if (usedId) counterRef.current = nextId;
       setLines(nextLines);
 
-      // Auto-stop on idle
-      if (parsed?.status === "idle" && counterRef.current > 1) {
+      // Auto-stop on idle, but only when this is a LIVE HeadlessEvent
+      // idle — never a replayed one. Two guards:
+      //   1. phaseRef === "live": before the broker's replay-end marker,
+      //      every entry is history. Closing on a replayed idle would
+      //      silently kill the live stream the moment a user opens the
+      //      stream view for an agent that just went idle.
+      //   2. parsed.kind === "headless_event": the runner-emitted
+      //      typed envelope. Other JSON shapes (raw provider events,
+      //      mcp_tool_event audit lines, pane-capture noise) may carry
+      //      unrelated `status` strings and must not trigger close.
+      if (
+        phaseRef.current === "live" &&
+        parsed?.kind === "headless_event" &&
+        parsed?.status === "idle"
+      ) {
         source.close();
         setConnected(false);
       }
@@ -130,6 +163,7 @@ export function useAgentStream(
     };
 
     return () => {
+      source.removeEventListener("replay-end", replayEndListener);
       source.close();
       sourceRef.current = null;
       setConnected(false);


### PR DESCRIPTION
## Summary

Slice A2 of the Flue extraction (follows up [PR #670](https://github.com/nex-crm/wuphf/pull/670), drain-hardening, which merged 2026-05-06). Adds a provider-agnostic event envelope so the web UI can render a normalized agent-turn timeline regardless of which runner (Claude / Codex / Opencode / OpenAI-compat) is executing, and fixes the silent-stream-kill bug where a replayed \`status: \"idle\"\` from the recent-history buffer would close the live EventSource the moment a user opened the viewer for an agent that just went idle.

### Backend
- New \`HeadlessEvent\` Go struct + \`kind: \"headless_event\"\` JSON discriminator. Wire fields: \`provider\`, \`agent\`, \`turn_id\`, \`task_id\`, \`parent_id\`, \`tool_name\`, \`text\`, \`detail\`, \`status\`, RFC3339 \`started_at\`, plus turn-level \`metrics\` (total_ms, ttft, ttfTool, input_tokens, output_tokens). A2-MVP emits only \`idle\` and \`error\`; \`text\`/\`tool_use\`/\`tool_result\` slots are reserved so the wire shape will not churn when later slices wire up per-phase events.
- \`emitHeadlessTerminal()\` helper called at every terminal exit point in the four headless runners. Idle carries the latency summary + token usage; error carries the failure detail and is also pushed before the runner returns its \`error\`.
- \`handleAgentStream\` now sends \`event: replay-end\\ndata: {}\` between history catch-up and live entries. Default \`data:\` framing for both history and live is preserved so existing consumers keep working without any code change.

### Frontend
- \`useAgentStream\` tracks a \`phaseRef\` (\"replay\" -> \"live\"), flipped by an \`addEventListener(\"replay-end\")\`. Auto-close on idle now requires both \`parsed.kind === \"headless_event\"\` AND \`phase === \"live\"\`, so a replayed terminal event cannot kill the live stream and a foreign JSON object that happens to carry \`status: \"idle\"\` (raw provider chunk, mcp_tool_event, pane-capture noise) is ignored.
- \`HeadlessEventView\` component routed from \`StreamLineView\` when \`parsed.kind === \"headless_event\"\`. Renders idle as a status card with metrics and error as a failure card. Unknown HeadlessEvent types fall through to the generic card so future variants render usefully before they earn dedicated chrome.

### Why this slice
- Forces a single timeline shape across all four runners. Today the front-end has 5+ branches per provider; future renderers can branch on one discriminator.
- Unblocks the rest of the Flue extraction — every later slice (manifest, error envelope, structured result, provenance, grants, run-agent) builds on top of this typed channel.
- Fixes the latent replayed-idle bug that would silently disconnect the stream view on agent-restart.

## Test plan
- [x] \`bash scripts/test-go.sh ./internal/team\` green (97.7s, 0 failures)
- [x] \`bash scripts/test-go.sh ./internal/provider\` green (10.6s)
- [x] \`gofmt -l\`, \`go vet ./internal/...\`, \`golangci-lint run ./internal/team/...\` — 0 issues
- [x] \`bash scripts/test-web.sh\` for the touched files — 18/18 pass (incl. 2 new HeadlessEventView render tests + 2 new replay-phase hook tests)
- [x] \`bunx biome check\` — clean
- [x] \`bunx tsc --noEmit\` — no new errors (pre-existing milkdown-package noise unrelated)
- [ ] Dogfood: run a real agent turn end-to-end and confirm the idle event appears in the SSE stream and the EventSource stays open through the replay window.

## Stacked on
This branch was cut from \`origin/main\` after PR #670 (drain hardening) merged. No stacked-PR dependency — clean cut from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)