### PR TITLE
feat(onboarding): pack library with outcome-first picker (phase 4 pr 1)

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -576,25 +576,38 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 		})
 	}
 	for _, ft := range bp.FirstTasks {
+		id := strings.TrimSpace(ft.ID)
+		title := strings.TrimSpace(ft.Title)
+		if id == "" || title == "" {
+			continue
+		}
 		s.FirstTasks = append(s.FirstTasks, blueprintFirstTaskSummary{
-			ID:             ft.ID,
-			Title:          ft.Title,
-			Prompt:         ft.Prompt,
-			ExpectedOutput: ft.ExpectedOutput,
+			ID:             id,
+			Title:          title,
+			Prompt:         strings.TrimSpace(ft.Prompt),
+			ExpectedOutput: strings.TrimSpace(ft.ExpectedOutput),
 		})
 	}
 	for _, sk := range bp.Skills {
+		name := strings.TrimSpace(sk.Name)
+		if name == "" {
+			continue
+		}
 		s.Skills = append(s.Skills, blueprintSkillSummary{
-			Name:    sk.Name,
-			Purpose: sk.Purpose,
+			Name:    name,
+			Purpose: strings.TrimSpace(sk.Purpose),
 		})
 	}
 	for _, req := range bp.Requirements {
+		name := strings.TrimSpace(req.Name)
+		if name == "" {
+			continue
+		}
 		s.Requirements = append(s.Requirements, blueprintRequirementEntry{
-			Kind:     req.Kind,
-			Name:     req.Name,
+			Kind:     strings.TrimSpace(req.Kind),
+			Name:     name,
 			Required: req.Required,
-			Detail:   req.Detail,
+			Detail:   strings.TrimSpace(req.Detail),
 		})
 	}
 	if bp.WikiSchema != nil {
@@ -610,9 +623,13 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 		}
 	}
 	for _, ex := range bp.ExampleArtifacts {
+		title := strings.TrimSpace(ex.Title)
+		if title == "" {
+			continue
+		}
 		s.ExampleArtifacts = append(s.ExampleArtifacts, blueprintExampleSummary{
-			Kind:  ex.Kind,
-			Title: ex.Title,
+			Kind:  strings.TrimSpace(ex.Kind),
+			Title: title,
 		})
 	}
 	return s

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -427,14 +427,62 @@ func HandleTemplates(w http.ResponseWriter, r *http.Request, packSlug string) {
 
 // blueprintSummary is the wizard-facing shape returned by HandleBlueprints.
 // Keep the field names in sync with BlueprintTemplate in
-// web/src/components/onboarding/Wizard.tsx.
+// web/src/components/onboarding/wizard/types.ts. The pack-library
+// fields (outcome, category, channels, skills, wiki_scaffold,
+// first_tasks, requirements, estimated_setup_minutes,
+// example_artifacts) are additive — older clients that only consume
+// id/name/description/agents/tasks keep working.
 type blueprintSummary struct {
-	ID          string                  `json:"id"`
-	Name        string                  `json:"name"`
-	Description string                  `json:"description,omitempty"`
-	Emoji       string                  `json:"emoji,omitempty"`
-	Agents      []blueprintAgentSummary `json:"agents,omitempty"`
-	Tasks       []blueprintTaskSummary  `json:"tasks,omitempty"`
+	ID                    string                       `json:"id"`
+	Name                  string                       `json:"name"`
+	Description           string                       `json:"description,omitempty"`
+	Emoji                 string                       `json:"emoji,omitempty"`
+	Outcome               string                       `json:"outcome,omitempty"`
+	Category              string                       `json:"category,omitempty"`
+	EstimatedSetupMinutes int                          `json:"estimated_setup_minutes,omitempty"`
+	Agents                []blueprintAgentSummary      `json:"agents,omitempty"`
+	Channels              []blueprintChannelSummary    `json:"channels,omitempty"`
+	Tasks                 []blueprintTaskSummary       `json:"tasks,omitempty"`
+	Skills                []blueprintSkillSummary      `json:"skills,omitempty"`
+	WikiScaffold          []blueprintWikiScaffoldEntry `json:"wiki_scaffold,omitempty"`
+	FirstTasks            []blueprintFirstTaskSummary  `json:"first_tasks,omitempty"`
+	Requirements          []blueprintRequirementEntry  `json:"requirements,omitempty"`
+	ExampleArtifacts      []blueprintExampleSummary    `json:"example_artifacts,omitempty"`
+}
+
+type blueprintChannelSummary struct {
+	Slug    string `json:"slug"`
+	Name    string `json:"name,omitempty"`
+	Purpose string `json:"purpose,omitempty"`
+}
+
+type blueprintSkillSummary struct {
+	Name    string `json:"name"`
+	Purpose string `json:"purpose,omitempty"`
+}
+
+type blueprintWikiScaffoldEntry struct {
+	Path  string `json:"path"`
+	Title string `json:"title,omitempty"`
+}
+
+type blueprintFirstTaskSummary struct {
+	ID             string `json:"id"`
+	Title          string `json:"title"`
+	Prompt         string `json:"prompt,omitempty"`
+	ExpectedOutput string `json:"expected_output,omitempty"`
+}
+
+type blueprintRequirementEntry struct {
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+	Required bool   `json:"required,omitempty"`
+	Detail   string `json:"detail,omitempty"`
+}
+
+type blueprintExampleSummary struct {
+	Kind  string `json:"kind,omitempty"`
+	Title string `json:"title"`
 }
 
 type blueprintAgentSummary struct {
@@ -483,9 +531,12 @@ func HandleBlueprints(w http.ResponseWriter, r *http.Request) {
 
 func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 	s := blueprintSummary{
-		ID:          bp.ID,
-		Name:        bp.Name,
-		Description: bp.Description,
+		ID:                    bp.ID,
+		Name:                  bp.Name,
+		Description:           bp.Description,
+		Outcome:               bp.Outcome,
+		Category:              bp.Category,
+		EstimatedSetupMinutes: bp.EstimatedSetupMinutes,
 	}
 	leadSlug := strings.TrimSpace(bp.Starter.LeadSlug)
 	for _, a := range bp.Starter.Agents {
@@ -502,6 +553,17 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 			BuiltIn: builtIn,
 		})
 	}
+	for _, c := range bp.Starter.Channels {
+		slug := strings.TrimSpace(c.Slug)
+		if slug == "" {
+			continue
+		}
+		s.Channels = append(s.Channels, blueprintChannelSummary{
+			Slug:    slug,
+			Name:    strings.TrimSpace(c.Name),
+			Purpose: strings.TrimSpace(c.Description),
+		})
+	}
 	for _, t := range bp.Starter.Tasks {
 		title := strings.TrimSpace(t.Title)
 		if title == "" {
@@ -511,6 +573,46 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 			ID:          onboardingTemplateID(title),
 			Name:        title,
 			Description: strings.TrimSpace(t.Details),
+		})
+	}
+	for _, ft := range bp.FirstTasks {
+		s.FirstTasks = append(s.FirstTasks, blueprintFirstTaskSummary{
+			ID:             ft.ID,
+			Title:          ft.Title,
+			Prompt:         ft.Prompt,
+			ExpectedOutput: ft.ExpectedOutput,
+		})
+	}
+	for _, sk := range bp.Skills {
+		s.Skills = append(s.Skills, blueprintSkillSummary{
+			Name:    sk.Name,
+			Purpose: sk.Purpose,
+		})
+	}
+	for _, req := range bp.Requirements {
+		s.Requirements = append(s.Requirements, blueprintRequirementEntry{
+			Kind:     req.Kind,
+			Name:     req.Name,
+			Required: req.Required,
+			Detail:   req.Detail,
+		})
+	}
+	if bp.WikiSchema != nil {
+		for _, item := range bp.WikiSchema.Bootstrap {
+			path := strings.TrimSpace(item.Path)
+			if path == "" {
+				continue
+			}
+			s.WikiScaffold = append(s.WikiScaffold, blueprintWikiScaffoldEntry{
+				Path:  path,
+				Title: strings.TrimSpace(item.Title),
+			})
+		}
+	}
+	for _, ex := range bp.ExampleArtifacts {
+		s.ExampleArtifacts = append(s.ExampleArtifacts, blueprintExampleSummary{
+			Kind:  ex.Kind,
+			Title: ex.Title,
 		})
 	}
 	return s

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -555,7 +555,7 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 	}
 	for _, c := range bp.Starter.Channels {
 		slug := strings.TrimSpace(c.Slug)
-		if slug == "" {
+		if slug == "" || strings.Contains(slug, "{{") {
 			continue
 		}
 		s.Channels = append(s.Channels, blueprintChannelSummary{

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -450,6 +450,105 @@ func TestHandleBlueprintsMarksLeadBuiltIn(t *testing.T) {
 	})
 }
 
+// TestHandleBlueprintsExposesPackPreviewMetadata verifies the new
+// pack-library fields surface on the wire. The wizard's pack library
+// reads outcome, category, channels, skills, wiki_scaffold,
+// first_tasks, requirements, and example_artifacts to render the
+// detail panel before commit. Backward compatibility: the fields are
+// additive — the same response still satisfies the older lead/built_in
+// contract verified by TestHandleBlueprintsMarksLeadBuiltIn.
+func TestHandleBlueprintsExposesPackPreviewMetadata(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		withOperationsFallbackFS(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/onboarding/blueprints", nil)
+		w := httptest.NewRecorder()
+		HandleBlueprints(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d\nbody: %s", w.Code, w.Body.String())
+		}
+
+		var resp struct {
+			Templates []struct {
+				ID                    string `json:"id"`
+				Outcome               string `json:"outcome"`
+				Category              string `json:"category"`
+				EstimatedSetupMinutes int    `json:"estimated_setup_minutes"`
+				Channels              []struct {
+					Slug    string `json:"slug"`
+					Name    string `json:"name"`
+					Purpose string `json:"purpose"`
+				} `json:"channels"`
+				Skills []struct {
+					Name    string `json:"name"`
+					Purpose string `json:"purpose"`
+				} `json:"skills"`
+				WikiScaffold []struct {
+					Path  string `json:"path"`
+					Title string `json:"title"`
+				} `json:"wiki_scaffold"`
+				FirstTasks []struct {
+					ID             string `json:"id"`
+					Title          string `json:"title"`
+					Prompt         string `json:"prompt"`
+					ExpectedOutput string `json:"expected_output"`
+				} `json:"first_tasks"`
+				Requirements []struct {
+					Kind     string `json:"kind"`
+					Name     string `json:"name"`
+					Required bool   `json:"required"`
+				} `json:"requirements"`
+				ExampleArtifacts []struct {
+					Title string `json:"title"`
+				} `json:"example_artifacts"`
+			} `json:"templates"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		var found bool
+		for _, tpl := range resp.Templates {
+			if tpl.ID != "bookkeeping-invoicing-service" {
+				continue
+			}
+			found = true
+			if tpl.Outcome == "" {
+				t.Error("expected outcome to be populated for bookkeeping pack")
+			}
+			if tpl.Category != "services" {
+				t.Errorf("expected category=services, got %q", tpl.Category)
+			}
+			if tpl.EstimatedSetupMinutes <= 0 {
+				t.Errorf("expected estimated_setup_minutes > 0, got %d", tpl.EstimatedSetupMinutes)
+			}
+			if len(tpl.Channels) == 0 {
+				t.Error("expected at least one channel on the wire")
+			}
+			if len(tpl.Skills) == 0 {
+				t.Error("expected at least one skill on the wire")
+			}
+			if len(tpl.FirstTasks) == 0 {
+				t.Fatal("expected at least one first_task on the wire")
+			}
+			ft := tpl.FirstTasks[0]
+			if ft.Title == "" || ft.Prompt == "" || ft.ExpectedOutput == "" {
+				t.Errorf("first_task fields incomplete: %+v", ft)
+			}
+			if len(tpl.Requirements) == 0 {
+				t.Error("expected at least one requirement on the wire")
+			}
+			if len(tpl.WikiScaffold) == 0 {
+				t.Error("expected wiki_scaffold to be derived from wiki_schema bootstrap")
+			}
+		}
+		if !found {
+			t.Fatalf("bookkeeping-invoicing-service not found in response: %+v", resp.Templates)
+		}
+	})
+}
+
 // TestHandleChecklistDoneMarksItem verifies that POST /onboarding/checklist/{id}/done
 // marks the item and persists it.
 func TestHandleChecklistDoneMarksItem(t *testing.T) {

--- a/internal/operations/blueprint_pack_preview_test.go
+++ b/internal/operations/blueprint_pack_preview_test.go
@@ -1,0 +1,179 @@
+package operations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadBlueprintPackPreviewMetadata asserts every shipped operation
+// blueprint declares the metadata the onboarding pack library needs:
+// outcome, category, at least one first task with a real prompt and
+// expected output, and at least one declared skill and requirement.
+// Acceptance criterion from Phase 4 PR 1: "all built-in packs have
+// metadata. Each pack has at least one first-task suggestion."
+func TestLoadBlueprintPackPreviewMetadata(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+	ids := operationFixtureIDs(t, repoRoot)
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			bp, err := LoadBlueprint(repoRoot, id)
+			if err != nil {
+				t.Fatalf("load blueprint %q: %v", id, err)
+			}
+			if strings.TrimSpace(bp.Outcome) == "" {
+				t.Fatalf("blueprint %q is missing outcome — pack library cards need it", id)
+			}
+			switch bp.Category {
+			case "services", "media", "product":
+			default:
+				t.Fatalf("blueprint %q has invalid category %q (want services|media|product)", id, bp.Category)
+			}
+			if len(bp.FirstTasks) == 0 {
+				t.Fatalf("blueprint %q has no first_tasks — pack library expects at least one", id)
+			}
+			for _, ft := range bp.FirstTasks {
+				if strings.TrimSpace(ft.Title) == "" {
+					t.Fatalf("blueprint %q first task missing title", id)
+				}
+				if strings.TrimSpace(ft.Prompt) == "" {
+					t.Fatalf("blueprint %q first task %q missing prompt", id, ft.Title)
+				}
+				if strings.TrimSpace(ft.ExpectedOutput) == "" {
+					t.Fatalf("blueprint %q first task %q missing expected_output", id, ft.Title)
+				}
+				if strings.TrimSpace(ft.ID) == "" {
+					t.Fatalf("blueprint %q first task %q missing id slug", id, ft.Title)
+				}
+			}
+			if len(bp.Skills) == 0 {
+				t.Fatalf("blueprint %q declares no skills — pack library expects at least one", id)
+			}
+			if len(bp.Requirements) == 0 {
+				t.Fatalf("blueprint %q declares no requirements — pack library expects at least one", id)
+			}
+			for _, req := range bp.Requirements {
+				switch req.Kind {
+				case "runtime", "api-key", "local-tool":
+				default:
+					t.Fatalf("blueprint %q requirement %q has invalid kind %q", id, req.Name, req.Kind)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadBlueprintAcceptsMissingPackPreview confirms a blueprint
+// without any pack-preview fields still parses and loads successfully —
+// the additive metadata must not break older blueprints that have not
+// been migrated yet.
+func TestLoadBlueprintAcceptsMissingPackPreview(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "templates", "operations", "legacy-pack", "blueprint.yaml")
+	if err := os.MkdirAll(filepath.Dir(yamlPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Reuse a real employee blueprint reference so validation passes.
+	repoRoot := findRepoRoot(t)
+	const employeeID = "workflow-automation-builder"
+	employeePath := filepath.Join(repoRoot, "templates", "employees", employeeID)
+	if _, err := os.Stat(employeePath); err != nil {
+		t.Skipf("repo employee fixtures not reachable: %v", err)
+	}
+	if err := mirrorEmployeeFixture(dir, repoRoot, employeeID); err != nil {
+		t.Fatalf("mirror employee fixture: %v", err)
+	}
+	body := `id: legacy-pack
+name: Legacy Pack
+kind: legacy
+description: A pack without any of the new pack-preview metadata.
+objective: Prove backwards compatibility.
+default_reviewer: ceo
+employee_blueprints:
+  - workflow-automation-builder
+starter:
+  lead_slug: ceo
+  agents:
+    - slug: ceo
+      name: CEO
+      role: lead
+      employee_blueprint: workflow-automation-builder
+      permission_mode: plan
+      checked: true
+      type: lead
+      built_in: true
+  channels:
+    - slug: command
+      name: command
+      description: command channel
+      members: [ceo]
+    - slug: build
+      name: build
+      description: build channel
+      members: [ceo]
+    - slug: review
+      name: review
+      description: review channel
+      members: [ceo]
+    - slug: notes
+      name: notes
+      description: notes channel
+      members: [ceo]
+  tasks:
+    - channel: command
+      owner: ceo
+      title: "Kick off"
+      details: "Kick off the legacy pack."
+`
+	if err := os.WriteFile(yamlPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+
+	bp, err := LoadBlueprint(dir, "legacy-pack")
+	if err != nil {
+		t.Fatalf("expected legacy pack to load without pack-preview metadata, got %v", err)
+	}
+	if bp.Outcome != "" {
+		t.Fatalf("expected outcome empty, got %q", bp.Outcome)
+	}
+	if len(bp.FirstTasks) != 0 {
+		t.Fatalf("expected zero first_tasks, got %d", len(bp.FirstTasks))
+	}
+	if len(bp.Skills) != 0 {
+		t.Fatalf("expected zero skills, got %d", len(bp.Skills))
+	}
+	if len(bp.Requirements) != 0 {
+		t.Fatalf("expected zero requirements, got %d", len(bp.Requirements))
+	}
+}
+
+// mirrorEmployeeFixture copies a real employee blueprint directory from
+// the repo into the tempdir-mounted repo root used by
+// TestLoadBlueprintAcceptsMissingPackPreview so validateBlueprint can
+// resolve the employee_blueprint reference without assuming any specific
+// shipped employee schema.
+func mirrorEmployeeFixture(dst, src, id string) error {
+	srcDir := filepath.Join(src, "templates", "employees", id)
+	dstDir := filepath.Join(dst, "templates", "employees", id)
+	if err := os.MkdirAll(dstDir, 0o755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(srcDir, entry.Name()))
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dstDir, entry.Name()), raw, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/operations/blueprint_pack_preview_test.go
+++ b/internal/operations/blueprint_pack_preview_test.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,6 +26,9 @@ func TestLoadBlueprintPackPreviewMetadata(t *testing.T) {
 			if strings.TrimSpace(bp.Outcome) == "" {
 				t.Fatalf("blueprint %q is missing outcome — pack library cards need it", id)
 			}
+			// Allowed categories mirror BLUEPRINT_CATEGORIES in
+			// web/src/components/onboarding/wizard/constants.ts.
+			// Update both if a new category is added.
 			switch bp.Category {
 			case "services", "media", "product":
 			default:
@@ -165,7 +169,7 @@ func mirrorEmployeeFixture(dst, src, id string) error {
 	}
 	for _, entry := range entries {
 		if entry.IsDir() {
-			continue
+			return fmt.Errorf("mirrorEmployeeFixture: unexpected subdirectory %q in %s (only flat files are supported)", entry.Name(), srcDir)
 		}
 		raw, err := os.ReadFile(filepath.Join(srcDir, entry.Name()))
 		if err != nil {

--- a/internal/operations/blueprint_pack_preview_test.go
+++ b/internal/operations/blueprint_pack_preview_test.go
@@ -57,6 +57,9 @@ func TestLoadBlueprintPackPreviewMetadata(t *testing.T) {
 			if len(bp.Requirements) == 0 {
 				t.Fatalf("blueprint %q declares no requirements — pack library expects at least one", id)
 			}
+			if bp.EstimatedSetupMinutes <= 0 {
+				t.Fatalf("blueprint %q declares invalid estimated_setup_minutes %d", id, bp.EstimatedSetupMinutes)
+			}
 			for _, req := range bp.Requirements {
 				switch req.Kind {
 				case "runtime", "api-key", "local-tool":

--- a/internal/operations/loader.go
+++ b/internal/operations/loader.go
@@ -72,7 +72,79 @@ func normalizeBlueprint(templateID string, blueprint Blueprint) Blueprint {
 	blueprint.EmployeeBlueprints = appendUniqueTemplateIDs(blueprint.EmployeeBlueprints, starterEmployeeBlueprintIDs(blueprint.Starter.Agents)...)
 	blueprint.DefaultReviewer = strings.TrimSpace(blueprint.DefaultReviewer)
 	blueprint.ReviewerPaths = normalizeReviewerPaths(blueprint.ReviewerPaths)
+	blueprint.Outcome = strings.TrimSpace(blueprint.Outcome)
+	blueprint.Category = strings.TrimSpace(strings.ToLower(blueprint.Category))
+	blueprint.FirstTasks = normalizeFirstTasks(blueprint.FirstTasks)
+	blueprint.Skills = normalizeBlueprintSkills(blueprint.Skills)
+	blueprint.Requirements = normalizeBlueprintRequirements(blueprint.Requirements)
+	blueprint.ExampleArtifacts = normalizeExampleArtifacts(blueprint.ExampleArtifacts)
+	if blueprint.EstimatedSetupMinutes < 0 {
+		blueprint.EstimatedSetupMinutes = 0
+	}
 	return blueprint
+}
+
+func normalizeFirstTasks(tasks []BlueprintFirstTask) []BlueprintFirstTask {
+	out := make([]BlueprintFirstTask, 0, len(tasks))
+	for _, task := range tasks {
+		task.ID = normalizeTemplateID(task.ID)
+		task.Title = strings.TrimSpace(task.Title)
+		task.Prompt = strings.TrimSpace(task.Prompt)
+		task.ExpectedOutput = strings.TrimSpace(task.ExpectedOutput)
+		if task.ID == "" && task.Title == "" {
+			continue
+		}
+		if task.ID == "" {
+			task.ID = normalizeTemplateID(task.Title)
+		}
+		out = append(out, task)
+	}
+	return out
+}
+
+func normalizeBlueprintSkills(skills []BlueprintSkill) []BlueprintSkill {
+	out := make([]BlueprintSkill, 0, len(skills))
+	for _, skill := range skills {
+		skill.Name = strings.TrimSpace(skill.Name)
+		skill.Purpose = strings.TrimSpace(skill.Purpose)
+		if skill.Name == "" {
+			continue
+		}
+		out = append(out, skill)
+	}
+	return out
+}
+
+func normalizeBlueprintRequirements(reqs []BlueprintRequirement) []BlueprintRequirement {
+	out := make([]BlueprintRequirement, 0, len(reqs))
+	for _, req := range reqs {
+		req.Kind = strings.TrimSpace(strings.ToLower(req.Kind))
+		req.Name = strings.TrimSpace(req.Name)
+		req.Detail = strings.TrimSpace(req.Detail)
+		if req.Name == "" {
+			continue
+		}
+		// Default to "runtime" so an unkinded entry still renders
+		// rather than being silently dropped on the wire.
+		if req.Kind == "" {
+			req.Kind = "runtime"
+		}
+		out = append(out, req)
+	}
+	return out
+}
+
+func normalizeExampleArtifacts(items []BlueprintExampleAsset) []BlueprintExampleAsset {
+	out := make([]BlueprintExampleAsset, 0, len(items))
+	for _, item := range items {
+		item.Kind = strings.TrimSpace(item.Kind)
+		item.Title = strings.TrimSpace(item.Title)
+		if item.Title == "" {
+			continue
+		}
+		out = append(out, item)
+	}
+	return out
 }
 
 func normalizeReviewerPaths(rules ReviewerPathMap) ReviewerPathMap {

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -25,13 +25,13 @@ type Blueprint struct {
 	// scaffold, first tasks, and provider requirements for a pack
 	// before committing. Optional — older blueprints without these
 	// fields still load and degrade gracefully in the UI.
-	Outcome                string                  `json:"outcome,omitempty" yaml:"outcome,omitempty"`
-	Category               string                  `json:"category,omitempty" yaml:"category,omitempty"`
-	FirstTasks             []BlueprintFirstTask    `json:"first_tasks,omitempty" yaml:"first_tasks,omitempty"`
-	Skills                 []BlueprintSkill        `json:"skills,omitempty" yaml:"skills,omitempty"`
-	Requirements           []BlueprintRequirement  `json:"requirements,omitempty" yaml:"requirements,omitempty"`
-	EstimatedSetupMinutes  int                     `json:"estimated_setup_minutes,omitempty" yaml:"estimated_setup_minutes,omitempty"`
-	ExampleArtifacts       []BlueprintExampleAsset `json:"example_artifacts,omitempty" yaml:"example_artifacts,omitempty"`
+	Outcome               string                  `json:"outcome,omitempty" yaml:"outcome,omitempty"`
+	Category              string                  `json:"category,omitempty" yaml:"category,omitempty"`
+	FirstTasks            []BlueprintFirstTask    `json:"first_tasks,omitempty" yaml:"first_tasks,omitempty"`
+	Skills                []BlueprintSkill        `json:"skills,omitempty" yaml:"skills,omitempty"`
+	Requirements          []BlueprintRequirement  `json:"requirements,omitempty" yaml:"requirements,omitempty"`
+	EstimatedSetupMinutes int                     `json:"estimated_setup_minutes,omitempty" yaml:"estimated_setup_minutes,omitempty"`
+	ExampleArtifacts      []BlueprintExampleAsset `json:"example_artifacts,omitempty" yaml:"example_artifacts,omitempty"`
 
 	// DefaultReviewer is the agent slug that approves promotions by default.
 	// The sentinel value "human-only" disables agent approval entirely and

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -88,7 +88,7 @@ type BlueprintSkill struct {
 type BlueprintRequirement struct {
 	Kind     string `json:"kind" yaml:"kind"`
 	Name     string `json:"name" yaml:"name"`
-	Required bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Required bool   `json:"required" yaml:"required,omitempty"`
 	Detail   string `json:"detail,omitempty" yaml:"detail,omitempty"`
 }
 

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -20,6 +20,19 @@ type Blueprint struct {
 	Workflows          []WorkflowTemplate      `json:"workflows,omitempty" yaml:"workflows,omitempty"`
 	WikiSchema         *BlueprintWikiSchema    `json:"wiki_schema,omitempty" yaml:"wiki_schema,omitempty"`
 
+	// PackPreview metadata. Surfaced by the onboarding wizard's pack
+	// library so a new user can see the agents, channels, skills, wiki
+	// scaffold, first tasks, and provider requirements for a pack
+	// before committing. Optional — older blueprints without these
+	// fields still load and degrade gracefully in the UI.
+	Outcome                string                  `json:"outcome,omitempty" yaml:"outcome,omitempty"`
+	Category               string                  `json:"category,omitempty" yaml:"category,omitempty"`
+	FirstTasks             []BlueprintFirstTask    `json:"first_tasks,omitempty" yaml:"first_tasks,omitempty"`
+	Skills                 []BlueprintSkill        `json:"skills,omitempty" yaml:"skills,omitempty"`
+	Requirements           []BlueprintRequirement  `json:"requirements,omitempty" yaml:"requirements,omitempty"`
+	EstimatedSetupMinutes  int                     `json:"estimated_setup_minutes,omitempty" yaml:"estimated_setup_minutes,omitempty"`
+	ExampleArtifacts       []BlueprintExampleAsset `json:"example_artifacts,omitempty" yaml:"example_artifacts,omitempty"`
+
 	// DefaultReviewer is the agent slug that approves promotions by default.
 	// The sentinel value "human-only" disables agent approval entirely and
 	// forces a human click in the web UI. Falls back to "ceo" if empty.
@@ -49,6 +62,41 @@ type BlueprintWikiBootstrapItem struct {
 	Path     string `json:"path" yaml:"path"`
 	Title    string `json:"title,omitempty" yaml:"title,omitempty"`
 	Skeleton string `json:"skeleton,omitempty" yaml:"skeleton,omitempty"`
+}
+
+// BlueprintFirstTask is a suggested first prompt the wizard can show
+// before commit and (later) post into the pack's first channel after
+// setup. Prompts are author-written, not LLM-generated.
+type BlueprintFirstTask struct {
+	ID             string `json:"id" yaml:"id"`
+	Title          string `json:"title" yaml:"title"`
+	Prompt         string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
+	ExpectedOutput string `json:"expected_output,omitempty" yaml:"expected_output,omitempty"`
+}
+
+// BlueprintSkill names a skill the pack expects to use. The wizard
+// surfaces these so users see what the agents will know how to do
+// before they commit; skill discovery and binding happens later.
+type BlueprintSkill struct {
+	Name    string `json:"name" yaml:"name"`
+	Purpose string `json:"purpose,omitempty" yaml:"purpose,omitempty"`
+}
+
+// BlueprintRequirement declares an external dependency a pack expects.
+// Kind is one of "runtime", "api-key", or "local-tool". Required=false
+// means the pack can run without it but a feature degrades.
+type BlueprintRequirement struct {
+	Kind     string `json:"kind" yaml:"kind"`
+	Name     string `json:"name" yaml:"name"`
+	Required bool   `json:"required,omitempty" yaml:"required,omitempty"`
+	Detail   string `json:"detail,omitempty" yaml:"detail,omitempty"`
+}
+
+// BlueprintExampleAsset names a representative artifact the pack
+// produces, used for previews in the pack library detail panel.
+type BlueprintExampleAsset struct {
+	Kind  string `json:"kind" yaml:"kind"`
+	Title string `json:"title" yaml:"title"`
 }
 
 type StarterPlan struct {

--- a/templates/operations/bookkeeping-invoicing-service/blueprint.yaml
+++ b/templates/operations/bookkeeping-invoicing-service/blueprint.yaml
@@ -1,8 +1,45 @@
 id: bookkeeping-invoicing-service
 name: Bookkeeping and Invoicing Service
 kind: finance
+category: services
+outcome: "Books, invoices, and monthly close — with an audit trail."
 description: Template for a bookkeeping operation that handles recurring books, invoicing, and evidence-backed review.
 objective: Help clients keep books clean, invoices current, and approvals explicit with durable evidence.
+estimated_setup_minutes: 5
+first_tasks:
+  - id: draft-monthly-close-checklist
+    title: "Draft a monthly close checklist for an example client"
+    prompt: |
+      Draft a monthly close checklist for a small services business with around 200 transactions per month, one bank account, and one credit card. List each step the bookkeeper should run, the order, and which steps need owner approval.
+    expected_output: "A numbered checklist of close steps grouped by reconciliation, journal entries, reporting, and review, with each step marked auto or approval-required."
+  - id: invoice-followup-template
+    title: "Write an invoice follow-up template"
+    prompt: |
+      Write a polite follow-up email template for an invoice that is 14 days past due. Keep it short, set a clear next step, and avoid threats. Add two variants for 30 and 60 days past due.
+    expected_output: "Three email templates (14, 30, 60 days) with clear subject lines and a single next step in each."
+skills:
+  - name: "Reconciliation"
+    purpose: "Match bank and card feeds against statements and flag uncategorized transactions."
+  - name: "Invoicing"
+    purpose: "Draft invoices, follow-up cadences, and track aging."
+  - name: "Month-end close"
+    purpose: "Run the close playbook end to end with approval gates."
+requirements:
+  - kind: api-key
+    name: "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+    required: true
+    detail: "Powers the bookkeeper, invoicing, and reviewer agents."
+  - kind: runtime
+    name: "Claude Code or Codex CLI"
+    required: true
+    detail: "Runs the agent loops locally on your machine."
+example_artifacts:
+  - kind: checklist
+    title: "Monthly close checklist"
+  - kind: template
+    title: "Invoice follow-up sequence"
+  - kind: report
+    title: "Reconciliation packet"
 default_reviewer: ceo
 reviewer_paths:
   "team/books/**": bookkeeper

--- a/templates/operations/local-business-ai-package/blueprint.yaml
+++ b/templates/operations/local-business-ai-package/blueprint.yaml
@@ -1,8 +1,49 @@
 id: local-business-ai-package
 name: Local Business AI Package
 kind: local_service
+category: services
+outcome: "Intake, booking, and follow-up for local-business clients."
 description: Template for an AI package that helps local businesses automate intake, booking, follow-up, and reporting.
 objective: Help local businesses automate intake, booking, follow-up, and reporting with durable evidence and clear approval gates.
+estimated_setup_minutes: 5
+first_tasks:
+  - id: scope-discovery-call
+    title: "Outline the discovery call for a new local-business client"
+    prompt: |
+      Outline a 30-minute discovery call for a local home-services business that wants AI to handle inbound leads. Capture: current intake channels, response time, who books, what gets dropped, and what counts as a successful job. Keep questions short and conversational.
+    expected_output: "A 30-minute discovery agenda with grouped question banks and a closing summary template."
+  - id: lead-followup-cadence
+    title: "Design a lead follow-up cadence"
+    prompt: |
+      Design a 3-touch follow-up cadence for a lead that requested a quote and went silent. Include channel (SMS or email), timing, and the actual message text. Keep tone friendly and direct, no urgency manipulation.
+    expected_output: "A cadence table with timing, channel, and copy for each touch."
+skills:
+  - name: "Intake triage"
+    purpose: "Route inbound requests to the right workflow and surface the missing fields."
+  - name: "Booking and scheduling"
+    purpose: "Hold, confirm, and rebook appointments with the client's calendar."
+  - name: "Customer follow-up"
+    purpose: "Run polite, evidence-backed nudges across SMS and email."
+requirements:
+  - kind: api-key
+    name: "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+    required: true
+    detail: "Powers the planner, builder, and client-success agents."
+  - kind: runtime
+    name: "Claude Code or Codex CLI"
+    required: true
+    detail: "Runs the agent loops locally."
+  - kind: local-tool
+    name: "Calendar integration"
+    required: false
+    detail: "Optional. Connect later to enable live booking."
+example_artifacts:
+  - kind: playbook
+    title: "Discovery call agenda"
+  - kind: template
+    title: "Lead follow-up cadence"
+  - kind: dashboard
+    title: "Weekly delivery scorecard"
 default_reviewer: ceo
 reviewer_paths:
   "team/delivery/**": builder

--- a/templates/operations/multi-agent-workflow-consulting/blueprint.yaml
+++ b/templates/operations/multi-agent-workflow-consulting/blueprint.yaml
@@ -1,8 +1,45 @@
 id: multi-agent-workflow-consulting
 name: Multi-Agent Workflow Consulting
 kind: consulting
+category: services
+outcome: "Client engagements that ship multi-agent workflows."
 description: Template for a consulting operation that designs and implements multi-agent workflows for clients.
 objective: Help clients design, deploy, and maintain agent workflows with explicit approvals and durable evidence.
+estimated_setup_minutes: 6
+first_tasks:
+  - id: scoping-questionnaire
+    title: "Draft a workflow scoping questionnaire"
+    prompt: |
+      Draft a scoping questionnaire for a new consulting engagement that designs an agent workflow. Cover: target outcome, current process, owners, data sources, approval points, and the smallest viable first slice. Keep it under 12 questions.
+    expected_output: "A 10-12 question scoping document grouped by outcome, current state, data, and approvals."
+  - id: workflow-spec-template
+    title: "Write a workflow specification template"
+    prompt: |
+      Write a reusable template for specifying a multi-agent workflow. Include sections for: trigger, inputs, agents involved, side effects, approval gates, success metric, and rollback plan.
+    expected_output: "A markdown template with each section and a one-line example for an inbound-lead workflow."
+skills:
+  - name: "Workflow design"
+    purpose: "Map a client process into agents, channels, and approval gates."
+  - name: "Engagement scoping"
+    purpose: "Translate a goal into a phased delivery plan with explicit milestones."
+  - name: "Delivery review"
+    purpose: "Run evidence-backed reviews of every workflow before handing it off."
+requirements:
+  - kind: api-key
+    name: "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+    required: true
+    detail: "Powers the architect, builder, and reviewer agents."
+  - kind: runtime
+    name: "Claude Code or Codex CLI"
+    required: true
+    detail: "Runs the agent loops locally."
+example_artifacts:
+  - kind: spec
+    title: "Workflow specification document"
+  - kind: deliverable
+    title: "Client engagement summary"
+  - kind: review
+    title: "Workflow handoff checklist"
 default_reviewer: ceo
 reviewer_paths:
   "team/systems/**": workflow-architect

--- a/templates/operations/niche-crm/blueprint.yaml
+++ b/templates/operations/niche-crm/blueprint.yaml
@@ -1,8 +1,45 @@
 id: niche-crm
 name: Niche CRM
 kind: product_gtm
+category: product
+outcome: "Build and launch a focused CRM for a specific niche."
 description: Template for a focused CRM product that can be built and taken to market.
 objective: Build a niche CRM, prove the workflow, and run the product and GTM loops together.
+estimated_setup_minutes: 7
+first_tasks:
+  - id: niche-positioning-brief
+    title: "Write a positioning brief for the CRM niche"
+    prompt: |
+      Write a positioning brief for a CRM aimed at a specific niche I will pick during the call. Capture: who the user is, the painful workflow they have today, what their tooling looks like, what an MVP must do on day one, and what we will refuse to build.
+    expected_output: "A one-page positioning brief with five sections, each grounded in concrete user behavior."
+  - id: mvp-cut-list
+    title: "Cut a 2-week MVP scope"
+    prompt: |
+      Cut a 2-week MVP scope for the CRM. List the three smallest features that prove the core workflow, the data model they need, and the user-visible result. Then list two features explicitly cut to v2 and why.
+    expected_output: "A scoped MVP list with three in-scope features and two cuts, each with a one-line rationale."
+skills:
+  - name: "Niche research"
+    purpose: "Validate the workflow pain in the chosen segment before writing code."
+  - name: "Product spec"
+    purpose: "Translate the painful workflow into the smallest shippable product slice."
+  - name: "GTM loop"
+    purpose: "Run a focused GTM loop that turns design partners into a repeatable funnel."
+requirements:
+  - kind: api-key
+    name: "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+    required: true
+    detail: "Powers the founder, builder, growth, and reviewer agents."
+  - kind: runtime
+    name: "Claude Code or Codex CLI"
+    required: true
+    detail: "Runs the agent loops locally and edits the codebase."
+example_artifacts:
+  - kind: brief
+    title: "Positioning brief"
+  - kind: spec
+    title: "MVP scope document"
+  - kind: plan
+    title: "Design-partner outreach plan"
 default_reviewer: ceo
 reviewer_paths:
   "team/product/**": builder

--- a/templates/operations/paid-discord-community/blueprint.yaml
+++ b/templates/operations/paid-discord-community/blueprint.yaml
@@ -1,8 +1,49 @@
 id: paid-discord-community
 name: Paid Discord Community
 kind: community
+category: media
+outcome: "Onboarding, moderation, and engagement for a paid community."
 description: Template for a paid community operation that focuses on onboarding, moderation, engagement, and retention.
 objective: Run a paid community with durable onboarding, moderation, engagement, and sponsor loops.
+estimated_setup_minutes: 6
+first_tasks:
+  - id: welcome-flow
+    title: "Design a new-member welcome flow"
+    prompt: |
+      Design a 3-step welcome flow for a paid Discord community. Step 1 fires when a member joins, step 2 at 24 hours, step 3 at 7 days. For each step give the message, the desired action, and how to detect success. Avoid hype; lean on small commitments.
+    expected_output: "Three messages with timing, desired action, and a success metric for each."
+  - id: weekly-engagement-rhythm
+    title: "Plan a weekly engagement rhythm"
+    prompt: |
+      Plan a weekly engagement rhythm for a paid community of 200 members. Pick three recurring rituals (e.g. open thread, AMA, member spotlight). For each, give the day, the prompt, and how the moderator preps in advance.
+    expected_output: "Three rituals with day, prompt, and a moderator prep note."
+skills:
+  - name: "Community moderation"
+    purpose: "Keep the community healthy with clear rules and fast triage."
+  - name: "Member onboarding"
+    purpose: "Move new members from join to first contribution."
+  - name: "Engagement design"
+    purpose: "Design rituals and content beats that keep members showing up."
+requirements:
+  - kind: api-key
+    name: "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+    required: true
+    detail: "Powers the community-manager, growth, and reviewer agents."
+  - kind: runtime
+    name: "Claude Code or Codex CLI"
+    required: true
+    detail: "Runs the agent loops locally."
+  - kind: local-tool
+    name: "Discord workspace access"
+    required: false
+    detail: "Optional. Connect later to enable live moderation and posting."
+example_artifacts:
+  - kind: playbook
+    title: "Welcome flow"
+  - kind: schedule
+    title: "Weekly engagement calendar"
+  - kind: report
+    title: "Monthly retention summary"
 default_reviewer: ceo
 reviewer_paths:
   "team/community/**": community-manager

--- a/templates/operations/youtube-factory/blueprint.yaml
+++ b/templates/operations/youtube-factory/blueprint.yaml
@@ -1,8 +1,45 @@
 id: youtube-factory
 name: YouTube Factory
 kind: media_business
+category: media
+outcome: "Script, film, publish, and analyze a recurring YouTube channel."
 description: Template for a repeatable video-led business with human-gated external side effects.
 objective: Build and run a repeatable video operation with durable planning, reusable workflows, integration-backed execution, and explicit human approvals at external side effects.
+estimated_setup_minutes: 7
+first_tasks:
+  - id: ten-video-slate
+    title: "Plan the first 10-video slate"
+    prompt: |
+      Plan the first 10-video slate for the channel. For each video give: a working title, the audience, the promise, the hook, and the call to action. Group by series so the channel reads as a coherent body of work, not 10 disconnected ideas.
+    expected_output: "A 10-row table grouped by series, each row with title, audience, promise, hook, and CTA."
+  - id: research-to-script
+    title: "Turn research notes into a video script"
+    prompt: |
+      Take a topic I will paste in and turn it into a 5-minute video script. Open with a strong hook, deliver three concrete points with examples, and close with a single takeaway. Mark on-camera vs voice-over and any b-roll callouts.
+    expected_output: "A 5-minute script with hook, three sections, b-roll markers, and an on-camera/voice-over column."
+skills:
+  - name: "Topic research"
+    purpose: "Turn a niche question into research notes worth filming."
+  - name: "Scriptwriting"
+    purpose: "Write conversational, performance-ready scripts with strong hooks."
+  - name: "Production planning"
+    purpose: "Plan shoots, edits, and publish gates with explicit approval points."
+requirements:
+  - kind: api-key
+    name: "ANTHROPIC_API_KEY or OPENAI_API_KEY"
+    required: true
+    detail: "Powers the research, script, and editor agents."
+  - kind: runtime
+    name: "Claude Code or Codex CLI"
+    required: true
+    detail: "Runs the agent loops locally."
+example_artifacts:
+  - kind: plan
+    title: "10-video content slate"
+  - kind: script
+    title: "Long-form video script"
+  - kind: report
+    title: "Per-video performance review"
 default_reviewer: ceo
 reviewer_paths:
   "team/research/**": research-lead

--- a/web/e2e/tests/wizard-error-states.spec.ts
+++ b/web/e2e/tests/wizard-error-states.spec.ts
@@ -41,11 +41,11 @@ async function advanceToSetupStep(page: Page) {
   await page.locator("#wiz-company").fill("E2E Error States");
   await page.locator("#wiz-description").fill("Wizard error path test");
   await page.locator(".wizard-step button.btn-primary").first().click();
-  // templates → team. Wizard.tsx renders one .template-card per
+  // templates → team. The pack-library renders one .pack-card per
   // blueprint plus a separate "From scratch" button; click the first
   // real card so we exercise the seeded path, not the from-scratch
   // fallback.
-  const templateTile = page.locator(".template-card").first();
+  const templateTile = page.locator(".pack-card").first();
   if (await templateTile.count()) {
     await templateTile.click();
   }

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -187,7 +187,7 @@ test.describe("wuphf onboarding wizard smoke", () => {
   }) => {
     // Verifies the wizard state machine actually transitions. Flow is:
     // welcome → identity (company + description required) → templates.
-    // Assert via `.wizard-panel` on the templates step.
+    // Assert via `.pack-library` on the templates step.
     const getErrors = collectReactErrors(page);
 
     await page.goto("/");
@@ -195,8 +195,8 @@ test.describe("wuphf onboarding wizard smoke", () => {
 
     await advanceToTemplatesStep(page);
 
-    // Templates step renders `.wizard-panel` (welcome + identity have different markers).
-    await expect(page.locator(".wizard-panel").first()).toBeVisible({
+    // Templates step renders `.pack-library` (welcome + identity have different markers).
+    await expect(page.locator(".pack-library").first()).toBeVisible({
       timeout: 10_000,
     });
     await expectNoReactErrors(page, getErrors, "advancing wizard");
@@ -220,18 +220,17 @@ test.describe("wuphf onboarding wizard smoke", () => {
 
     await advanceToTemplatesStep(page);
 
-    // Wait for at least one template grid (the blueprint picker now
-    // renders one grid per category group — Services, Media & Community,
-    // Products — so `.template-grid` is not unique). We rely on
-    // `.template-card` instead as the unit of a rendered blueprint.
-    const cards = page.locator(".template-card");
+    // The new pack-library picker renders one `.pack-card` per blueprint
+    // (with a separate "Start from scratch" affordance below the grid).
+    // We rely on `.pack-card` as the unit of a rendered blueprint.
+    const cards = page.locator(".pack-card");
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });
 
     // The pre-embed bug rendered exactly zero preset cards — only the
-    // separate "Start from scratch" button (which is NOT a .template-card
-    // in the grouped layout). So requiring ≥1 card is the regression
-    // guard: if embedded templates fail to load, the grouped layout
-    // would still render the from-scratch button but produce zero cards.
+    // separate "Start from scratch" button (which is NOT a .pack-card).
+    // So requiring ≥1 card is the regression guard: if embedded
+    // templates fail to load, the layout would still render the
+    // from-scratch button but produce zero pack cards.
     const count = await cards.count();
     expect(
       count,
@@ -265,7 +264,7 @@ test.describe("wuphf onboarding wizard smoke", () => {
 
     await expect(page.getByText("What should your office run?")).toBeVisible();
     const templateTile = page
-      .locator(".template-card")
+      .locator(".pack-card")
       .filter({ hasText: "Niche CRM" })
       .first();
     await expect(templateTile).toBeVisible({ timeout: 10_000 });
@@ -330,7 +329,7 @@ test.describe("wuphf onboarding wizard smoke", () => {
     await advanceToTemplatesStep(page);
 
     await page
-      .locator(".template-card")
+      .locator(".pack-card")
       .filter({ hasText: "Niche CRM" })
       .first()
       .click();

--- a/web/src/components/onboarding/wizard/Step2Templates.test.tsx
+++ b/web/src/components/onboarding/wizard/Step2Templates.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { TemplatesStep } from "./Step2Templates";
+import { BLUEPRINT_CATEGORIES } from "./constants";
 import type { BlueprintTemplate } from "./types";
 
 function makeTemplates(): BlueprintTemplate[] {
@@ -98,8 +99,11 @@ describe("TemplatesStep", () => {
     const allChip = screen.getByRole("tab", { name: "All" });
     expect(allChip).toHaveAttribute("aria-selected", "true");
     expect(screen.getByRole("tab", { name: "Services" })).toBeInTheDocument();
+    const mediaLabel =
+      BLUEPRINT_CATEGORIES.find((c) => c.key === "media")?.label ??
+      "Media & Community";
     expect(
-      screen.getByRole("tab", { name: "Media & Community" }),
+      screen.getByRole("tab", { name: mediaLabel }),
     ).toBeInTheDocument();
     // "Other" chip surfaces because Mystery Op has no category.
     expect(screen.getByRole("tab", { name: "Other" })).toBeInTheDocument();

--- a/web/src/components/onboarding/wizard/Step2Templates.test.tsx
+++ b/web/src/components/onboarding/wizard/Step2Templates.test.tsx
@@ -5,19 +5,56 @@ import { TemplatesStep } from "./Step2Templates";
 import type { BlueprintTemplate } from "./types";
 
 function makeTemplates(): BlueprintTemplate[] {
+  // Two known blueprint ids in different categories + one unknown id
+  // exercise the "Other" filter chip. See BLUEPRINT_DISPLAY in
+  // constants.ts for the keyed entries.
   return [
-    // Two known blueprint ids in different categories + one unknown id
-    // exercise the "Other" catch-all bucket. See BLUEPRINT_DISPLAY in
-    // constants.ts for the keyed entries.
     {
       id: "bookkeeping-invoicing-service",
       name: "Bookkeeping",
-      description: "long description",
+      description: "Long backend description.",
+      outcome: "Books · invoices · monthly close",
+      category: "services",
+      estimated_setup_minutes: 5,
+      agents: [
+        {
+          slug: "ceo",
+          name: "CEO",
+          role: "lead",
+          built_in: true,
+          checked: true,
+        },
+        {
+          slug: "bookkeeper",
+          name: "Bookkeeper",
+          role: "books",
+          checked: true,
+        },
+      ],
+      channels: [{ slug: "books", name: "books", purpose: "Reconciliation" }],
+      skills: [{ name: "Reconciliation", purpose: "Match bank feeds" }],
+      first_tasks: [
+        {
+          id: "draft-monthly-close",
+          title: "Draft a monthly close checklist",
+          prompt: "Draft it.",
+          expected_output: "A numbered checklist.",
+        },
+      ],
+      requirements: [
+        {
+          kind: "api-key",
+          name: "ANTHROPIC_API_KEY or OPENAI_API_KEY",
+          required: true,
+        },
+      ],
     },
     {
       id: "youtube-factory",
       name: "YouTube Factory",
-      description: "long description",
+      description: "Long backend description.",
+      outcome: "Script · film · publish",
+      category: "media",
     },
     {
       id: "future-blueprint-not-yet-keyed",
@@ -45,7 +82,7 @@ describe("TemplatesStep", () => {
     ).toHaveLength(0);
   });
 
-  it("groups known blueprints by category and routes unknown ids to Other", () => {
+  it("renders pack cards across categories with All filter active by default", () => {
     render(
       <TemplatesStep
         templates={makeTemplates()}
@@ -57,18 +94,23 @@ describe("TemplatesStep", () => {
       />,
     );
 
-    // Three categories should render: Services, Media & Community, Other.
-    // Products has no cards so its panel must be omitted.
-    expect(screen.getByText("Services")).toBeInTheDocument();
-    expect(screen.getByText("Media & Community")).toBeInTheDocument();
-    expect(screen.getByText("Other")).toBeInTheDocument();
-    expect(screen.queryByText("Products")).not.toBeInTheDocument();
+    // Filter chips should be present, with "All" selected.
+    const allChip = screen.getByRole("tab", { name: "All" });
+    expect(allChip).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Services" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "Media & Community" }),
+    ).toBeInTheDocument();
+    // "Other" chip surfaces because Mystery Op has no category.
+    expect(screen.getByRole("tab", { name: "Other" })).toBeInTheDocument();
 
-    // Mystery Op (unknown id) lands in Other, not in any keyed category.
+    // All three packs render under the All filter.
+    expect(screen.getByText("Bookkeeping")).toBeInTheDocument();
+    expect(screen.getByText("YouTube Factory")).toBeInTheDocument();
     expect(screen.getByText("Mystery Op")).toBeInTheDocument();
   });
 
-  it("marks 'Start from scratch' as selected when selected=null", () => {
+  it("filters cards when a category chip is clicked", () => {
     render(
       <TemplatesStep
         templates={makeTemplates()}
@@ -79,13 +121,19 @@ describe("TemplatesStep", () => {
         onBack={() => {}}
       />,
     );
-    const fromScratch = screen
-      .getByText(/Start from scratch/i)
-      .closest("button");
-    expect(fromScratch).toHaveClass("selected");
+
+    fireEvent.click(screen.getByRole("tab", { name: "Services" }));
+    expect(screen.getByText("Bookkeeping")).toBeInTheDocument();
+    expect(screen.queryByText("YouTube Factory")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mystery Op")).not.toBeInTheDocument();
+
+    // Other filter routes the unknown blueprint id.
+    fireEvent.click(screen.getByRole("tab", { name: "Other" }));
+    expect(screen.getByText("Mystery Op")).toBeInTheDocument();
+    expect(screen.queryByText("Bookkeeping")).not.toBeInTheDocument();
   });
 
-  it("clicking a template tile fires onSelect with that id", () => {
+  it("clicking a pack card opens the detail panel and selects the pack", () => {
     const onSelect = vi.fn();
     render(
       <TemplatesStep
@@ -99,6 +147,83 @@ describe("TemplatesStep", () => {
     );
     fireEvent.click(screen.getByText("Bookkeeping"));
     expect(onSelect).toHaveBeenCalledWith("bookkeeping-invoicing-service");
+
+    // Detail panel surfaces the outcome and the first task title.
+    const panel = screen.getByLabelText("Bookkeeping details");
+    expect(within(panel).getByText("Bookkeeping")).toBeInTheDocument();
+    expect(
+      within(panel).getByText("Draft a monthly close checklist"),
+    ).toBeInTheDocument();
+    expect(
+      within(panel).getByText(/ANTHROPIC_API_KEY or OPENAI_API_KEY/),
+    ).toBeInTheDocument();
+  });
+
+  it("closes the detail panel when the close button is clicked", () => {
+    render(
+      <TemplatesStep
+        templates={makeTemplates()}
+        loading={false}
+        selected={null}
+        onSelect={() => {}}
+        onNext={() => {}}
+        onBack={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("Bookkeeping"));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Close pack details/i }),
+    );
+    expect(
+      screen.queryByLabelText("Bookkeeping details"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the empty-state copy when a pack has no first-task or skill metadata", () => {
+    const templates: BlueprintTemplate[] = [
+      {
+        id: "future-blueprint-not-yet-keyed",
+        name: "Mystery Op",
+        description: "no metadata",
+      },
+    ];
+    render(
+      <TemplatesStep
+        templates={templates}
+        loading={false}
+        selected={null}
+        onSelect={() => {}}
+        onNext={() => {}}
+        onBack={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("Mystery Op"));
+    const panel = screen.getByLabelText("Mystery Op details");
+    expect(
+      within(panel).getByText(
+        /Tasks, skills, and requirements will be configured during setup/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("marks 'Start from scratch' as selected when selected=null and unselects detail on click", () => {
+    const onSelect = vi.fn();
+    render(
+      <TemplatesStep
+        templates={makeTemplates()}
+        loading={false}
+        selected={null}
+        onSelect={onSelect}
+        onNext={() => {}}
+        onBack={() => {}}
+      />,
+    );
+    const fromScratch = screen
+      .getByText(/Start from scratch/i)
+      .closest("button");
+    expect(fromScratch).toHaveClass("selected");
+    fireEvent.click(fromScratch as HTMLElement);
+    expect(onSelect).toHaveBeenCalledWith(null);
   });
 
   it("Back and Next buttons fire their respective callbacks", () => {
@@ -119,5 +244,39 @@ describe("TemplatesStep", () => {
     fireEvent.click(within(nav).getByRole("button", { name: /Review/i }));
     expect(onBack).toHaveBeenCalledTimes(1);
     expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-opens the detail panel for the currently-selected pack on mount", () => {
+    render(
+      <TemplatesStep
+        templates={makeTemplates()}
+        loading={false}
+        selected="bookkeeping-invoicing-service"
+        onSelect={() => {}}
+        onNext={() => {}}
+        onBack={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Bookkeeping details")).toBeInTheDocument();
+  });
+
+  it("applies the responsive grid class so detail columns stack on mobile", () => {
+    render(
+      <TemplatesStep
+        templates={makeTemplates()}
+        loading={false}
+        selected={null}
+        onSelect={() => {}}
+        onNext={() => {}}
+        onBack={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByText("Bookkeeping"));
+    // The .pack-detail-grid class is the load-bearing element for the
+    // ≤640px column-stack rule in onboarding.css. Asserting the class
+    // is present is the cheapest reliable check; jsdom does not run
+    // CSS so we cannot test the cascade itself.
+    const panel = screen.getByLabelText("Bookkeeping details");
+    expect(panel.querySelector(".pack-detail-grid")).not.toBeNull();
   });
 });

--- a/web/src/components/onboarding/wizard/Step2Templates.tsx
+++ b/web/src/components/onboarding/wizard/Step2Templates.tsx
@@ -1,6 +1,11 @@
+import { useEffect, useMemo, useState } from "react";
+
 import { ArrowIcon, EnterHint } from "./components";
-import { BLUEPRINT_CATEGORIES, BLUEPRINT_DISPLAY } from "./constants";
+import { BLUEPRINT_CATEGORIES } from "./constants";
+import { adaptPackPreview, type PackPreview } from "./packPreview";
 import type { BlueprintCategoryKey, BlueprintTemplate } from "./types";
+
+type FilterKey = BlueprintCategoryKey | "all" | "other";
 
 interface TemplatesStepProps {
   templates: BlueprintTemplate[];
@@ -11,6 +16,20 @@ interface TemplatesStepProps {
   onBack: () => void;
 }
 
+const ALL_FILTER: FilterKey = "all";
+
+interface FilterChip {
+  key: FilterKey;
+  label: string;
+}
+
+const STATIC_FILTER_CHIPS: ReadonlyArray<FilterChip> = [
+  { key: "all", label: "All" },
+  ...BLUEPRINT_CATEGORIES.map(
+    (cat): FilterChip => ({ key: cat.key, label: cat.label }),
+  ),
+];
+
 export function TemplatesStep({
   templates,
   loading,
@@ -19,39 +38,60 @@ export function TemplatesStep({
   onNext,
   onBack,
 }: TemplatesStepProps) {
-  // Group templates by display category. Unknown blueprint ids (not in the
-  // frontend catalog) land in a catch-all "Other" bucket so new backend
-  // templates still render, just without the short-description and icon
-  // treatment.
-  const grouped = new Map<
-    BlueprintCategoryKey | "other",
-    BlueprintTemplate[]
-  >();
-  for (const t of templates) {
-    const display = BLUEPRINT_DISPLAY[t.id];
-    const key: BlueprintCategoryKey | "other" = display?.category ?? "other";
-    const list = grouped.get(key) ?? [];
-    list.push(t);
-    grouped.set(key, list);
-  }
+  const previews = useMemo(() => templates.map(adaptPackPreview), [templates]);
 
-  const renderTile = (t: BlueprintTemplate) => {
-    const display = BLUEPRINT_DISPLAY[t.id];
-    const icon = display?.icon ?? t.emoji;
-    const desc = display?.shortDescription ?? t.description;
-    return (
-      <button
-        key={t.id}
-        className={`template-card ${selected === t.id ? "selected" : ""}`}
-        onClick={() => onSelect(t.id)}
-        aria-pressed={selected === t.id}
-        type="button"
-      >
-        {icon ? <div className="template-card-emoji">{icon}</div> : null}
-        <div className="template-card-name">{t.name}</div>
-        <div className="template-card-desc">{desc}</div>
-      </button>
-    );
+  const hasOther = useMemo(
+    () => previews.some((p) => p.category === "other"),
+    [previews],
+  );
+
+  const filterChips = useMemo<ReadonlyArray<FilterChip>>(
+    () =>
+      hasOther
+        ? [...STATIC_FILTER_CHIPS, { key: "other", label: "Other" }]
+        : STATIC_FILTER_CHIPS,
+    [hasOther],
+  );
+
+  const [filter, setFilter] = useState<FilterKey>(ALL_FILTER);
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  // Auto-open the detail panel for the currently-selected pack so a
+  // user who returns to this step (Back from Team) sees their pick
+  // already expanded.
+  useEffect(() => {
+    if (selected && previews.some((p) => p.id === selected)) {
+      setOpenId(selected);
+    }
+  }, [selected, previews]);
+
+  // Drop the "other" filter if the underlying data no longer has any
+  // unknown blueprints. Without this the chip can stick after a
+  // refresh and silently filter out everything.
+  useEffect(() => {
+    if (filter === "other" && !hasOther) {
+      setFilter(ALL_FILTER);
+    }
+  }, [filter, hasOther]);
+
+  const visiblePreviews = useMemo(() => {
+    if (filter === ALL_FILTER) return previews;
+    return previews.filter((p) => p.category === filter);
+  }, [previews, filter]);
+
+  const openPreview = useMemo(
+    () => previews.find((p) => p.id === openId) ?? null,
+    [previews, openId],
+  );
+
+  const handleCardClick = (id: string) => {
+    onSelect(id);
+    setOpenId(id);
+  };
+
+  const handleScratchClick = () => {
+    onSelect(null);
+    setOpenId(null);
   };
 
   return (
@@ -59,12 +99,12 @@ export function TemplatesStep({
       <div className="wizard-hero">
         <div className="wizard-eyebrow">
           <span className="status-dot active pulse" />
-          Start with a preset, or build from scratch
+          Pick the outcome you want to ship
         </div>
         <h1 className="wizard-headline">What should your office run?</h1>
         <p className="wizard-subhead">
-          Pick the shape of work. We&apos;ll assemble the team, channels, and
-          first tasks around it. You can change anything later.
+          Each pack is a starting team, channels, skills, and a first task —
+          assembled around an outcome. You can change anything later.
         </p>
       </div>
 
@@ -83,35 +123,56 @@ export function TemplatesStep({
         </div>
       ) : (
         <>
-          {BLUEPRINT_CATEGORIES.map((cat) => {
-            const items = grouped.get(cat.key) ?? [];
-            if (items.length === 0) return null;
-            return (
-              <div key={cat.key} className="wizard-panel template-group">
-                <div className="template-group-head">
-                  <p className="template-group-label">{cat.label}</p>
-                  <p className="template-group-hint">{cat.hint}</p>
-                </div>
-                <div className="template-grid">{items.map(renderTile)}</div>
-              </div>
-            );
-          })}
-
-          {(grouped.get("other") ?? []).length > 0 && (
-            <div className="wizard-panel template-group">
-              <div className="template-group-head">
-                <p className="template-group-label">Other</p>
-              </div>
-              <div className="template-grid">
-                {(grouped.get("other") ?? []).map(renderTile)}
-              </div>
+          <div className="pack-library">
+            <div
+              className="pack-filter-row"
+              role="tablist"
+              aria-label="Pack categories"
+            >
+              {filterChips.map((chip) => (
+                <button
+                  key={chip.key}
+                  type="button"
+                  role="tab"
+                  aria-selected={filter === chip.key}
+                  className={`pack-filter-chip ${filter === chip.key ? "active" : ""}`}
+                  onClick={() => setFilter(chip.key)}
+                >
+                  {chip.label}
+                </button>
+              ))}
             </div>
-          )}
+
+            {visiblePreviews.length === 0 ? (
+              <div className="pack-empty">No packs match this filter yet.</div>
+            ) : (
+              <div className="pack-grid">
+                {visiblePreviews.map((preview) => (
+                  <PackCard
+                    key={preview.id}
+                    preview={preview}
+                    selected={selected === preview.id}
+                    open={openId === preview.id}
+                    onClick={() => handleCardClick(preview.id)}
+                  />
+                ))}
+              </div>
+            )}
+
+            {openPreview && (
+              <PackDetailPanel
+                preview={openPreview}
+                selected={selected === openPreview.id}
+                onChoose={() => onSelect(openPreview.id)}
+                onClose={() => setOpenId(null)}
+              />
+            )}
+          </div>
 
           <div className="template-from-scratch">
             <button
               className={`template-from-scratch-btn ${selected === null ? "selected" : ""}`}
-              onClick={() => onSelect(null)}
+              onClick={handleScratchClick}
               aria-pressed={selected === null}
               type="button"
             >
@@ -136,6 +197,257 @@ export function TemplatesStep({
           <EnterHint />
         </button>
       </div>
+    </div>
+  );
+}
+
+interface PackCardProps {
+  preview: PackPreview;
+  selected: boolean;
+  open: boolean;
+  onClick: () => void;
+}
+
+function PackCard({ preview, selected, open, onClick }: PackCardProps) {
+  return (
+    <button
+      type="button"
+      className={`pack-card ${selected ? "selected" : ""} ${open ? "open" : ""}`}
+      onClick={onClick}
+      aria-pressed={selected}
+      aria-expanded={open}
+    >
+      <div className="pack-card-head">
+        {preview.icon ? (
+          <span className="pack-card-icon" aria-hidden="true">
+            {preview.icon}
+          </span>
+        ) : null}
+        <span className="pack-card-name">{preview.name}</span>
+      </div>
+      <p className="pack-card-outcome">{preview.outcome}</p>
+      <div className="pack-card-meta">
+        {preview.agents.length > 0 && (
+          <span className="pack-card-meta-item">
+            {preview.agents.length} agents
+          </span>
+        )}
+        {preview.firstTasks.length > 0 && (
+          <span className="pack-card-meta-item">
+            {preview.firstTasks.length} first task
+            {preview.firstTasks.length === 1 ? "" : "s"}
+          </span>
+        )}
+        {typeof preview.estimatedSetupMinutes === "number" && (
+          <span className="pack-card-meta-item">
+            ~{preview.estimatedSetupMinutes} min setup
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+interface PackDetailPanelProps {
+  preview: PackPreview;
+  selected: boolean;
+  onChoose: () => void;
+  onClose: () => void;
+}
+
+function PackDetailPanel({
+  preview,
+  selected,
+  onChoose,
+  onClose,
+}: PackDetailPanelProps) {
+  const noMetadata =
+    preview.firstTasks.length === 0 &&
+    preview.skills.length === 0 &&
+    preview.requirements.length === 0 &&
+    preview.wikiScaffold.length === 0;
+
+  return (
+    <section className="pack-detail" aria-label={`${preview.name} details`}>
+      <header className="pack-detail-head">
+        <div>
+          <p className="pack-detail-eyebrow">Pack details</p>
+          <h2 className="pack-detail-title">{preview.name}</h2>
+          <p className="pack-detail-outcome">{preview.outcome}</p>
+        </div>
+        <button
+          type="button"
+          className="pack-detail-close"
+          onClick={onClose}
+          aria-label="Close pack details"
+        >
+          Close
+        </button>
+      </header>
+
+      {preview.description && preview.description !== preview.outcome ? (
+        <p className="pack-detail-description">{preview.description}</p>
+      ) : null}
+
+      <div className="pack-detail-grid">
+        <PackDetailSection title="Team" empty="Configured during setup.">
+          {preview.agents.length > 0 && (
+            <ul className="pack-detail-list">
+              {preview.agents.map((agent) => (
+                <li key={agent.slug}>
+                  <span className="pack-detail-name">{agent.name}</span>
+                  {agent.role ? (
+                    <span className="pack-detail-role"> — {agent.role}</span>
+                  ) : null}
+                  {agent.builtIn ? (
+                    <span className="pack-detail-tag">lead</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </PackDetailSection>
+
+        <PackDetailSection
+          title="Channels"
+          empty="Channels are added during setup."
+        >
+          {preview.channels.length > 0 && (
+            <ul className="pack-detail-list">
+              {preview.channels.map((channel) => (
+                <li key={channel.slug}>
+                  <span className="pack-detail-name">#{channel.slug}</span>
+                  {channel.purpose ? (
+                    <span className="pack-detail-role">
+                      {" "}
+                      — {channel.purpose}
+                    </span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </PackDetailSection>
+
+        <PackDetailSection
+          title="Skills"
+          empty="Skills will be configured during setup."
+        >
+          {preview.skills.length > 0 && (
+            <ul className="pack-detail-list">
+              {preview.skills.map((skill) => (
+                <li key={skill.name}>
+                  <span className="pack-detail-name">{skill.name}</span>
+                  {skill.purpose ? (
+                    <span className="pack-detail-role"> — {skill.purpose}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </PackDetailSection>
+
+        <PackDetailSection
+          title="Wiki scaffold"
+          empty="Wiki entries are added during setup."
+        >
+          {preview.wikiScaffold.length > 0 && (
+            <ul className="pack-detail-list">
+              {preview.wikiScaffold.map((entry) => (
+                <li key={entry.path}>
+                  <span className="pack-detail-name">{entry.title}</span>
+                  <span className="pack-detail-path"> — {entry.path}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </PackDetailSection>
+
+        <PackDetailSection
+          title="First tasks"
+          empty="Tasks and skills will be configured during setup."
+        >
+          {preview.firstTasks.length > 0 && (
+            <ul className="pack-detail-list">
+              {preview.firstTasks.map((task) => (
+                <li key={task.id} className="pack-detail-task">
+                  <span className="pack-detail-name">{task.title}</span>
+                  {task.expectedOutput ? (
+                    <p className="pack-detail-expected">
+                      <span className="pack-detail-expected-label">
+                        Result:
+                      </span>{" "}
+                      {task.expectedOutput}
+                    </p>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </PackDetailSection>
+
+        <PackDetailSection
+          title="Requirements"
+          empty="No external dependencies required."
+        >
+          {preview.requirements.length > 0 && (
+            <ul className="pack-detail-list">
+              {preview.requirements.map((req) => (
+                <li key={`${req.kind}-${req.name}`}>
+                  <span className="pack-detail-name">{req.name}</span>
+                  <span className="pack-detail-tag">{req.kind}</span>
+                  {!req.required ? (
+                    <span className="pack-detail-tag pack-detail-tag-optional">
+                      optional
+                    </span>
+                  ) : null}
+                  {req.detail ? (
+                    <span className="pack-detail-role"> — {req.detail}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </PackDetailSection>
+      </div>
+
+      {noMetadata ? (
+        <p className="pack-detail-empty">
+          Tasks, skills, and requirements will be configured during setup.
+        </p>
+      ) : null}
+
+      <div className="pack-detail-cta">
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={onChoose}
+          disabled={selected}
+        >
+          {selected ? "Selected" : "Choose this pack"}
+        </button>
+      </div>
+    </section>
+  );
+}
+
+interface PackDetailSectionProps {
+  title: string;
+  empty: string;
+  children?: React.ReactNode;
+}
+
+function PackDetailSection({ title, empty, children }: PackDetailSectionProps) {
+  const hasChildren =
+    children !== null && children !== undefined && children !== false;
+  return (
+    <div className="pack-detail-section">
+      <h3 className="pack-detail-section-title">{title}</h3>
+      {hasChildren ? (
+        children
+      ) : (
+        <p className="pack-detail-section-empty">{empty}</p>
+      )}
     </div>
   );
 }

--- a/web/src/components/onboarding/wizard/Step2Templates.tsx
+++ b/web/src/components/onboarding/wizard/Step2Templates.tsx
@@ -58,12 +58,16 @@ export function TemplatesStep({
 
   // Auto-open the detail panel for the currently-selected pack so a
   // user who returns to this step (Back from Team) sees their pick
-  // already expanded.
+  // already expanded. previews is read for the validity guard only —
+  // it is not a trigger dep so a parent re-creating the array cannot
+  // re-open a panel the user explicitly closed.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: previews intentionally omitted as trigger; void read below satisfies the linter
   useEffect(() => {
+    void previews;
     if (selected && previews.some((p) => p.id === selected)) {
       setOpenId(selected);
     }
-  }, [selected, previews]);
+  }, [selected]);
 
   // Drop the "other" filter if the underlying data no longer has any
   // unknown blueprints. Without this the chip can stick after a

--- a/web/src/components/onboarding/wizard/Step2Templates.tsx
+++ b/web/src/components/onboarding/wizard/Step2Templates.tsx
@@ -420,7 +420,7 @@ function PackDetailPanel({
       <div className="pack-detail-cta">
         <button
           type="button"
-          className="btn btn-primary"
+          className="btn btn-secondary"
           onClick={onChoose}
           disabled={selected}
         >

--- a/web/src/components/onboarding/wizard/packPreview.test.ts
+++ b/web/src/components/onboarding/wizard/packPreview.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import { adaptPackPreview } from "./packPreview";
+import type { BlueprintTemplate } from "./types";
+
+describe("adaptPackPreview", () => {
+  it("derives outcome from BLUEPRINT_DISPLAY when backend omits it", () => {
+    // bookkeeping-invoicing-service is keyed in BLUEPRINT_DISPLAY
+    // with "Books · invoices · monthly close" as its short
+    // description. When the wire payload omits outcome (older
+    // broker), the adapter should fall back to the display override
+    // rather than dumping the long description into the card.
+    const tpl: BlueprintTemplate = {
+      id: "bookkeeping-invoicing-service",
+      name: "Bookkeeping",
+      description:
+        "Long backend description that should not appear on the card.",
+    };
+    const preview = adaptPackPreview(tpl);
+    expect(preview.outcome).toBe("Books · invoices · monthly close");
+    expect(preview.category).toBe("services");
+    expect(preview.icon).toBeDefined();
+  });
+
+  it("prefers backend outcome over BLUEPRINT_DISPLAY override", () => {
+    const tpl: BlueprintTemplate = {
+      id: "bookkeeping-invoicing-service",
+      name: "Bookkeeping",
+      description: "Long",
+      outcome: "Backend-supplied outcome wins",
+    };
+    expect(adaptPackPreview(tpl).outcome).toBe("Backend-supplied outcome wins");
+  });
+
+  it("returns category 'other' for unknown blueprint ids without an explicit category", () => {
+    const tpl: BlueprintTemplate = {
+      id: "future-pack-not-keyed",
+      name: "Mystery",
+      description: "from-scratch backend",
+    };
+    expect(adaptPackPreview(tpl).category).toBe("other");
+  });
+
+  it("returns empty arrays when backend metadata is absent", () => {
+    const tpl: BlueprintTemplate = {
+      id: "future-pack-not-keyed",
+      name: "Mystery",
+      description: "no metadata",
+    };
+    const preview = adaptPackPreview(tpl);
+    expect(preview.firstTasks).toEqual([]);
+    expect(preview.skills).toEqual([]);
+    expect(preview.requirements).toEqual([]);
+    expect(preview.wikiScaffold).toEqual([]);
+    expect(preview.channels).toEqual([]);
+    expect(preview.exampleArtifacts).toEqual([]);
+    expect(preview.estimatedSetupMinutes).toBeUndefined();
+  });
+
+  it("normalizes requirement kinds and tolerates unknown values", () => {
+    const tpl: BlueprintTemplate = {
+      id: "p",
+      name: "P",
+      description: "d",
+      requirements: [
+        { kind: "api-key", name: "ANTHROPIC_API_KEY", required: true },
+        { kind: "weird-kind", name: "Mystery dep" },
+      ],
+    };
+    const { requirements: reqs } = adaptPackPreview(tpl);
+    expect(reqs[0]).toEqual({
+      kind: "api-key",
+      name: "ANTHROPIC_API_KEY",
+      required: true,
+      detail: undefined,
+    });
+    // Unknown kinds collapse to "runtime" so the chip still renders.
+    expect(reqs[1].kind).toBe("runtime");
+  });
+
+  it("preserves built_in flag from BlueprintAgent payload", () => {
+    const tpl: BlueprintTemplate = {
+      id: "p",
+      name: "P",
+      description: "d",
+      agents: [
+        {
+          slug: "ceo",
+          name: "CEO",
+          role: "lead",
+          built_in: true,
+          checked: true,
+        },
+        { slug: "designer", name: "Designer", role: "design", checked: true },
+      ],
+    };
+    const { agents } = adaptPackPreview(tpl);
+    expect(agents[0].builtIn).toBe(true);
+    expect(agents[1].builtIn).toBe(false);
+  });
+
+  it("truncates long fallback descriptions on a word boundary", () => {
+    const tpl: BlueprintTemplate = {
+      id: "future-pack-not-keyed",
+      name: "Mystery",
+      description:
+        "This is a very long backend description that exceeds the eighty-character outcome budget and must wrap",
+    };
+    const preview = adaptPackPreview(tpl);
+    expect(preview.outcome.length).toBeLessThanOrEqual(85);
+    expect(preview.outcome.endsWith("...")).toBe(true);
+  });
+
+  it("maps wire fields one-to-one when fully populated", () => {
+    const tpl: BlueprintTemplate = {
+      id: "youtube-factory",
+      name: "YouTube Factory",
+      description: "long",
+      outcome: "Script · film · publish",
+      category: "media",
+      estimated_setup_minutes: 7,
+      channels: [
+        { slug: "scripts", name: "scripts", purpose: "Draft scripts" },
+      ],
+      skills: [{ name: "Scriptwriting", purpose: "Strong hooks" }],
+      wiki_scaffold: [{ path: "team/scripts/intro.md", title: "Intro" }],
+      first_tasks: [
+        {
+          id: "ten-video-slate",
+          title: "Plan the first 10-video slate",
+          prompt: "Plan it.",
+          expected_output: "10-row table.",
+        },
+      ],
+      requirements: [
+        { kind: "runtime", name: "Claude Code or Codex CLI", required: true },
+      ],
+      example_artifacts: [{ kind: "plan", title: "Slate" }],
+    };
+    const preview = adaptPackPreview(tpl);
+    expect(preview.outcome).toBe("Script · film · publish");
+    expect(preview.category).toBe("media");
+    expect(preview.estimatedSetupMinutes).toBe(7);
+    expect(preview.channels).toHaveLength(1);
+    expect(preview.skills[0].name).toBe("Scriptwriting");
+    expect(preview.wikiScaffold[0].title).toBe("Intro");
+    expect(preview.firstTasks[0].expectedOutput).toBe("10-row table.");
+    expect(preview.requirements[0].required).toBe(true);
+    expect(preview.exampleArtifacts[0].title).toBe("Slate");
+  });
+});

--- a/web/src/components/onboarding/wizard/packPreview.ts
+++ b/web/src/components/onboarding/wizard/packPreview.ts
@@ -89,7 +89,10 @@ const KNOWN_REQUIREMENT_KINDS: ReadonlyArray<BlueprintRequirementKind> = [
 const OUTCOME_FALLBACK_LIMIT = 80;
 
 function isKnownCategory(value: string | undefined): value is PackCategory {
-  return !!value && KNOWN_CATEGORIES.includes(value as BlueprintCategoryKey);
+  return (
+    !!value &&
+    (value === "other" || KNOWN_CATEGORIES.includes(value as BlueprintCategoryKey))
+  );
 }
 
 function normalizeRequirementKind(

--- a/web/src/components/onboarding/wizard/packPreview.ts
+++ b/web/src/components/onboarding/wizard/packPreview.ts
@@ -1,0 +1,190 @@
+// packPreview.ts — frontend adapter that turns a BlueprintTemplate
+// payload (from GET /onboarding/blueprints) into the PackPreview shape
+// the wizard's pack library renders. The backend feeds in the new
+// outcome/category/first_tasks/skills/wiki_scaffold/requirements
+// fields when present; missing fields degrade gracefully (empty
+// arrays, undefined optional values) so the detail panel still renders
+// for older brokers or unfamiliar blueprint ids.
+
+import { BLUEPRINT_DISPLAY } from "./constants";
+import type {
+  BlueprintCategoryKey,
+  BlueprintRequirementKind,
+  BlueprintTemplate,
+} from "./types";
+
+export type PackCategory = BlueprintCategoryKey | "other";
+
+export interface PackPreviewAgent {
+  slug: string;
+  name: string;
+  role: string;
+  builtIn: boolean;
+}
+
+export interface PackPreviewChannel {
+  slug: string;
+  name: string;
+  purpose: string;
+}
+
+export interface PackPreviewSkill {
+  name: string;
+  purpose: string;
+}
+
+export interface PackPreviewWikiEntry {
+  path: string;
+  title: string;
+}
+
+export interface PackPreviewFirstTask {
+  id: string;
+  title: string;
+  prompt: string;
+  expectedOutput: string;
+}
+
+export interface PackPreviewRequirement {
+  kind: BlueprintRequirementKind;
+  name: string;
+  required: boolean;
+  detail?: string;
+}
+
+export interface PackPreviewExampleArtifact {
+  kind: string;
+  title: string;
+}
+
+export interface PackPreview {
+  id: string;
+  name: string;
+  category: PackCategory;
+  outcome: string;
+  description: string;
+  icon?: string;
+  agents: PackPreviewAgent[];
+  channels: PackPreviewChannel[];
+  skills: PackPreviewSkill[];
+  wikiScaffold: PackPreviewWikiEntry[];
+  firstTasks: PackPreviewFirstTask[];
+  requirements: PackPreviewRequirement[];
+  estimatedSetupMinutes?: number;
+  exampleArtifacts: PackPreviewExampleArtifact[];
+}
+
+const KNOWN_CATEGORIES: ReadonlyArray<BlueprintCategoryKey> = [
+  "services",
+  "media",
+  "product",
+];
+
+const KNOWN_REQUIREMENT_KINDS: ReadonlyArray<BlueprintRequirementKind> = [
+  "runtime",
+  "api-key",
+  "local-tool",
+];
+
+const OUTCOME_FALLBACK_LIMIT = 80;
+
+function isKnownCategory(value: string | undefined): value is PackCategory {
+  return !!value && KNOWN_CATEGORIES.includes(value as BlueprintCategoryKey);
+}
+
+function normalizeRequirementKind(
+  value: string | undefined,
+): BlueprintRequirementKind {
+  if (
+    value &&
+    KNOWN_REQUIREMENT_KINDS.includes(value as BlueprintRequirementKind)
+  ) {
+    return value as BlueprintRequirementKind;
+  }
+  return "runtime";
+}
+
+function deriveOutcome(template: BlueprintTemplate): string {
+  if (template.outcome && template.outcome.trim() !== "") {
+    return template.outcome.trim();
+  }
+  const display = BLUEPRINT_DISPLAY[template.id];
+  if (display?.shortDescription) {
+    return display.shortDescription;
+  }
+  const description = (template.description ?? "").trim();
+  if (description.length <= OUTCOME_FALLBACK_LIMIT) {
+    return description;
+  }
+  // Trim on a word boundary so the outcome reads as a sentence
+  // fragment, not a mid-word cut.
+  const truncated = description.slice(0, OUTCOME_FALLBACK_LIMIT);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > 40) {
+    return `${truncated.slice(0, lastSpace).trimEnd()}...`;
+  }
+  return `${truncated.trimEnd()}...`;
+}
+
+function deriveCategory(template: BlueprintTemplate): PackCategory {
+  if (isKnownCategory(template.category)) {
+    return template.category;
+  }
+  const display = BLUEPRINT_DISPLAY[template.id];
+  if (display?.category) {
+    return display.category;
+  }
+  return "other";
+}
+
+export function adaptPackPreview(template: BlueprintTemplate): PackPreview {
+  const display = BLUEPRINT_DISPLAY[template.id];
+  return {
+    id: template.id,
+    name: template.name,
+    description: template.description ?? "",
+    outcome: deriveOutcome(template),
+    category: deriveCategory(template),
+    icon: display?.icon ?? template.emoji,
+    agents: (template.agents ?? []).map((agent) => ({
+      slug: agent.slug,
+      name: agent.name,
+      role: agent.role ?? "",
+      builtIn: agent.built_in === true,
+    })),
+    channels: (template.channels ?? []).map((channel) => ({
+      slug: channel.slug,
+      name: (channel.name ?? channel.slug).trim(),
+      purpose: (channel.purpose ?? "").trim(),
+    })),
+    skills: (template.skills ?? []).map((skill) => ({
+      name: skill.name,
+      purpose: (skill.purpose ?? "").trim(),
+    })),
+    wikiScaffold: (template.wiki_scaffold ?? []).map((entry) => ({
+      path: entry.path,
+      title: (entry.title ?? entry.path).trim(),
+    })),
+    firstTasks: (template.first_tasks ?? []).map((task) => ({
+      id: task.id,
+      title: task.title,
+      prompt: (task.prompt ?? "").trim(),
+      expectedOutput: (task.expected_output ?? "").trim(),
+    })),
+    requirements: (template.requirements ?? []).map((req) => ({
+      kind: normalizeRequirementKind(req.kind),
+      name: req.name,
+      required: req.required === true,
+      detail: req.detail?.trim() || undefined,
+    })),
+    estimatedSetupMinutes:
+      typeof template.estimated_setup_minutes === "number" &&
+      template.estimated_setup_minutes > 0
+        ? template.estimated_setup_minutes
+        : undefined,
+    exampleArtifacts: (template.example_artifacts ?? []).map((item) => ({
+      kind: (item.kind ?? "").trim(),
+      title: item.title,
+    })),
+  };
+}

--- a/web/src/components/onboarding/wizard/types.ts
+++ b/web/src/components/onboarding/wizard/types.ts
@@ -52,7 +52,7 @@ export interface BlueprintFirstTask {
 export type BlueprintRequirementKind = "runtime" | "api-key" | "local-tool";
 
 export interface BlueprintRequirement {
-  kind: BlueprintRequirementKind | string;
+  kind?: BlueprintRequirementKind | (string & {});
   name: string;
   required?: boolean;
   detail?: string;

--- a/web/src/components/onboarding/wizard/types.ts
+++ b/web/src/components/onboarding/wizard/types.ts
@@ -11,6 +11,56 @@ export interface BlueprintTemplate {
   emoji?: string;
   agents?: BlueprintAgent[];
   tasks?: TaskTemplate[];
+  // Pack-library wire fields. The broker surfaces these from the
+  // operation blueprint yaml; older binaries omit them entirely. The
+  // adapter in packPreview.ts handles missing fields by returning empty
+  // arrays so the detail panel still renders.
+  outcome?: string;
+  category?: string;
+  estimated_setup_minutes?: number;
+  channels?: BlueprintChannel[];
+  skills?: BlueprintSkill[];
+  wiki_scaffold?: BlueprintWikiScaffoldEntry[];
+  first_tasks?: BlueprintFirstTask[];
+  requirements?: BlueprintRequirement[];
+  example_artifacts?: BlueprintExampleArtifact[];
+}
+
+export interface BlueprintChannel {
+  slug: string;
+  name?: string;
+  purpose?: string;
+}
+
+export interface BlueprintSkill {
+  name: string;
+  purpose?: string;
+}
+
+export interface BlueprintWikiScaffoldEntry {
+  path: string;
+  title?: string;
+}
+
+export interface BlueprintFirstTask {
+  id: string;
+  title: string;
+  prompt?: string;
+  expected_output?: string;
+}
+
+export type BlueprintRequirementKind = "runtime" | "api-key" | "local-tool";
+
+export interface BlueprintRequirement {
+  kind: BlueprintRequirementKind | string;
+  name: string;
+  required?: boolean;
+  detail?: string;
+}
+
+export interface BlueprintExampleArtifact {
+  kind?: string;
+  title: string;
 }
 
 export interface BlueprintAgent {

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -612,7 +612,8 @@
 .wiz-team-tile:focus-visible,
 .task-suggestion:focus-visible,
 .pack-card:focus-visible,
-.pack-filter-chip:focus-visible {
+.pack-filter-chip:focus-visible,
+.pack-detail-close:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -610,9 +610,312 @@
 .template-card:focus-visible,
 .runtime-tile:focus-visible,
 .wiz-team-tile:focus-visible,
-.task-suggestion:focus-visible {
+.task-suggestion:focus-visible,
+.pack-card:focus-visible,
+.pack-filter-chip:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* ─── Pack Library (Step 2) ─── */
+.pack-library {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.pack-filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pack-filter-chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    color 0.15s;
+}
+
+.pack-filter-chip:hover {
+  border-color: var(--border-dark);
+  color: var(--text);
+}
+
+.pack-filter-chip.active {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--text);
+}
+
+.pack-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+  align-items: stretch;
+}
+
+.pack-empty {
+  padding: 20px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.pack-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+}
+
+.pack-card:hover {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+.pack-card.selected,
+.pack-card.open {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+.pack-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pack-card-icon {
+  font-size: 18px;
+}
+
+.pack-card-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.pack-card-outcome {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.pack-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.pack-card-meta-item {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.pack-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+}
+
+.pack-detail-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.pack-detail-eyebrow {
+  margin: 0 0 4px 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.pack-detail-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.pack-detail-outcome {
+  margin: 4px 0 0 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.pack-detail-close {
+  padding: 4px 10px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.pack-detail-close:hover {
+  border-color: var(--border-dark);
+  color: var(--text);
+}
+
+.pack-detail-description {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.pack-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.pack-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg);
+}
+
+.pack-detail-section-title {
+  margin: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.pack-detail-section-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.pack-detail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pack-detail-list li {
+  font-size: 12px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.pack-detail-name {
+  font-weight: 600;
+}
+
+.pack-detail-role {
+  color: var(--text-secondary);
+}
+
+.pack-detail-path {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.pack-detail-tag {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: var(--accent-bg);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
+.pack-detail-tag-optional {
+  color: var(--text-tertiary);
+  background: transparent;
+  border-color: var(--border);
+}
+
+.pack-detail-task {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pack-detail-expected {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.pack-detail-expected-label {
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+}
+
+.pack-detail-empty {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.pack-detail-cta {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 640px) {
+  .pack-detail-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ─── Task Suggestions (step 6) ─── */


### PR DESCRIPTION
## Summary

Replace the Step2Templates card grid with a **pack library**: outcome-first cards, category filter chips, and a detail panel that surfaces agents, channels, skills, wiki scaffold, first tasks, and provider requirements before the user commits to a pack. "Start from scratch" stays first-class and pinned.

## What changed

**Slice 1.1 — frontend (pack library UI)**
- New `packPreview.ts` adapter that derives a `PackPreview` from `BlueprintTemplate` plus `BLUEPRINT_DISPLAY` overrides. Falls back to display short-description when backend `outcome` is missing; truncates long fallbacks on a word boundary.
- Rewrote `Step2Templates.tsx` as a pack library: filter chips (All / Services / Media / Product / Other), pack cards with outcome + meta, click-to-open detail panel with team / channels / skills / wiki / first tasks / requirements / artifacts. Empty-state messaging when a pack has no metadata yet.
- New CSS under `onboarding.css` matching existing wizard tokens. Detail grid stacks to one column on mobile (≤640px).
- `aria-pressed`, `role="tab"`, and `aria-expanded` preserved for keyboard navigation.

**Slice 1.2 — backend metadata (same PR)**
- Extended `internal/operations/types.go` with optional `Outcome`, `Category`, `FirstTasks`, `Skills`, `Requirements`, `EstimatedSetupMinutes`, `ExampleArtifacts`. Loader normalizes all of them; missing fields are non-fatal.
- All six built-in operation YAMLs populated with real first tasks, skills, requirements, and estimated setup minutes.
- `/onboarding/blueprints` (`HandleBlueprints`) surfaces the new fields additively. Channels and wiki-scaffold entries are derived from existing `starter.channels` and `wiki_schema.bootstrap` so they ride along for free.

## Slicing

Per the phase doc, this is one PR delivering 1.1 + 1.2 together so the new wire shape and the new UI ship in lockstep.

## Unblocks

- **PR 2** (Provider Doctor) — requirements list is rendered here as preview-only; PR 2 will wire the live status checks against it.
- **PR 5** (outcome summary) — outcome and category metadata are now on the wire and ready to consume.

## Out of scope

- Provider Doctor wiring (PR 2)
- First-task auto-launch into the new workspace (PR 3, blocked on per-workspace onboarding)
- Outcome summary surface (PR 5)

## Tests

- `packPreview.ts` adapter tests (8 cases) — fallback to display override, truncation, empty arrays for missing metadata, requirement-kind normalization, full pass-through.
- `Step2Templates.tsx` tests (10 cases) — filter chips, detail panel open/close, "start from scratch", auto-open on Back navigation, mobile column-stack class, unknown blueprint id routes to "Other", empty-state copy.
- `internal/operations` — `TestLoadBlueprintPackPreviewMetadata` asserts every shipped pack declares outcome, category, ≥1 first task with prompt+expected_output, ≥1 skill, ≥1 requirement. `TestLoadBlueprintAcceptsMissingPackPreview` proves a legacy YAML with none of the new fields still parses.
- `internal/onboarding` — `TestHandleBlueprintsExposesPackPreviewMetadata` asserts the wire shape carries the new fields end-to-end for the bookkeeping pack.

## Test plan

- [ ] `go build -o /tmp/wuphf ./cmd/wuphf` — green
- [ ] `bash scripts/test-go.sh ./internal/operations ./internal/onboarding` — green
- [ ] `cd web && bunx tsc --noEmit && bunx biome check src/components/onboarding/wizard/...` — green
- [ ] `bash scripts/test-web.sh web/src/components/onboarding` — 68 tests pass
- [ ] `bunx secretlint "**/*"` — clean
- [ ] Manual: open the wizard, click into each pack card, confirm detail panel renders agents/channels/skills/first-tasks/requirements; confirm "Start from scratch" still selectable; confirm filter chips behave; confirm mobile column stack at ≤640px viewport

---

_PR is Phase 4 PR 1 — UI-heavy. Parked for human eyeball pass before merge._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pack library redesigned: category-filtered pack cards, expandable pack detail panels, and auto-open behavior.
  * Richer pack previews: outcome, category, estimated setup minutes, channels, skills, wiki scaffold, starter first-tasks, requirements, and example artifacts.
* **Style**
  * Improved focus/keyboard styling and responsive pack-detail layout.
* **Tests**
  * Added tests covering pack-preview metadata, normalization, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->