### PR TITLE
feat(web): show transport presence on agent rail and peek card

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -394,6 +394,21 @@ export interface OfficeMember {
   built_in?: boolean;
   /** Per-channel disabled state when the list is sourced from `/members?channel=…`. */
   disabled?: boolean;
+  /**
+   * Transport-presence flag: true when an adapter session is currently live for
+   * this member. Distinct from `status`/`activity` (which reflect "is the
+   * agent processing right now") — `online` reflects "is the adapter
+   * reachable at all". Always present (no omitempty on the Go side) so
+   * "false" and "missing field" cannot be confused.
+   */
+  online?: boolean;
+  /**
+   * RFC3339 timestamp of the most recent UpsertParticipant for this slug.
+   * Empty when no adapter has ever upserted (e.g. built-in members without an
+   * openclaw provider) — the consumer should treat empty as "never observed"
+   * and not render a "last seen" line.
+   */
+  last_seen_at?: string;
 }
 
 /**

--- a/web/src/components/sidebar/AgentEventPeek.test.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.test.tsx
@@ -360,3 +360,73 @@ describe("<AgentEventPeek> interaction and accessibility", () => {
     expect(dialog.getAttribute("aria-describedby")).toBeNull();
   });
 });
+
+// ─── presence row ────────────────────────────────────────────────────────────
+
+describe("<AgentEventPeek> presence row", () => {
+  it("renders 'Online' with the green dot when online=true", () => {
+    const anchorRef = makeAnchorRef();
+    render(
+      <AgentEventPeek {...defaultProps} anchorRef={anchorRef} online={true} />,
+    );
+    const presence = document.querySelector(
+      ".sidebar-agent-peek-presence",
+    ) as HTMLElement;
+    expect(presence).not.toBeNull();
+    expect(presence.dataset.state).toBe("online");
+    expect(presence.textContent).toContain("Online");
+    expect(
+      document.querySelector(".sidebar-agent-peek-presence-dot"),
+    ).not.toBeNull();
+  });
+
+  it("renders 'Last seen' relative time when offline with a parseable timestamp", () => {
+    const anchorRef = makeAnchorRef();
+    const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        online={false}
+        lastSeenAt={fiveMinAgo}
+      />,
+    );
+    const presence = document.querySelector(
+      ".sidebar-agent-peek-presence",
+    ) as HTMLElement;
+    expect(presence).not.toBeNull();
+    expect(presence.dataset.state).toBe("offline");
+    expect(presence.textContent).toMatch(/Last seen \d+m ago/);
+    // Green dot is intentionally absent in the offline state — color encodes
+    // a live transport, not historical activity.
+    expect(
+      document.querySelector(".sidebar-agent-peek-presence-dot"),
+    ).toBeNull();
+  });
+
+  it("omits the presence row entirely when offline with no last_seen_at (never observed)", () => {
+    const anchorRef = makeAnchorRef();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        online={false}
+        lastSeenAt=""
+      />,
+    );
+    expect(document.querySelector(".sidebar-agent-peek-presence")).toBeNull();
+  });
+
+  it("omits the presence row when last_seen_at is unparseable", () => {
+    const anchorRef = makeAnchorRef();
+    render(
+      <AgentEventPeek
+        {...defaultProps}
+        anchorRef={anchorRef}
+        online={false}
+        lastSeenAt="not-a-timestamp"
+      />,
+    );
+    expect(document.querySelector(".sidebar-agent-peek-presence")).toBeNull();
+  });
+});

--- a/web/src/components/sidebar/AgentEventPeek.tsx
+++ b/web/src/components/sidebar/AgentEventPeek.tsx
@@ -14,6 +14,11 @@ export interface AgentEventPeekProps {
   anchorRef: React.RefObject<HTMLElement | null>;
   onClose: () => void;
   onOpenWorkspace: () => void;
+  /** Transport-presence flag from /office-members. Drives the connection-state
+   *  indicator below the role line. */
+  online?: boolean;
+  /** RFC3339 timestamp of last UpsertParticipant. Empty when never observed. */
+  lastSeenAt?: string;
 }
 
 interface Position {
@@ -51,6 +56,41 @@ function kindLabel(kind: StoredActivitySnapshot["kind"]): string {
   return "routine";
 }
 
+// PresenceRow renders the connection-state line under the role. Three states:
+//  - online === true                         → "Online" with green dot
+//  - !online && lastSeenAt parses cleanly    → "Last seen Xm ago"
+//  - everything else (never observed)        → null
+// Built-in members without an adapter (e.g. CEO with no openclaw provider)
+// hit the third branch — showing them as "offline" would be misleading.
+// Extracted from AgentEventPeek so the parent component's cognitive
+// complexity score stays under the biome cap.
+function PresenceRow({
+  online,
+  lastSeenAt,
+  nowMs,
+}: {
+  online?: boolean;
+  lastSeenAt?: string;
+  nowMs: number;
+}): React.ReactElement | null {
+  if (online) {
+    return (
+      <span className="sidebar-agent-peek-presence" data-state="online">
+        <span className="sidebar-agent-peek-presence-dot" aria-hidden="true" />
+        Online
+      </span>
+    );
+  }
+  if (!lastSeenAt) return null;
+  const lastMs = Date.parse(lastSeenAt);
+  if (Number.isNaN(lastMs)) return null;
+  return (
+    <span className="sidebar-agent-peek-presence" data-state="offline">
+      Last seen {formatRelative(lastMs, nowMs)}
+    </span>
+  );
+}
+
 export function AgentEventPeek({
   slug,
   agentName,
@@ -61,6 +101,8 @@ export function AgentEventPeek({
   anchorRef,
   onClose,
   onOpenWorkspace,
+  online,
+  lastSeenAt,
 }: AgentEventPeekProps) {
   const [now, setNow] = useState<number>(() => Date.now());
   const [pos, setPos] = useState<Position>({ top: 0, left: 0 });
@@ -185,6 +227,7 @@ export function AgentEventPeek({
           {!!agentRole && (
             <span className="sidebar-agent-peek-role">{agentRole}</span>
           )}
+          <PresenceRow online={online} lastSeenAt={lastSeenAt} nowMs={now} />
         </div>
         {isStuck && (
           <span className="sidebar-agent-peek-blocked-chip">BLOCKED</span>

--- a/web/src/components/sidebar/AgentList.test.tsx
+++ b/web/src/components/sidebar/AgentList.test.tsx
@@ -406,4 +406,40 @@ describe("<AgentList>", () => {
     );
     expect(chevron3?.getAttribute("aria-expanded")).toBe("true");
   });
+
+  // ─── presence badge ──────────────────────────────────────────────────────
+  it("renders the online badge on rows whose member has online=true", () => {
+    setMembers([
+      {
+        slug: "tess",
+        name: "Tess",
+        role: "engineer",
+        online: true,
+        last_seen_at: "2026-05-07T00:00:00Z",
+      },
+      {
+        slug: "ava",
+        name: "Ava",
+        role: "designer",
+        online: false,
+        last_seen_at: "2026-05-06T22:00:00Z",
+      },
+      // Built-in member without an adapter session — no presence record at all.
+      // The badge must not render and the absence of an "offline" marker is
+      // intentional: not-connected and never-connected are the same shape on
+      // the avatar, only differentiated inside the peek card.
+      { slug: "devon", name: "Devon", role: "engineer" },
+    ]);
+
+    const { container } = renderList();
+    expect(
+      container.querySelector('[data-testid="online-badge-tess"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="online-badge-ava"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="online-badge-devon"]'),
+    ).toBeNull();
+  });
 });

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -95,6 +95,22 @@ function SidebarAgentRow({
             size={10}
             className="harness-badge-on-avatar"
           />
+          {/* Transport-presence dot. Top-right corner so it does not collide
+              with the harness badge at bottom-right. Hidden entirely when the
+              member has never been upserted (built-ins without an adapter)
+              so we do not invent an "offline" state for members that never
+              had a connection concept. */}
+          {agent.online ? (
+            // Decorative: the same presence state is conveyed textually in
+            // the peek card ("Online" / "Last seen Xm ago"), so the badge
+            // itself is hidden from assistive tech to avoid announcing the
+            // same fact on every row.
+            <span
+              className="online-badge"
+              data-testid={`online-badge-${agent.slug}`}
+              aria-hidden="true"
+            />
+          ) : null}
         </span>
         <div className="sidebar-agent-wrap">
           <span className="sidebar-agent-name">{displayName}</span>
@@ -143,6 +159,8 @@ function SidebarAgentRow({
           peek.close();
           onSelect(agent.slug);
         }}
+        online={agent.online}
+        lastSeenAt={agent.last_seen_at}
       />
       {isFirst && showNudge ? (
         <span className="sidebar-agent-nudge" data-testid="first-run-nudge">

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -496,6 +496,23 @@ body {
   pointer-events: none;
 }
 
+/* Transport-presence indicator on agent avatars. Sits at top-right so it
+   does not collide with the harness badge at bottom-right. Rendered only
+   when the member's `online` flag is true (see AgentList SidebarAgentRow);
+   absence of the dot encodes "offline OR never connected" — the peek card
+   surfaces the distinction via "Last seen". */
+.online-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--green, #03a04c);
+  box-shadow: 0 0 0 1.5px var(--bg-card, #fff);
+  pointer-events: none;
+}
+
 /* ─── Status Dot ─── */
 .status-dot {
   width: 6px;

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2302,6 +2302,25 @@ html[data-theme="nex"]
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.sidebar-agent-peek-presence {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+.sidebar-agent-peek-presence[data-state="online"] {
+  color: var(--green-dark, var(--text-secondary));
+}
+.sidebar-agent-peek-presence-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green, #03a04c);
+  flex-shrink: 0;
+}
 .sidebar-agent-peek-blocked-chip {
   flex-shrink: 0;
   font-size: 9px;


### PR DESCRIPTION
## Summary

Surfaces the new \`online\` + \`last_seen_at\` fields shipped in #673 onto the office sidebar — the second half of the presence slice.

## What changed

**Sidebar avatar dot** (\`web/src/components/sidebar/AgentList.tsx\` + \`web/src/styles/global.css\`)
- Small green dot at top-right of the agent avatar when \`online === true\`.
- Top-right keeps it clear of the harness badge at bottom-right.
- Decorative (\`aria-hidden\`); the same fact is read out textually inside the peek card.
- Hidden entirely when offline — absence encodes "offline OR never connected"; the peek card distinguishes the two.

**Peek-card presence row** (\`web/src/components/sidebar/AgentEventPeek.tsx\` + \`web/src/styles/layout.css\`)
- Sits under the role line, three branches via a tiny \`PresenceRow\` subcomponent:
  | State | Render |
  |---|---|
  | \`online === true\` | "Online" with green dot |
  | \`!online && last_seen_at\` parseable | "Last seen Xm ago" |
  | never observed | row omitted entirely |
- Third branch covers built-in members without an adapter (e.g. CEO with no openclaw provider) — calling them "offline" would be misleading.
- Extracting \`PresenceRow\` keeps \`AgentEventPeek\`'s cognitive-complexity score at its pre-existing baseline (18) rather than rising past biome's cap.

**Type** (\`web/src/api/client.ts\`)
- Adds \`online?: boolean\` and \`last_seen_at?: string\` to \`OfficeMember\`. Comments call out that "false" is meaningful (Go side dropped \`omitempty\`) and empty \`last_seen_at\` means "never observed".

## Tests

\`AgentEventPeek.test.tsx\` — 4 new \`<AgentEventPeek> presence row\` cases:
- \`online=true\` renders "Online" with the dot.
- \`!online && lastSeenAt\` parseable renders "Last seen Xm ago" without the green dot.
- \`!online && lastSeenAt=""\` (never observed) omits the row.
- \`!online && lastSeenAt="not-a-timestamp"\` omits the row.

\`AgentList.test.tsx\` — 1 new case covering the sidebar badge across three rows: online (badge present), offline (badge hidden), never-observed (badge hidden).

## Why this slice (not the others)

After the backend presence work merged in #673, the API carries the data but no UI consumed it yet. This is the smallest possible follow-up that closes the loop and gives the user something visible. The two remaining transport-contract leftovers (\`ShareTransport.Send\` push + telegram outbound dispatch) are larger and unchanged in priority.

## Test plan

- [x] \`bun install && bunx tsc --noEmit\` — clean on edited files
- [x] \`bunx biome check\` — 1 pre-existing complexity warning (18, baseline before this PR), no new findings
- [x] \`bash scripts/test-web.sh\` — full suite green (1062/1062, 14s)
- [ ] Manual: launch \`wuphf-dev\`, hire an openclaw agent → green dot appears; \`wuphf-dev openclaw stop\` → dot disappears, peek card shows "Last seen Xm ago"; built-in CEO without adapter shows neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added agent presence indicators showing online/offline status throughout the interface
  * Displays "Last seen" timestamps for offline agents, providing insight into recent activity
  * Visual presence badges appear next to agent avatars for quick status identification

* **Tests**
  * Comprehensive test coverage for presence indicators and last seen functionality across components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->