### PR TITLE
feat(web): remove per-message token count from agent UI

### DIFF
--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -5,7 +5,7 @@ import type { Message } from "../../api/client";
 import { toggleReaction } from "../../api/client";
 import { useDefaultHarness } from "../../hooks/useConfig";
 import { useOfficeMembers } from "../../hooks/useMembers";
-import { formatTime, formatTokens } from "../../lib/format";
+import { formatTime } from "../../lib/format";
 import { resolveHarness } from "../../lib/harness";
 import { renderMentions } from "../../lib/mentions";
 import {
@@ -61,14 +61,6 @@ export function MessageBubble({
   const harness = !isHuman
     ? resolveHarness(agent?.provider, defaultHarness)
     : null;
-
-  const usageTotal = message.usage
-    ? (message.usage.total_tokens ??
-      (message.usage.input_tokens ?? 0) +
-        (message.usage.output_tokens ?? 0) +
-        (message.usage.cache_read_tokens ?? 0) +
-        (message.usage.cache_creation_tokens ?? 0))
-    : 0;
 
   const reactions = message.reactions
     ? Array.isArray(message.reactions)
@@ -166,11 +158,6 @@ export function MessageBubble({
           <span className="message-time" title={message.timestamp}>
             {formatTime(message.timestamp)}
           </span>
-          {usageTotal > 0 && (
-            <span className="message-token-badge">
-              {formatTokens(usageTotal)} tok
-            </span>
-          )}
         </div>
 
         {/* Text — humans render mention chips via safe ReactNode children;

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -12,8 +12,8 @@ interface StreamLineViewProps {
 /**
  * Renders one SSE line from the agent stream. Understands the broker's
  * OpenAI-Responses-style events — agent messages render as dim thinking
- * lines, tool calls render as collapsible cards, token totals render as
- * a single line. Everything else falls back to pretty-printed JSON.
+ * lines, tool calls render as collapsible cards. Everything else falls
+ * back to pretty-printed JSON.
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
@@ -39,10 +39,8 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
     return null;
   }
 
-  // Token total line for turn/response completed
+  // Suppress per-turn completion frames — they used to render a token total.
   if (evtType === "turn.completed" || evtType === "response.completed") {
-    const tokens = renderTokens(parsed);
-    if (tokens) return <div className="cc-token-line">{tokens}</div>;
     return null;
   }
 
@@ -261,49 +259,6 @@ function stringFromToolContent(content: unknown): string {
     return JSON.stringify(content);
   }
   return "";
-}
-
-function renderTokens(parsed: Record<string, unknown>): string | null {
-  const u = extractUsage(parsed);
-  if (!u) return null;
-  const inTok = toNum(u.input_tokens);
-  const outTok = toNum(u.output_tokens);
-  const cacheRead = toNum(
-    u.cached_input_tokens ?? u.cache_read_input_tokens ?? u.cache_read_tokens,
-  );
-  const cacheCreate = toNum(
-    u.cache_creation_input_tokens ?? u.cache_creation_tokens,
-  );
-  const total = inTok + outTok + cacheRead + cacheCreate;
-  if (total === 0) return null;
-  const parts = [`${formatTokens(inTok)} in`, `${formatTokens(outTok)} out`];
-  if (cacheRead > 0) parts.push(`${formatTokens(cacheRead)} cache read`);
-  if (cacheCreate > 0) parts.push(`${formatTokens(cacheCreate)} cache write`);
-  return `\u2500\u2500 ${formatTokens(total)} tokens (${parts.join(", ")})`;
-}
-
-function extractUsage(
-  parsed: Record<string, unknown>,
-): Record<string, unknown> | null {
-  const candidates: unknown[] = [
-    parsed.usage,
-    (parsed.response as Record<string, unknown> | undefined)?.usage,
-    (parsed.turn as Record<string, unknown> | undefined)?.usage,
-  ];
-  for (const c of candidates) {
-    if (c && typeof c === "object") return c as Record<string, unknown>;
-  }
-  return null;
-}
-
-function toNum(v: unknown): number {
-  return typeof v === "number" && Number.isFinite(v) ? v : 0;
-}
-
-function formatTokens(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
 }
 
 const ARG_SKIP = new Set(["my_slug", "new_topic", "viewer_slug", "tagged"]);

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -91,10 +91,6 @@
 .message-reply .message-time {
   font-size: 10.5px;
 }
-.message-reply .message-token-badge {
-  font-size: 10px;
-  padding: 0 5px;
-}
 .message-reply .message-text {
   /* Readability is non-negotiable. Match parent size; tighten leading
      one notch so the reply feels dense without being cramped. */
@@ -149,18 +145,6 @@
 .message-time {
   font-size: 11px;
   color: var(--text-tertiary);
-}
-.message-token-badge {
-  display: inline-flex;
-  align-items: center;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: rgba(18, 100, 163, 0.08);
-  border: 1px solid rgba(18, 100, 163, 0.18);
-  color: var(--accent);
-  font-size: 11px;
-  font-weight: 600;
-  font-family: var(--font-mono);
 }
 .message-text {
   font-size: 14px;
@@ -808,12 +792,6 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
 }
 
 /* ─── Stream event cards (CC style) ─── */
-.cc-token-line {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-tertiary);
-  padding: 4px 0;
-}
 .cc-thinking {
   font-family: var(--font-mono);
   font-size: 11px;


### PR DESCRIPTION
## Summary

- Removes the `… tok` badge in agent message headers (`MessageBubble.tsx`)
- Removes the per-turn `── N tokens (…)` line in the streaming SSE view (`StreamLineView.tsx`)
- Drops the now-dead `.message-token-badge` and `.cc-token-line` CSS rules + the `renderTokens` / `extractUsage` / local `formatTokens` helpers

Workspace-level usage panels (sidebar `UsagePanel`, `WorkspaceSummary`, `StatusPill`, `ArtifactsApp` session totals, `CollapsedSidebar`) are intentionally untouched — only the per-agent-message surface is stripped.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check` clean on changed files
- [x] `bash scripts/test-web.sh web/src/components/messages/StreamLineView.test.tsx` (5/5)
- [ ] Manual: open a channel in dev, send to an agent, confirm no `tok` chip appears next to timestamps and no `── N tokens` line at end of agent turns
- [ ] Manual: confirm sidebar / status pill still show session token totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed token usage display from messages and stream views
  * Adjusted timestamp styling in message replies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->