### PR TITLE
feat(web): show slash and @ popovers in thread composer

### DIFF
--- a/scripts/complexity-baseline.txt
+++ b/scripts/complexity-baseline.txt
@@ -32,7 +32,6 @@ web/src/components/layout/UpgradeBanner.tsx|lint/complexity/noExcessiveCognitive
 web/src/components/layout/UpgradeBanner.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
 web/src/components/messages/Composer.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/messages/Composer.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
-web/src/components/messages/Composer.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/messages/InterviewBar.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/messages/InterviewBar.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
 web/src/components/messages/InterviewBar.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
@@ -42,6 +41,7 @@ web/src/components/messages/MessageFeed.tsx|lint/complexity/noExcessiveCognitive
 web/src/components/messages/StreamLineView.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/messages/StreamLineView.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/messages/StreamLineView.tsx|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/ThreadPanel.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Composer wiring fans out into mutation, autocomplete, and slash-command branches that share state.
 web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
 web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
@@ -59,10 +59,10 @@ web/src/components/wiki/Pam.tsx|lint/complexity/noExcessiveCognitiveComplexity|1
 web/src/components/wiki/PlaybookExecutionLog.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/wiki/WikiAudit.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/wiki/WikiEditor.test.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
-web/src/components/wiki/WikiEditor.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/components/wiki/WikiLint.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/hooks/useKeyboardShortcuts.ts|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/lib/messageMarkdown.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/lib/slashCommands.ts|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/lib/wikilink.ts|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
 web/src/styles/global.css|lint/complexity/noImportantStyles|1|Responsive panel width override must win over fixed desktop sizing.
 web/src/styles/global.css|lint/complexity/noImportantStyles|1|Mobile full-width panel override must win over wider breakpoints.

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -6,15 +6,7 @@ import {
   useQueryClient,
 } from "@tanstack/react-query";
 
