### PR TITLE
feat(team): public-tunnel hardening — passcode + rate limit + audit (Phase 2)

### DIFF
--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -507,26 +507,32 @@ func isPrivateIP(ip net.IP) bool {
 }
 
 // shareHandlerConfig is the dial-tone for the unauthenticated /join/ HTTP
-// surface. brokerURL + brokerToken are required (the handler proxies the
-// authenticated invite-accept call to the broker on the joiner's behalf).
-// onJoin is the host-side join notification (printed on the wuphf share
-// terminal). joinGate and rateLimiter are tunnel-only hardening; both nil
-// in network-share mode preserves Phase 1 behaviour byte-for-byte.
+// surface. BrokerURL is required (the handler proxies the invite-accept
+// call to the broker on the joiner's behalf — the broker accepts based on
+// the invite token in the body, not a bearer token, so no broker token is
+// needed here). OnJoin is the host-side join notification (printed on the
+// wuphf share terminal). JoinGate and RateLimiter are tunnel-only
+// hardening; both nil in network-share mode preserves Phase 1 behaviour
+// byte-for-byte.
 type shareHandlerConfig struct {
 	BrokerURL   string
-	BrokerToken string
 	OnJoin      func()
 	JoinGate    joinGateFn
 	RateLimiter *joinRateLimiter
 }
 
 func newShareHTTPServer(bind string, port int, brokerURL, brokerToken string, onJoin func()) *http.Server {
+	// brokerToken is part of the legacy signature; it's used elsewhere in
+	// this file (see runShareServer) but the share HTTP handler itself has
+	// no use for it because the join POST sends the invite token in the
+	// body and the broker's /humans/invites/accept endpoint accepts on
+	// that alone. Drop it on the way into the handler config.
+	_ = brokerToken
 	return &http.Server{
 		Addr: fmt.Sprintf("%s:%d", bind, port),
 		Handler: newShareHandler(shareHandlerConfig{
-			BrokerURL:   brokerURL,
-			BrokerToken: brokerToken,
-			OnJoin:      onJoin,
+			BrokerURL: brokerURL,
+			OnJoin:    onJoin,
 		}),
 		ReadHeaderTimeout: 5 * time.Second,
 	}

--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -505,15 +506,35 @@ func isPrivateIP(ip net.IP) bool {
 	return v4[0] == 10 || (v4[0] == 172 && v4[1] >= 16 && v4[1] <= 31) || (v4[0] == 192 && v4[1] == 168)
 }
 
+// shareHandlerConfig is the dial-tone for the unauthenticated /join/ HTTP
+// surface. brokerURL + brokerToken are required (the handler proxies the
+// authenticated invite-accept call to the broker on the joiner's behalf).
+// onJoin is the host-side join notification (printed on the wuphf share
+// terminal). joinGate and rateLimiter are tunnel-only hardening; both nil
+// in network-share mode preserves Phase 1 behaviour byte-for-byte.
+type shareHandlerConfig struct {
+	BrokerURL   string
+	BrokerToken string
+	OnJoin      func()
+	JoinGate    joinGateFn
+	RateLimiter *joinRateLimiter
+}
+
 func newShareHTTPServer(bind string, port int, brokerURL, brokerToken string, onJoin func()) *http.Server {
 	return &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", bind, port),
-		Handler:           newShareHandler(brokerURL, brokerToken, onJoin),
+		Addr: fmt.Sprintf("%s:%d", bind, port),
+		Handler: newShareHandler(shareHandlerConfig{
+			BrokerURL:   brokerURL,
+			BrokerToken: brokerToken,
+			OnJoin:      onJoin,
+		}),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 }
 
-func newShareHandler(brokerURL, brokerToken string, onJoin func()) http.Handler {
+func newShareHandler(cfg shareHandlerConfig) http.Handler {
+	brokerURL := cfg.BrokerURL
+	onJoin := cfg.OnJoin
 	mux := http.NewServeMux()
 	mux.HandleFunc("/join/", func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.URL.Path, "/join/")
@@ -527,7 +548,21 @@ func newShareHandler(brokerURL, brokerToken string, onJoin func()) http.Handler 
 			// SPA's relative asset URLs do not need a path rewrite.
 			http.Redirect(w, r, "/?invite="+url.QueryEscape(token), http.StatusFound)
 		case http.MethodPost:
-			handleShareJoinSubmit(w, r, brokerURL, token, onJoin)
+			if cfg.RateLimiter != nil {
+				ip := extractJoinSourceIP(r)
+				if !cfg.RateLimiter.allow(ip) {
+					// Conservative HTTP signalling: 429 + Retry-After so
+					// well-behaved clients back off. The message is
+					// joiner-friendly; the structured `error` code lets the
+					// React JoinPage suppress the passcode field while the
+					// limit is in force.
+					w.Header().Set("Retry-After", "60")
+					writeShareJoinError(w, http.StatusTooManyRequests, "rate_limited",
+						"Too many join attempts from this network. Wait a minute and try again.")
+					return
+				}
+			}
+			handleShareJoinSubmit(w, r, brokerURL, token, onJoin, cfg.JoinGate)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}
@@ -571,9 +606,14 @@ type shareJoinError struct {
 // into the JSON decoder. 8 KiB is ample for a display_name payload.
 const maxShareJoinBodyBytes = 8 << 10
 
-func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, token string, onJoin func()) {
+func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, token string, onJoin func(), gate joinGateFn) {
 	var submission struct {
 		DisplayName string `json:"display_name"`
+		// Passcode is the second factor for tunnel-mode invites. Empty in
+		// network-share mode (and on the first submit when the joiner has
+		// not been told a passcode is required) — the gate is responsible
+		// for distinguishing "missing" from "wrong" without leaking which.
+		Passcode string `json:"passcode,omitempty"`
 	}
 	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxShareJoinBodyBytes))
 	dec.DisallowUnknownFields()
@@ -584,6 +624,28 @@ func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, to
 	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		writeShareJoinError(w, http.StatusBadRequest, "invalid_request", "We could not read your invite submission. Reload and try again.")
 		return
+	}
+	if gate != nil {
+		if gateErr := gate(token, submission.Passcode); gateErr != nil {
+			// Audit log: the host's terminal sees one line per failed
+			// passcode attempt so suspicious activity is visible without
+			// having to scrape proxy logs. Token is not logged in full —
+			// a 6-char prefix is enough to correlate without making the
+			// log file an oracle for stolen tokens.
+			tokenPrefix := token
+			if len(tokenPrefix) > 6 {
+				tokenPrefix = tokenPrefix[:6]
+			}
+			log.Printf("tunnel: passcode rejected (%s) for invite %s… from %s", gateErr, tokenPrefix, extractJoinSourceIP(r))
+			// 401 Unauthorized so the JoinPage flips into the
+			// "show passcode field + retry" state without retrying the
+			// rate-limit bucket on the next attempt — see writeShareJoinError.
+			// Always send the same user-facing message regardless of which
+			// sentinel fired so attackers cannot tell "wrong passcode" from
+			// "no passcode registered for this token" by inspection.
+			writeShareJoinError(w, http.StatusUnauthorized, "passcode_required", shareJoinPasscodeRequiredMessage)
+			return
+		}
 	}
 	displayName := strings.TrimSpace(submission.DisplayName)
 	if displayName == "" {

--- a/cmd/wuphf/share_join_guard.go
+++ b/cmd/wuphf/share_join_guard.go
@@ -85,6 +85,11 @@ type joinRateLimiter struct {
 	burst       int
 	interval    time.Duration
 	lastSweepAt time.Time
+	// now is the clock the limiter reads. Defaults to time.Now; tests
+	// substitute a controllable closure so refill semantics can be
+	// exercised without sleeping (CONTRIBUTING.md hard-bans new time.Sleep
+	// in tests, and a sleep-loop here flakes anyway).
+	now func() time.Time
 }
 
 type joinRateBucket struct {
@@ -104,6 +109,7 @@ func newJoinRateLimiter() *joinRateLimiter {
 		buckets:  make(map[string]*joinRateBucket),
 		burst:    joinRateBurst,
 		interval: joinRateInterval,
+		now:      time.Now,
 	}
 }
 
@@ -117,7 +123,11 @@ func (l *joinRateLimiter) allow(ip string) bool {
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	now := time.Now()
+	clock := l.now
+	if clock == nil {
+		clock = time.Now
+	}
+	now := clock()
 	l.gcLocked(now)
 	bucket, ok := l.buckets[ip]
 	if !ok {

--- a/cmd/wuphf/share_join_guard.go
+++ b/cmd/wuphf/share_join_guard.go
@@ -60,13 +60,14 @@ func generatePasscode() (string, error) {
 // constantTimeCompare returns true iff a and b are equal as byte slices,
 // without leaking the first differing index through timing. Used by
 // joinGateFn implementations to compare the supplied passcode against the
-// stored one — equal-length compare so an attacker cannot use response
-// time to learn the passcode prefix.
+// stored one. When the lengths differ we still run a same-length dummy
+// compare sized to the stored secret (b), so an attacker cannot learn the
+// stored length from the response time of a too-short submission — a bare
+// `[]byte(a)` dummy would process len(a) bytes, leaking len(b).
 func constantTimeCompare(a, b string) bool {
 	if len(a) != len(b) {
-		// Still run the compare on a same-length pair so the early-return
-		// path takes the same wall-clock as the unequal-length path.
-		_ = subtle.ConstantTimeCompare([]byte(a), []byte(a))
+		dummy := make([]byte, len(b))
+		_ = subtle.ConstantTimeCompare(dummy, dummy)
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1

--- a/cmd/wuphf/share_join_guard.go
+++ b/cmd/wuphf/share_join_guard.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"errors"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// joinGateFn returns nil when a (token, suppliedPasscode) pair is allowed to
+// proceed to the broker's invite-accept endpoint, or an error whose message
+// is safe to render to the unauthenticated joiner. Returning a non-nil
+// error MUST NOT distinguish "unknown token" from "wrong passcode" — both
+// surface as the same client-visible string so a stranger holding the
+// tunnel URL cannot enumerate which tokens were issued.
+//
+// nil joinGateFn = no passcode gate (network-share path); supplied passcode
+// is ignored entirely. The tunnel path always installs a non-nil gate.
+type joinGateFn func(token, passcode string) error
+
+// joinAttemptOutcome lets the rate limiter charge a different rate against
+// "took a real shot at the gate" vs. "submitted nothing / malformed".
+// Currently both count the same — the distinction is here so a future
+// refinement (e.g. don't charge the bucket for empty-passcode pre-flights)
+// is a one-line change instead of a refactor.
+type joinAttemptOutcome int
+
+const (
+	joinAttemptAccepted joinAttemptOutcome = iota
+	joinAttemptRejected
+)
+
+// passcodeLength is the digit count the host UI surfaces and the joiner
+// types in. 6 digits = ~20 bits of entropy. Combined with a one-use 24h
+// invite token (already crypto-random), the joint search space is well
+// out of reach for an online attacker even before the rate limit clamps.
+const passcodeLength = 6
+
+// generatePasscode mints a uniformly-distributed numeric passcode of length
+// passcodeLength using crypto/rand. Rolling each digit independently keeps
+// the implementation obvious and avoids modulo-bias on a 32-bit truncation
+// of a wider random integer.
+func generatePasscode() (string, error) {
+	digits := make([]byte, passcodeLength)
+	for i := range digits {
+		n, err := rand.Int(rand.Reader, big.NewInt(10))
+		if err != nil {
+			return "", err
+		}
+		digits[i] = '0' + byte(n.Int64())
+	}
+	return string(digits), nil
+}
+
+// constantTimeCompare returns true iff a and b are equal as byte slices,
+// without leaking the first differing index through timing. Used by
+// joinGateFn implementations to compare the supplied passcode against the
+// stored one — equal-length compare so an attacker cannot use response
+// time to learn the passcode prefix.
+func constantTimeCompare(a, b string) bool {
+	if len(a) != len(b) {
+		// Still run the compare on a same-length pair so the early-return
+		// path takes the same wall-clock as the unequal-length path.
+		_ = subtle.ConstantTimeCompare([]byte(a), []byte(a))
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
+}
+
+// joinRateLimiter is a per-source-IP token bucket that brakes brute-force
+// attempts at the unauthenticated /join/<token> POST. Bucket size is
+// joinRateBurst; tokens refill at one per joinRateInterval. With 6-digit
+// passcodes this caps an attacker's effective guess rate to a few per
+// minute per IP — well below the rate they'd need to win the lottery in a
+// 24h invite window. A goroutine-free design (lazy GC during allow())
+// keeps the surface small and easy to reason about.
+type joinRateLimiter struct {
+	mu          sync.Mutex
+	buckets     map[string]*joinRateBucket
+	burst       int
+	interval    time.Duration
+	lastSweepAt time.Time
+}
+
+type joinRateBucket struct {
+	tokens   float64
+	updated  time.Time
+	lastUsed time.Time
+}
+
+const (
+	joinRateBurst    = 5                // 5 attempts immediately available
+	joinRateInterval = 12 * time.Second // refill 1 token / 12s = ~5/min steady state
+	joinRateGCAfter  = 10 * time.Minute // drop buckets that haven't been touched recently
+)
+
+func newJoinRateLimiter() *joinRateLimiter {
+	return &joinRateLimiter{
+		buckets:  make(map[string]*joinRateBucket),
+		burst:    joinRateBurst,
+		interval: joinRateInterval,
+	}
+}
+
+// allow returns true if the source IP may attempt a join right now. It
+// always charges a token from the bucket on success; on rejection it
+// leaves the (already-empty) bucket alone so a flood of attackers cannot
+// keep the bucket from refilling. The function is safe for concurrent use.
+func (l *joinRateLimiter) allow(ip string) bool {
+	if l == nil {
+		return true
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := time.Now()
+	l.gcLocked(now)
+	bucket, ok := l.buckets[ip]
+	if !ok {
+		bucket = &joinRateBucket{tokens: float64(l.burst), updated: now, lastUsed: now}
+		l.buckets[ip] = bucket
+	} else {
+		elapsed := now.Sub(bucket.updated)
+		if elapsed > 0 {
+			bucket.tokens += elapsed.Seconds() / l.interval.Seconds()
+			if bucket.tokens > float64(l.burst) {
+				bucket.tokens = float64(l.burst)
+			}
+			bucket.updated = now
+		}
+	}
+	bucket.lastUsed = now
+	if bucket.tokens < 1 {
+		return false
+	}
+	bucket.tokens--
+	return true
+}
+
+// gcLocked drops cold buckets so a long-lived process whose attackers
+// rotate IPs faster than they re-attack does not retain state forever.
+// Sweeps at most every joinRateGCAfter/2 to keep the hot-path cost ~O(1).
+func (l *joinRateLimiter) gcLocked(now time.Time) {
+	if now.Sub(l.lastSweepAt) < joinRateGCAfter/2 {
+		return
+	}
+	for ip, b := range l.buckets {
+		if now.Sub(b.lastUsed) > joinRateGCAfter {
+			delete(l.buckets, ip)
+		}
+	}
+	l.lastSweepAt = now
+}
+
+// extractJoinSourceIP picks the right "remote IP" for the rate limiter
+// when the share HTTP server runs behind cloudflared. cloudflared injects
+// Cf-Connecting-Ip with the real visitor address; r.RemoteAddr by then is
+// the loopback connection from cloudflared itself, which would put every
+// attacker into one bucket and let them DoS legitimate joiners.
+//
+// The header is trusted ONLY when the immediate r.RemoteAddr is loopback,
+// which is the case when running the tunnel-mode share server (bound to
+// 127.0.0.1) but NOT when the network-share server is bound to a
+// Tailscale address. Outside loopback we fall back to r.RemoteAddr so a
+// LAN attacker cannot spoof the header.
+func extractJoinSourceIP(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if isLoopbackHost(host) {
+		if cf := strings.TrimSpace(r.Header.Get("Cf-Connecting-Ip")); cf != "" {
+			return cf
+		}
+	}
+	return host
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "" {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// errJoinPasscodeRequired and errJoinPasscodeInvalid are the canonical gate
+// failures. The two sentinels are kept distinct so callers (audit log,
+// future telemetry) can distinguish the cases internally, but they collapse
+// to the same user-visible message via shareJoinPasscodeRequiredMessage so
+// an attacker sweeping for "is this token live without the passcode" sees
+// identical responses to "valid token + missing passcode" and "valid token
+// + wrong passcode" — see the comment on joinGateFn.
+var (
+	errJoinPasscodeRequired = errors.New("passcode required")
+	errJoinPasscodeInvalid  = errors.New("passcode invalid")
+)
+
+// shareJoinPasscodeRequiredMessage is the only string the joiner sees for
+// either gate failure. Lives next to the errors so a future copy tweak
+// keeps the indistinguishability invariant in one place.
+const shareJoinPasscodeRequiredMessage = "This invite needs a passcode. Ask the host to read it to you."

--- a/cmd/wuphf/share_join_guard_test.go
+++ b/cmd/wuphf/share_join_guard_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGeneratePasscodeShape(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 8; i++ {
+		p, err := generatePasscode()
+		if err != nil {
+			t.Fatalf("generatePasscode: %v", err)
+		}
+		if len(p) != passcodeLength {
+			t.Fatalf("len(passcode)=%d want %d", len(p), passcodeLength)
+		}
+		for _, c := range p {
+			if c < '0' || c > '9' {
+				t.Fatalf("non-digit %q in %q", c, p)
+			}
+		}
+		seen[p] = true
+	}
+	if len(seen) < 6 {
+		// Two collisions in 8 draws over a 1M space is astronomically
+		// unlikely; if we see it, the RNG is broken.
+		t.Fatalf("expected near-unique passcodes; got %d distinct in 8 draws: %v", len(seen), seen)
+	}
+}
+
+func TestConstantTimeCompareMatchesAndDiffers(t *testing.T) {
+	if !constantTimeCompare("123456", "123456") {
+		t.Fatal("equal strings reported unequal")
+	}
+	if constantTimeCompare("123456", "123450") {
+		t.Fatal("different strings reported equal")
+	}
+	// Length-mismatch must NOT panic and must return false.
+	if constantTimeCompare("123456", "12345") {
+		t.Fatal("length-mismatch reported equal")
+	}
+}
+
+func TestJoinRateLimiterBlocksAfterBurst(t *testing.T) {
+	rl := newJoinRateLimiter()
+	for i := 0; i < joinRateBurst; i++ {
+		if !rl.allow("1.2.3.4") {
+			t.Fatalf("burst attempt %d unexpectedly blocked", i+1)
+		}
+	}
+	if rl.allow("1.2.3.4") {
+		t.Fatal("attempt past burst was not blocked")
+	}
+	// A different IP starts with a fresh bucket — don't punish unrelated joiners.
+	if !rl.allow("5.6.7.8") {
+		t.Fatal("second IP blocked by first IP's bucket")
+	}
+}
+
+func TestJoinRateLimiterRefillsOverTime(t *testing.T) {
+	rl := &joinRateLimiter{
+		buckets:  make(map[string]*joinRateBucket),
+		burst:    1,
+		interval: 10 * time.Millisecond,
+	}
+	if !rl.allow("ip") {
+		t.Fatal("first attempt blocked")
+	}
+	if rl.allow("ip") {
+		t.Fatal("second attempt should be blocked before refill")
+	}
+	time.Sleep(15 * time.Millisecond)
+	if !rl.allow("ip") {
+		t.Fatal("post-refill attempt blocked")
+	}
+}
+
+func TestExtractJoinSourceIPPrefersCFConnectingIPOnLoopback(t *testing.T) {
+	r := httptest.NewRequest("POST", "/join/abc", nil)
+	r.RemoteAddr = "127.0.0.1:54321"
+	r.Header.Set("Cf-Connecting-Ip", "203.0.113.99")
+	if got := extractJoinSourceIP(r); got != "203.0.113.99" {
+		t.Fatalf("extractJoinSourceIP = %q, want CF-Connecting-Ip on loopback", got)
+	}
+}
+
+func TestExtractJoinSourceIPIgnoresCFOnNonLoopback(t *testing.T) {
+	// A LAN attacker at 10.0.0.5 cannot spoof a CF-Connecting-Ip header to
+	// dodge their own bucket. Tunnel mode is loopback-only, so non-loopback
+	// requests are network-share traffic where the header is untrusted.
+	r := httptest.NewRequest("POST", "/join/abc", nil)
+	r.RemoteAddr = "10.0.0.5:54321"
+	r.Header.Set("Cf-Connecting-Ip", "203.0.113.99")
+	if got := extractJoinSourceIP(r); got != "10.0.0.5" {
+		t.Fatalf("extractJoinSourceIP = %q, want RemoteAddr (no header trust)", got)
+	}
+}
+
+// TestPasscodeRequiredAndInvalidProduceSameUserMessage guards the
+// indistinguishability invariant that protects against token enumeration.
+// If a future refactor lets one path leak a different message, an attacker
+// can sweep the trycloudflare URL space and learn which tokens are live by
+// the response copy alone.
+func TestPasscodeRequiredAndInvalidProduceSameUserMessage(t *testing.T) {
+	if !strings.EqualFold(shareJoinPasscodeRequiredMessage, shareJoinPasscodeRequiredMessage) {
+		t.Fatal("constant should equal itself; unreachable")
+	}
+	// We assert by inspection that exactly one user-facing string covers
+	// both paths: handleShareJoinSubmit calls
+	// writeShareJoinError(..., "passcode_required", shareJoinPasscodeRequiredMessage)
+	// regardless of which sentinel the gate returned. The two error
+	// sentinels exist so audit logs can distinguish them, but neither
+	// sentinel's .Error() string flows to the client.
+	if errJoinPasscodeRequired.Error() == errJoinPasscodeInvalid.Error() {
+		t.Fatal("internal sentinels collapsed; audit trail loses fidelity")
+	}
+}

--- a/cmd/wuphf/share_join_guard_test.go
+++ b/cmd/wuphf/share_join_guard_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -110,15 +113,79 @@ func TestExtractJoinSourceIPIgnoresCFOnNonLoopback(t *testing.T) {
 // can sweep the trycloudflare URL space and learn which tokens are live by
 // the response copy alone.
 func TestPasscodeRequiredAndInvalidProduceSameUserMessage(t *testing.T) {
-	if !strings.EqualFold(shareJoinPasscodeRequiredMessage, shareJoinPasscodeRequiredMessage) {
-		t.Fatal("constant should equal itself; unreachable")
+	// Run an actual /join POST through the share handler with a stub gate
+	// that returns each sentinel in turn, then assert the two responses
+	// are byte-identical (status, error code, and message). A future
+	// refactor that accidentally lets one sentinel surface a different
+	// user-facing message would let an attacker fingerprint live tokens
+	// by sweeping the trycloudflare URL space — this test is the only
+	// thing pinning that invariant mechanically.
+	type wireResponse struct {
+		Status int
+		Body   string
 	}
-	// We assert by inspection that exactly one user-facing string covers
-	// both paths: handleShareJoinSubmit calls
-	// writeShareJoinError(..., "passcode_required", shareJoinPasscodeRequiredMessage)
-	// regardless of which sentinel the gate returned. The two error
-	// sentinels exist so audit logs can distinguish them, but neither
-	// sentinel's .Error() string flows to the client.
+	captureGateResponse := func(t *testing.T, gateErr error) wireResponse {
+		t.Helper()
+		srv := httptest.NewServer(newShareHandler(shareHandlerConfig{
+			BrokerURL: "http://unused.invalid",
+			JoinGate: func(_, _ string) error {
+				return gateErr
+			},
+		}))
+		t.Cleanup(srv.Close)
+		req, err := http.NewRequest(
+			http.MethodPost,
+			srv.URL+"/join/some-token",
+			strings.NewReader(`{"display_name":"Maya"}`),
+		)
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("do request: %v", err)
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		return wireResponse{Status: resp.StatusCode, Body: string(body)}
+	}
+
+	required := captureGateResponse(t, errJoinPasscodeRequired)
+	invalid := captureGateResponse(t, errJoinPasscodeInvalid)
+
+	if required.Status != http.StatusUnauthorized {
+		t.Errorf("required: status=%d want 401", required.Status)
+	}
+	if invalid.Status != http.StatusUnauthorized {
+		t.Errorf("invalid: status=%d want 401", invalid.Status)
+	}
+	if required.Body != invalid.Body {
+		t.Fatalf("indistinguishability invariant broken:\nrequired: %s\ninvalid:  %s",
+			required.Body, invalid.Body)
+	}
+
+	// Sanity: the body actually contains the canonical message + code.
+	var decoded struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(strings.NewReader(required.Body)).Decode(&decoded); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if decoded.Error != "passcode_required" {
+		t.Errorf("error code = %q, want passcode_required", decoded.Error)
+	}
+	if decoded.Message != shareJoinPasscodeRequiredMessage {
+		t.Errorf("message = %q, want shareJoinPasscodeRequiredMessage", decoded.Message)
+	}
+
+	// The internal sentinels must still differ so the audit log can
+	// distinguish "unknown token" from "wrong passcode" without leaking
+	// to the wire.
 	if errJoinPasscodeRequired.Error() == errJoinPasscodeInvalid.Error() {
 		t.Fatal("internal sentinels collapsed; audit trail loses fidelity")
 	}

--- a/cmd/wuphf/share_join_guard_test.go
+++ b/cmd/wuphf/share_join_guard_test.go
@@ -61,10 +61,15 @@ func TestJoinRateLimiterBlocksAfterBurst(t *testing.T) {
 }
 
 func TestJoinRateLimiterRefillsOverTime(t *testing.T) {
+	// Drive an injected clock so the refill semantics are exercised
+	// deterministically — CONTRIBUTING.md hard-bans new time.Sleep in
+	// tests, and a sleep-loop here would flake under load anyway.
+	clock := time.Unix(0, 0)
 	rl := &joinRateLimiter{
 		buckets:  make(map[string]*joinRateBucket),
 		burst:    1,
 		interval: 10 * time.Millisecond,
+		now:      func() time.Time { return clock },
 	}
 	if !rl.allow("ip") {
 		t.Fatal("first attempt blocked")
@@ -72,7 +77,7 @@ func TestJoinRateLimiterRefillsOverTime(t *testing.T) {
 	if rl.allow("ip") {
 		t.Fatal("second attempt should be blocked before refill")
 	}
-	time.Sleep(15 * time.Millisecond)
+	clock = clock.Add(15 * time.Millisecond)
 	if !rl.allow("ip") {
 		t.Fatal("post-refill attempt blocked")
 	}

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -92,8 +92,12 @@ func TestShareJoinFlowEndToEnd(t *testing.T) {
 		t.Fatalf("create invite: %v", err)
 	}
 	joined := false
-	shareSrv := httptest.NewServer(newShareHandler("http://"+b.Addr(), b.Token(), func() {
-		joined = true
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{
+		BrokerURL:   "http://" + b.Addr(),
+		BrokerToken: b.Token(),
+		OnJoin: func() {
+			joined = true
+		},
 	}))
 	t.Cleanup(shareSrv.Close)
 
@@ -164,7 +168,7 @@ func TestShareJoinInvalidInviteReturnsGone(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
 	t.Cleanup(shareSrv.Close)
 
 	resp := joinSubmit(t, nil, shareSrv.URL, "missing-token", "")
@@ -190,7 +194,7 @@ func TestShareJoinMalformedBodyReturnsInvalidRequest(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
 	t.Cleanup(shareSrv.Close)
 
 	req, err := http.NewRequest(http.MethodPost, shareSrv.URL+"/join/abc", strings.NewReader("not json"))
@@ -224,7 +228,7 @@ func TestShareJoinRejectsOversizedBody(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
 	t.Cleanup(shareSrv.Close)
 
 	// Construct a body larger than the 8 KiB cap. The decoder should error
@@ -262,7 +266,7 @@ func TestShareJoinRejectsUnknownFields(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
 	t.Cleanup(shareSrv.Close)
 
 	body := `{"display_name":"Maya","admin":true}`
@@ -290,7 +294,7 @@ func TestShareJoinBrokerFailureReturnsBadGateway(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
 	t.Cleanup(shareSrv.Close)
 
 	resp := joinSubmit(t, nil, shareSrv.URL, "retry-token", "")
@@ -312,7 +316,7 @@ func TestShareProxyDoesNotExposeBrokerToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create invite: %v", err)
 	}
-	shareSrv := httptest.NewServer(newShareHandler("http://"+b.Addr(), b.Token(), nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: "http://" + b.Addr(), BrokerToken: b.Token()}))
 	t.Cleanup(shareSrv.Close)
 
 	joinResp := joinSubmit(t, nil, shareSrv.URL, invite.Token, "")
@@ -355,7 +359,7 @@ func TestShareProxyOnboardingStateOnlyAllowsReadMethods(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
 	t.Cleanup(shareSrv.Close)
 
 	for _, tc := range []struct {
@@ -405,7 +409,7 @@ func TestShareProxyDoesNotForwardBrokerToken(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(broker.URL, brokerToken, nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: brokerToken}))
 	t.Cleanup(shareSrv.Close)
 
 	req, err := http.NewRequest(http.MethodGet, shareSrv.URL+"/api/messages", nil)
@@ -451,7 +455,7 @@ func TestShareProxyStampsHumanActor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create invite: %v", err)
 	}
-	shareSrv := httptest.NewServer(newShareHandler("http://"+b.Addr(), b.Token(), nil))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: "http://" + b.Addr(), BrokerToken: b.Token()}))
 	t.Cleanup(shareSrv.Close)
 
 	joinResp := joinSubmit(t, nil, shareSrv.URL, invite.Token, "")

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -93,8 +93,7 @@ func TestShareJoinFlowEndToEnd(t *testing.T) {
 	}
 	joined := false
 	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{
-		BrokerURL:   "http://" + b.Addr(),
-		BrokerToken: b.Token(),
+		BrokerURL: "http://" + b.Addr(),
 		OnJoin: func() {
 			joined = true
 		},
@@ -168,7 +167,7 @@ func TestShareJoinInvalidInviteReturnsGone(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	resp := joinSubmit(t, nil, shareSrv.URL, "missing-token", "")
@@ -194,7 +193,7 @@ func TestShareJoinMalformedBodyReturnsInvalidRequest(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	req, err := http.NewRequest(http.MethodPost, shareSrv.URL+"/join/abc", strings.NewReader("not json"))
@@ -228,7 +227,7 @@ func TestShareJoinRejectsOversizedBody(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	// Construct a body larger than the 8 KiB cap. The decoder should error
@@ -266,7 +265,7 @@ func TestShareJoinRejectsUnknownFields(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	body := `{"display_name":"Maya","admin":true}`
@@ -294,7 +293,7 @@ func TestShareJoinBrokerFailureReturnsBadGateway(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	resp := joinSubmit(t, nil, shareSrv.URL, "retry-token", "")
@@ -316,7 +315,7 @@ func TestShareProxyDoesNotExposeBrokerToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create invite: %v", err)
 	}
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: "http://" + b.Addr(), BrokerToken: b.Token()}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: "http://" + b.Addr()}))
 	t.Cleanup(shareSrv.Close)
 
 	joinResp := joinSubmit(t, nil, shareSrv.URL, invite.Token, "")
@@ -359,7 +358,7 @@ func TestShareProxyOnboardingStateOnlyAllowsReadMethods(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: "broker-token"}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	for _, tc := range []struct {
@@ -409,7 +408,7 @@ func TestShareProxyDoesNotForwardBrokerToken(t *testing.T) {
 	}))
 	t.Cleanup(broker.Close)
 
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL, BrokerToken: brokerToken}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: broker.URL}))
 	t.Cleanup(shareSrv.Close)
 
 	req, err := http.NewRequest(http.MethodGet, shareSrv.URL+"/api/messages", nil)
@@ -455,7 +454,7 @@ func TestShareProxyStampsHumanActor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create invite: %v", err)
 	}
-	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: "http://" + b.Addr(), BrokerToken: b.Token()}))
+	shareSrv := httptest.NewServer(newShareHandler(shareHandlerConfig{BrokerURL: "http://" + b.Addr()}))
 	t.Cleanup(shareSrv.Close)
 
 	joinResp := joinSubmit(t, nil, shareSrv.URL, invite.Token, "")

--- a/cmd/wuphf/tunnel.go
+++ b/cmd/wuphf/tunnel.go
@@ -250,11 +250,15 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 		c.err = err.Error()
 		return c.statusLocked(), err
 	}
+	// brokerToken is read above only because readBrokerToken's failure mode
+	// is the same one we want to surface here (broker not running). The
+	// share HTTP handler itself doesn't need the token — see the doc on
+	// shareHandlerConfig.
+	_ = brokerToken
 	server := &http.Server{
 		Addr: loopbackAddr,
 		Handler: newShareHandler(shareHandlerConfig{
 			BrokerURL:   brokerURL,
-			BrokerToken: brokerToken,
 			OnJoin:      nil,
 			JoinGate:    c.joinGate,
 			RateLimiter: c.rateLimiter,
@@ -463,6 +467,16 @@ func (c *webTunnelController) mintInviteLocked(publicURL string) (string, string
 	})
 	if err != nil {
 		return "", "", "", err
+	}
+	// CreateInviteDetailedWithBuilder is contractually expected to call the
+	// builder exactly once on success; guard against a future refactor that
+	// returns success without invoking it. Without this check we'd register
+	// c.passcodes[""] = passcode and the joinGate would key off the empty
+	// string forever — the join handler rejects empty tokens at 400 so the
+	// security posture is fail-closed, but the symptom is a silently-broken
+	// invite. Better to fail the start() with a clear error.
+	if capturedToken == "" {
+		return "", "", "", errors.New("tunnel: invite builder was not called; token capture failed")
 	}
 	passcode, err := generatePasscode()
 	if err != nil {

--- a/cmd/wuphf/tunnel.go
+++ b/cmd/wuphf/tunnel.go
@@ -499,16 +499,29 @@ func (c *webTunnelController) mintInviteLocked(publicURL string) (string, string
 //   - the invite token must be one this tunnel issued (an attacker who
 //     guesses or steals a network-share token cannot redeem it through the
 //     tunnel),
+//   - a non-empty passcode must be supplied,
 //   - the supplied passcode must match the one we minted alongside the
 //     token (constant-time compare).
 //
-// Both failure modes return the SAME error message via errJoinPasscodeRequired
-// to avoid leaking which condition was hit.
+// Internally the three failure modes use distinct sentinels so the audit
+// log in share.go can attribute attempts (unknown token / no passcode /
+// wrong passcode), but the wire response collapses to one shape — see
+// shareJoinPasscodeRequiredMessage and the indistinguishability test.
 func (c *webTunnelController) joinGate(token, supplied string) error {
 	c.mu.Lock()
 	expected, ok := c.passcodes[token]
 	c.mu.Unlock()
 	if !ok {
+		return errJoinPasscodeRequired
+	}
+	// Distinguish "joiner submitted nothing" from "joiner submitted the
+	// wrong code". Both produce identical wire responses (the gate's
+	// indistinguishability invariant), but the audit log loses fidelity
+	// if both paths return the same sentinel — operators investigating
+	// suspicious traffic want to tell brute-force attempts (many
+	// non-empty mismatches) apart from the legitimate "joiner forgot
+	// to type the passcode and clicked submit" case.
+	if strings.TrimSpace(supplied) == "" {
 		return errJoinPasscodeRequired
 	}
 	if !constantTimeCompare(supplied, expected) {

--- a/cmd/wuphf/tunnel.go
+++ b/cmd/wuphf/tunnel.go
@@ -304,8 +304,17 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 			if c.server == server {
 				c.err = fmt.Sprintf("tunnel loopback server failed: %v", err)
 				c.running = false
-				c.clearInviteLocked()
 				c.publicURL = ""
+				// Mirror the watcher-goroutine + stop() teardown: when
+				// the loopback server dies, the cloudflared subprocess
+				// is still running but cannot reach the broker, so the
+				// session is unusable. Reset c.passcodes and the IP
+				// rate limiter so a subsequent Start (which the user
+				// will need to click manually) gets a clean slate
+				// instead of inheriting the dead session's buckets.
+				c.passcodes = make(map[string]string)
+				c.rateLimiter = newJoinRateLimiter()
+				c.clearInviteLocked()
 			}
 		}
 	}()
@@ -465,8 +474,17 @@ func (c *webTunnelController) mintInviteLocked(publicURL string) (string, string
 	// Capture the token via the URL builder closure: CreateInviteDetailedWithBuilder
 	// returns the formatted URL, not the bare token, and we need the bare
 	// token to key the passcode map.
+	//
+	// mintInviteLocked runs under c.mu, so a stalled broker call would
+	// hold the mutex and block status() / stop() / re-clicks of Start.
+	// Cap the broker call with a tight deadline — invite creation is an
+	// in-process function call to the broker today, so a healthy mint is
+	// sub-millisecond; 10s is a generous ceiling on a hung broker before
+	// we surface the error to the UI rather than freeze the tunnel card.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	var capturedToken string
-	details, err := st.CreateInviteDetailedWithBuilder(context.Background(), func(token string) string {
+	details, err := st.CreateInviteDetailedWithBuilder(ctx, func(token string) string {
 		capturedToken = token
 		return tunnelJoinURL(publicURL, token)
 	})

--- a/cmd/wuphf/tunnel.go
+++ b/cmd/wuphf/tunnel.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -120,14 +121,32 @@ type webTunnelController struct {
 	starting  bool
 	publicURL string
 	inviteURL string
-	expiresAt string
-	err       string
-	missing   bool
-	broker    *team.Broker
+	// inviteToken is the token portion of inviteURL (the bit after /join/).
+	// Tracked separately so the join handler can identify the most-recent
+	// invite without re-parsing the URL on every request.
+	inviteToken string
+	// passcode is the second factor displayed next to inviteURL. Rotates
+	// with each minted invite; the gate accepts only this passcode for
+	// the current inviteToken.
+	passcode string
+	// passcodes maps every still-redeemable invite token to its passcode.
+	// Old tokens linger here until the tunnel is stopped — that is fine
+	// because (a) the broker independently expires tokens after 24h and
+	// (b) joiners who already grabbed a stale URL may legitimately submit
+	// before the host clicks "Create new invite".
+	passcodes   map[string]string
+	expiresAt   string
+	err         string
+	missing     bool
+	broker      *team.Broker
+	rateLimiter *joinRateLimiter
 }
 
 func newWebTunnelController() *webTunnelController {
-	return &webTunnelController{}
+	return &webTunnelController{
+		passcodes:   make(map[string]string),
+		rateLimiter: newJoinRateLimiter(),
+	}
 }
 
 // SetBroker installs the in-process broker handle. Required before start():
@@ -150,6 +169,7 @@ func (c *webTunnelController) statusLocked() team.WebTunnelStatus {
 		Running:            c.running,
 		PublicURL:          c.publicURL,
 		InviteURL:          c.inviteURL,
+		Passcode:           c.passcode,
 		ExpiresAt:          c.expiresAt,
 		Error:              c.err,
 		CloudflaredMissing: c.missing,
@@ -158,6 +178,8 @@ func (c *webTunnelController) statusLocked() team.WebTunnelStatus {
 
 func (c *webTunnelController) clearInviteLocked() {
 	c.inviteURL = ""
+	c.inviteToken = ""
+	c.passcode = ""
 	c.expiresAt = ""
 }
 
@@ -169,12 +191,13 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 	// tunnel down and back up — same shape as webShareController.start().
 	if c.running && c.cmd != nil && c.publicURL != "" {
 		defer c.mu.Unlock()
-		inviteURL, expiresAt, err := c.mintInviteLocked(c.publicURL)
+		inviteURL, passcode, expiresAt, err := c.mintInviteLocked(c.publicURL)
 		if err != nil {
 			c.err = err.Error()
 			return c.statusLocked(), err
 		}
 		c.inviteURL = inviteURL
+		c.passcode = passcode
 		c.expiresAt = expiresAt
 		c.err = ""
 		return c.statusLocked(), nil
@@ -228,8 +251,14 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 		return c.statusLocked(), err
 	}
 	server := &http.Server{
-		Addr:              loopbackAddr,
-		Handler:           newShareHandler(brokerURL, brokerToken, nil),
+		Addr: loopbackAddr,
+		Handler: newShareHandler(shareHandlerConfig{
+			BrokerURL:   brokerURL,
+			BrokerToken: brokerToken,
+			OnJoin:      nil,
+			JoinGate:    c.joinGate,
+			RateLimiter: c.rateLimiter,
+		}),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
@@ -341,9 +370,10 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 	c.publicURL = publicURL
 	c.running = true
 	c.stopGuard = make(chan struct{})
+	log.Printf("tunnel: cloudflared up at %s", publicURL)
 
 	// Mint the first invite against the freshly-published public URL.
-	inviteURL, expiresAt, ierr := c.mintInviteLocked(publicURL)
+	inviteURL, passcode, expiresAt, ierr := c.mintInviteLocked(publicURL)
 	if ierr != nil {
 		// Tunnel is up but the invite call failed. Surface the error but
 		// keep the tunnel running — a retry can mint a new invite without
@@ -353,6 +383,7 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 		return c.statusLocked(), ierr
 	}
 	c.inviteURL = inviteURL
+	c.passcode = passcode
 	c.expiresAt = expiresAt
 	c.err = ""
 
@@ -384,6 +415,7 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 		c.publicURL = ""
 		c.server = nil
 		c.listener = nil
+		c.passcodes = make(map[string]string)
 		c.clearInviteLocked()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			c.err = fmt.Sprintf("cloudflared exited unexpectedly: %v", err)
@@ -401,29 +433,74 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 }
 
 // mintInviteLocked issues a fresh invite token via the registered share
-// transport and formats the joiner-facing URL against the tunnel's public
-// origin. Caller must hold c.mu.
+// transport, generates a one-off passcode for it, and formats the joiner-
+// facing URL against the tunnel's public origin. Side-effect: registers
+// (token -> passcode) in c.passcodes so the share-handler joinGate can
+// verify subsequent /join POSTs. Caller must hold c.mu.
+//
+// Returns (inviteURL, passcode, expiresAt, err).
 //
 // Uses CreateInviteDetailedWithBuilder so the tunnel-URL builder is bound
-// atomically to this single call — the network-share path can run a parallel
-// SetURLBuilder/CreateInviteDetailed pair without overwriting our builder
-// mid-flight. SetURLBuilder is intentionally NOT used here; it would
-// recreate the very race the atomic-builder API exists to prevent.
-func (c *webTunnelController) mintInviteLocked(publicURL string) (string, string, error) {
+// atomically to this single invite-creation — the network-share path can
+// run a parallel call against the same ShareTransport without overwriting
+// our builder mid-flight. SetURLBuilder is intentionally NOT used here; it
+// would recreate the very race the atomic-builder API exists to prevent.
+func (c *webTunnelController) mintInviteLocked(publicURL string) (string, string, string, error) {
 	if c.broker == nil {
-		return "", "", errors.New("tunnel controller has no broker handle")
+		return "", "", "", errors.New("tunnel controller has no broker handle")
 	}
 	st := c.broker.ShareTransport()
 	if st == nil {
-		return "", "", errors.New("share transport is not registered; tunnel cannot mint invites")
+		return "", "", "", errors.New("share transport is not registered; tunnel cannot mint invites")
 	}
+	// Capture the token via the URL builder closure: CreateInviteDetailedWithBuilder
+	// returns the formatted URL, not the bare token, and we need the bare
+	// token to key the passcode map.
+	var capturedToken string
 	details, err := st.CreateInviteDetailedWithBuilder(context.Background(), func(token string) string {
+		capturedToken = token
 		return tunnelJoinURL(publicURL, token)
 	})
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
-	return details.URL, details.ExpiresAt, nil
+	passcode, err := generatePasscode()
+	if err != nil {
+		return "", "", "", fmt.Errorf("tunnel: generate passcode: %w", err)
+	}
+	if c.passcodes == nil {
+		c.passcodes = make(map[string]string)
+	}
+	c.passcodes[capturedToken] = passcode
+	c.inviteToken = capturedToken
+	tokenPrefix := capturedToken
+	if len(tokenPrefix) > 6 {
+		tokenPrefix = tokenPrefix[:6]
+	}
+	log.Printf("tunnel: invite minted token=%s… expires=%s", tokenPrefix, details.ExpiresAt)
+	return details.URL, passcode, details.ExpiresAt, nil
+}
+
+// joinGate is the share-handler hook. It enforces:
+//   - the invite token must be one this tunnel issued (an attacker who
+//     guesses or steals a network-share token cannot redeem it through the
+//     tunnel),
+//   - the supplied passcode must match the one we minted alongside the
+//     token (constant-time compare).
+//
+// Both failure modes return the SAME error message via errJoinPasscodeRequired
+// to avoid leaking which condition was hit.
+func (c *webTunnelController) joinGate(token, supplied string) error {
+	c.mu.Lock()
+	expected, ok := c.passcodes[token]
+	c.mu.Unlock()
+	if !ok {
+		return errJoinPasscodeRequired
+	}
+	if !constantTimeCompare(supplied, expected) {
+		return errJoinPasscodeInvalid
+	}
+	return nil
 }
 
 // tunnelJoinURL is the canonical "<public-base>/join/<token>" formatter.
@@ -440,6 +517,7 @@ func (c *webTunnelController) stop() error {
 	server := c.server
 	ln := c.listener
 	stopGuard := c.stopGuard
+	wasRunning := c.running
 	c.cmd = nil
 	c.cancel = nil
 	c.server = nil
@@ -447,9 +525,13 @@ func (c *webTunnelController) stop() error {
 	c.stopGuard = nil
 	c.running = false
 	c.publicURL = ""
+	c.passcodes = make(map[string]string)
 	c.clearInviteLocked()
 	c.err = ""
 	c.mu.Unlock()
+	if wasRunning {
+		log.Printf("tunnel: stopped")
+	}
 
 	if stopGuard != nil {
 		close(stopGuard)

--- a/cmd/wuphf/tunnel.go
+++ b/cmd/wuphf/tunnel.go
@@ -420,6 +420,11 @@ func (c *webTunnelController) start() (team.WebTunnelStatus, error) {
 		c.server = nil
 		c.listener = nil
 		c.passcodes = make(map[string]string)
+		// Each tunnel session is its own share window — give the next
+		// start() a fresh per-IP bucket map so a joiner who burned their
+		// burst on the previous invite isn't throttled when the host
+		// rotates the tunnel and shares a new URL with them.
+		c.rateLimiter = newJoinRateLimiter()
 		c.clearInviteLocked()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			c.err = fmt.Sprintf("cloudflared exited unexpectedly: %v", err)
@@ -559,6 +564,10 @@ func (c *webTunnelController) stop() error {
 	c.running = false
 	c.publicURL = ""
 	c.passcodes = make(map[string]string)
+	// Same fresh-bucket-per-session reasoning as the watcher-goroutine
+	// teardown path above: a joiner whose IP burned the burst on the
+	// previous invite gets a clean slate on the next Start.
+	c.rateLimiter = newJoinRateLimiter()
 	c.clearInviteLocked()
 	c.err = ""
 	c.mu.Unlock()

--- a/cmd/wuphf/tunnel.go
+++ b/cmd/wuphf/tunnel.go
@@ -514,17 +514,23 @@ func (c *webTunnelController) joinGate(token, supplied string) error {
 	if !ok {
 		return errJoinPasscodeRequired
 	}
-	// Distinguish "joiner submitted nothing" from "joiner submitted the
-	// wrong code". Both produce identical wire responses (the gate's
-	// indistinguishability invariant), but the audit log loses fidelity
-	// if both paths return the same sentinel — operators investigating
-	// suspicious traffic want to tell brute-force attempts (many
-	// non-empty mismatches) apart from the legitimate "joiner forgot
-	// to type the passcode and clicked submit" case.
-	if strings.TrimSpace(supplied) == "" {
+	// Trim once and use the canonicalised value for BOTH the emptiness
+	// check AND the constant-time compare. Without this, a programmatic
+	// caller submitting "835291 " (trailing space) would hit the
+	// "wrong passcode" path even though the digits match — the bundled
+	// React client strips non-digits before submit, so this is
+	// unreachable from the UI, but the gate is what enforces the shape.
+	//
+	// Distinguishing "joiner submitted nothing" from "joiner submitted
+	// wrong digits" is intentional: both produce the same wire response
+	// (the indistinguishability invariant), but the audit log loses
+	// fidelity if both collapse to one sentinel — operators want to tell
+	// brute-force attempts apart from a click-through-without-passcode.
+	trimmed := strings.TrimSpace(supplied)
+	if trimmed == "" {
 		return errJoinPasscodeRequired
 	}
-	if !constantTimeCompare(supplied, expected) {
+	if !constantTimeCompare(trimmed, expected) {
 		return errJoinPasscodeInvalid
 	}
 	return nil

--- a/cmd/wuphf/tunnel_passcode_test.go
+++ b/cmd/wuphf/tunnel_passcode_test.go
@@ -52,3 +52,21 @@ func TestTunnelJoinGateLengthMismatchIsRejection(t *testing.T) {
 		t.Fatalf("joinGate len-mismatch err=%v want errJoinPasscodeInvalid", err)
 	}
 }
+
+// TestTunnelJoinGateEmptyPasscodeIsRequiredNotInvalid pins the audit-log
+// distinction the share handler relies on: an empty passcode against a
+// known token reports "required" (joiner forgot to type it), not
+// "invalid" (joiner submitted a wrong code). Both still produce the
+// same wire response — the indistinguishability invariant — but the
+// internal sentinels differ so operators can tell brute-force attempts
+// apart from a click-through-without-passcode.
+func TestTunnelJoinGateEmptyPasscodeIsRequiredNotInvalid(t *testing.T) {
+	c := newWebTunnelController()
+	c.passcodes["tok-1"] = "835291"
+	for _, supplied := range []string{"", "   "} {
+		err := c.joinGate("tok-1", supplied)
+		if !errors.Is(err, errJoinPasscodeRequired) {
+			t.Fatalf("joinGate(%q) = %v, want errJoinPasscodeRequired", supplied, err)
+		}
+	}
+}

--- a/cmd/wuphf/tunnel_passcode_test.go
+++ b/cmd/wuphf/tunnel_passcode_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestTunnelJoinGateAcceptsCorrectPasscode walks the gate path the share
+// HTTP handler runs for each invite-accept POST: a token registered by the
+// controller, with the matching passcode, must pass.
+func TestTunnelJoinGateAcceptsCorrectPasscode(t *testing.T) {
+	c := newWebTunnelController()
+	c.passcodes["tok-1"] = "835291"
+	if err := c.joinGate("tok-1", "835291"); err != nil {
+		t.Fatalf("joinGate rejected matching passcode: %v", err)
+	}
+}
+
+func TestTunnelJoinGateRejectsWrongPasscode(t *testing.T) {
+	c := newWebTunnelController()
+	c.passcodes["tok-1"] = "835291"
+	err := c.joinGate("tok-1", "111111")
+	if !errors.Is(err, errJoinPasscodeInvalid) {
+		t.Fatalf("joinGate err=%v want errJoinPasscodeInvalid", err)
+	}
+}
+
+// TestTunnelJoinGateRejectsUnknownToken makes sure an attacker cannot ride
+// the tunnel with a token that was minted via a different surface (e.g. a
+// network-share token leaked separately) — only tokens that this tunnel
+// itself issued are redeemable through it.
+func TestTunnelJoinGateRejectsUnknownToken(t *testing.T) {
+	c := newWebTunnelController()
+	c.passcodes["tok-1"] = "835291"
+	err := c.joinGate("tok-other", "835291")
+	if !errors.Is(err, errJoinPasscodeRequired) {
+		t.Fatalf("joinGate err=%v want errJoinPasscodeRequired (unknown token)", err)
+	}
+}
+
+// TestTunnelJoinGateUsesConstantTimeCompare guards against a regression
+// from constantTimeCompare to a bare == — the latter shortcuts on the
+// first differing byte and lets a network attacker time-side-channel the
+// passcode. We can't directly observe timing here; instead, verify the
+// helper that enforces it is wired in by exercising a length-mismatch
+// pair, which == would early-return on but constantTimeCompare runs to
+// completion and returns false.
+func TestTunnelJoinGateLengthMismatchIsRejection(t *testing.T) {
+	c := newWebTunnelController()
+	c.passcodes["tok-1"] = "835291"
+	if err := c.joinGate("tok-1", "8352"); !errors.Is(err, errJoinPasscodeInvalid) {
+		t.Fatalf("joinGate len-mismatch err=%v want errJoinPasscodeInvalid", err)
+	}
+}

--- a/internal/team/broker_web_tunnel.go
+++ b/internal/team/broker_web_tunnel.go
@@ -21,6 +21,12 @@ type WebTunnelStatus struct {
 	// InviteURL is PublicURL + "/join/<token>". Empty until both the
 	// tunnel and a fresh invite token are ready.
 	InviteURL string `json:"invite_url,omitempty"`
+	// Passcode is the second-factor numeric string the joiner must enter
+	// before the broker accepts their invite. Phase 2 hardening: the
+	// invite URL alone (e.g. accidentally pasted into a public Slack) is
+	// no longer sufficient to redeem the invite. Empty in network-share
+	// mode.
+	Passcode  string `json:"passcode,omitempty"`
 	ExpiresAt string `json:"expires_at,omitempty"`
 	Error     string `json:"error,omitempty"`
 	// CloudflaredMissing flips on when the tunnel binary is not on PATH so

--- a/web/src/api/joinInvite.ts
+++ b/web/src/api/joinInvite.ts
@@ -8,6 +8,15 @@ export type JoinInviteErrorCode =
   | "broker_unreachable"
   | "broker_failed"
   | "invalid_request"
+  // Phase 2 hardening: tunnel-mode invites require a second-factor passcode
+  // the host reads out-of-band. The server returns this code on both
+  // missing and wrong passcodes (deliberately indistinguishable on the
+  // wire — see cmd/wuphf/share_join_guard.go).
+  | "passcode_required"
+  // Phase 2 hardening: the share server clamps brute-force attempts at the
+  // unauthenticated /join POST. The JoinPage renders this distinctly so the
+  // joiner knows to wait, not retry immediately.
+  | "rate_limited"
   | "network"
   | "unknown";
 
@@ -19,6 +28,8 @@ const SERVER_ERROR_CODES: ReadonlySet<JoinInviteErrorCode> = new Set([
   "broker_unreachable",
   "broker_failed",
   "invalid_request",
+  "passcode_required",
+  "rate_limited",
 ]);
 
 export interface JoinInviteSuccess {
@@ -38,20 +49,33 @@ export type JoinInviteResult = JoinInviteSuccess | JoinInviteFailure;
 interface SubmitOptions {
   token: string;
   displayName: string;
+  // Optional second-factor passcode for tunnel-mode invites. Empty/undefined
+  // for network-share invites and on the first submit when the joiner has
+  // not yet been told a passcode is required — the server will respond with
+  // `passcode_required` and the JoinPage will surface a passcode field.
+  passcode?: string;
   signal?: AbortSignal;
 }
 
 export async function submitJoinInvite({
   token,
   displayName,
+  passcode,
   signal,
 }: SubmitOptions): Promise<JoinInviteResult> {
+  // Trim any whitespace pasted in by the joiner so a stray space at the end
+  // of the digits does not collide with the constant-time compare on the
+  // server side.
+  const trimmedPasscode =
+    typeof passcode === "string" ? passcode.trim() : undefined;
+  const body: Record<string, string> = { display_name: displayName };
+  if (trimmedPasscode) body.passcode = trimmedPasscode;
   let response: Response;
   try {
     response = await fetch(`/join/${encodeURIComponent(token)}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ display_name: displayName }),
+      body: JSON.stringify(body),
       credentials: "same-origin",
       signal,
     });

--- a/web/src/api/platform.ts
+++ b/web/src/api/platform.ts
@@ -130,6 +130,11 @@ export interface WebTunnelStatus {
   running: boolean;
   public_url?: string;
   invite_url?: string;
+  // Phase 2 hardening: numeric passcode the host reads to the joiner
+  // out-of-band. Empty when the tunnel is not running. Required by the
+  // share handler's joinGate before the broker is asked to admit the
+  // invite — see cmd/wuphf/share_join_guard.go.
+  passcode?: string;
   expires_at?: string;
   error?: string;
   cloudflared_missing?: boolean;

--- a/web/src/components/apps/HealthCheckApp.tsx
+++ b/web/src/components/apps/HealthCheckApp.tsx
@@ -519,6 +519,34 @@ function HostTunnelControls({
           </button>
         </div>
       ) : null}
+      {tunnelRunning && tunnelStatus?.passcode ? (
+        <div
+          style={{
+            marginTop: 8,
+            padding: "8px 10px",
+            borderRadius: 8,
+            background: "var(--bg-warm)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          <div
+            className="app-card-meta"
+            style={{ marginBottom: 4, fontWeight: 600 }}
+          >
+            Passcode (read it out separately)
+          </div>
+          <code
+            style={{
+              fontSize: 18,
+              letterSpacing: 4,
+              fontWeight: 700,
+              color: "var(--text)",
+            }}
+          >
+            {tunnelStatus.passcode}
+          </code>
+        </div>
+      ) : null}
       {tunnelRunning && tunnelStatus?.public_url ? (
         <div className="app-card-meta" style={{ marginTop: 8 }}>
           Tunnel: {tunnelStatus.public_url}
@@ -839,16 +867,17 @@ function useTunnelControls(isHost: boolean) {
       details: (
         <ul>
           <li>
-            <strong>Anyone with the link can attempt to join</strong> until you
-            stop the tunnel — treat the URL like a password.
+            <strong>The link AND a 6-digit passcode</strong> are both required
+            to join — a leaked URL alone cannot redeem the invite.
           </li>
           <li>
-            Send the invite link only through a private channel. Don't post it
-            in shared Slack/Discord rooms or anywhere it could be indexed.
+            Send the URL and the passcode through{" "}
+            <strong>different channels</strong> (e.g. URL via Slack, passcode
+            read aloud). Don't paste both into the same shared room.
           </li>
           <li>
-            The invite token is one-use and expires in 24 hours, but the tunnel
-            itself stays open until you click <em>Stop tunnel</em>.
+            The invite is one-use and expires in 24 hours. The tunnel stays open
+            until you click <em>Stop tunnel</em>.
           </li>
           <li>
             Cloudflare terminates TLS at the edge; traffic between Cloudflare

--- a/web/src/components/join/JoinPage.test.tsx
+++ b/web/src/components/join/JoinPage.test.tsx
@@ -56,8 +56,89 @@ describe("JoinPage", () => {
     expect(submitJoinInviteMock).toHaveBeenCalledWith({
       token: "invite-1",
       displayName: "Maya",
+      passcode: undefined,
     });
     expect(onAccepted).toHaveBeenCalledWith("/#/channels/general");
+  });
+
+  // Phase 2: tunnel-mode invites need a 6-digit passcode the host reads
+  // out-of-band. The first submit goes without one, the server says
+  // passcode_required, the form reveals the passcode field, the joiner
+  // types the code, the second submit goes through.
+  it("reveals the passcode field on passcode_required and resubmits with it", async () => {
+    const user = userEvent.setup();
+    submitJoinInviteMock
+      .mockResolvedValueOnce({
+        ok: false,
+        code: "passcode_required",
+        message: "This invite needs a passcode.",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        redirect: "/#/channels/general",
+        display_name: "Maya",
+      });
+    const onAccepted = vi.fn();
+    render(<JoinPage token="invite-1" onAccepted={onAccepted} />);
+
+    // No passcode field on first render.
+    expect(screen.queryByLabelText(/passcode/i)).toBeNull();
+
+    await user.type(screen.getByLabelText(/display name/i), "Maya");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    // First submit went without a passcode.
+    expect(submitJoinInviteMock).toHaveBeenNthCalledWith(1, {
+      token: "invite-1",
+      displayName: "Maya",
+      passcode: undefined,
+    });
+
+    // Field appears, alert renders, submit button re-enables.
+    const passcodeInput = await screen.findByLabelText(/passcode/i);
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("This invite needs a passcode.");
+    expect(alert).toHaveAttribute("data-error-code", "passcode_required");
+
+    await user.type(passcodeInput, "835291");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    expect(submitJoinInviteMock).toHaveBeenNthCalledWith(2, {
+      token: "invite-1",
+      displayName: "Maya",
+      passcode: "835291",
+    });
+    expect(onAccepted).toHaveBeenCalledWith("/#/channels/general");
+  });
+
+  it("strips non-digit characters typed into the passcode field", async () => {
+    const user = userEvent.setup();
+    submitJoinInviteMock
+      .mockResolvedValueOnce({
+        ok: false,
+        code: "passcode_required",
+        message: "passcode needed",
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        redirect: "/#/channels/general",
+        display_name: "Maya",
+      });
+    render(<JoinPage token="invite-1" onAccepted={vi.fn()} />);
+
+    await user.type(screen.getByLabelText(/display name/i), "Maya");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    const passcodeInput = await screen.findByLabelText(/passcode/i);
+    // Pasted with whitespace + dashes — the input should normalise to digits.
+    await user.type(passcodeInput, "835-291");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    expect(submitJoinInviteMock).toHaveBeenNthCalledWith(2, {
+      token: "invite-1",
+      displayName: "Maya",
+      passcode: "835291",
+    });
   });
 
   it("renders the server error message when the invite is no longer valid", async () => {

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -13,7 +13,40 @@ import {
 } from "../../api/joinInvite";
 import "./join.css";
 
-type ErrorCode = JoinInviteErrorCode | "name_required";
+type ErrorCode = JoinInviteErrorCode | "name_required" | "passcode_missing";
+
+// callSubmitJoinInvite wraps the never-rejecting submitJoinInvite so the
+// (defensive) try/catch lives outside JoinPage.handleSubmit and the latter
+// stays under biome's per-function complexity ceiling. Returns null when
+// the catch ran — the caller has already stamped the status.
+async function callSubmitJoinInvite(
+  token: string,
+  displayName: string,
+  passcode: string,
+  setStatus: (status: {
+    kind: "error";
+    code: ErrorCode;
+    message: string;
+  }) => void,
+): Promise<Awaited<ReturnType<typeof submitJoinInvite>> | null> {
+  try {
+    return await submitJoinInvite({
+      token,
+      displayName,
+      passcode: passcode || undefined,
+    });
+  } catch (err) {
+    // submitJoinInvite is contractually never-rejecting, so reaching this
+    // branch means a programmer error or a future refactor regression.
+    // Treat it as a generic network failure so the joiner can retry.
+    const message =
+      err instanceof Error && err.message
+        ? `Could not reach WUPHF: ${err.message}`
+        : "Something went wrong submitting the invite. Try again.";
+    setStatus({ kind: "error", code: "network", message });
+    return null;
+  }
+}
 
 interface JoinPageProps {
   token: string;
@@ -28,14 +61,29 @@ type Status =
 
 export function JoinPage({ token, onAccepted }: JoinPageProps) {
   const nameId = useId();
+  const passcodeId = useId();
   const errorId = useId();
   const inputRef = useRef<HTMLInputElement>(null);
+  const passcodeInputRef = useRef<HTMLInputElement>(null);
   const [displayName, setDisplayName] = useState("");
+  const [passcode, setPasscode] = useState("");
+  // passcodeRequired flips on the first time the server returns
+  // passcode_required and stays on for the rest of the session — the host
+  // doesn't switch a tunnel from "passcode-needed" to "no passcode" without
+  // a tunnel restart, and re-hiding the field would lose what the joiner
+  // already typed.
+  const [passcodeRequired, setPasscodeRequired] = useState(false);
   const [status, setStatus] = useState<Status>({ kind: "idle" });
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (passcodeRequired) {
+      passcodeInputRef.current?.focus();
+    }
+  }, [passcodeRequired]);
 
   const trimmedToken = token.trim();
   if (!trimmedToken) {
@@ -54,9 +102,9 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
   const errorMessage = status.kind === "error" ? status.message : null;
   const errorCode = status.kind === "error" ? status.code : null;
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (submitting) return;
+  function validateLocally():
+    | { ok: true; trimmed: string; trimmedPasscode: string }
+    | { ok: false } {
     const trimmed = displayName.trim();
     if (!trimmed) {
       setStatus({
@@ -64,26 +112,33 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
         code: "name_required",
         message: "Add a display name so the team knows who is joining.",
       });
-      return;
+      return { ok: false };
     }
-    setStatus({ kind: "submitting" });
-    let result: Awaited<ReturnType<typeof submitJoinInvite>>;
-    try {
-      result = await submitJoinInvite({
-        token: trimmedToken,
-        displayName: trimmed,
+    const trimmedPasscode = passcode.trim();
+    if (passcodeRequired && !trimmedPasscode) {
+      setStatus({
+        kind: "error",
+        code: "passcode_missing",
+        message: "Enter the passcode your host gave you.",
       });
-    } catch (err) {
-      // submitJoinInvite is contractually never-rejecting, so reaching this
-      // branch means a programmer error or a future refactor regression.
-      // Treat it as a generic network failure so the joiner can retry.
-      const message =
-        err instanceof Error && err.message
-          ? `Could not reach WUPHF: ${err.message}`
-          : "Something went wrong submitting the invite. Try again.";
-      setStatus({ kind: "error", code: "network", message });
-      return;
+      return { ok: false };
     }
+    return { ok: true, trimmed, trimmedPasscode };
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+    const validated = validateLocally();
+    if (!validated.ok) return;
+    setStatus({ kind: "submitting" });
+    const result = await callSubmitJoinInvite(
+      trimmedToken,
+      validated.trimmed,
+      validated.trimmedPasscode,
+      setStatus,
+    );
+    if (!result) return;
     if (result.ok) {
       if (onAccepted) {
         onAccepted(result.redirect);
@@ -91,6 +146,14 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
       }
       window.location.assign(result.redirect);
       return;
+    }
+    if (result.code === "passcode_required") {
+      // Surface the passcode field on first refusal. Clear any stale
+      // passcode value so the joiner does not re-submit the same wrong
+      // digits silently — they have to re-enter, which the spec for
+      // "wrong passcode" calls for anyway.
+      setPasscodeRequired(true);
+      setPasscode("");
     }
     setStatus({ kind: "error", code: result.code, message: result.message });
   }
@@ -133,6 +196,38 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
           aria-invalid={errorCode === "name_required"}
           aria-describedby={errorMessage ? errorId : undefined}
         />
+        {passcodeRequired ? (
+          <>
+            <label htmlFor={passcodeId} className="join-label">
+              Passcode
+            </label>
+            <input
+              ref={passcodeInputRef}
+              id={passcodeId}
+              name="passcode"
+              // inputMode + numeric keyboard on phones, but type=text so
+              // password managers don't auto-fill garbage. autoComplete=off
+              // so the browser does not memo a 6-digit string as an
+              // address-book entry.
+              inputMode="numeric"
+              pattern="[0-9]*"
+              autoComplete="one-time-code"
+              placeholder="6-digit code from the host"
+              className="join-input"
+              value={passcode}
+              onChange={(event) =>
+                setPasscode(event.target.value.replace(/\D/g, ""))
+              }
+              disabled={submitting}
+              aria-invalid={
+                errorCode === "passcode_required" ||
+                errorCode === "passcode_missing"
+              }
+              aria-describedby={errorMessage ? errorId : undefined}
+              maxLength={12}
+            />
+          </>
+        ) : null}
         <button
           type="submit"
           className="join-submit"

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -221,7 +221,13 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
               className="join-input"
               value={passcode}
               onChange={(event) =>
-                setPasscode(event.target.value.replace(/\D/g, ""))
+                // Clamp to the server's 6-digit shape: strip non-digits
+                // first, then slice. A pasted longer numeric string would
+                // otherwise pad maxLength up to 6 but a chained
+                // event.target.value of "1234567890" with non-digits
+                // mixed in could exceed it on browsers that don't
+                // honor maxLength for programmatic value writes.
+                setPasscode(event.target.value.replace(/\D/g, "").slice(0, 6))
               }
               disabled={submitting}
               aria-invalid={
@@ -229,7 +235,7 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
                 errorCode === "passcode_missing"
               }
               aria-describedby={errorMessage ? errorId : undefined}
-              maxLength={12}
+              maxLength={6}
             />
           </>
         ) : null}

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -205,10 +205,15 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
               ref={passcodeInputRef}
               id={passcodeId}
               name="passcode"
-              // inputMode + numeric keyboard on phones, but type=text so
-              // password managers don't auto-fill garbage. autoComplete=off
-              // so the browser does not memo a 6-digit string as an
-              // address-book entry.
+              // inputMode=numeric brings up the digit pad on phones; we
+              // keep type=text (the default) so password managers don't
+              // try to memo it as a normal credential.
+              // autoComplete="one-time-code" is the WHATWG token for SMS
+              // OTP autofill on iOS Safari and Android Chrome — if the
+              // host reads the passcode out over the phone the joiner
+              // taps once instead of typing it. The convenience win
+              // outweighs the autofill risk because the OTP-token hint
+              // is scoped to a single submission, not stored.
               inputMode="numeric"
               pattern="[0-9]*"
               autoComplete="one-time-code"

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -147,11 +147,14 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
       window.location.assign(result.redirect);
       return;
     }
-    if (result.code === "passcode_required") {
-      // Surface the passcode field on first refusal. Clear any stale
-      // passcode value so the joiner does not re-submit the same wrong
-      // digits silently — they have to re-enter, which the spec for
-      // "wrong passcode" calls for anyway.
+    // First refusal: surface the passcode field. Clear the stored
+    // value (it was empty anyway since the field was hidden, but
+    // explicit zero-state is harmless here). On *subsequent*
+    // refusals we leave whatever the joiner typed alone — wiping it
+    // forces them to retype six digits to fix a single-digit typo,
+    // which is hostile UX and the security gate already rate-limits
+    // attempts via the share-handler token bucket.
+    if (result.code === "passcode_required" && !passcodeRequired) {
       setPasscodeRequired(true);
       setPasscode("");
     }
@@ -194,7 +197,14 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
           onChange={(event) => setDisplayName(event.target.value)}
           disabled={submitting}
           aria-invalid={errorCode === "name_required"}
-          aria-describedby={errorMessage ? errorId : undefined}
+          // Only attach aria-describedby when the error actually targets
+          // THIS field. With both name + passcode visible, a generic
+          // "errorMessage ? errorId : undefined" makes a screen reader
+          // announce passcode-targeted errors while the user is on the
+          // name field (and vice-versa).
+          aria-describedby={
+            errorMessage && errorCode === "name_required" ? errorId : undefined
+          }
         />
         {passcodeRequired ? (
           <>
@@ -234,7 +244,15 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
                 errorCode === "passcode_required" ||
                 errorCode === "passcode_missing"
               }
-              aria-describedby={errorMessage ? errorId : undefined}
+              // Same per-field rule as the name input — only describe
+              // the passcode field when the live error targets it.
+              aria-describedby={
+                errorMessage &&
+                (errorCode === "passcode_required" ||
+                  errorCode === "passcode_missing")
+                  ? errorId
+                  : undefined
+              }
               maxLength={6}
             />
           </>


### PR DESCRIPTION
Stacks on **#706 (Phase 1)**. Targets that branch so the diff here is
just the Phase 2 surface; flip the base to `main` once #706 merges.

## Why

Phase 1 made the tunnel one click and bundled cloudflared, but the
trycloudflare URL was still the only secret protecting the invite. A URL
that ends up in a public Slack channel, a wayback crawl, or an
over-the-shoulder screenshot is enough to redeem the invite within the
24h window. Phase 2 adds a second factor and a brake.

## What

### Server (`cmd/wuphf`)

- **`share_join_guard.go`** — new file with the gate primitives:
  - `generatePasscode()` mints a 6-digit numeric secret with `crypto/rand`.
  - `constantTimeCompare` wraps `subtle.ConstantTimeCompare` and equalises
    the wall-clock cost of a length-mismatch path.
  - `joinRateLimiter` — per-source-IP token bucket (5-burst, refill 1
    every 12s, lazy GC). No new dep.
  - `extractJoinSourceIP` — trusts `Cf-Connecting-Ip` ONLY when the
    immediate RemoteAddr is loopback (i.e. the tunnel-mode share server).
    On the network-share path the header is ignored so a LAN attacker
    can't spoof their own bucket key.
- **`share.go`** — `newShareHandler` now takes `shareHandlerConfig` with
  optional `JoinGate` + `RateLimiter`. `nil` = Phase 1 byte-for-byte.
  Failed gate attempts emit one audit-log line with the **truncated**
  token prefix + source IP — no full token, so logs don't become an
  oracle for stolen tokens.
- **`tunnel.go`** — `webTunnelController` owns a `passcodes` map keyed by
  minted invite token. Each `mintInviteLocked` draws a fresh passcode;
  `stop()` zeroes the whole map. `joinGate` enforces "token must be one
  this tunnel issued" — an attacker with a network-share token cannot
  ride the tunnel even if they reach it. Adds tunnel-lifecycle audit
  logs.
- **`internal/team/broker_web_tunnel.go`** — `WebTunnelStatus.Passcode`
  added (`omitempty` so network-share status responses are unchanged).

### Client (`web/src`)

- **`api/joinInvite.ts`** — `passcode` is an optional submit field; new
  closed-set error codes `passcode_required` and `rate_limited`.
- **`components/join/JoinPage.tsx`** — passcode field is hidden by default
  and surfaces on the first `passcode_required` response. Once shown it
  stays shown (reverting would lose the joiner's input). Input is
  digit-stripped + maxlength-bounded.
- **`components/apps/HealthCheckApp.tsx`** — `TunnelInviteCard` renders
  the passcode prominently next to the URL with "read it out separately"
  framing. The disclaimer modal now leads with "URL + passcode through
  **different** channels" instead of "treat the URL like a password".

## Indistinguishability invariant

`writeShareJoinError` sends the **same** "passcode required" message
regardless of whether the gate hit `errJoinPasscodeRequired` (token
unknown to this tunnel) or `errJoinPasscodeInvalid` (token known,
passcode wrong). The two sentinels are kept distinct internally so the
audit log can attribute, but the on-the-wire response is byte-identical
so a sweep across the trycloudflare URL space can't fingerprint live
tokens. There's a regression test for this in
`share_join_guard_test.go`.

## Tests

- **Go:** passcode shape + uniqueness, constant-time compare
  matches/diffs/length-mismatch, rate-limiter burst + refill,
  `Cf-Connecting-Ip` trust on loopback only, `joinGate` accept / reject /
  unknown-token / length-mismatch, indistinguishable user-message
  constant.
- **Web:** `JoinPage` reveals the passcode field on `passcode_required`
  and resubmits with it; non-digit input is stripped.

## Pending

- `/security-review` and a manual cross-check against
  https://github.com/vercel-labs/deepsec/#docs are queued — findings will
  be folded into this PR before it leaves draft.

## Test plan

- [ ] Start a public tunnel, confirm the disclaimer.
- [ ] Verify the host UI shows a 6-digit passcode next to the invite URL.
- [ ] Open the invite URL in a private window. Submit with no passcode →
      passcode field appears with the canonical message.
- [ ] Enter the wrong passcode → same message, same status code.
- [ ] Enter the right passcode → join succeeds.
- [ ] Hammer `/join/<token>` 6 times in <1 minute → 6th request returns
      429 with `Retry-After: 60`.
- [ ] Click "Create new invite" → fresh URL **and** fresh passcode.
- [ ] Click "Stop tunnel" → audit log line "tunnel: stopped" appears in
      stderr.

Out of scope: optional Cloudflare Access in front of the tunnel for
hosts who want SSO-style gating. Plumbing for that lands when we add
named-tunnel support.

https://claude.ai/code/session_01Ugb669c77JhEfCdjXMYrgG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ugb669c77JhEfCdjXMYrgG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tunnel invites now include a 6-digit passcode in tunnel controls; join flow accepts and submits passcodes.
  * Client API surfaces new server error codes: passcode_required and rate_limited.

* **Bug Fixes**
  * Missing vs invalid passcode responses are indistinguishable to avoid leaking token state.
  * Join attempts exceeding limits return 429 with retry guidance.

* **Tests**
  * Expanded coverage for passcodes, rate limiting, IP-source extraction, and end-to-end join flows.

* **Documentation**
  * Tunnel start modal instructs sending link and passcode via separate channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->