### PR TITLE
feat(onboarding): resumeable wizard with secret-safe drafts (phase 4 pr 4)

### DIFF
--- a/web/src/components/onboarding/Wizard.resume.test.tsx
+++ b/web/src/components/onboarding/Wizard.resume.test.tsx
@@ -1,0 +1,123 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../stores/app";
+import { Wizard } from "./Wizard";
+import {
+  CURRENT_VERSION,
+  LOCAL_STORAGE_KEY,
+  STALE_BANNER_KEY,
+} from "./wizard/onboardingDraft";
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    get: vi.fn().mockResolvedValue({ templates: [], prereqs: [] }),
+    post: vi.fn().mockResolvedValue({}),
+    getConfig: vi.fn().mockResolvedValue({}),
+  };
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  window.history.replaceState({}, "", "/");
+  useAppStore.setState({ onboardingComplete: false });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function seedDraft(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const draft = {
+    version: CURRENT_VERSION,
+    step: "identity",
+    selectedBlueprint: null,
+    company: "Acme",
+    description: "We do things",
+    priority: "growth",
+    runtimePriority: ["Claude Code"],
+    localProvider: "",
+    selectedTaskTemplate: null,
+    taskText: "",
+    savedAt: new Date().toISOString(),
+    ...overrides,
+  };
+  window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(draft));
+  return draft;
+}
+
+describe("Wizard resume", () => {
+  it("restores wizard state from a saved draft on mount", async () => {
+    seedDraft({ step: "identity" });
+
+    render(<Wizard onComplete={vi.fn()} />);
+
+    // Identity step renders with company prefilled
+    const company = (await waitFor(() =>
+      screen.getByLabelText(/Company or project name/i),
+    )) as HTMLInputElement;
+    expect(company.value).toBe("Acme");
+
+    const description = screen.getByLabelText(
+      /One-liner description/i,
+    ) as HTMLInputElement;
+    expect(description.value).toBe("We do things");
+
+    expect(screen.getByTestId("onboarding-resume-banner")).toBeInTheDocument();
+  });
+
+  it("Reset link on welcome screen wipes state and clears draft", async () => {
+    seedDraft({ step: "welcome", company: "Acme" });
+
+    render(<Wizard onComplete={vi.fn()} />);
+
+    const trigger = await waitFor(() =>
+      screen.getByTestId("welcome-reset-trigger"),
+    );
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByTestId("welcome-reset-confirm"));
+
+    // Draft cleared synchronously
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+    // Banner gone, Reset link gone (no draft)
+    expect(screen.queryByTestId("onboarding-resume-banner")).toBeNull();
+    expect(screen.queryByTestId("welcome-reset-trigger")).toBeNull();
+  });
+
+  it("stale-draft banner appears once on the next mount and dismisses", async () => {
+    window.sessionStorage.setItem(STALE_BANNER_KEY, "42");
+
+    render(<Wizard onComplete={vi.fn()} />);
+
+    const banner = await waitFor(() =>
+      screen.getByTestId("onboarding-stale-banner"),
+    );
+    expect(banner).toHaveTextContent(/42 days ago/);
+
+    fireEvent.click(screen.getByTestId("onboarding-stale-dismiss"));
+    expect(screen.queryByTestId("onboarding-stale-banner")).toBeNull();
+
+    // The flag was consumed at mount, so it would not show again on
+    // a hypothetical remount.
+    expect(window.sessionStorage.getItem(STALE_BANNER_KEY)).toBeNull();
+  });
+
+  it("does not show the resume banner when there is no draft", () => {
+    render(<Wizard onComplete={vi.fn()} />);
+    expect(screen.queryByTestId("onboarding-resume-banner")).toBeNull();
+  });
+});

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -16,6 +16,13 @@ import {
   STEP_ORDER,
 } from "./wizard/constants";
 import {
+  clearDraft,
+  consumeStaleBannerDays,
+  loadDraft,
+  seedFromDraft,
+} from "./wizard/onboardingDraft";
+import { OnboardingBanners } from "./wizard/ResumeBanner";
+import {
   canSetupContinue,
   detectedBinary,
   localProviderKindFromRuntimePriority,
@@ -38,6 +45,7 @@ import type {
   TaskTemplate,
   WizardStep,
 } from "./wizard/types";
+import { useOnboardingDraftSync } from "./wizard/useOnboardingDraftSync";
 
 // runtimeIsReady + detectedBinary moved to wizard/runtime-helpers.ts.
 // ArrowIcon, CheckIcon, EnterHint, ProgressDots moved to wizard/components.tsx.
@@ -121,20 +129,37 @@ export function Wizard({ onComplete }: WizardProps) {
     ? STEP_ORDER.filter((s) => s !== "identity")
     : STEP_ORDER;
 
+  // Resume support: load any saved draft once on first render. Captured
+  // into a ref so the useState initializers below can seed from it
+  // without re-running loadDraft on every render. The stale-banner flag
+  // is consumed at the same time so it only ever shows once.
+  const initialDraftRef = useRef(loadDraft());
+  const initialDraft = initialDraftRef.current;
+  const seed = seedFromDraft(initialDraft);
+  const [hasSavedDraft, setHasSavedDraft] = useState<boolean>(
+    initialDraft !== null,
+  );
+  const [showResumeBanner, setShowResumeBanner] = useState<boolean>(
+    initialDraft !== null,
+  );
+  const [staleBannerDays, setStaleBannerDays] = useState<number | null>(() =>
+    consumeStaleBannerDays(),
+  );
+
   // Navigation
-  const [step, setStep] = useState<WizardStep>("welcome");
+  const [step, setStep] = useState<WizardStep>(seed.step);
 
   // Step 2: templates
   const [blueprints, setBlueprints] = useState<BlueprintTemplate[]>([]);
   const [blueprintsLoading, setBlueprintsLoading] = useState(true);
   const [selectedBlueprint, setSelectedBlueprint] = useState<string | null>(
-    null,
+    seed.selectedBlueprint,
   );
 
   // Step 3: identity
-  const [company, setCompany] = useState("");
-  const [description, setDescription] = useState("");
-  const [priority, setPriority] = useState("");
+  const [company, setCompany] = useState(seed.company);
+  const [description, setDescription] = useState(seed.description);
+  const [priority, setPriority] = useState(seed.priority);
   // Optional in-wizard Nex registration. Mirrors the TUI's InitNexRegister
   // phase — we POST /nex/register which shells out to `nex-cli setup <email>`.
   // If nex-cli isn't installed we flip to `fallback` (external link to
@@ -155,21 +180,27 @@ export function Wizard({ onComplete }: WizardProps) {
   // the array is the fallback priority. Initially empty — we prefer explicit
   // config/launch choices, then auto-populate with the first installed CLI so
   // the happy path still works with zero clicks.
-  const [runtimePriority, setRuntimePriority] = useState<string[]>([]);
+  const [runtimePriority, setRuntimePriority] = useState<string[]>(
+    seed.runtimePriority,
+  );
   // localProvider is the local OpenAI-compat kind the user opted into in
   // the SetupStep subsection (mlx-lm | ollama | exo | "" for none).
   // When non-empty, it overrides whatever cloud CLI was selected and is
   // applied as llm_provider on /onboarding/complete.
-  const [localProvider, setLocalProvider] = useState<string>("");
+  const [localProvider, setLocalProvider] = useState<string>(
+    seed.localProvider,
+  );
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
-  const userEditedRuntimeRef = useRef(false);
+  // If we restored runtime choices from a draft, mark as user-edited so
+  // the prereq bootstrap effect doesn't overwrite them with defaults.
+  const userEditedRuntimeRef = useRef(initialDraft !== null);
 
   // Step 6: first task
   const [taskTemplates, setTaskTemplates] = useState<TaskTemplate[]>([]);
   const [selectedTaskTemplate, setSelectedTaskTemplate] = useState<
     string | null
-  >(null);
-  const [taskText, setTaskText] = useState("");
+  >(seed.selectedTaskTemplate);
+  const [taskText, setTaskText] = useState(seed.taskText);
   const taskTextAutofilled = useRef(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
@@ -300,7 +331,19 @@ export function Wizard({ onComplete }: WizardProps) {
   // blueprint only. Previously we flattened tasks across every blueprint, so
   // the task step showed ~26 tiles of unrelated work — including tasks from
   // blueprints the user never picked.
+  // Resume guard: on the very first render after restoring a draft, the
+  // selectedBlueprint state arrives non-null and would otherwise wipe the
+  // restored taskText / selectedTaskTemplate. Skip exactly one run.
+  const skipFirstBlueprintEffect = useRef(initialDraft !== null);
   useEffect(() => {
+    if (skipFirstBlueprintEffect.current) {
+      skipFirstBlueprintEffect.current = false;
+      const bp = blueprints.find((b) => b.id === selectedBlueprint);
+      if (selectedBlueprint !== null && bp?.tasks) {
+        setTaskTemplates(bp.tasks);
+      }
+      return;
+    }
     // Clear suggestion-derived text when the blueprint changes. Track this
     // separately from selectedTaskTemplate because re-clicking a suggestion
     // intentionally deselects the tile while leaving its autofilled text in
@@ -626,6 +669,9 @@ export function Wizard({ onComplete }: WizardProps) {
         return;
       }
 
+      // Onboarding succeeded — discard the resumeable draft so a return
+      // visit lands on the post-setup app, not a half-filled wizard.
+      clearDraft();
       setOnboardingComplete(true);
       onComplete?.();
     },
@@ -743,13 +789,58 @@ export function Wizard({ onComplete }: WizardProps) {
     localProvider,
   ]);
 
+  // Debounced persistence of the non-secret draft. extractDraftableState
+  // is a pure mapper inside the hook; secret-bearing fields like
+  // apiKeys are never passed in or read.
+  useOnboardingDraftSync({
+    step,
+    selectedBlueprint,
+    company,
+    description,
+    priority,
+    runtimePriority,
+    localProvider,
+    selectedTaskTemplate,
+    taskText,
+  });
+
+  const resetDraft = useCallback(() => {
+    clearDraft();
+    setHasSavedDraft(false);
+    setShowResumeBanner(false);
+    setStep("welcome");
+    setSelectedBlueprint(null);
+    setCompany("");
+    setDescription("");
+    setPriority("");
+    setRuntimePriority([]);
+    setLocalProvider("");
+    setApiKeys({});
+    setSelectedTaskTemplate(null);
+    setTaskText("");
+    userEditedRuntimeRef.current = false;
+    taskTextAutofilled.current = false;
+  }, []);
+
   return (
     <div className="wizard-container">
       <div className="wizard-body">
         <ProgressDots current={step} steps={activeSteps} />
 
+        <OnboardingBanners
+          resumeDraft={showResumeBanner ? initialDraft : null}
+          staleBannerDays={staleBannerDays}
+          onResetResume={resetDraft}
+          onDismissResume={() => setShowResumeBanner(false)}
+          onDismissStale={() => setStaleBannerDays(null)}
+        />
+
         {step === "welcome" && (
-          <WelcomeStep onNext={() => goTo(activeSteps[1] ?? "templates")} />
+          <WelcomeStep
+            onNext={() => goTo(activeSteps[1] ?? "templates")}
+            hasSavedDraft={hasSavedDraft}
+            onResetDraft={resetDraft}
+          />
         )}
 
         {step === "templates" && (

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -130,11 +130,12 @@ export function Wizard({ onComplete }: WizardProps) {
     : STEP_ORDER;
 
   // Resume support: load any saved draft once on first render. Captured
-  // into a ref so the useState initializers below can seed from it
-  // without re-running loadDraft on every render. The stale-banner flag
-  // is consumed at the same time so it only ever shows once.
-  const initialDraftRef = useRef(loadDraft());
-  const initialDraft = initialDraftRef.current;
+  // via a useState lazy initializer so loadDraft (which has side effects
+  // like clearing stale drafts and setting the session-storage banner
+  // flag) runs exactly once on mount rather than on every render. The
+  // stale-banner flag is consumed at the same time so it only ever shows
+  // once.
+  const [initialDraft] = useState(() => loadDraft());
   const seed = seedFromDraft(initialDraft);
   const [hasSavedDraft, setHasSavedDraft] = useState<boolean>(
     initialDraft !== null,

--- a/web/src/components/onboarding/wizard/ResumeBanner.tsx
+++ b/web/src/components/onboarding/wizard/ResumeBanner.tsx
@@ -1,0 +1,107 @@
+// Resume banners shown at the top of the wizard. Extracted from
+// Wizard.tsx so the parent component's complexity stays within the
+// repo's biome budget. Two flavors:
+//   - ResumeBanner: shown on mount when a saved draft was restored.
+//     Offers Start-over (clears draft) and Dismiss.
+//   - StaleBanner: shown once after loadDraft auto-discards a draft
+//     older than the 30-day staleness threshold.
+//
+// OnboardingBanners is the combined surface Wizard renders — a single
+// JSX node so the parent's render stays flat.
+
+import type { OnboardingDraft } from "./onboardingDraft";
+
+interface OnboardingBannersProps {
+  resumeDraft: OnboardingDraft | null;
+  staleBannerDays: number | null;
+  onResetResume: () => void;
+  onDismissResume: () => void;
+  onDismissStale: () => void;
+}
+
+export function OnboardingBanners({
+  resumeDraft,
+  staleBannerDays,
+  onResetResume,
+  onDismissResume,
+  onDismissStale,
+}: OnboardingBannersProps) {
+  return (
+    <>
+      {resumeDraft ? (
+        <ResumeBanner
+          draft={resumeDraft}
+          onReset={onResetResume}
+          onDismiss={onDismissResume}
+        />
+      ) : null}
+      {staleBannerDays !== null ? (
+        <StaleBanner days={staleBannerDays} onDismiss={onDismissStale} />
+      ) : null}
+    </>
+  );
+}
+
+interface ResumeBannerProps {
+  draft: OnboardingDraft;
+  onReset: () => void;
+  onDismiss: () => void;
+}
+
+export function ResumeBanner({ draft, onReset, onDismiss }: ResumeBannerProps) {
+  return (
+    <div
+      className="wizard-resume-banner"
+      role="status"
+      data-testid="onboarding-resume-banner"
+    >
+      <span>
+        Picking up where you left off ·{" "}
+        {new Date(draft.savedAt).toLocaleString()}
+      </span>
+      <button
+        type="button"
+        className="link-btn"
+        onClick={onReset}
+        data-testid="onboarding-resume-reset"
+      >
+        Start over
+      </button>
+      <button
+        type="button"
+        className="link-btn"
+        onClick={onDismiss}
+        data-testid="onboarding-resume-dismiss"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}
+
+interface StaleBannerProps {
+  days: number;
+  onDismiss: () => void;
+}
+
+export function StaleBanner({ days, onDismiss }: StaleBannerProps) {
+  return (
+    <div
+      className="wizard-resume-banner"
+      role="status"
+      data-testid="onboarding-stale-banner"
+    >
+      <span>
+        Cleared an old setup from {days} day{days === 1 ? "" : "s"} ago.
+      </span>
+      <button
+        type="button"
+        className="link-btn"
+        onClick={onDismiss}
+        data-testid="onboarding-stale-dismiss"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/wizard/Step1Welcome.test.tsx
+++ b/web/src/components/onboarding/wizard/Step1Welcome.test.tsx
@@ -24,4 +24,44 @@ describe("WelcomeStep", () => {
     expect(onNext).toHaveBeenCalledTimes(1);
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it("does not show the reset link when no draft exists", () => {
+    render(<WelcomeStep onNext={vi.fn()} />);
+    expect(screen.queryByTestId("welcome-reset-trigger")).toBeNull();
+  });
+
+  it("shows reset link when a saved draft exists and confirms inline", () => {
+    const onResetDraft = vi.fn();
+    render(
+      <WelcomeStep
+        onNext={vi.fn()}
+        hasSavedDraft={true}
+        onResetDraft={onResetDraft}
+      />,
+    );
+
+    const trigger = screen.getByTestId("welcome-reset-trigger");
+    fireEvent.click(trigger);
+
+    // Inline confirmation, not window.confirm
+    const confirm = screen.getByTestId("welcome-reset-confirm");
+    fireEvent.click(confirm);
+    expect(onResetDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel returns from confirmation without resetting", () => {
+    const onResetDraft = vi.fn();
+    render(
+      <WelcomeStep
+        onNext={vi.fn()}
+        hasSavedDraft={true}
+        onResetDraft={onResetDraft}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("welcome-reset-trigger"));
+    fireEvent.click(screen.getByTestId("welcome-reset-cancel"));
+    expect(onResetDraft).not.toHaveBeenCalled();
+    expect(screen.getByTestId("welcome-reset-trigger")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/onboarding/wizard/Step1Welcome.tsx
+++ b/web/src/components/onboarding/wizard/Step1Welcome.tsx
@@ -1,11 +1,23 @@
+import { useState } from "react";
+
 import { ONBOARDING_COPY } from "../../../lib/constants";
 import { ArrowIcon, EnterHint } from "./components";
 
 interface WelcomeStepProps {
   onNext: () => void;
+  // Resume affordance: when a previous draft is detected, offer a way
+  // to wipe it before starting again. Optional so existing call sites
+  // (and tests that don't care about resume) keep working.
+  hasSavedDraft?: boolean;
+  onResetDraft?: () => void;
 }
 
-export function WelcomeStep({ onNext }: WelcomeStepProps) {
+export function WelcomeStep({
+  onNext,
+  hasSavedDraft = false,
+  onResetDraft,
+}: WelcomeStepProps) {
+  const [confirmingReset, setConfirmingReset] = useState(false);
   return (
     <div className="wizard-step">
       <div className="wizard-hero">
@@ -23,6 +35,52 @@ export function WelcomeStep({ onNext }: WelcomeStepProps) {
           <EnterHint />
         </button>
       </div>
+      {hasSavedDraft && onResetDraft ? (
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            marginTop: 16,
+          }}
+          data-testid="welcome-reset-row"
+        >
+          {confirmingReset ? (
+            <span style={{ display: "inline-flex", gap: 12 }}>
+              <span style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
+                Discard your saved progress?
+              </span>
+              <button
+                type="button"
+                className="link-btn"
+                onClick={() => {
+                  onResetDraft();
+                  setConfirmingReset(false);
+                }}
+                data-testid="welcome-reset-confirm"
+              >
+                Yes, start over
+              </button>
+              <button
+                type="button"
+                className="link-btn"
+                onClick={() => setConfirmingReset(false)}
+                data-testid="welcome-reset-cancel"
+              >
+                Cancel
+              </button>
+            </span>
+          ) : (
+            <button
+              type="button"
+              className="link-btn"
+              onClick={() => setConfirmingReset(true)}
+              data-testid="welcome-reset-trigger"
+            >
+              Reset setup
+            </button>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/onboarding/wizard/onboardingDraft.test.ts
+++ b/web/src/components/onboarding/wizard/onboardingDraft.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  CURRENT_VERSION,
+  clearDraft,
+  consumeStaleBannerDays,
+  type DraftableWizardState,
+  extractDraftableState,
+  LOCAL_STORAGE_KEY,
+  loadDraft,
+  MAX_AGE_MS,
+  STALE_BANNER_KEY,
+  saveDraft,
+} from "./onboardingDraft";
+
+// State that intentionally extends the typed shape with secret-bearing
+// fields so the negative test can verify they are stripped. We only ever
+// pass this through unknown into extractDraftableState — never directly.
+interface StateWithSecrets extends DraftableWizardState {
+  apiKeys: Record<string, string>;
+  nexEmail: string;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("extractDraftableState", () => {
+  it("includes only the persisted fields, never API keys", () => {
+    // The mapper accepts a typed DraftableWizardState. As an extra
+    // regression guard we cast through unknown to slip in fields that
+    // would never appear in the real type — and assert they don't make
+    // it into the saved payload.
+    const stateWithSecrets: StateWithSecrets = {
+      step: "setup",
+      selectedBlueprint: "niche-crm",
+      company: "Acme",
+      description: "We do things",
+      priority: "growth",
+      runtimePriority: ["Claude Code"],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "Reach out to first 10 customers",
+      // Secrets that must never be persisted:
+      apiKeys: {
+        ANTHROPIC_API_KEY: "sk-test-placeholder",
+        OPENAI_API_KEY: "sk-test-placeholder",
+        GOOGLE_API_KEY: "google-test-placeholder",
+      },
+      nexEmail: "user@example.com",
+    };
+
+    // Cast through unknown so the secret-bearing fields are present at
+    // runtime but the typed surface still matches DraftableWizardState.
+    const draft = extractDraftableState(
+      stateWithSecrets as unknown as DraftableWizardState,
+    );
+    const serialized = JSON.stringify(draft);
+
+    expect(serialized).not.toContain("sk-test-placeholder");
+    expect(serialized).not.toContain("google-test-placeholder");
+    expect(serialized).not.toContain("ANTHROPIC_API_KEY");
+    expect(serialized).not.toContain("OPENAI_API_KEY");
+    expect(serialized).not.toContain("GOOGLE_API_KEY");
+    expect(serialized).not.toContain("apiKeys");
+    expect(serialized).not.toContain("nexEmail");
+    expect(serialized).not.toContain("user@example.com");
+
+    expect(draft.company).toBe("Acme");
+    expect(draft.runtimePriority).toEqual(["Claude Code"]);
+    expect(draft.version).toBe(CURRENT_VERSION);
+    expect(typeof draft.savedAt).toBe("string");
+  });
+});
+
+describe("save/load round-trip", () => {
+  it("save → load returns equal object", () => {
+    const source = extractDraftableState({
+      step: "team",
+      selectedBlueprint: null,
+      company: "Acme",
+      description: "We do things",
+      priority: "",
+      runtimePriority: ["Claude Code", "Codex"],
+      localProvider: "",
+      selectedTaskTemplate: "first-customer",
+      taskText: "First task",
+    });
+    saveDraft(source);
+    const loaded = loadDraft();
+    expect(loaded).toEqual(source);
+  });
+
+  it("does not persist API keys when saved alongside the draft", () => {
+    // Even if a caller mistakenly saved a draft directly, the saved JSON
+    // is exactly the OnboardingDraft shape and contains no secret keys.
+    const source = extractDraftableState({
+      step: "setup",
+      selectedBlueprint: null,
+      company: "",
+      description: "",
+      priority: "",
+      runtimePriority: [],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "",
+    });
+    saveDraft(source);
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY) ?? "";
+    expect(raw).not.toMatch(/api[_-]?key/i);
+    expect(raw).not.toMatch(/anthropic/i);
+    expect(raw).not.toMatch(/openai/i);
+  });
+});
+
+describe("loadDraft validation", () => {
+  it("returns null for version mismatch and clears storage", () => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify({
+        version: 0,
+        step: "welcome",
+        selectedBlueprint: null,
+        company: "",
+        description: "",
+        priority: "",
+        runtimePriority: [],
+        localProvider: "",
+        selectedTaskTemplate: null,
+        taskText: "",
+        savedAt: new Date().toISOString(),
+      }),
+    );
+    expect(loadDraft()).toBeNull();
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns null and clears storage for stale drafts (>30 days)", () => {
+    vi.useFakeTimers();
+    const now = new Date("2026-05-07T00:00:00Z");
+    vi.setSystemTime(now);
+    const draft = extractDraftableState({
+      step: "team",
+      selectedBlueprint: null,
+      company: "Acme",
+      description: "x",
+      priority: "",
+      runtimePriority: [],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "",
+    });
+    // Backdate savedAt by 31 days.
+    draft.savedAt = new Date(now.getTime() - MAX_AGE_MS - 1000).toISOString();
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(draft));
+
+    expect(loadDraft()).toBeNull();
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(STALE_BANNER_KEY)).not.toBeNull();
+  });
+
+  it("returns null on malformed JSON without throwing", () => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, "{not valid json");
+    expect(() => loadDraft()).not.toThrow();
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("returns null when shape is wrong (missing fields)", () => {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_KEY,
+      JSON.stringify({ version: CURRENT_VERSION, step: "welcome" }),
+    );
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("returns null when step is unknown", () => {
+    const draft = extractDraftableState({
+      step: "welcome",
+      selectedBlueprint: null,
+      company: "",
+      description: "",
+      priority: "",
+      runtimePriority: [],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "",
+    });
+    const tampered = { ...draft, step: "not-a-step" };
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(tampered));
+    expect(loadDraft()).toBeNull();
+  });
+});
+
+describe("saveDraft resilience", () => {
+  it("swallows QuotaExceededError silently", () => {
+    const setItem = vi
+      .spyOn(window.localStorage, "setItem")
+      .mockImplementation(() => {
+        throw new Error("QuotaExceededError");
+      });
+
+    const draft = extractDraftableState({
+      step: "welcome",
+      selectedBlueprint: null,
+      company: "",
+      description: "",
+      priority: "",
+      runtimePriority: [],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "",
+    });
+    expect(() => saveDraft(draft)).not.toThrow();
+    expect(setItem).toHaveBeenCalled();
+  });
+});
+
+describe("clearDraft", () => {
+  it("removes the saved draft", () => {
+    const draft = extractDraftableState({
+      step: "welcome",
+      selectedBlueprint: null,
+      company: "",
+      description: "",
+      priority: "",
+      runtimePriority: [],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "",
+    });
+    saveDraft(draft);
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).not.toBeNull();
+    clearDraft();
+    expect(window.localStorage.getItem(LOCAL_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("consumeStaleBannerDays", () => {
+  it("returns null when no flag is set", () => {
+    expect(consumeStaleBannerDays()).toBeNull();
+  });
+  it("returns the day count once and clears the flag", () => {
+    window.sessionStorage.setItem(STALE_BANNER_KEY, "42");
+    expect(consumeStaleBannerDays()).toBe(42);
+    expect(consumeStaleBannerDays()).toBeNull();
+  });
+});

--- a/web/src/components/onboarding/wizard/onboardingDraft.test.ts
+++ b/web/src/components/onboarding/wizard/onboardingDraft.test.ts
@@ -119,6 +119,47 @@ describe("save/load round-trip", () => {
   });
 });
 
+describe("saveDraft defensive whitelist", () => {
+  it("strips secret-bearing fields even when bypassing extractDraftableState", () => {
+    // Simulate a future caller that builds an OnboardingDraft-shaped
+    // object directly and smuggles secrets onto it. The storage-boundary
+    // re-projection inside saveDraft must drop them.
+    const tainted = {
+      version: CURRENT_VERSION,
+      step: "setup",
+      selectedBlueprint: null,
+      company: "Acme",
+      description: "",
+      priority: "",
+      runtimePriority: ["Claude Code"],
+      localProvider: "",
+      selectedTaskTemplate: null,
+      taskText: "",
+      savedAt: new Date().toISOString(),
+      // Fields that must never reach storage.
+      apiKeys: {
+        ANTHROPIC_API_KEY: "sk-test-placeholder",
+        OPENAI_API_KEY: "sk-test-placeholder",
+      },
+      nexEmail: "user@example.com",
+    };
+
+    saveDraft(tainted as unknown as Parameters<typeof saveDraft>[0]);
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY) ?? "";
+
+    expect(raw).not.toContain("sk-test-placeholder");
+    expect(raw).not.toContain("apiKeys");
+    expect(raw).not.toContain("ANTHROPIC_API_KEY");
+    expect(raw).not.toContain("OPENAI_API_KEY");
+    expect(raw).not.toContain("nexEmail");
+    expect(raw).not.toContain("user@example.com");
+
+    const reloaded = loadDraft();
+    expect(reloaded?.company).toBe("Acme");
+    expect(reloaded?.runtimePriority).toEqual(["Claude Code"]);
+  });
+});
+
 describe("loadDraft validation", () => {
   it("returns null for version mismatch and clears storage", () => {
     window.localStorage.setItem(

--- a/web/src/components/onboarding/wizard/onboardingDraft.ts
+++ b/web/src/components/onboarding/wizard/onboardingDraft.ts
@@ -1,0 +1,257 @@
+// onboardingDraft.ts — local persistence for the onboarding wizard so a
+// page refresh restores wizard progress instead of wiping it. Secrets
+// (API keys) NEVER persist; only the non-sensitive shape below does.
+//
+// Storage shape is versioned. A version mismatch — the schema bumped but
+// the user has an older draft — drops the draft cleanly rather than
+// crashing on missing fields. Drafts older than MAX_AGE_MS are also
+// auto-discarded; we surface a one-time banner via a sessionStorage flag
+// the caller (Wizard.tsx) consumes once on mount.
+
+import type { WizardStep } from "./types";
+
+export const LOCAL_STORAGE_KEY = "wuphf:onboarding-draft";
+export const STALE_BANNER_KEY = "wuphf:onboarding-draft-stale-banner";
+export const CURRENT_VERSION = 1;
+export const MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface OnboardingDraft {
+  version: number;
+  step: WizardStep;
+  selectedBlueprint: string | null;
+  company: string;
+  description: string;
+  priority: string;
+  runtimePriority: string[];
+  localProvider: string;
+  selectedTaskTemplate: string | null;
+  taskText: string;
+  savedAt: string;
+}
+
+// Source state we accept from the wizard. We model this loosely so
+// future fields can be added without breaking callers — but only the
+// keys listed above are ever read into the persisted shape, so a stray
+// `apiKeys` (or any other secret-bearing field) on the source object
+// CANNOT slip into storage. That is the secret-exclusion guarantee.
+export interface DraftableWizardState {
+  step: WizardStep;
+  selectedBlueprint: string | null;
+  company: string;
+  description: string;
+  priority: string;
+  runtimePriority: string[];
+  localProvider: string;
+  selectedTaskTemplate: string | null;
+  taskText: string;
+}
+
+const VALID_STEPS: ReadonlySet<WizardStep> = new Set<WizardStep>([
+  "welcome",
+  "templates",
+  "identity",
+  "team",
+  "setup",
+  "task",
+  "ready",
+]);
+
+export function extractDraftableState(
+  state: DraftableWizardState,
+): OnboardingDraft {
+  return {
+    version: CURRENT_VERSION,
+    step: state.step,
+    selectedBlueprint: state.selectedBlueprint,
+    company: state.company,
+    description: state.description,
+    priority: state.priority,
+    runtimePriority: [...state.runtimePriority],
+    localProvider: state.localProvider,
+    selectedTaskTemplate: state.selectedTaskTemplate,
+    taskText: state.taskText,
+    savedAt: new Date().toISOString(),
+  };
+}
+
+function isStringOrNull(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((s) => typeof s === "string");
+}
+
+function hasValidStringFields(draft: Record<string, unknown>): boolean {
+  return (
+    typeof draft.company === "string" &&
+    typeof draft.description === "string" &&
+    typeof draft.priority === "string" &&
+    typeof draft.localProvider === "string" &&
+    typeof draft.taskText === "string" &&
+    typeof draft.savedAt === "string"
+  );
+}
+
+function isValidDraft(value: unknown): value is OnboardingDraft {
+  if (typeof value !== "object" || value === null) return false;
+  const draft = value as Record<string, unknown>;
+  if (draft.version !== CURRENT_VERSION) return false;
+  if (typeof draft.step !== "string") return false;
+  if (!VALID_STEPS.has(draft.step as WizardStep)) return false;
+  if (!isStringOrNull(draft.selectedBlueprint)) return false;
+  if (!isStringOrNull(draft.selectedTaskTemplate)) return false;
+  if (!isStringArray(draft.runtimePriority)) return false;
+  return hasValidStringFields(draft);
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeSessionStorage(): Storage | null {
+  try {
+    return typeof window !== "undefined" ? window.sessionStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadDraft(): OnboardingDraft | null {
+  const storage = safeStorage();
+  if (!storage) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(LOCAL_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed JSON — drop it so we don't keep failing on every load.
+    clearDraft();
+    return null;
+  }
+
+  if (!isValidDraft(parsed)) {
+    // Either an older schema version or shape that no longer matches.
+    // Discard and start fresh — degrades safely per spec.
+    clearDraft();
+    return null;
+  }
+
+  const savedAtMs = new Date(parsed.savedAt).getTime();
+  if (Number.isNaN(savedAtMs)) {
+    clearDraft();
+    return null;
+  }
+  const age = Date.now() - savedAtMs;
+  if (age > MAX_AGE_MS) {
+    // Stash a flag so Wizard.tsx can show a single banner on this load.
+    const session = safeSessionStorage();
+    if (session) {
+      try {
+        const days = Math.floor(age / (24 * 60 * 60 * 1000));
+        session.setItem(STALE_BANNER_KEY, String(days));
+      } catch {
+        // Best-effort — banner is a nice-to-have, not load-bearing.
+      }
+    }
+    clearDraft();
+    return null;
+  }
+
+  return parsed;
+}
+
+export function saveDraft(draft: OnboardingDraft): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(draft));
+  } catch {
+    // QuotaExceededError, SecurityError (private mode), etc. — onboarding
+    // is more important than persistence; swallow silently.
+  }
+}
+
+export function clearDraft(): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(LOCAL_STORAGE_KEY);
+  } catch {
+    // Best-effort.
+  }
+}
+
+// seedFromDraft maps a possibly-null restored draft into the initial
+// values for the wizard's per-field useState calls. Centralized here so
+// the Wizard component itself doesn't carry a long sequence of
+// `draft?.foo ?? defaultFoo` ternaries inflating its complexity score.
+export interface DraftSeed {
+  step: WizardStep;
+  selectedBlueprint: string | null;
+  company: string;
+  description: string;
+  priority: string;
+  runtimePriority: string[];
+  localProvider: string;
+  selectedTaskTemplate: string | null;
+  taskText: string;
+}
+
+const EMPTY_SEED: DraftSeed = {
+  step: "welcome",
+  selectedBlueprint: null,
+  company: "",
+  description: "",
+  priority: "",
+  runtimePriority: [],
+  localProvider: "",
+  selectedTaskTemplate: null,
+  taskText: "",
+};
+
+export function seedFromDraft(draft: OnboardingDraft | null): DraftSeed {
+  if (draft === null) return EMPTY_SEED;
+  return {
+    step: draft.step,
+    selectedBlueprint: draft.selectedBlueprint,
+    company: draft.company,
+    description: draft.description,
+    priority: draft.priority,
+    runtimePriority: draft.runtimePriority,
+    localProvider: draft.localProvider,
+    selectedTaskTemplate: draft.selectedTaskTemplate,
+    taskText: draft.taskText,
+  };
+}
+
+export function consumeStaleBannerDays(): number | null {
+  const session = safeSessionStorage();
+  if (!session) return null;
+  let raw: string | null;
+  try {
+    raw = session.getItem(STALE_BANNER_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  try {
+    session.removeItem(STALE_BANNER_KEY);
+  } catch {
+    // If we can't remove it, the banner may show twice — preferable to
+    // throwing during onboarding.
+  }
+  const days = Number.parseInt(raw, 10);
+  return Number.isFinite(days) ? days : null;
+}

--- a/web/src/components/onboarding/wizard/onboardingDraft.ts
+++ b/web/src/components/onboarding/wizard/onboardingDraft.ts
@@ -74,6 +74,29 @@ export function extractDraftableState(
   };
 }
 
+// sanitizeDraft re-projects an OnboardingDraft to exactly the whitelisted
+// schema before it crosses the storage boundary. This is the second
+// layer of the secret-exclusion guarantee: even if a future caller
+// bypasses extractDraftableState and hands saveDraft an object with
+// extra fields (an `apiKeys` smuggled onto the draft, etc.), the call
+// site below will strip them. version is forced to CURRENT_VERSION so a
+// caller cannot persist a stale schema marker either.
+function sanitizeDraft(draft: OnboardingDraft): OnboardingDraft {
+  return {
+    version: CURRENT_VERSION,
+    step: draft.step,
+    selectedBlueprint: draft.selectedBlueprint,
+    company: draft.company,
+    description: draft.description,
+    priority: draft.priority,
+    runtimePriority: [...draft.runtimePriority],
+    localProvider: draft.localProvider,
+    selectedTaskTemplate: draft.selectedTaskTemplate,
+    taskText: draft.taskText,
+    savedAt: draft.savedAt,
+  };
+}
+
 function isStringOrNull(value: unknown): value is string | null {
   return value === null || typeof value === "string";
 }
@@ -175,8 +198,11 @@ export function loadDraft(): OnboardingDraft | null {
 export function saveDraft(draft: OnboardingDraft): void {
   const storage = safeStorage();
   if (!storage) return;
+  // Re-project to the whitelist at the storage boundary so secrets
+  // cannot leak even if a future caller bypasses extractDraftableState.
+  const sanitized = sanitizeDraft(draft);
   try {
-    storage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(draft));
+    storage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(sanitized));
   } catch {
     // QuotaExceededError, SecurityError (private mode), etc. — onboarding
     // is more important than persistence; swallow silently.

--- a/web/src/components/onboarding/wizard/useOnboardingDraftSync.ts
+++ b/web/src/components/onboarding/wizard/useOnboardingDraftSync.ts
@@ -1,0 +1,80 @@
+// useOnboardingDraftSync — debounced persistence of the non-secret
+// wizard draft. Extracted from Wizard.tsx to keep the parent
+// component's cognitive complexity under the repo's biome budget.
+//
+// The hook does one thing: schedules a setTimeout to write the
+// draftable subset of state to localStorage 300ms after any change.
+// API keys and other secrets are never read here — saveDraft only
+// persists the OnboardingDraft shape.
+
+import { useEffect } from "react";
+
+import {
+  type DraftableWizardState,
+  extractDraftableState,
+  saveDraft,
+} from "./onboardingDraft";
+
+const SAVE_DEBOUNCE_MS = 300;
+
+// Skip the save when the user has not touched anything yet — avoids
+// writing an empty placeholder draft on first welcome-step render that
+// would then flag a "resumeable session" the user never started.
+function isPristine(state: DraftableWizardState): boolean {
+  return (
+    state.step === "welcome" &&
+    state.selectedBlueprint === null &&
+    state.company === "" &&
+    state.description === "" &&
+    state.priority === "" &&
+    state.runtimePriority.length === 0 &&
+    state.localProvider === "" &&
+    state.selectedTaskTemplate === null &&
+    state.taskText === ""
+  );
+}
+
+export function useOnboardingDraftSync(state: DraftableWizardState): void {
+  const {
+    step,
+    selectedBlueprint,
+    company,
+    description,
+    priority,
+    runtimePriority,
+    localProvider,
+    selectedTaskTemplate,
+    taskText,
+  } = state;
+
+  useEffect(() => {
+    const next: DraftableWizardState = {
+      step,
+      selectedBlueprint,
+      company,
+      description,
+      priority,
+      runtimePriority,
+      localProvider,
+      selectedTaskTemplate,
+      taskText,
+    };
+    if (isPristine(next)) return;
+    const handle = window.setTimeout(() => {
+      saveDraft(extractDraftableState(next));
+    }, SAVE_DEBOUNCE_MS);
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [
+    step,
+    selectedBlueprint,
+    company,
+    description,
+    priority,
+    runtimePriority,
+    localProvider,
+    selectedTaskTemplate,
+    taskText,
+  ]);
+}

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -913,3 +913,37 @@
   color: var(--text-secondary);
   margin-top: 2px;
 }
+
+.wizard-resume-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  margin: 0 auto 16px;
+  max-width: 680px;
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  background: var(--surface-1, rgba(0, 0, 0, 0.02));
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.wizard-resume-banner > span {
+  flex: 1;
+  min-width: 0;
+}
+
+.link-btn {
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: var(--accent, #2563eb);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.link-btn:hover,
+.link-btn:focus-visible {
+  color: var(--accent-hover, #1d4ed8);
+}


### PR DESCRIPTION
## Summary

Phase 4 PR 4. A user partway through the onboarding wizard who refreshed the page or closed the tab lost every choice they made. This PR persists non-secret wizard state to localStorage so a refresh restores where they left off.

> **Parked for human eyeball pass before merge.** The resume banner renders on the welcome screen — keeping this Ready For Review (not auto-merged) so it can be visually verified.

- New module `web/src/components/onboarding/wizard/onboardingDraft.ts` owns the schema, validation, save/load/clear, stale-draft detection, and a one-time stale banner flag.
- New hook `useOnboardingDraftSync` debounces saves at 300ms and skips writes when the wizard is fully pristine.
- Wizard restores state on mount from the saved draft, shows a "Picking up where you left off" banner, and offers reset via the welcome screen with inline confirmation (no `window.confirm`).
- Successful onboarding clears the draft. Stale drafts (>30 days) auto-discard with a single banner ("Cleared an old setup from N days ago").

## Persisted vs excluded

**Persisted (non-secret only):**
- `step`, `selectedBlueprint`, `company`, `description`, `priority`
- `runtimePriority`, `localProvider`
- `selectedTaskTemplate`, `taskText`
- `savedAt` (ISO timestamp), `version` (schema version, currently 1)

**Excluded — verified by `extractDraftableState` test:**
- `apiKeys` (ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY, any future provider)
- `nexEmail`, `nexSignupStatus`, `nexSignupError`
- `agents` (derived from blueprint server-side)
- `blueprints`, `taskTemplates`, `prereqs` (fetched on mount)
- `submitting`, `submitError`, `nexSignupStatus`, transient UI state

The critical regression guard is the secret-exclusion test in `onboardingDraft.test.ts` — it passes a state object containing API keys through `extractDraftableState` and asserts the serialized payload contains none of them.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check src/components/onboarding` clean
- [x] `bunx secretlint "**/*"` clean
- [x] Onboarding suite green (74 tests)
- [x] Full web suite green (1076 tests)
- [ ] Manual: refresh on each step → state restored
- [ ] Manual: API key fields empty after refresh
- [ ] Manual: completed onboarding wipes draft
- [ ] Manual: reset link on welcome screen wipes draft
- [ ] Manual: stale draft (>30 days) shows the one-time banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding progress is automatically saved and can be resumed across sessions
  * Saved draft indicator banner shows when progress is ready to restore
  * "Start over" option resets saved draft from the welcome screen
  * Stale draft notification alerts users when saved progress is outdated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