-import {
-  createDM,
-  get,
-  getConfig,
-  type Message,
-  post,
-  postMessage,
-  setMemory,
-} from "../../api/client";
+import { getConfig, type Message, postMessage } from "../../api/client";
 import { useCommands } from "../../hooks/useCommands";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import {
@@ -22,21 +14,20 @@ import {
   parseMentions,
   renderMentionTokens,
 } from "../../lib/mentions";
-import { router } from "../../lib/router";
+import {
+  askPrefix,
+  handleSlashCommand,
+  resolveLeadSlug,
+  unknownSlashCommandMessage,
+} from "../../lib/slashCommands";
 import { useChannelSlug } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
-import { confirm } from "../ui/ConfirmDialog";
-import { openProviderSwitcher } from "../ui/ProviderSwitcher";
 import { showNotice } from "../ui/Toast";
 import {
   Autocomplete,
   type AutocompleteItem,
   applyAutocomplete,
 } from "./Autocomplete";
-
-function navigateToApp(appId: string): void {
-  void router.navigate({ to: "/apps/$appId", params: { appId } });
-}
 
 /** How many sent messages to keep in per-channel history. */
 const COMPOSER_HISTORY_LIMIT = 20;
@@ -83,31 +74,6 @@ function pushHistory(channel: string, message: string): void {
   writeHistory(channel, next);
 }
 
-/** Routing prefix for `/ask`: mirrors TUI cmdAsk which always goes to the lead. */
-function askPrefix(leadSlug: string | undefined): string {
-  const slug = (leadSlug || "ceo").trim().toLowerCase() || "ceo";
-  return `@${slug} `;
-}
-
-function unknownSlashCommandMessage(command: string): string {
-  const name = command.trim().split(/\s+/)[0] || "/";
-  return `Unknown command: ${name}. Try /help.`;
-}
-
-/** Pick the team-lead slug: configured first, else first built-in agent, else 'ceo'. */
-function resolveLeadSlug(
-  configured: string | undefined,
-  members: { slug?: string; built_in?: boolean }[],
-): string {
-  const explicit = (configured ?? "").trim().toLowerCase();
-  if (explicit) return explicit;
-  const builtin = members.find(
-    (m) => m.built_in && m.slug && m.slug !== "human" && m.slug !== "you",
-  );
-  if (builtin?.slug) return builtin.slug;
-  return "ceo";
-}
-
 interface MessagesQueryData {
   messages?: Message[];
 }
@@ -144,240 +110,9 @@ function emptyMessagesQueryData(
   return { ...data, messages: [] };
 }
 
-interface SlashHandlers {
-  /** Team lead slug used for `/ask` routing. */
-  leadSlug: string | undefined;
-  /** Send the given text as a normal message (bypasses slash parsing). */
-  sendAsMessage: (text: string) => void;
-  /** Clear the visible transcript for the active channel. */
-  clearMessages: () => void;
-  /** Active channel slug for slash commands that scope server requests. */
-  channel: string;
-}
-
 interface OutboundMessage {
   content: string;
   tagged: string[];
-}
-
-/**
- * Handle slash commands. Returns true if the input was consumed as a command.
- *
- * Some commands (e.g. `/ask`) rewrite the input and invoke sendAsMessage so
- * the broker sees a normal user message with the right @mention routing.
- */
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
-function handleSlashCommand(input: string, handlers: SlashHandlers): boolean {
-  const parts = input.split(/\s+/);
-  const cmd = parts[0].toLowerCase();
-  const args = parts.slice(1).join(" ").trim();
-  const store = useAppStore.getState();
-
-  switch (cmd) {
-    case "/clear":
-      handlers.clearMessages();
-      return true;
-    case "/help":
-      store.setComposerHelpOpen(true);
-      return true;
-    case "/requests":
-      navigateToApp("requests");
-      return true;
-    case "/policies":
-      navigateToApp("policies");
-      return true;
-    case "/skills":
-      navigateToApp("skills");
-      return true;
-    case "/calendar":
-      navigateToApp("calendar");
-      return true;
-    case "/tasks":
-      navigateToApp("tasks");
-      return true;
-    case "/recover":
-    case "/doctor":
-      navigateToApp("health-check");
-      return true;
-    case "/provider":
-      openProviderSwitcher();
-      return true;
-    case "/search":
-      store.setComposerSearchInitialQuery(args);
-      store.setSearchOpen(true);
-      return true;
-    case "/ask": {
-      if (!args) {
-        showNotice("Usage: /ask <question>", "info");
-        return true;
-      }
-      // TUI's cmdAsk always routes to the team lead. Mirror that by
-      // prefixing an @mention so the broker's routing picks up the lead.
-      handlers.sendAsMessage(askPrefix(handlers.leadSlug) + args);
-      return true;
-    }
-    case "/lookup": {
-      if (!args) {
-        showNotice("Usage: /lookup <question>", "info");
-        return true;
-      }
-      showNotice("Looking up in wiki…", "info");
-      get("/wiki/lookup", { q: args, channel: handlers.channel }).catch(
-        (e: Error) => {
-          showNotice(`Wiki lookup failed: ${e.message}`, "error");
-        },
-      );
-      return true;
-    }
-    case "/lint": {
-      void router.navigate({ to: "/wiki/$", params: { _splat: "_lint" } });
-      return true;
-    }
-    case "/remember": {
-      if (!args) {
-        showNotice("Usage: /remember <fact>", "info");
-        return true;
-      }
-      // Broker /memory requires namespace + key + value. Use a stable
-      // human-owned namespace and a short timestamp key so repeated
-      // /remember calls do not collide.
-      const key = `note-${Date.now().toString(36)}`;
-      setMemory("human-notes", key, args)
-        .then(() =>
-          showNotice(
-            "Stored in memory: " +
-              (args.length > 40 ? `${args.slice(0, 40)}…` : args),
-            "success",
-          ),
-        )
-        .catch((e: Error) =>
-          showNotice(`Remember failed: ${e.message}`, "error"),
-        );
-      return true;
-    }
-    case "/focus":
-      post("/focus-mode", { focus_mode: true })
-        .then(() => showNotice("Switched to delegation mode", "success"))
-        .catch(() => showNotice("Failed to switch mode", "error"));
-      return true;
-    case "/collab":
-      post("/focus-mode", { focus_mode: false })
-        .then(() => showNotice("Switched to collaborative mode", "success"))
-        .catch(() => showNotice("Failed to switch mode", "error"));
-      return true;
-    case "/pause":
-      post("/signals", { kind: "pause", summary: "Human paused all agents" })
-        .then(() => showNotice("All agents paused", "success"))
-        .catch((e: Error) => showNotice(`Pause failed: ${e.message}`, "error"));
-      return true;
-    case "/resume":
-      post("/signals", { kind: "resume", summary: "Human resumed agents" })
-        .then(() => showNotice("Agents resumed", "success"))
-        .catch((e: Error) =>
-          showNotice(`Resume failed: ${e.message}`, "error"),
-        );
-      return true;
-    case "/reset":
-      confirm({
-        title: "Reset the office?",
-        message:
-          "Clears channels back to #general and drops in-memory state. Persisted tasks and requests stay on the broker.",
-        confirmLabel: "Reset",
-        danger: true,
-        onConfirm: () =>
-          post("/reset", {})
-            .then(() => {
-              void router.navigate({
-                to: "/channels/$channelSlug",
-                params: { channelSlug: "general" },
-              });
-              showNotice("Office reset", "success");
-            })
-            .catch((e: Error) =>
-              showNotice(`Reset failed: ${e.message}`, "error"),
-            ),
-      });
-      return true;
-    case "/1o1": {
-      if (!args) {
-        showNotice("Usage: /1o1 <agent-slug>", "info");
-        return true;
-      }
-      const slug = args.trim().toLowerCase();
-      createDM(slug)
-        .then(() => {
-          void router.navigate({
-            to: "/dm/$agentSlug",
-            params: { agentSlug: slug },
-          });
-        })
-        .catch(() => showNotice(`Agent not found: ${args.trim()}`, "error"));
-      return true;
-    }
-    case "/task": {
-      const taskParts = args.split(/\s+/);
-      const action = (taskParts[0] || "").toLowerCase();
-      const taskId = taskParts[1] || "";
-      const extra = taskParts.slice(2).join(" ");
-      if (!(action && taskId)) {
-        showNotice(
-          "Usage: /task <claim|release|complete|block|approve> <task-id>",
-          "info",
-        );
-        return true;
-      }
-      const body: Record<string, string> = {
-        action,
-        id: taskId,
-        channel: handlers.channel,
-      };
-      if (action === "claim") body.owner = "human";
-      if (extra) body.details = extra;
-      post("/tasks", body)
-        .then(() => showNotice(`Task ${taskId} → ${action}`, "success"))
-        .catch((e: Error) =>
-          showNotice(`Task action failed: ${e.message}`, "error"),
-        );
-      return true;
-    }
-    case "/cancel": {
-      if (!args) {
-        showNotice("Usage: /cancel <task-id>", "info");
-        return true;
-      }
-      post("/tasks", {
-        action: "release",
-        id: args.trim(),
-        channel: handlers.channel,
-      })
-        .then(() => showNotice(`Task ${args.trim()} cancelled`, "success"))
-        .catch(() => showNotice("Cancel failed", "error"));
-      return true;
-    }
-    case "/connect": {
-      // Bare `/connect` opens the provider picker (parity with the TUI's
-      // `/connect` 4-option picker — see cmd/wuphf/channel.go:4871). Direct
-      // forms like `/connect telegram` skip the picker and land straight in
-      // the integration's wizard, also matching TUI behaviour.
-      const target = args.trim().toLowerCase();
-      if (!target) {
-        store.openConnectWizard("provider");
-        return true;
-      }
-      if (target === "telegram") {
-        store.openConnectWizard("telegram");
-        return true;
-      }
-      showNotice(
-        `Integration "${target}" doesn't have a web wizard yet — try /connect on its own to see what's available.`,
-        "info",
-      );
-      return true;
-    }
-    default:
-      showNotice(unknownSlashCommandMessage(cmd), "info");
-      return true;
-  }
 }
 
 /**

--- a/web/src/components/messages/ThreadPanel.test.tsx
+++ b/web/src/components/messages/ThreadPanel.test.tsx
@@ -42,9 +42,9 @@ vi.mock("../../hooks/useMessages", () => ({
 }));
 
 vi.mock("../../hooks/useCommands", async () => {
-  const actual = await vi.importActual<typeof import("../../hooks/useCommands")>(
-    "../../hooks/useCommands",
-  );
+  const actual = await vi.importActual<
+    typeof import("../../hooks/useCommands")
+  >("../../hooks/useCommands");
   return {
     ...actual,
     useCommands: () => actual.FALLBACK_SLASH_COMMANDS,
@@ -58,9 +58,10 @@ vi.mock("./MessageBubble", () => ({
 }));
 
 vi.mock("../../api/client", async () => {
-  const actual = await vi.importActual<typeof import("../../api/client")>(
-    "../../api/client",
-  );
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
   return {
     ...actual,
     getConfig: vi.fn().mockResolvedValue({ team_lead_slug: "ceo" }),
@@ -146,5 +147,24 @@ describe("ThreadPanel autocomplete popovers", () => {
 
     fireEvent.change(textarea, { target: { value: "/clear extra" } });
     expect(document.querySelector(".autocomplete.open")).toBeNull();
+  });
+
+  it("Escape inside an open autocomplete does not bubble to close the thread panel", () => {
+    render(wrap(<ThreadPanel />));
+
+    const textarea = screen.getByPlaceholderText(
+      "Reply to thread…",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "/" } });
+    expect(document.querySelector(".autocomplete.open")).not.toBeNull();
+
+    fireEvent.keyDown(textarea, { key: "Escape" });
+
+    // The window-level "Escape closes the panel" handler must not fire when
+    // the autocomplete branch consumes the event. CodeRabbit flagged the
+    // missing stopPropagation in PR #702.
+    expect(useAppStore.getState().activeThread).not.toBeNull();
+    // Draft preserved (closing the panel would also reset text to "").
+    expect(textarea.value).toBe("/");
   });
 });

--- a/web/src/components/messages/ThreadPanel.test.tsx
+++ b/web/src/components/messages/ThreadPanel.test.tsx
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Message, OfficeMember } from "../../api/client";
+import { useAppStore } from "../../stores/app";
+
+const officeMembers: OfficeMember[] = [
+  {
+    slug: "ceo",
+    name: "Carmen",
+    role: "CEO",
+    emoji: "👑",
+    built_in: true,
+  } as OfficeMember,
+  {
+    slug: "pm",
+    name: "Mara",
+    role: "Product",
+    emoji: "📋",
+    built_in: false,
+  } as OfficeMember,
+];
+
+vi.mock("../../hooks/useMembers", () => ({
+  useOfficeMembers: () => ({ data: officeMembers, isLoading: false }),
+}));
+
+vi.mock("../../hooks/useMessages", () => ({
+  useThreadMessages: () => ({
+    data: [
+      {
+        id: "thread-1",
+        from: "ceo",
+        content: "Parent message",
+        channel: "general",
+      } as Message,
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../../hooks/useCommands", async () => {
+  const actual = await vi.importActual<typeof import("../../hooks/useCommands")>(
+    "../../hooks/useCommands",
+  );
+  return {
+    ...actual,
+    useCommands: () => actual.FALLBACK_SLASH_COMMANDS,
+  };
+});
+
+vi.mock("./MessageBubble", () => ({
+  MessageBubble: ({ message }: { message: Message }) => (
+    <div data-testid="bubble">{message.content}</div>
+  ),
+}));
+
+vi.mock("../../api/client", async () => {
+  const actual = await vi.importActual<typeof import("../../api/client")>(
+    "../../api/client",
+  );
+  return {
+    ...actual,
+    getConfig: vi.fn().mockResolvedValue({ team_lead_slug: "ceo" }),
+    postMessage: vi.fn().mockResolvedValue({ id: "reply-1" }),
+  };
+});
+
+import { ThreadPanel } from "./ThreadPanel";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  useAppStore.getState().setActiveThread({
+    id: "thread-1",
+    channelSlug: "general",
+  });
+});
+
+afterEach(() => {
+  useAppStore.getState().setActiveThread(null);
+});
+
+describe("ThreadPanel autocomplete popovers", () => {
+  it("opens the slash-command popover when the user types '/'", () => {
+    render(wrap(<ThreadPanel />));
+
+    // Before typing, no popover.
+    expect(document.querySelector(".autocomplete.open")).toBeNull();
+
+    const textarea = screen.getByPlaceholderText(
+      "Reply to thread…",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "/" } });
+
+    const popover = document.querySelector(".autocomplete.open");
+    expect(popover).not.toBeNull();
+    // Renders at least one slash command (e.g. /clear from FALLBACK).
+    expect(popover?.textContent).toMatch(/\//);
+  });
+
+  it("opens the @-mention popover when the user types '@'", () => {
+    render(wrap(<ThreadPanel />));
+
+    const textarea = screen.getByPlaceholderText(
+      "Reply to thread…",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "@" } });
+
+    const popover = document.querySelector(".autocomplete.open");
+    expect(popover).not.toBeNull();
+    // Should at least surface @all and a non-human member.
+    expect(popover?.textContent).toContain("@all");
+    expect(popover?.textContent).toContain("@ceo");
+  });
+
+  it("filters @-mentions by partial match on the query", () => {
+    render(wrap(<ThreadPanel />));
+
+    const textarea = screen.getByPlaceholderText(
+      "Reply to thread…",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "@ce" } });
+
+    const popover = document.querySelector(".autocomplete.open");
+    expect(popover).not.toBeNull();
+    expect(popover?.textContent).toContain("@ceo");
+    expect(popover?.textContent).not.toContain("@pm");
+  });
+
+  it("hides the popover once the trigger no longer applies (text after slash)", () => {
+    render(wrap(<ThreadPanel />));
+
+    const textarea = screen.getByPlaceholderText(
+      "Reply to thread…",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "/clear" } });
+    expect(document.querySelector(".autocomplete.open")).not.toBeNull();
+
+    fireEvent.change(textarea, { target: { value: "/clear extra" } });
+    expect(document.querySelector(".autocomplete.open")).toBeNull();
+  });
+});

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -277,7 +277,11 @@ export function ThreadPanel() {
           return true;
         }
         case "Escape":
+          // Escape consumed by the autocomplete branch must not bubble to
+          // the window-level keydown handler, which would close the entire
+          // thread panel and discard the draft.
           e.preventDefault();
+          e.stopPropagation();
           setAcItems([]);
           return true;
         default:
@@ -296,7 +300,10 @@ export function ThreadPanel() {
         return;
       }
       if (e.key === "Escape" && quoting) {
+        // Same reason as the autocomplete branch: cancel the quote chip
+        // without also asking the global handler to close the thread.
         e.preventDefault();
+        e.stopPropagation();
         setQuoting(null);
       }
     },

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -1,18 +1,62 @@
-import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
-import type { Message } from "../../api/client";
-import { postMessage } from "../../api/client";
+import { getConfig, type Message, postMessage } from "../../api/client";
+import { useCommands } from "../../hooks/useCommands";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { useThreadMessages } from "../../hooks/useMessages";
 import { extractTaggedMentions } from "../../lib/mentions";
+import { handleSlashCommand, resolveLeadSlug } from "../../lib/slashCommands";
 import { useAppStore } from "../../stores/app";
 import { showNotice } from "../ui/Toast";
+import {
+  Autocomplete,
+  type AutocompleteItem,
+  applyAutocomplete,
+} from "./Autocomplete";
 import { MessageBubble } from "./MessageBubble";
 
+interface MessagesQueryData {
+  messages?: Message[];
+}
+
+function latestCachedMessageId(
+  queryClient: QueryClient,
+  channel: string,
+): string | null {
+  const entries = queryClient.getQueriesData<MessagesQueryData>({
+    queryKey: ["messages", channel],
+  });
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const [, data] = entries[i];
+    const messages = data?.messages;
+    if (!messages) continue;
+    for (let j = messages.length - 1; j >= 0; j--) {
+      const id = messages[j]?.id?.trim();
+      if (id) return id;
+    }
+  }
+  return null;
+}
+
+function emptyMessagesQueryData(
+  data: MessagesQueryData | undefined,
+): MessagesQueryData | undefined {
+  if (!data?.messages) return data;
+  return { ...data, messages: [] };
+}
+
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Composer wiring fans out into mutation, autocomplete, and slash-command branches that share state.
 export function ThreadPanel() {
   const activeThread = useAppStore((s) => s.activeThread);
   const setActiveThread = useAppStore((s) => s.setActiveThread);
+  const setLastMessageId = useAppStore((s) => s.setLastMessageId);
+  const setChannelClearMarker = useAppStore((s) => s.setChannelClearMarker);
   // Channel is captured at thread-open time and stored on activeThread so
   // replies posted while the user has navigated away from the originating
   // channel still land in the right place. Reading useChannelSlug() here
@@ -21,12 +65,27 @@ export function ThreadPanel() {
   const activeThreadId = activeThread?.id ?? null;
   const currentChannel = activeThread?.channelSlug ?? "general";
   const [text, setText] = useState("");
+  const [caret, setCaret] = useState(0);
+  const [acItems, setAcItems] = useState<AutocompleteItem[]>([]);
+  const [acIdx, setAcIdx] = useState(0);
   const [quoting, setQuoting] = useState<Message | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
+  const { data: cfg } = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    staleTime: 60_000,
+  });
   const { data: members = [] } = useOfficeMembers();
   const knownSlugs = useMemo(() => members.map((m) => m.slug), [members]);
+  const leadSlug = useMemo(
+    () => resolveLeadSlug(cfg?.team_lead_slug, members),
+    [cfg?.team_lead_slug, members],
+  );
+  // Broker-backed slash-command registry; same source the channel composer
+  // reads. Falls back to a hardcoded list if the broker is unreachable.
+  const commands = useCommands();
 
   const { data: messages = [] } = useThreadMessages(
     currentChannel,
@@ -66,6 +125,9 @@ export function ThreadPanel() {
     void activeThreadId;
     setQuoting(null);
     setText("");
+    setCaret(0);
+    setAcItems([]);
+    setAcIdx(0);
   }, [activeThreadId]);
 
   // Focus the composer on open so users can start typing immediately.
@@ -95,13 +157,15 @@ export function ThreadPanel() {
   const replyTarget = quoting?.id ?? activeThreadId ?? undefined;
 
   const sendReply = useMutation({
-    mutationFn: (content: string) =>
-      postMessage(
-        content,
-        currentChannel,
-        replyTarget,
-        extractTaggedMentions(content, knownSlugs),
-      ),
+    mutationFn: ({
+      content,
+      tagged,
+      target,
+    }: {
+      content: string;
+      tagged: string[];
+      target: string | undefined;
+    }) => postMessage(content, currentChannel, target, tagged),
     onSuccess: () => {
       setText("");
       setQuoting(null);
@@ -117,11 +181,127 @@ export function ThreadPanel() {
     },
   });
 
-  const handleSend = () => {
+  const sendThreadMessage = useCallback(
+    (content: string) => {
+      sendReply.mutate({
+        content,
+        tagged: extractTaggedMentions(content, knownSlugs),
+        target: replyTarget,
+      });
+    },
+    [sendReply, knownSlugs, replyTarget],
+  );
+
+  const clearParentChannelMessages = useCallback(() => {
+    const markerId = latestCachedMessageId(queryClient, currentChannel);
+    setLastMessageId(null);
+    setChannelClearMarker(currentChannel, markerId);
+    queryClient.setQueriesData<MessagesQueryData>(
+      { queryKey: ["messages", currentChannel] },
+      emptyMessagesQueryData,
+    );
+    queryClient.invalidateQueries({ queryKey: ["messages", currentChannel] });
+    showNotice("Messages cleared", "info");
+  }, [currentChannel, queryClient, setChannelClearMarker, setLastMessageId]);
+
+  const handleSend = useCallback(() => {
     const trimmed = text.trim();
     if (!trimmed || sendReply.isPending) return;
-    sendReply.mutate(trimmed);
-  };
+
+    if (trimmed.startsWith("/")) {
+      const consumed = handleSlashCommand(trimmed, {
+        leadSlug,
+        sendAsMessage: sendThreadMessage,
+        clearMessages: clearParentChannelMessages,
+        channel: currentChannel,
+      });
+      if (consumed) {
+        setText("");
+        setQuoting(null);
+        return;
+      }
+    }
+
+    sendThreadMessage(trimmed);
+  }, [
+    text,
+    sendReply.isPending,
+    leadSlug,
+    sendThreadMessage,
+    clearParentChannelMessages,
+    currentChannel,
+  ]);
+
+  const pickAutocomplete = useCallback(
+    (item: AutocompleteItem) => {
+      const next = applyAutocomplete(text, caret, item);
+      setText(next.text);
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(next.caret, next.caret);
+        setCaret(next.caret);
+      });
+    },
+    [text, caret],
+  );
+
+  const handleAcItems = useCallback((items: AutocompleteItem[]) => {
+    setAcItems(items);
+    setAcIdx((idx) => Math.min(idx, Math.max(items.length - 1, 0)));
+  }, []);
+
+  const syncCaret = useCallback(() => {
+    const el = textareaRef.current;
+    if (el) setCaret(el.selectionStart ?? 0);
+  }, []);
+
+  const handleAutocompleteKey = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (acItems.length === 0) return false;
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setAcIdx((i) => (i + 1) % acItems.length);
+          return true;
+        case "ArrowUp":
+          e.preventDefault();
+          setAcIdx((i) => (i - 1 + acItems.length) % acItems.length);
+          return true;
+        case "Enter":
+        case "Tab": {
+          e.preventDefault();
+          const pick = acItems[acIdx] ?? acItems[0];
+          if (pick) pickAutocomplete(pick);
+          return true;
+        }
+        case "Escape":
+          e.preventDefault();
+          setAcItems([]);
+          return true;
+        default:
+          return false;
+      }
+    },
+    [acItems, acIdx, pickAutocomplete],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (handleAutocompleteKey(e)) return;
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSend();
+        return;
+      }
+      if (e.key === "Escape" && quoting) {
+        e.preventDefault();
+        setQuoting(null);
+      }
+    },
+    [handleAutocompleteKey, handleSend, quoting],
+  );
 
   if (!activeThreadId) return null;
 
@@ -239,6 +419,14 @@ export function ThreadPanel() {
             </button>
           </div>
         ) : null}
+        <Autocomplete
+          value={text}
+          caret={caret}
+          selectedIdx={acIdx}
+          onItems={handleAcItems}
+          onPick={pickAutocomplete}
+          commands={commands}
+        />
         <div className="composer-inner">
           <textarea
             ref={textareaRef}
@@ -247,17 +435,13 @@ export function ThreadPanel() {
               quoting ? `Reply to @${quoting.from}…` : "Reply to thread…"
             }
             value={text}
-            onChange={(e) => setText(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                handleSend();
-              }
-              if (e.key === "Escape" && quoting) {
-                e.preventDefault();
-                setQuoting(null);
-              }
+            onChange={(e) => {
+              setText(e.target.value);
+              setCaret(e.target.selectionStart ?? 0);
             }}
+            onKeyDown={handleKeyDown}
+            onKeyUp={syncCaret}
+            onClick={syncCaret}
             rows={1}
           />
           <button

--- a/web/src/lib/slashCommands.ts
+++ b/web/src/lib/slashCommands.ts
@@ -1,0 +1,269 @@
+import { createDM, get, post, setMemory } from "../api/client";
+import { confirm } from "../components/ui/ConfirmDialog";
+import { openProviderSwitcher } from "../components/ui/ProviderSwitcher";
+import { showNotice } from "../components/ui/Toast";
+import { useAppStore } from "../stores/app";
+import { router } from "./router";
+
+function navigateToApp(appId: string): void {
+  void router.navigate({ to: "/apps/$appId", params: { appId } });
+}
+
+/** Routing prefix for `/ask`: mirrors TUI cmdAsk which always goes to the lead. */
+export function askPrefix(leadSlug: string | undefined): string {
+  const slug = (leadSlug || "ceo").trim().toLowerCase() || "ceo";
+  return `@${slug} `;
+}
+
+export function unknownSlashCommandMessage(command: string): string {
+  const name = command.trim().split(/\s+/)[0] || "/";
+  return `Unknown command: ${name}. Try /help.`;
+}
+
+/** Pick the team-lead slug: configured first, else first built-in agent, else 'ceo'. */
+export function resolveLeadSlug(
+  configured: string | undefined,
+  members: { slug?: string; built_in?: boolean }[],
+): string {
+  const explicit = (configured ?? "").trim().toLowerCase();
+  if (explicit) return explicit;
+  const builtin = members.find(
+    (m) => m.built_in && m.slug && m.slug !== "human" && m.slug !== "you",
+  );
+  if (builtin?.slug) return builtin.slug;
+  return "ceo";
+}
+
+export interface SlashHandlers {
+  /** Team lead slug used for `/ask` routing. */
+  leadSlug: string | undefined;
+  /** Send the given text as a normal message (bypasses slash parsing). */
+  sendAsMessage: (text: string) => void;
+  /** Clear the visible transcript for the active channel. */
+  clearMessages: () => void;
+  /** Active channel slug for slash commands that scope server requests. */
+  channel: string;
+}
+
+/**
+ * Handle slash commands. Returns true if the input was consumed as a command.
+ *
+ * Some commands (e.g. `/ask`) rewrite the input and invoke sendAsMessage so
+ * the broker sees a normal user message with the right @mention routing.
+ */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
+export function handleSlashCommand(
+  input: string,
+  handlers: SlashHandlers,
+): boolean {
+  const parts = input.split(/\s+/);
+  const cmd = parts[0].toLowerCase();
+  const args = parts.slice(1).join(" ").trim();
+  const store = useAppStore.getState();
+
+  switch (cmd) {
+    case "/clear":
+      handlers.clearMessages();
+      return true;
+    case "/help":
+      store.setComposerHelpOpen(true);
+      return true;
+    case "/requests":
+      navigateToApp("requests");
+      return true;
+    case "/policies":
+      navigateToApp("policies");
+      return true;
+    case "/skills":
+      navigateToApp("skills");
+      return true;
+    case "/calendar":
+      navigateToApp("calendar");
+      return true;
+    case "/tasks":
+      navigateToApp("tasks");
+      return true;
+    case "/recover":
+    case "/doctor":
+      navigateToApp("health-check");
+      return true;
+    case "/provider":
+      openProviderSwitcher();
+      return true;
+    case "/search":
+      store.setComposerSearchInitialQuery(args);
+      store.setSearchOpen(true);
+      return true;
+    case "/ask": {
+      if (!args) {
+        showNotice("Usage: /ask <question>", "info");
+        return true;
+      }
+      // TUI's cmdAsk always routes to the team lead. Mirror that by
+      // prefixing an @mention so the broker's routing picks up the lead.
+      handlers.sendAsMessage(askPrefix(handlers.leadSlug) + args);
+      return true;
+    }
+    case "/lookup": {
+      if (!args) {
+        showNotice("Usage: /lookup <question>", "info");
+        return true;
+      }
+      showNotice("Looking up in wiki…", "info");
+      get("/wiki/lookup", { q: args, channel: handlers.channel }).catch(
+        (e: Error) => {
+          showNotice(`Wiki lookup failed: ${e.message}`, "error");
+        },
+      );
+      return true;
+    }
+    case "/lint": {
+      void router.navigate({ to: "/wiki/$", params: { _splat: "_lint" } });
+      return true;
+    }
+    case "/remember": {
+      if (!args) {
+        showNotice("Usage: /remember <fact>", "info");
+        return true;
+      }
+      // Broker /memory requires namespace + key + value. Use a stable
+      // human-owned namespace and a short timestamp key so repeated
+      // /remember calls do not collide.
+      const key = `note-${Date.now().toString(36)}`;
+      setMemory("human-notes", key, args)
+        .then(() =>
+          showNotice(
+            "Stored in memory: " +
+              (args.length > 40 ? `${args.slice(0, 40)}…` : args),
+            "success",
+          ),
+        )
+        .catch((e: Error) =>
+          showNotice(`Remember failed: ${e.message}`, "error"),
+        );
+      return true;
+    }
+    case "/focus":
+      post("/focus-mode", { focus_mode: true })
+        .then(() => showNotice("Switched to delegation mode", "success"))
+        .catch(() => showNotice("Failed to switch mode", "error"));
+      return true;
+    case "/collab":
+      post("/focus-mode", { focus_mode: false })
+        .then(() => showNotice("Switched to collaborative mode", "success"))
+        .catch(() => showNotice("Failed to switch mode", "error"));
+      return true;
+    case "/pause":
+      post("/signals", { kind: "pause", summary: "Human paused all agents" })
+        .then(() => showNotice("All agents paused", "success"))
+        .catch((e: Error) => showNotice(`Pause failed: ${e.message}`, "error"));
+      return true;
+    case "/resume":
+      post("/signals", { kind: "resume", summary: "Human resumed agents" })
+        .then(() => showNotice("Agents resumed", "success"))
+        .catch((e: Error) =>
+          showNotice(`Resume failed: ${e.message}`, "error"),
+        );
+      return true;
+    case "/reset":
+      confirm({
+        title: "Reset the office?",
+        message:
+          "Clears channels back to #general and drops in-memory state. Persisted tasks and requests stay on the broker.",
+        confirmLabel: "Reset",
+        danger: true,
+        onConfirm: () =>
+          post("/reset", {})
+            .then(() => {
+              void router.navigate({
+                to: "/channels/$channelSlug",
+                params: { channelSlug: "general" },
+              });
+              showNotice("Office reset", "success");
+            })
+            .catch((e: Error) =>
+              showNotice(`Reset failed: ${e.message}`, "error"),
+            ),
+      });
+      return true;
+    case "/1o1": {
+      if (!args) {
+        showNotice("Usage: /1o1 <agent-slug>", "info");
+        return true;
+      }
+      const slug = args.trim().toLowerCase();
+      createDM(slug)
+        .then(() => {
+          void router.navigate({
+            to: "/dm/$agentSlug",
+            params: { agentSlug: slug },
+          });
+        })
+        .catch(() => showNotice(`Agent not found: ${args.trim()}`, "error"));
+      return true;
+    }
+    case "/task": {
+      const taskParts = args.split(/\s+/);
+      const action = (taskParts[0] || "").toLowerCase();
+      const taskId = taskParts[1] || "";
+      const extra = taskParts.slice(2).join(" ");
+      if (!(action && taskId)) {
+        showNotice(
+          "Usage: /task <claim|release|complete|block|approve> <task-id>",
+          "info",
+        );
+        return true;
+      }
+      const body: Record<string, string> = {
+        action,
+        id: taskId,
+        channel: handlers.channel,
+      };
+      if (action === "claim") body.owner = "human";
+      if (extra) body.details = extra;
+      post("/tasks", body)
+        .then(() => showNotice(`Task ${taskId} → ${action}`, "success"))
+        .catch((e: Error) =>
+          showNotice(`Task action failed: ${e.message}`, "error"),
+        );
+      return true;
+    }
+    case "/cancel": {
+      if (!args) {
+        showNotice("Usage: /cancel <task-id>", "info");
+        return true;
+      }
+      post("/tasks", {
+        action: "release",
+        id: args.trim(),
+        channel: handlers.channel,
+      })
+        .then(() => showNotice(`Task ${args.trim()} cancelled`, "success"))
+        .catch(() => showNotice("Cancel failed", "error"));
+      return true;
+    }
+    case "/connect": {
+      // Bare `/connect` opens the provider picker (parity with the TUI's
+      // `/connect` 4-option picker — see cmd/wuphf/channel.go:4871). Direct
+      // forms like `/connect telegram` skip the picker and land straight in
+      // the integration's wizard, also matching TUI behaviour.
+      const target = args.trim().toLowerCase();
+      if (!target) {
+        store.openConnectWizard("provider");
+        return true;
+      }
+      if (target === "telegram") {
+        store.openConnectWizard("telegram");
+        return true;
+      }
+      showNotice(
+        `Integration "${target}" doesn't have a web wizard yet — try /connect on its own to see what's available.`,
+        "info",
+      );
+      return true;
+    }
+    default:
+      showNotice(unknownSlashCommandMessage(cmd), "info");
+      return true;
+  }
+}


### PR DESCRIPTION
## Summary

The thread reply composer rendered a bare `<textarea>`, so typing `/` or `@` inside a thread did nothing — even though both work in the main channel composer. This broke the muscle memory the rest of the app trains.

- Extracted `handleSlashCommand` (and the team-lead resolver) into `web/src/lib/slashCommands.ts` so both composers share one registry.
- Wired `Autocomplete` + caret tracking + keyboard navigation (Arrow keys, Enter, Tab, Escape) into `ThreadPanel`.
- Slash commands picked from a thread run with thread-aware routing: `/ask` posts as a thread reply, `/clear` still clears the parent channel transcript.

## Test plan

- [x] `bash scripts/test-web.sh` — 1061 / 1061 pass
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check .` clean
- [x] `bun run build` succeeds
- [x] `go build ./cmd/wuphf` succeeds
- [x] New `ThreadPanel.test.tsx` covers slash trigger, mention trigger, mention filtering, and trigger dismissal
- [ ] Manual: open a thread in `general`, type `/`, confirm popover; arrow + Enter inserts; type `@ce`, confirm filtered list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread replies now include autocomplete with context-aware popovers for slash commands and mentions; popovers auto-close when context changes
* **Refactor**
  * Slash-command handling centralized for more consistent behavior across composer and threads
* **Tests**
  * Added comprehensive tests covering ThreadPanel autocomplete and mention behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->