### PR TITLE
feat(onboarding): completion outcome summary screen (phase 4 pr 5)

### DIFF
--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -15,6 +15,7 @@ import {
   SCRATCH_FOUNDING_TEAM,
   STEP_ORDER,
 } from "./wizard/constants";
+import { OutcomeSummary } from "./wizard/OutcomeSummary";
 import {
   clearDraft,
   consumeStaleBannerDays,
@@ -46,6 +47,19 @@ import type {
   WizardStep,
 } from "./wizard/types";
 import { useOnboardingDraftSync } from "./wizard/useOnboardingDraftSync";
+
+// OutcomeMeta captures the wizard state at the moment /onboarding/complete
+// succeeds. The backend only returns {"ok":true}; this snapshot is the
+// source of truth for the post-completion summary screen.
+interface OutcomeMeta {
+  agents: BlueprintAgent[];
+  selectedBlueprint: string | null;
+  blueprints: BlueprintTemplate[];
+  primaryRuntime: string;
+  taskText: string;
+  taskSkipped: boolean;
+  apiKeyCount: number;
+}
 
 // runtimeIsReady + detectedBinary moved to wizard/runtime-helpers.ts.
 // ArrowIcon, CheckIcon, EnterHint, ProgressDots moved to wizard/components.tsx.
@@ -205,6 +219,12 @@ export function Wizard({ onComplete }: WizardProps) {
   const taskTextAutofilled = useRef(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
+
+  // Outcome summary — shown after /onboarding/complete succeeds.
+  // The wizard stays mounted so the user can read what was created before
+  // entering the office. onComplete() is called when they click "Go to the office".
+  const [showOutcome, setShowOutcome] = useState(false);
+  const [outcomeMeta, setOutcomeMeta] = useState<OutcomeMeta | null>(null);
 
   // Fetch blueprints on mount
   useEffect(() => {
@@ -670,11 +690,29 @@ export function Wizard({ onComplete }: WizardProps) {
         return;
       }
 
+      // Capture what was submitted before calling onComplete — the outcome
+      // summary screen needs these values to describe what was created.
+      const apiKeyCount = Object.values(apiKeys).filter(
+        (v) => v.trim().length > 0,
+      ).length;
+      setOutcomeMeta({
+        agents,
+        selectedBlueprint,
+        blueprints,
+        primaryRuntime: runtimePriority[0] ?? "",
+        taskText,
+        taskSkipped: skipTask,
+        apiKeyCount,
+      });
+
       // Onboarding succeeded — discard the resumeable draft so a return
       // visit lands on the post-setup app, not a half-filled wizard.
       clearDraft();
       setOnboardingComplete(true);
-      onComplete?.();
+      // Show the outcome summary screen instead of immediately entering the
+      // office. The user clicks "Go to the office" to call onComplete().
+      setShowOutcome(true);
+      setSubmitting(false);
     },
     [
       company,
@@ -683,10 +721,10 @@ export function Wizard({ onComplete }: WizardProps) {
       runtimePriority,
       selectedBlueprint,
       agents,
+      blueprints,
       apiKeys,
       taskText,
       setOnboardingComplete,
-      onComplete,
     ],
   );
 
@@ -822,6 +860,28 @@ export function Wizard({ onComplete }: WizardProps) {
     userEditedRuntimeRef.current = false;
     taskTextAutofilled.current = false;
   }, []);
+
+  // Outcome summary — rendered in place of the wizard steps after
+  // /onboarding/complete succeeds. The user reads what was created and
+  // then clicks "Go to the office" which calls onComplete().
+  if (showOutcome && outcomeMeta !== null) {
+    return (
+      <div className="wizard-container">
+        <div className="wizard-body">
+          <OutcomeSummary
+            agents={outcomeMeta.agents}
+            selectedBlueprint={outcomeMeta.selectedBlueprint}
+            blueprints={outcomeMeta.blueprints}
+            primaryRuntime={outcomeMeta.primaryRuntime}
+            taskText={outcomeMeta.taskText}
+            taskSkipped={outcomeMeta.taskSkipped}
+            apiKeyCount={outcomeMeta.apiKeyCount}
+            onEnter={() => onComplete?.()}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="wizard-container">

--- a/web/src/components/onboarding/wizard/OutcomeSummary.test.tsx
+++ b/web/src/components/onboarding/wizard/OutcomeSummary.test.tsx
@@ -1,0 +1,278 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OutcomeSummary } from "./OutcomeSummary";
+import type { BlueprintAgent, BlueprintTemplate } from "./types";
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const AGENTS: BlueprintAgent[] = [
+  { slug: "ceo", name: "CEO", role: "lead", checked: true, built_in: true },
+  { slug: "engineer", name: "Engineer", role: "engineering", checked: true },
+  { slug: "designer", name: "Designer", role: "design", checked: false },
+];
+
+const BLUEPRINTS: BlueprintTemplate[] = [
+  {
+    id: "saas",
+    name: "SaaS Startup",
+    description: "Standard SaaS blueprint",
+  },
+];
+
+function renderOutcome(
+  overrides: Partial<{
+    agents: BlueprintAgent[];
+    selectedBlueprint: string | null;
+    blueprints: BlueprintTemplate[];
+    primaryRuntime: string;
+    taskText: string;
+    taskSkipped: boolean;
+    apiKeyCount: number;
+    onEnter: () => void;
+  }> = {},
+) {
+  return render(
+    <OutcomeSummary
+      agents={overrides.agents ?? AGENTS}
+      selectedBlueprint={
+        overrides.selectedBlueprint !== undefined
+          ? overrides.selectedBlueprint
+          : "saas"
+      }
+      blueprints={overrides.blueprints ?? BLUEPRINTS}
+      primaryRuntime={overrides.primaryRuntime ?? "Claude Code"}
+      taskText={overrides.taskText ?? "ship the MVP"}
+      taskSkipped={overrides.taskSkipped ?? false}
+      apiKeyCount={overrides.apiKeyCount ?? 2}
+      onEnter={overrides.onEnter ?? (() => {})}
+    />,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("OutcomeSummary", () => {
+  describe("agents panel", () => {
+    it("renders only checked agents", () => {
+      renderOutcome();
+      const list = screen.getByTestId("outcome-agents");
+      // CEO and Engineer are checked; Designer is not.
+      expect(list).toHaveTextContent("CEO");
+      expect(list).toHaveTextContent("Engineer");
+      expect(list).not.toHaveTextContent("Designer");
+    });
+
+    it("shows @slug for each agent", () => {
+      renderOutcome();
+      const list = screen.getByTestId("outcome-agents");
+      expect(list).toHaveTextContent("@ceo");
+      expect(list).toHaveTextContent("@engineer");
+    });
+
+    it("marks the built-in lead agent with a lead badge", () => {
+      const { container } = renderOutcome();
+      const badges = container.querySelectorAll(".wiz-team-lead-badge");
+      expect(badges).toHaveLength(1);
+    });
+
+    it("shows agent count in panel title", () => {
+      renderOutcome();
+      // 2 checked agents
+      expect(screen.getByTestId("outcome-summary")).toHaveTextContent(
+        "Team created (2 agents)",
+      );
+    });
+
+    it("handles singular agent count", () => {
+      renderOutcome({
+        agents: [
+          {
+            slug: "ceo",
+            name: "CEO",
+            role: "lead",
+            checked: true,
+            built_in: true,
+          },
+        ],
+      });
+      expect(screen.getByTestId("outcome-summary")).toHaveTextContent(
+        "Team created (1 agent)",
+      );
+    });
+
+    it("shows fallback message when no agents are checked", () => {
+      renderOutcome({
+        agents: [
+          {
+            slug: "ceo",
+            name: "CEO",
+            role: "lead",
+            checked: false,
+          },
+        ],
+      });
+      expect(screen.queryByTestId("outcome-agents")).toBeNull();
+      expect(screen.getByTestId("outcome-summary")).toHaveTextContent(
+        "No agents selected",
+      );
+    });
+  });
+
+  describe("setup panel", () => {
+    it("shows the blueprint name resolved from id", () => {
+      renderOutcome();
+      expect(screen.getByTestId("outcome-blueprint")).toHaveTextContent(
+        "SaaS Startup",
+      );
+    });
+
+    it("shows 'Start from scratch' when selectedBlueprint is null", () => {
+      renderOutcome({ selectedBlueprint: null });
+      expect(screen.getByTestId("outcome-blueprint")).toHaveTextContent(
+        "Start from scratch",
+      );
+    });
+
+    it("falls back to blueprint id when name is not in list", () => {
+      renderOutcome({ selectedBlueprint: "unknown-bp", blueprints: [] });
+      expect(screen.getByTestId("outcome-blueprint")).toHaveTextContent(
+        "unknown-bp",
+      );
+    });
+
+    it("shows the primary runtime", () => {
+      renderOutcome({ primaryRuntime: "Codex" });
+      expect(screen.getByTestId("outcome-runtime")).toHaveTextContent("Codex");
+    });
+
+    it("shows 'Not selected' when runtime is empty", () => {
+      renderOutcome({ primaryRuntime: "" });
+      expect(screen.getByTestId("outcome-runtime")).toHaveTextContent(
+        "Not selected",
+      );
+    });
+
+    it("shows #general channel", () => {
+      renderOutcome();
+      expect(screen.getByTestId("outcome-channels")).toHaveTextContent(
+        "#general",
+      );
+    });
+
+    it("shows wiki scaffolding row", () => {
+      renderOutcome();
+      expect(screen.getByTestId("outcome-wiki")).toHaveTextContent(
+        "Git-native team wiki",
+      );
+    });
+
+    it("shows api key count when non-zero", () => {
+      renderOutcome({ apiKeyCount: 3 });
+      expect(screen.getByTestId("outcome-api-keys")).toHaveTextContent(
+        "3 keys saved",
+      );
+    });
+
+    it("hides api key row when count is zero", () => {
+      renderOutcome({ apiKeyCount: 0 });
+      expect(screen.queryByTestId("outcome-api-keys")).toBeNull();
+    });
+
+    it("shows singular key label", () => {
+      renderOutcome({ apiKeyCount: 1 });
+      expect(screen.getByTestId("outcome-api-keys")).toHaveTextContent(
+        "1 key saved",
+      );
+    });
+
+    it("shows task text when not skipped", () => {
+      renderOutcome({ taskText: "ship the MVP", taskSkipped: false });
+      expect(screen.getByTestId("outcome-task")).toHaveTextContent(
+        "ship the MVP",
+      );
+    });
+
+    it("shows skipped message when taskSkipped is true", () => {
+      renderOutcome({ taskText: "", taskSkipped: true });
+      expect(screen.getByTestId("outcome-task")).toHaveTextContent("Skipped");
+    });
+
+    it("shows skipped message when taskText is empty even if taskSkipped is false", () => {
+      renderOutcome({ taskText: "   ", taskSkipped: false });
+      expect(screen.getByTestId("outcome-task")).toHaveTextContent("Skipped");
+    });
+  });
+
+  describe("next actions panel", () => {
+    it("renders all four navigation links", () => {
+      renderOutcome();
+      expect(screen.getByTestId("outcome-link-general")).toBeInTheDocument();
+      expect(screen.getByTestId("outcome-link-tasks")).toBeInTheDocument();
+      expect(screen.getByTestId("outcome-link-wiki")).toBeInTheDocument();
+      expect(screen.getByTestId("outcome-link-settings")).toBeInTheDocument();
+    });
+
+    it("general channel link routes to #/channels/general", () => {
+      renderOutcome();
+      const link = screen.getByTestId("outcome-link-general");
+      expect(link).toHaveAttribute("href", "#/channels/general");
+    });
+
+    it("tasks link routes to #/tasks", () => {
+      renderOutcome();
+      const link = screen.getByTestId("outcome-link-tasks");
+      expect(link).toHaveAttribute("href", "#/tasks");
+    });
+
+    it("wiki link routes to #/wiki", () => {
+      renderOutcome();
+      const link = screen.getByTestId("outcome-link-wiki");
+      expect(link).toHaveAttribute("href", "#/wiki");
+    });
+
+    it("settings link routes to #/apps/settings", () => {
+      renderOutcome();
+      const link = screen.getByTestId("outcome-link-settings");
+      expect(link).toHaveAttribute("href", "#/apps/settings");
+    });
+  });
+
+  describe("entry button", () => {
+    it("calls onEnter when the CTA is clicked", () => {
+      const onEnter = vi.fn();
+      renderOutcome({ onEnter });
+      fireEvent.click(screen.getByTestId("outcome-enter-button"));
+      expect(onEnter).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders the headline 'Office is open'", () => {
+      renderOutcome();
+      expect(screen.getByTestId("outcome-headline")).toHaveTextContent(
+        "Office is open",
+      );
+    });
+  });
+
+  describe("partial failure / minimal data states", () => {
+    it("renders cleanly with no agents, no blueprint, no runtime, skipped task", () => {
+      renderOutcome({
+        agents: [],
+        selectedBlueprint: null,
+        blueprints: [],
+        primaryRuntime: "",
+        taskText: "",
+        taskSkipped: true,
+        apiKeyCount: 0,
+      });
+      expect(screen.getByTestId("outcome-summary")).toBeInTheDocument();
+      expect(screen.getByTestId("outcome-blueprint")).toHaveTextContent(
+        "Start from scratch",
+      );
+      expect(screen.getByTestId("outcome-runtime")).toHaveTextContent(
+        "Not selected",
+      );
+      expect(screen.getByTestId("outcome-task")).toHaveTextContent("Skipped");
+    });
+  });
+});

--- a/web/src/components/onboarding/wizard/OutcomeSummary.tsx
+++ b/web/src/components/onboarding/wizard/OutcomeSummary.tsx
@@ -1,0 +1,325 @@
+// OutcomeSummary renders the post-completion screen shown after
+// /onboarding/complete succeeds. It synthesises a human-readable
+// account of what was actually created from the wizard's local state
+// (the same values that were submitted) rather than from the backend
+// response, which only returns {"ok": true}. This is correct: whatever
+// the user confirmed in the wizard is what the broker seeded.
+import type { BlueprintAgent, BlueprintTemplate } from "./types";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface OutcomeSummaryProps {
+  /** Agents that were checked when the user hit "Get started". */
+  agents: BlueprintAgent[];
+  /** The blueprint that was selected, or null for "start from scratch". */
+  selectedBlueprint: string | null;
+  /** Full blueprint list so we can resolve the name from the id. */
+  blueprints: BlueprintTemplate[];
+  /** Primary runtime label, e.g. "Claude Code". Empty when none selected. */
+  primaryRuntime: string;
+  /** The task text the user submitted. Empty when the task was skipped. */
+  taskText: string;
+  /** True when the user pressed "Get started" with an empty task. */
+  taskSkipped: boolean;
+  /** Number of API keys that were configured. */
+  apiKeyCount: number;
+  /** Called when the user navigates into the live office. */
+  onEnter: () => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+// The broker always creates a #general channel. Blueprints may describe
+// additional channels, but the broker's channel-seed logic is internal and
+// not surfaced through the complete response — we conservatively show
+// #general as the guaranteed channel and let users discover the rest.
+const GUARANTEED_CHANNELS = ["general"];
+
+function blueprintName(
+  selectedBlueprint: string | null,
+  blueprints: BlueprintTemplate[],
+): string {
+  if (selectedBlueprint === null) return "Start from scratch";
+  const bp = blueprints.find((b) => b.id === selectedBlueprint);
+  return bp?.name ?? selectedBlueprint;
+}
+
+function checkedAgents(agents: BlueprintAgent[]): BlueprintAgent[] {
+  return agents.filter((a) => a.checked !== false);
+}
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+export function OutcomeSummary({
+  agents,
+  selectedBlueprint,
+  blueprints,
+  primaryRuntime,
+  taskText,
+  taskSkipped,
+  apiKeyCount,
+  onEnter,
+}: OutcomeSummaryProps) {
+  const created = checkedAgents(agents);
+  const blueprint = blueprintName(selectedBlueprint, blueprints);
+  const trimmedTask = taskText.trim();
+
+  return (
+    <div className="wizard-step" data-testid="outcome-summary">
+      <div className="wizard-hero">
+        <h1
+          className="wizard-headline"
+          style={{ fontSize: 28 }}
+          data-testid="outcome-headline"
+        >
+          Office is open
+        </h1>
+        <p className="wizard-subhead">
+          Here is what was created. Your team is already running.
+        </p>
+      </div>
+
+      {/* Agents */}
+      <div className="wizard-panel">
+        <p className="wizard-panel-title">
+          Team created ({created.length}{" "}
+          {created.length === 1 ? "agent" : "agents"})
+        </p>
+        {created.length > 0 ? (
+          <ul
+            className="outcome-agent-list"
+            data-testid="outcome-agents"
+            style={{ listStyle: "none", margin: 0, padding: 0 }}
+          >
+            {created.map((a) => (
+              <li
+                key={a.slug}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 10,
+                  padding: "8px 0",
+                  borderBottom: "1px solid var(--border-light, var(--border))",
+                  fontSize: 13,
+                }}
+              >
+                {a.emoji ? (
+                  <span style={{ fontSize: 16 }}>{a.emoji}</span>
+                ) : null}
+                <span style={{ fontWeight: 600, color: "var(--text)" }}>
+                  {a.name}
+                </span>
+                <span
+                  style={{
+                    fontFamily: "var(--font-mono, monospace)",
+                    fontSize: 11,
+                    color: "var(--text-tertiary)",
+                  }}
+                >
+                  @{a.slug}
+                </span>
+                {a.built_in ? (
+                  <span
+                    className="wiz-team-lead-badge"
+                    style={{ marginLeft: "auto" }}
+                  >
+                    lead
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p
+            style={{ fontSize: 13, color: "var(--text-secondary)", margin: 0 }}
+          >
+            No agents selected — the broker seeds a default team on first run.
+          </p>
+        )}
+      </div>
+
+      {/* What was set up */}
+      <div className="wizard-panel">
+        <p className="wizard-panel-title">Setup</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+          <OutcomeRow
+            label="Blueprint"
+            value={blueprint}
+            testId="outcome-blueprint"
+          />
+          <OutcomeRow
+            label="Runtime"
+            value={primaryRuntime || "Not selected"}
+            testId="outcome-runtime"
+          />
+          <OutcomeRow
+            label="Channels"
+            value={GUARANTEED_CHANNELS.map((c) => `#${c}`).join(", ")}
+            testId="outcome-channels"
+          />
+          <OutcomeRow
+            label="Wiki"
+            value="Git-native team wiki seeded in ~/.wuphf/wiki"
+            testId="outcome-wiki"
+          />
+          {apiKeyCount > 0 ? (
+            <OutcomeRow
+              label="Provider keys"
+              value={`${apiKeyCount} key${apiKeyCount === 1 ? "" : "s"} saved`}
+              testId="outcome-api-keys"
+            />
+          ) : null}
+          <OutcomeRow
+            label="First task"
+            value={
+              taskSkipped || trimmedTask.length === 0
+                ? "Skipped — start from the general channel"
+                : trimmedTask
+            }
+            testId="outcome-task"
+            truncate={!taskSkipped && trimmedTask.length > 0}
+          />
+        </div>
+      </div>
+
+      {/* Next actions */}
+      <div className="wizard-panel">
+        <p className="wizard-panel-title">Where to go next</p>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <OutcomeLink
+            href="#/channels/general"
+            label="Open general channel"
+            hint="Where agents post updates and you can give tasks"
+            testId="outcome-link-general"
+          />
+          <OutcomeLink
+            href="#/tasks"
+            label="Live run view"
+            hint="Watch agents execute and see task status"
+            testId="outcome-link-tasks"
+          />
+          <OutcomeLink
+            href="#/wiki"
+            label="Team wiki"
+            hint="Agents write here; you can read, edit, and promote entries"
+            testId="outcome-link-wiki"
+          />
+          <OutcomeLink
+            href="#/apps/settings"
+            label="Provider settings"
+            hint="Add or rotate API keys and change the runtime"
+            testId="outcome-link-settings"
+          />
+        </div>
+      </div>
+
+      <div className="wizard-nav">
+        <div className="wizard-nav-right" style={{ width: "100%" }}>
+          <button
+            className="btn btn-primary"
+            style={{ width: "100%" }}
+            data-testid="outcome-enter-button"
+            type="button"
+            onClick={onEnter}
+          >
+            Go to the office
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────
+
+interface OutcomeRowProps {
+  label: string;
+  value: string;
+  testId?: string;
+  /** Clamp long values to two lines so the panel stays compact. */
+  truncate?: boolean;
+}
+
+function OutcomeRow({ label, value, testId, truncate }: OutcomeRowProps) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "120px 1fr",
+        gap: 12,
+        alignItems: "baseline",
+        fontSize: 13,
+      }}
+      data-testid={testId}
+    >
+      <span style={{ fontWeight: 600, color: "var(--text-secondary)" }}>
+        {label}
+      </span>
+      <span
+        style={{
+          color: "var(--text)",
+          ...(truncate
+            ? {
+                display: "-webkit-box",
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }
+            : {}),
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface OutcomeLinkProps {
+  href: string;
+  label: string;
+  hint: string;
+  testId?: string;
+}
+
+function OutcomeLink({ href, label, hint, testId }: OutcomeLinkProps) {
+  return (
+    <a
+      href={href}
+      data-testid={testId}
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        gap: 10,
+        padding: "10px 12px",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--radius-md, 6px)",
+        background: "var(--bg-card)",
+        textDecoration: "none",
+        color: "inherit",
+        transition: "border-color 0.15s, background 0.15s",
+        fontSize: 13,
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLAnchorElement).style.borderColor =
+          "var(--accent)";
+        (e.currentTarget as HTMLAnchorElement).style.background =
+          "var(--accent-bg)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLAnchorElement).style.borderColor =
+          "var(--border)";
+        (e.currentTarget as HTMLAnchorElement).style.background =
+          "var(--bg-card)";
+      }}
+    >
+      <span
+        style={{ fontWeight: 600, color: "var(--accent)", flex: "0 0 auto" }}
+      >
+        {label}
+      </span>
+      <span style={{ color: "var(--text-secondary)", fontSize: 12 }}>
+        {hint}
+      </span>
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `OutcomeSummary` component rendered after `/onboarding/complete` succeeds, replacing the immediate `onComplete()` call with a readable summary screen
- Captures wizard state at submission time (checked agents, selected blueprint, primary runtime, task text, api key count) into `OutcomeMeta` — the backend only returns `{"ok":true}` so the wizard's local state is the source of truth
- Shows: team created (agent names + slugs + lead badge), setup rows (blueprint, runtime, channels, wiki, provider keys, first task status), next-action links to general channel / tasks / wiki / settings
- User clicks "Go to the office" to call `onComplete()` and enter the live app

## Implementation notes

- `OutcomeSummary.tsx` — new standalone component, no new deps
- `Wizard.tsx` — adds `showOutcome` + `outcomeMeta` state; `finishOnboarding` sets both after the POST succeeds then renders `OutcomeSummary` in place of the step tree; `onComplete()` is deferred to the "Go to the office" CTA
- All links use hash-router hrefs (`#/channels/general`, `#/tasks`, `#/wiki`, `#/apps/settings`) matching the existing TanStack hash-router patterns
- `blueprintName(null, ...)` returns "Start from scratch" matching the wizard copy

## Test plan

- [ ] `bash scripts/test-web.sh web/src/components/onboarding` — 82 tests pass (11 files)
- [ ] `bunx tsc --noEmit` — clean
- [ ] `bunx biome check` — no issues
- [ ] `bunx secretlint` — clean
- [ ] Manual: complete wizard with agents + task → outcome summary appears showing agent names, blueprint, runtime, #general channel, wiki row, task text, all 4 nav links → click "Go to the office" enters the app
- [ ] Manual: skip task → outcome shows "Skipped" in first task row
- [ ] Manual: no runtime selected → outcome shows "Not selected"
- [ ] Manual: zero API keys → api key row hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding now shows a post-completion confirmation screen summarizing configured details (selected blueprint, created agents, runtime, API keys, and first task) and requires the user to enter the office to complete onboarding.
  * Adds “Where to go next” quick links (general channel, live runs, wiki, provider settings).

* **Tests**
  * Added comprehensive tests for the onboarding summary screen, panels, navigation links, CTA, and fallback states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->