### PR TITLE
feat(web): typed object route registry (phase 5 pr 1)

### DIFF
--- a/web/src/components/wiki/WikiLink.tsx
+++ b/web/src/components/wiki/WikiLink.tsx
@@ -1,5 +1,7 @@
 /** Internal wiki link: dashed-underline blue by default, red-with-marker if broken. */
 
+import { resolveObjectRoute } from "../../lib/objectRoutes";
+
 interface WikiLinkProps {
   slug: string;
   display?: string;
@@ -15,7 +17,9 @@ export default function WikiLink({
 }: WikiLinkProps) {
   const label = display ?? slug;
   const className = broken ? "wk-wikilink wk-broken" : "wk-wikilink";
-  const href = `#/wiki/${encodeURI(slug)}`;
+  // Delegated to the typed object route registry so wiki link URLs
+  // stay in sync with future surfaces (palette, breadcrumbs, profile).
+  const { href } = resolveObjectRoute({ kind: "wiki-page", path: slug });
   return (
     <a
       href={href}

--- a/web/src/lib/objectRoutes.test.ts
+++ b/web/src/lib/objectRoutes.test.ts
@@ -93,6 +93,35 @@ describe("resolveObjectRoute", () => {
     expect(route.fallback?.reason).toBe("missing_id");
     expect(route.fallback?.message).toContain("task");
   });
+
+  it.each([
+    { kind: "run" as const, ref: { kind: "run" as const, id: "" } },
+    {
+      kind: "wiki-page" as const,
+      ref: { kind: "wiki-page" as const, path: "" },
+    },
+    {
+      kind: "workbench-item" as const,
+      ref: {
+        kind: "workbench-item" as const,
+        id: "",
+        itemKind: "approval",
+      },
+    },
+    {
+      kind: "artifact" as const,
+      ref: { kind: "artifact" as const, id: "" },
+    },
+  ])("returns a missing_id fallback when a required field is empty for $kind", ({
+    kind,
+    ref,
+  }) => {
+    const route = resolveObjectRoute(ref);
+    expect(route.href).toBe("#/");
+    expect(route.fallback?.reason).toBe("missing_id");
+    expect(route.fallback?.message).toContain(kind);
+    expect(route.appAction).toBeUndefined();
+  });
 });
 
 describe("resolveUnknownObjectRoute", () => {

--- a/web/src/lib/objectRoutes.test.ts
+++ b/web/src/lib/objectRoutes.test.ts
@@ -30,10 +30,25 @@ describe("resolveObjectRoute", () => {
       kind: "wiki-page",
       path: "people/nazz",
     });
-    // Matches the live WikiLink contract: encodeURI keeps `/`.
+    // Per-segment encodeURIComponent keeps `/` separators intact for
+    // nested slugs like `people/nazz`.
     expect(route.href).toBe("#/wiki/people/nazz");
     expect(route.label).toBe("Wiki: people/nazz");
     expect(route.appAction).toEqual({ app: "wiki" });
+  });
+
+  it("encodes reserved characters in wiki-page segments so the hash router cannot misparse them", () => {
+    const route = resolveObjectRoute({
+      kind: "wiki-page",
+      path: "concepts/foo?bar#baz&qux",
+    });
+    // `?`, `#`, and `&` would otherwise be parsed as query/fragment
+    // boundaries by `createHashHistory`. Per-segment encoding fixes
+    // it without losing the `/` separator.
+    expect(route.href).toBe("#/wiki/concepts/foo%3Fbar%23baz%26qux");
+    expect(route.href).not.toContain("?bar");
+    expect(route.href).not.toContain("#baz");
+    expect(route.label).toBe("Wiki: concepts/foo?bar#baz&qux");
   });
 
   it("resolves a workbench-item to the task route and surfaces its kind", () => {

--- a/web/src/lib/objectRoutes.test.ts
+++ b/web/src/lib/objectRoutes.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveObjectRoute, resolveUnknownObjectRoute } from "./objectRoutes";
+
+describe("resolveObjectRoute", () => {
+  it("resolves an agent slug to the DM hash route", () => {
+    const route = resolveObjectRoute({ kind: "agent", slug: "alex" });
+    expect(route.href).toBe("#/dm/alex");
+    expect(route.label).toBe("Agent: alex");
+    expect(route.appAction).toEqual({ app: "dm", channel: "alex" });
+    expect(route.fallback).toBeUndefined();
+  });
+
+  it("resolves a run id to the activity app with a query param", () => {
+    const route = resolveObjectRoute({ kind: "run", id: "run-123" });
+    expect(route.href).toBe("#/apps/activity?run=run-123");
+    expect(route.label).toBe("Run: run-123");
+    expect(route.appAction).toEqual({ app: "activity" });
+  });
+
+  it("resolves a task id to the tasks hash route", () => {
+    const route = resolveObjectRoute({ kind: "task", id: "task-7" });
+    expect(route.href).toBe("#/tasks/task-7");
+    expect(route.label).toBe("Task: task-7");
+    expect(route.appAction).toEqual({ app: "tasks" });
+  });
+
+  it("resolves a wiki-page path with encoded separators preserved", () => {
+    const route = resolveObjectRoute({
+      kind: "wiki-page",
+      path: "people/nazz",
+    });
+    // Matches the live WikiLink contract: encodeURI keeps `/`.
+    expect(route.href).toBe("#/wiki/people/nazz");
+    expect(route.label).toBe("Wiki: people/nazz");
+    expect(route.appAction).toEqual({ app: "wiki" });
+  });
+
+  it("resolves a workbench-item to the task route and surfaces its kind", () => {
+    const route = resolveObjectRoute({
+      kind: "workbench-item",
+      id: "wb-9",
+      itemKind: "approval",
+    });
+    expect(route.href).toBe("#/tasks/wb-9");
+    expect(route.label).toBe("Workbench approval: wb-9");
+    expect(route.appAction).toEqual({ app: "tasks" });
+  });
+
+  it("resolves an artifact to the receipts app with a query param", () => {
+    const route = resolveObjectRoute({ kind: "artifact", id: "art-1" });
+    expect(route.href).toBe("#/apps/receipts?artifact=art-1");
+    expect(route.label).toBe("Artifact: art-1");
+    expect(route.appAction).toEqual({ app: "receipts" });
+  });
+
+  it("resolves a settings-section to the settings app", () => {
+    const route = resolveObjectRoute({
+      kind: "settings-section",
+      section: "providers",
+    });
+    expect(route.href).toBe("#/apps/settings?section=providers");
+    expect(route.label).toBe("Settings: Providers");
+    expect(route.appAction).toEqual({ app: "settings" });
+  });
+
+  it("returns a missing_id fallback when a required slug is empty", () => {
+    const route = resolveObjectRoute({ kind: "agent", slug: "" });
+    expect(route.href).toBe("#/");
+    expect(route.fallback?.reason).toBe("missing_id");
+    expect(route.fallback?.message).toContain("agent");
+    expect(route.appAction).toBeUndefined();
+  });
+
+  it("returns a missing_id fallback when a required id is empty", () => {
+    const route = resolveObjectRoute({ kind: "task", id: "" });
+    expect(route.href).toBe("#/");
+    expect(route.fallback?.reason).toBe("missing_id");
+    expect(route.fallback?.message).toContain("task");
+  });
+});
+
+describe("resolveUnknownObjectRoute", () => {
+  it("returns a graceful unknown_kind fallback for runtime kinds we don't recognise", () => {
+    const route = resolveUnknownObjectRoute("mystery");
+    expect(route.href).toBe("#/");
+    expect(route.label).toBe("Unknown object: mystery");
+    expect(route.fallback?.reason).toBe("unknown_kind");
+    expect(route.fallback?.message).toContain("mystery");
+  });
+
+  it("handles an empty runtime kind without crashing", () => {
+    const route = resolveUnknownObjectRoute("");
+    expect(route.fallback?.reason).toBe("unknown_kind");
+    expect(route.label).toContain("(missing kind)");
+  });
+});

--- a/web/src/lib/objectRoutes.ts
+++ b/web/src/lib/objectRoutes.ts
@@ -1,0 +1,155 @@
+/**
+ * Typed object route registry — Phase 5 PR 1.
+ *
+ * Single source of truth for "given a domain object, where does it open
+ * in the app and what should we label it?" Today only one call-site
+ * uses this (WikiLink). Future Phase 5 PRs (command palette,
+ * breadcrumbs, profile pages, calendar click handlers) will all consume
+ * the same registry so navigation cannot drift between surfaces.
+ *
+ * Pure functions only — no React, no router imports, no side effects.
+ * Hash routes match the live shape produced by `createHashHistory()` in
+ * `lib/router.ts`.
+ */
+
+export type SettingsSection = "providers" | "team" | "workspace" | "skills";
+
+export type ObjectRef =
+  | { kind: "agent"; slug: string }
+  | { kind: "run"; id: string }
+  | { kind: "task"; id: string; agentSlug?: string }
+  | { kind: "wiki-page"; path: string }
+  | { kind: "workbench-item"; id: string; itemKind: string }
+  | { kind: "artifact"; id: string }
+  | { kind: "settings-section"; section: SettingsSection };
+
+export type ObjectRouteFallbackReason = "unknown_kind" | "missing_id";
+
+export interface ObjectRouteAppAction {
+  app: string;
+  channel?: string;
+}
+
+export interface ObjectRouteFallback {
+  reason: ObjectRouteFallbackReason;
+  message: string;
+}
+
+export interface ObjectRouteResolution {
+  href: string;
+  label: string;
+  appAction?: ObjectRouteAppAction;
+  fallback?: ObjectRouteFallback;
+}
+
+const FALLBACK_HREF = "#/";
+
+function missingIdFallback(
+  field: string,
+  kind: ObjectRef["kind"] | string,
+): ObjectRouteResolution {
+  return {
+    href: FALLBACK_HREF,
+    label: `Unknown ${kind}`,
+    fallback: {
+      reason: "missing_id",
+      message: `Cannot resolve ${kind} route: ${field} is empty.`,
+    },
+  };
+}
+
+function settingsLabel(section: SettingsSection): string {
+  switch (section) {
+    case "providers":
+      return "Settings: Providers";
+    case "team":
+      return "Settings: Team";
+    case "workspace":
+      return "Settings: Workspace";
+    case "skills":
+      return "Settings: Skills";
+  }
+}
+
+export function resolveObjectRoute(ref: ObjectRef): ObjectRouteResolution {
+  switch (ref.kind) {
+    case "agent": {
+      if (!ref.slug) return missingIdFallback("slug", "agent");
+      return {
+        href: `#/dm/${encodeURIComponent(ref.slug)}`,
+        label: `Agent: ${ref.slug}`,
+        appAction: { app: "dm", channel: ref.slug },
+      };
+    }
+    case "run": {
+      if (!ref.id) return missingIdFallback("id", "run");
+      // Runs do not have a dedicated route yet; surface them through
+      // the activity app so links remain valid until run pages land.
+      return {
+        href: `#/apps/activity?run=${encodeURIComponent(ref.id)}`,
+        label: `Run: ${ref.id}`,
+        appAction: { app: "activity" },
+      };
+    }
+    case "task": {
+      if (!ref.id) return missingIdFallback("id", "task");
+      return {
+        href: `#/tasks/${encodeURIComponent(ref.id)}`,
+        label: `Task: ${ref.id}`,
+        appAction: { app: "tasks" },
+      };
+    }
+    case "wiki-page": {
+      if (!ref.path) return missingIdFallback("path", "wiki-page");
+      // Match the existing wiki link contract: encodeURI preserves the
+      // path separators inside the slug (e.g. `people/nazz`).
+      return {
+        href: `#/wiki/${encodeURI(ref.path)}`,
+        label: `Wiki: ${ref.path}`,
+        appAction: { app: "wiki" },
+      };
+    }
+    case "workbench-item": {
+      if (!ref.id) return missingIdFallback("id", "workbench-item");
+      // Workbench items live under tasks today; pass the item kind
+      // through so future surfaces can route by kind without a second
+      // lookup.
+      return {
+        href: `#/tasks/${encodeURIComponent(ref.id)}`,
+        label: `Workbench ${ref.itemKind}: ${ref.id}`,
+        appAction: { app: "tasks" },
+      };
+    }
+    case "artifact": {
+      if (!ref.id) return missingIdFallback("id", "artifact");
+      return {
+        href: `#/apps/receipts?artifact=${encodeURIComponent(ref.id)}`,
+        label: `Artifact: ${ref.id}`,
+        appAction: { app: "receipts" },
+      };
+    }
+    case "settings-section": {
+      return {
+        href: `#/apps/settings?section=${encodeURIComponent(ref.section)}`,
+        label: settingsLabel(ref.section),
+        appAction: { app: "settings" },
+      };
+    }
+  }
+}
+
+/**
+ * For object kinds that arrive from the server at runtime and do not
+ * match the typed union. Surfaces (palette, breadcrumbs) should render
+ * the fallback instead of crashing or fabricating a URL.
+ */
+export function resolveUnknownObjectRoute(kind: string): ObjectRouteResolution {
+  return {
+    href: FALLBACK_HREF,
+    label: `Unknown object: ${kind || "(missing kind)"}`,
+    fallback: {
+      reason: "unknown_kind",
+      message: `Object kind "${kind}" is not supported by the route registry.`,
+    },
+  };
+}

--- a/web/src/lib/objectRoutes.ts
+++ b/web/src/lib/objectRoutes.ts
@@ -101,10 +101,13 @@ export function resolveObjectRoute(ref: ObjectRef): ObjectRouteResolution {
     }
     case "wiki-page": {
       if (!ref.path) return missingIdFallback("path", "wiki-page");
-      // Match the existing wiki link contract: encodeURI preserves the
-      // path separators inside the slug (e.g. `people/nazz`).
+      // Preserve `/` separators in nested slugs (e.g. `people/nazz`)
+      // while still encoding reserved characters like `?`, `#`, `&`
+      // per segment so the hash router cannot mistake them for query
+      // strings or fragments.
+      const encodedPath = ref.path.split("/").map(encodeURIComponent).join("/");
       return {
-        href: `#/wiki/${encodeURI(ref.path)}`,
+        href: `#/wiki/${encodedPath}`,
         label: `Wiki: ${ref.path}`,
         appAction: { app: "wiki" },
       };


### PR DESCRIPTION
## Summary
- Add `web/src/lib/objectRoutes.ts`: a discriminated-union `ObjectRef` plus `resolveObjectRoute` and `resolveUnknownObjectRoute` that map domain objects (agent, run, task, wiki-page, workbench-item, artifact, settings-section) to a hash `href`, human `label`, and optional `appAction`.
- Unknown runtime kinds and empty required ids return a `fallback` instead of fabricating URLs or crashing — surfaces (palette, breadcrumbs, profile pages) can render the fallback explicitly.
- Refactor one proof call-site: `WikiLink.tsx` now derives its href from `resolveObjectRoute({ kind: "wiki-page", path: slug })`. Existing `WikiLink` tests (5/5) continue to pass against the registry-derived href.

## Out of scope
Future Phase 5 PRs (command palette, breadcrumbs, profile pages, calendar click handlers) will consume this registry. This PR is the registry plus one proof call-site only — no broader nav refresh, no app-shell touches.

## Test plan
- [x] `web/src/lib/objectRoutes.test.ts` — 11 tests, one per supported kind plus missing-id and unknown-kind fallbacks.
- [x] `web/src/components/wiki/WikiLink.test.tsx` — 5/5 passing on the refactored callsite.
- [x] `bunx tsc --noEmit` clean.
- [x] `bunx biome check` clean on touched files.
- [x] `bunx secretlint` clean on touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized, typed object routing added so in-app links for agents, runs, tasks, wiki pages, workbench items, artifacts, and settings are generated consistently.

* **Bug Fixes**
  * Wiki page links updated to use the centralized routing logic, preserving existing label and click behavior while improving route consistency and encoding.

* **Tests**
  * Added comprehensive tests covering routing outputs and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->