### PR TITLE
feat(web): normalize spacing focus rings and layout stability (phase 5 pr 7)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -45,7 +45,7 @@
     // 10s Boot-timeout watchdog, or users lose the actionable signal. Any
     // fatal also flips bootDone so the watchdog is a no-op once a diagnostic
     // has already surfaced.
-    (function() {
+    (() => {
       var BOOT_TIMEOUT_MS = 10000;
       var bootDone = false;
 
@@ -71,7 +71,7 @@
         bootDone = true;
       }
 
-      window.addEventListener('error', function(e) {
+      window.addEventListener('error', (e) => {
         showFatal(
           'Uncaught error: ' + (e.message || 'unknown'),
           (e.filename ? e.filename + ':' + e.lineno + ':' + e.colno + '\n' : '') +
@@ -79,7 +79,7 @@
         );
       });
 
-      window.addEventListener('unhandledrejection', function(e) {
+      window.addEventListener('unhandledrejection', (e) => {
         var reason = e.reason;
         var detail = '';
         if (reason) {
@@ -90,7 +90,7 @@
         showFatal('Unhandled promise rejection', detail);
       });
 
-      window.__wuphfBootDone = function() { bootDone = true; };
+      window.__wuphfBootDone = () => { bootDone = true; };
 
       // Collect diagnostics from what we can see at watchdog fire time — the
       // specific error is gone by now (nothing caught it) so give the user
@@ -128,7 +128,7 @@
       }
 
       // If app hasn't rendered anything after 10s, show a timeout error
-      setTimeout(function() {
+      setTimeout(() => {
         if (bootDone) return;
         // Another handler already surfaced a specific error — don't replace it.
         if (document.getElementById('fatal-error')) return;

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
-}
+};

--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -5,43 +5,43 @@
    This file only overrides the semantic token layer.
    ═══════════════════════════════════════════════════════════════ */
 
-@import url('./nex.css');
+@import url("./nex.css");
 
 html[data-theme="nex-dark"] {
   /* ── Ramp overrides (reuse same palette, just reference different stops) ── */
 
   /* ── Overlays flipped for dark surface ── */
-  --overlay-soft:         rgba(255, 255, 255, 0.04);
-  --overlay:              rgba(255, 255, 255, 0.08);
-  --overlay-strong:       rgba(255, 255, 255, 0.16);
-  --scrim:                rgba(0, 0, 0, 0.7);
-  --overlay-white-soft:   rgba(255, 255, 255, 0.06);
-  --overlay-white:        rgba(255, 255, 255, 0.12);
+  --overlay-soft: rgba(255, 255, 255, 0.04);
+  --overlay: rgba(255, 255, 255, 0.08);
+  --overlay-strong: rgba(255, 255, 255, 0.16);
+  --scrim: rgba(0, 0, 0, 0.7);
+  --overlay-white-soft: rgba(255, 255, 255, 0.06);
+  --overlay-white: rgba(255, 255, 255, 0.12);
   --overlay-white-strong: rgba(255, 255, 255, 0.32);
 
   /* ── Semantic aliases ── */
-  --bg:             #111213;
-  --bg-warm:        #191a1b;
-  --bg-subtle:      #0d0e0f;
-  --bg-card:        #151617;
-  --text:           #e9eaeb;
+  --bg: #111213;
+  --bg-warm: #191a1b;
+  --bg-subtle: #0d0e0f;
+  --bg-card: #151617;
+  --text: #e9eaeb;
   --text-secondary: #aeb1b2;
-  --text-tertiary:  #686c6e;
-  --text-disabled:  #434647;
+  --text-tertiary: #686c6e;
+  --text-disabled: #434647;
 
   /* accent stays the same purple/tertiary */
 
-  --border:         #1e2022;
-  --border-light:   #171819;
-  --border-dark:    #2a2d2f;
-  --border-strong:  #434647;
+  --border: #1e2022;
+  --border-light: #171819;
+  --border-dark: #2a2d2f;
+  --border-strong: #434647;
 
   /* ── Sidebar – keep purple but use a deeper shade ── */
-  --nex-sidebar:             #4a1f70;
-  --nex-sidebar-hover:       rgba(255, 255, 255, 0.08);
-  --nex-sidebar-active:      var(--olive-400);
-  --nex-sidebar-text:        rgba(255, 255, 255, 0.65);
-  --nex-sidebar-text-active: #FFFFFF;
+  --nex-sidebar: #4a1f70;
+  --nex-sidebar-hover: rgba(255, 255, 255, 0.08);
+  --nex-sidebar-active: var(--olive-400);
+  --nex-sidebar-text: rgba(255, 255, 255, 0.65);
+  --nex-sidebar-text-active: #ffffff;
 }
 
 /* ── Override hard-coded message text color (not a CSS variable in nex.css) ── */

--- a/web/public/themes/noir-gold.css
+++ b/web/public/themes/noir-gold.css
@@ -17,8 +17,8 @@ html[data-theme="noir-gold"] {
   --neutral-300: #5a5d62;
   --neutral-200: #8a8d92;
   --neutral-100: #b39e6b;
-  --neutral-50:  #d9c897;
-  --neutral-10:  #f5e9c8;
+  --neutral-50: #d9c897;
+  --neutral-10: #f5e9c8;
 
   /* ── Gold ramp (oxidized → patina → polished → champagne) ── */
   --gold-950: #1a1206;
@@ -31,7 +31,7 @@ html[data-theme="noir-gold"] {
   --gold-300: #d9b84a;
   --gold-200: #f0c75e;
   --gold-100: #fce8a8;
-  --gold-50:  #fff5d4;
+  --gold-50: #fff5d4;
 
   /* ── Accent stand-ins so any code referencing tertiary/cyan/olive still works ── */
   --tertiary-500: var(--gold-700);
@@ -72,60 +72,62 @@ html[data-theme="noir-gold"] {
   --warning-100: #1f160a;
 
   /* ── Overlays ── */
-  --overlay-soft:         rgba(255, 232, 168, 0.04);
-  --overlay:              rgba(255, 232, 168, 0.08);
-  --overlay-strong:       rgba(255, 232, 168, 0.16);
-  --scrim:                rgba(0, 0, 0, 0.72);
-  --overlay-white-soft:   rgba(245, 233, 200, 0.06);
-  --overlay-white:        rgba(245, 233, 200, 0.12);
+  --overlay-soft: rgba(255, 232, 168, 0.04);
+  --overlay: rgba(255, 232, 168, 0.08);
+  --overlay-strong: rgba(255, 232, 168, 0.16);
+  --scrim: rgba(0, 0, 0, 0.72);
+  --overlay-white-soft: rgba(245, 233, 200, 0.06);
+  --overlay-white: rgba(245, 233, 200, 0.12);
   --overlay-white-strong: rgba(245, 233, 200, 0.32);
 
   /* ── Semantic aliases ── */
-  --bg:             #0a0a0b;
-  --bg-warm:        #111113;
-  --bg-subtle:      #060606;
-  --bg-card:        #111113;
-  --text:           #f5e9c8;
+  --bg: #0a0a0b;
+  --bg-warm: #111113;
+  --bg-subtle: #060606;
+  --bg-card: #111113;
+  --text: #f5e9c8;
   --text-secondary: #b39e6b;
-  --text-tertiary:  #7a6a45;
-  --text-disabled:  #4a4234;
+  --text-tertiary: #7a6a45;
+  --text-disabled: #4a4234;
 
-  --accent:      var(--gold-400);
+  --accent: var(--gold-400);
   --accent-warm: var(--gold-500);
-  --accent-bg:        rgba(201, 162, 39, 0.10);
-  --accent-bg-strong: rgba(201, 162, 39, 0.30);
+  --accent-bg: rgba(201, 162, 39, 0.1);
+  --accent-bg-strong: rgba(201, 162, 39, 0.3);
 
-  --border:        #1a1a1c;
-  --border-light:  #141416;
-  --border-dark:   #2a261d;
+  --border: #1a1a1c;
+  --border-light: #141416;
+  --border-dark: #2a261d;
   --border-strong: #3c3528;
 
-  --green:      var(--success-400);
+  --green: var(--success-400);
   --green-dark: var(--success-500);
-  --green-bg:   var(--success-100);
-  --red:        var(--error-400);
-  --red-dark:   var(--error-500);
-  --red-bg:     var(--error-100);
-  --yellow:     var(--warning-400);
-  --yellow-dark:var(--warning-500);
-  --yellow-bg:  var(--warning-100);
-  --blue:       var(--gold-400);
-  --blue-bg:    var(--accent-bg);
+  --green-bg: var(--success-100);
+  --red: var(--error-400);
+  --red-dark: var(--error-500);
+  --red-bg: var(--error-100);
+  --yellow: var(--warning-400);
+  --yellow-dark: var(--warning-500);
+  --yellow-bg: var(--warning-100);
+  --blue: var(--gold-400);
+  --blue-bg: var(--accent-bg);
 
-  --font-sans: "Source Serif 4", "IBM Plex Serif", Georgia, "Times New Roman", serif;
+  --font-sans:
+    "Source Serif 4", "IBM Plex Serif", Georgia, "Times New Roman", serif;
   --font-serif: "Fraunces", Georgia, "Times New Roman", serif;
   --font-logo: "Fraunces", Georgia, "Times New Roman", serif;
-  --font-mono: "Geist Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
+  --font-mono:
+    "Geist Mono", "SFMono-Regular", Menlo, Monaco, Consolas, monospace;
 
   /* ── Sidebar tokens (no purple anywhere) ── */
-  --nex-sidebar:             #0a0a0b;
-  --nex-sidebar-hover:       rgba(201, 162, 39, 0.12);
-  --nex-sidebar-active:      var(--gold-400);
-  --nex-sidebar-text:        rgba(245, 233, 200, 0.78);
+  --nex-sidebar: #0a0a0b;
+  --nex-sidebar-hover: rgba(201, 162, 39, 0.12);
+  --nex-sidebar-active: var(--gold-400);
+  --nex-sidebar-text: rgba(245, 233, 200, 0.78);
   --nex-sidebar-text-active: var(--gold-200);
 
   /* purple aliases redirected to gold so any stale rule is harmless */
-  --purple:    var(--gold-400);
+  --purple: var(--gold-400);
   --purple-bg: var(--accent-bg);
 
   --radius-sm: 8px;
@@ -257,8 +259,12 @@ html[data-theme="noir-gold"] .composer-inner {
   background: var(--bg-warm);
   border-color: var(--border-dark);
 }
-html[data-theme="noir-gold"] .message-text { color: var(--text); }
-html[data-theme="noir-gold"] .message:hover { background: var(--bg-warm); }
+html[data-theme="noir-gold"] .message-text {
+  color: var(--text);
+}
+html[data-theme="noir-gold"] .message:hover {
+  background: var(--bg-warm);
+}
 
 /* ─── Buttons ─── */
 html[data-theme="noir-gold"] .btn-primary,
@@ -308,11 +314,19 @@ html[data-theme="noir-gold"] .sidebar .sidebar-collapsible + .sidebar-section {
 }
 
 /* Gold gradient hairline that runs the width of the divider */
-html[data-theme="noir-gold"] .sidebar .sidebar-section + .sidebar-section::after,
+html[data-theme="noir-gold"] .sidebar
+  .sidebar-section
+  + .sidebar-section::after,
 html[data-theme="noir-gold"] .sidebar .sidebar-agents + .sidebar-section::after,
-html[data-theme="noir-gold"] .sidebar .sidebar-channels + .sidebar-section::after,
+html[data-theme="noir-gold"]
+  .sidebar
+  .sidebar-channels
+  + .sidebar-section::after,
 html[data-theme="noir-gold"] .sidebar .sidebar-apps + .sidebar-section::after,
-html[data-theme="noir-gold"] .sidebar .sidebar-collapsible + .sidebar-section::after {
+html[data-theme="noir-gold"]
+  .sidebar
+  .sidebar-collapsible
+  + .sidebar-section::after {
   content: "";
   position: absolute;
   top: 7px;
@@ -332,11 +346,22 @@ html[data-theme="noir-gold"] .sidebar .sidebar-collapsible + .sidebar-section::a
 }
 
 /* Centered diamond ornament — sits ON the hairline */
-html[data-theme="noir-gold"] .sidebar .sidebar-section + .sidebar-section::before,
-html[data-theme="noir-gold"] .sidebar .sidebar-agents + .sidebar-section::before,
-html[data-theme="noir-gold"] .sidebar .sidebar-channels + .sidebar-section::before,
+html[data-theme="noir-gold"] .sidebar
+  .sidebar-section
+  + .sidebar-section::before,
+html[data-theme="noir-gold"]
+  .sidebar
+  .sidebar-agents
+  + .sidebar-section::before,
+html[data-theme="noir-gold"]
+  .sidebar
+  .sidebar-channels
+  + .sidebar-section::before,
 html[data-theme="noir-gold"] .sidebar .sidebar-apps + .sidebar-section::before,
-html[data-theme="noir-gold"] .sidebar .sidebar-collapsible + .sidebar-section::before {
+html[data-theme="noir-gold"]
+  .sidebar
+  .sidebar-collapsible
+  + .sidebar-section::before {
   content: "◆";
   position: absolute;
   top: -1px;
@@ -399,7 +424,9 @@ html[data-theme="noir-gold"] .sidebar .sidebar-section-toggle:hover::before {
 }
 
 /* Collapsed section: dim the blade slightly so it reads "closed" */
-html[data-theme="noir-gold"] .sidebar .sidebar-section.is-collapsed .sidebar-section-toggle::before {
+html[data-theme="noir-gold"] .sidebar
+  .sidebar-section.is-collapsed
+  .sidebar-section-toggle::before {
   background: linear-gradient(
     to bottom,
     var(--gold-600) 0%,
@@ -426,22 +453,22 @@ html[data-theme="noir-gold"] .sidebar .sidebar-section-toggle:hover svg {
    same tokens and pick up the change automatically. */
 
 html[data-theme="noir-gold"] .notebook-surface {
-  --nb-paper:          #1a160e;
-  --nb-paper-dark:     #14110a;
-  --nb-rule:           rgba(201, 162, 39, 0.07);
-  --nb-surface:        #18140d;
-  --nb-text:           #e8d9a8;
-  --nb-text-muted:     #b39e6b;
-  --nb-text-tertiary:  #7a6a45;
-  --nb-border:         #2a261d;
-  --nb-border-light:   #1f1c14;
-  --nb-ink-blue:       #88a4c2;
-  --nb-stamp-red:      #d6443c;
-  --nb-amber:          var(--gold-400);
-  --nb-amber-bg:       rgba(201, 162, 39, 0.10);
-  --nb-amber-hover:    var(--gold-300);
-  --nb-green-approve:  var(--green);
-  --nb-green-bg:       rgba(47, 170, 100, 0.10);
+  --nb-paper: #1a160e;
+  --nb-paper-dark: #14110a;
+  --nb-rule: rgba(201, 162, 39, 0.07);
+  --nb-surface: #18140d;
+  --nb-text: #e8d9a8;
+  --nb-text-muted: #b39e6b;
+  --nb-text-tertiary: #7a6a45;
+  --nb-border: #2a261d;
+  --nb-border-light: #1f1c14;
+  --nb-ink-blue: #88a4c2;
+  --nb-stamp-red: #d6443c;
+  --nb-amber: var(--gold-400);
+  --nb-amber-bg: rgba(201, 162, 39, 0.1);
+  --nb-amber-hover: var(--gold-300);
+  --nb-green-approve: var(--green);
+  --nb-green-bg: rgba(47, 170, 100, 0.1);
 }
 
 /* The literal rgba(42, 39, 33, X) calls in notebook.css are the dark
@@ -452,10 +479,14 @@ html[data-theme="noir-gold"] .notebook-surface .nb-shelf-item:hover {
   background: rgba(232, 217, 168, 0.06);
 }
 html[data-theme="noir-gold"] .notebook-surface .nb-shelf-item.is-current {
-  background: rgba(232, 217, 168, 0.10);
+  background: rgba(232, 217, 168, 0.1);
 }
 html[data-theme="noir-gold"] .notebook-surface .nb-shelf-item .nb-shelf-meta,
-html[data-theme="noir-gold"] .notebook-surface .nb-shelf-card .nb-shelf-card-meta > span:not([class]) {
+html[data-theme="noir-gold"]
+  .notebook-surface
+  .nb-shelf-card
+  .nb-shelf-card-meta
+  > span:not([class]) {
   color: var(--nb-text-tertiary);
 }
 html[data-theme="noir-gold"] .notebook-surface .nb-tag,
@@ -472,7 +503,7 @@ html[data-theme="noir-gold"] .notebook-surface .nb-shelf-card {
 html[data-theme="noir-gold"] .notebook-surface .nb-shelf-card:hover {
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.55),
-    0 2px 4px rgba(201, 162, 39, 0.10);
+    0 2px 4px rgba(201, 162, 39, 0.1);
 }
 /* Sticky-note / draft stamp text colors that hardcoded gray/amber */
 html[data-theme="noir-gold"] .notebook-surface .nb-empty-hint {
@@ -493,18 +524,22 @@ html[data-theme="noir-gold"] .wk-section-new {
 
 /* Playbook synthesis status (success/error border + text) — keep semantic
    green/red but warm them so they read on dark gold parchment */
-html[data-theme="noir-gold"] .wk-playbook-synthesis[data-state='success'] .wk-playbook-synthesis__button {
+html[data-theme="noir-gold"] .wk-playbook-synthesis[data-state="success"]
+  .wk-playbook-synthesis__button {
   color: var(--green);
   border-color: var(--green);
 }
-html[data-theme="noir-gold"] .wk-playbook-synthesis[data-state='error'] .wk-playbook-synthesis__button {
+html[data-theme="noir-gold"]
+  .wk-playbook-synthesis[data-state="error"]
+  .wk-playbook-synthesis__button {
   color: var(--red);
   border-color: var(--red);
 }
 html[data-theme="noir-gold"] .wk-playbook-synthesis__pending {
   color: var(--gold-300);
 }
-html[data-theme="noir-gold"] .wk-playbook-synthesis__button:hover:not([disabled]) {
+html[data-theme="noir-gold"]
+  .wk-playbook-synthesis__button:hover:not([disabled]) {
   background: var(--overlay);
 }
 
@@ -538,7 +573,7 @@ html[data-theme="noir-gold"] .notebook-surface .nb-review-card:hover {
   box-shadow:
     0 1px 1px rgba(0, 0, 0, 0.55),
     0 3px 6px rgba(0, 0, 0, 0.45),
-    0 8px 14px rgba(201, 162, 39, 0.10);
+    0 8px 14px rgba(201, 162, 39, 0.1);
 }
 html[data-theme="noir-gold"] .notebook-surface .nb-review-card.is-active {
   outline: 2px solid var(--gold-400);
@@ -599,12 +634,12 @@ html[data-theme="noir-gold"] .wiki-tab-badge {
    #3d2e0a (deep oxidized) — too dark on dark bg. Re-route the wiki
    palette to gold tones so links and the active menu button read. */
 html[data-theme="noir-gold"] .wiki-root {
-  --wk-wikilink:        var(--gold-300);
+  --wk-wikilink: var(--gold-300);
   --wk-wikilink-broken: var(--red);
-  --wk-amber:           var(--gold-400);
-  --wk-amber-bg:        rgba(201, 162, 39, 0.10);
-  --wk-amber-banner:    rgba(201, 162, 39, 0.05);
-  --wk-code-bg:         var(--bg-warm);
+  --wk-amber: var(--gold-400);
+  --wk-amber-bg: rgba(201, 162, 39, 0.1);
+  --wk-amber-banner: rgba(201, 162, 39, 0.05);
+  --wk-code-bg: var(--bg-warm);
 }
 html[data-theme="noir-gold"] .wk-nav-sidebar h3 {
   color: var(--gold-300);
@@ -639,14 +674,14 @@ html[data-theme="noir-gold"] .wk-section-new {
    noir those wash out as bright neon dots; redirect to gold-toned
    variants tuned for the dark surface. */
 html[data-theme="noir-gold"] {
-  --graph-people-fill:       rgba(201, 162, 39, 0.14);
-  --graph-people-stroke:     var(--gold-300);
-  --graph-companies-fill:    rgba(136, 164, 194, 0.16);
-  --graph-companies-stroke:  #88a4c2;
-  --graph-customers-fill:    rgba(47, 170, 100, 0.15);
-  --graph-customers-stroke:  var(--green);
-  --graph-other-fill:        rgba(245, 233, 200, 0.06);
-  --graph-other-stroke:      var(--text-tertiary);
+  --graph-people-fill: rgba(201, 162, 39, 0.14);
+  --graph-people-stroke: var(--gold-300);
+  --graph-companies-fill: rgba(136, 164, 194, 0.16);
+  --graph-companies-stroke: #88a4c2;
+  --graph-customers-fill: rgba(47, 170, 100, 0.15);
+  --graph-customers-stroke: var(--green);
+  --graph-other-fill: rgba(245, 233, 200, 0.06);
+  --graph-other-stroke: var(--text-tertiary);
 }
 
 /* ─── Sidebar agent task / activity (the "token burn" line under each

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -624,9 +624,7 @@ function LocalLLMsSection({ cfg, save }: SectionProps) {
       </div>
 
       {isLoading ? (
-        <div style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
-          Detecting installed runtimes…
-        </div>
+        <div className="app-panel-loading">Detecting installed runtimes…</div>
       ) : null}
       {error ? (
         <div style={{ color: "var(--danger-500, #c33)", fontSize: 13 }}>

--- a/web/src/components/join/TeamMemberWelcome.tsx
+++ b/web/src/components/join/TeamMemberWelcome.tsx
@@ -55,7 +55,9 @@ export function TeamMemberWelcome() {
   // Possessive form: "Sam" → "Sam's", "Chris" → "Chris's". Names ending in
   // "s" still get an apostrophe-s — Strunk & White, and easier to read than
   // "Chris' office" which trips up scan-readers on a small card.
-  const officeLabel = hostDisplayName ? `${hostDisplayName}'s office` : "this office";
+  const officeLabel = hostDisplayName
+    ? `${hostDisplayName}'s office`
+    : "this office";
 
   return (
     <aside

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -70,13 +70,8 @@ export function MessageFeed() {
 
   if (isLoading && messages.length === 0) {
     return (
-      <div
-        className="messages"
-        style={{ alignItems: "center", justifyContent: "center" }}
-      >
-        <span style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
-          Loading messages...
-        </span>
+      <div className="messages">
+        <span className="messages-loading-label">Loading messages...</span>
       </div>
     );
   }

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -93,11 +93,19 @@
   border-radius: 6px;
   color: var(--text-secondary);
   flex-shrink: 0;
-  transition: all 0.15s;
+  /* Use specific properties instead of `all` to prevent unintended dimension
+     transitions on hover that could shift surrounding layout. */
+  transition:
+    background var(--duration-base, 0.15s),
+    color var(--duration-base, 0.15s);
 }
 .agent-panel-close:hover {
   background: var(--bg);
   color: var(--text);
+}
+.agent-panel-close:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .agent-panel-section {
@@ -392,8 +400,11 @@
   transition: border-color 0.2s;
   cursor: pointer;
 }
-.agent-wizard-field select:focus {
+.agent-wizard-field select:focus,
+.agent-wizard-field select:focus-visible {
   border-color: var(--accent);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .agent-wizard-footer {
@@ -468,6 +479,12 @@
 .agent-workbench-run-row:hover {
   border-color: var(--accent);
   background: var(--accent-bg);
+}
+.agent-workbench-task-row:focus-visible,
+.agent-workbench-run-row:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-color: var(--accent);
 }
 
 .agent-workbench-task-title {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -139,6 +139,41 @@
 
   /* Popover shadow — used by the Tier 2 hover peek card. */
   --shadow-popover: 0 8px 24px -8px rgba(0, 0, 0, 0.32);
+
+  /* ─── Focus ring ─── */
+  /* Single source-of-truth: all interactive elements use this token so
+     keyboard navigation is always visible and consistent across themes.
+     Offset keeps the ring outside the element border, not overlapping it. */
+  --focus-ring-color: var(--accent);
+  --focus-ring-offset: 2px;
+  --focus-ring-width: 2px;
+
+  /* ─── Spacing scale ─── */
+  /* Consistent spacing prevents scattered hardcoded values. */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+
+  /* ─── Typography scale ─── */
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 13px;
+  --text-md: 14px;
+  --text-lg: 15px;
+  --text-xl: 17px;
+  --text-2xl: 20px;
+
+  /* ─── Transition durations ─── */
+  --duration-fast: 0.12s;
+  --duration-base: 0.15s;
+  --duration-slow: 0.2s;
+
+  /* ─── Empty / loading state ─── */
+  --empty-state-color: var(--text-tertiary);
+  --empty-state-size: 13px;
 }
 
 html {
@@ -149,6 +184,34 @@ body {
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
+}
+
+/* ─── Global focus-visible baseline ─── */
+/* Keyboard-only focus ring that doesn't fire on mouse clicks.
+   All focusable elements get a consistent ring; component stylesheets may
+   narrow the offset for elements that need inside-border positioning. */
+:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
+/* Suppress the native ring for elements whose :hover state already provides
+   a strong enough signal (e.g. icon buttons that show a filled background).
+   Each of those components adds its own :focus-visible override below. */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* ─── Empty / loading state utilities ─── */
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--empty-state-color);
+  font-size: var(--empty-state-size);
+}
+.empty-state--padded {
+  padding: 32px 20px;
 }
 
 /* ─── Animations ─── */
@@ -200,12 +263,23 @@ body {
   font-weight: 500;
   border: none;
   cursor: pointer;
-  transition: all 0.2s;
+  /* Scope to compositor-safe properties — `transform` for the lift and
+     `background/color/filter` for state; avoids layout recalcs on hover. */
+  transition:
+    background var(--duration-slow, 0.2s),
+    color var(--duration-slow, 0.2s),
+    filter var(--duration-slow, 0.2s),
+    transform var(--duration-slow, 0.2s),
+    box-shadow var(--duration-slow, 0.2s);
   text-decoration: none;
   min-height: 44px;
 }
 .btn:not(.btn-sm):not(:disabled):hover {
   transform: translateY(-1px);
+}
+.btn:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .btn:disabled {
   opacity: 0.4;
@@ -267,6 +341,10 @@ body {
 .btn-text:hover:not(:disabled) {
   text-decoration: underline;
   color: var(--text);
+}
+.btn-text:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .btn-text:disabled {
   opacity: 0.5;

--- a/web/src/styles/kbd.css
+++ b/web/src/styles/kbd.css
@@ -152,11 +152,15 @@
     background 0.15s,
     color 0.15s;
 }
-.status-bar-shortcut:hover,
+.status-bar-shortcut:hover {
+  color: var(--text);
+  background: var(--accent-bg, rgba(0, 0, 0, 0.04));
+}
 .status-bar-shortcut:focus-visible {
   color: var(--text);
   background: var(--accent-bg, rgba(0, 0, 0, 0.04));
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .status-bar-shortcut .kbd {
   padding: 1px 5px;

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -267,6 +267,11 @@ html[data-theme] body .sidebar-rail-popover .sidebar-agent-name {
   background: var(--overlay-soft);
   color: var(--text);
 }
+.sidebar.sidebar-collapsed .sidebar-icon-btn:focus-visible,
+.sidebar.sidebar-collapsed .sidebar-rail-bottom:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
 .sidebar.sidebar-collapsed .sidebar-icon-btn.active,
 .sidebar.sidebar-collapsed .sidebar-icon-btn.active:hover,
 .sidebar.sidebar-collapsed .sidebar-rail-bottom.active,
@@ -336,12 +341,18 @@ html[data-theme="nex"]
   justify-content: center;
   border-radius: 6px;
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    color var(--duration-base, 0.15s);
   flex-shrink: 0;
 }
 .sidebar-icon-btn:hover {
   background: rgba(0, 0, 0, 0.04);
   color: var(--text);
+}
+.sidebar-icon-btn:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .sidebar-icon-btn.active {
   background: var(--accent-bg);
@@ -380,11 +391,17 @@ html[data-theme="nex"]
   justify-content: center;
   border-radius: 6px;
   color: var(--text-secondary);
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    color var(--duration-base, 0.15s);
 }
 .sidebar-btn:hover {
   background: var(--bg);
   color: var(--text);
+}
+.sidebar-btn:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .sidebar-section {
@@ -426,6 +443,11 @@ html[data-theme="nex"]
 .sidebar-section-toggle:hover {
   color: var(--text);
 }
+.sidebar-section-toggle:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: 4px;
+}
 
 .sidebar-item {
   display: flex;
@@ -438,7 +460,11 @@ html[data-theme="nex"]
   border: none;
   background: transparent;
   cursor: pointer;
-  transition: all 0.15s;
+  /* Scope transitions to compositor-safe properties only — avoids layout
+     recalculations on hover that can shift adjacent content. */
+  transition:
+    background var(--duration-base, 0.15s),
+    color var(--duration-base, 0.15s);
   color: var(--text-secondary);
   font-family: var(--font-sans);
   text-align: left;
@@ -498,6 +524,12 @@ html[data-theme="nex"]
   border-radius: 9px;
 }
 .sidebar-item:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+.sidebar-item:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
   background: rgba(0, 0, 0, 0.04);
   color: var(--text);
 }
@@ -586,7 +618,9 @@ html[data-theme="nex"]
   border-radius: var(--radius-md);
   background: var(--bg);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    border-color var(--duration-base, 0.15s);
   font-family: var(--font-sans);
   text-align: left;
   width: 100%;
@@ -595,6 +629,11 @@ html[data-theme="nex"]
 .provider-option:hover {
   border-color: var(--accent);
   background: var(--accent-bg);
+}
+.provider-option:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-color: var(--accent);
 }
 .provider-option.active {
   border-color: var(--accent);
@@ -884,13 +923,21 @@ html[data-theme="nex"]
   border: none;
   background: transparent;
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    color var(--duration-base, 0.15s);
   color: var(--text-secondary);
   font-family: var(--font-sans);
   text-align: left;
   position: relative;
 }
 .sidebar-agent:hover {
+  background: rgba(0, 0, 0, 0.04);
+  color: var(--text);
+}
+.sidebar-agent:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
   background: rgba(0, 0, 0, 0.04);
   color: var(--text);
 }
@@ -1076,6 +1123,11 @@ html[data-theme="nex"]
 }
 .usage-toggle:hover {
   color: var(--text);
+}
+.usage-toggle:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+  border-radius: 4px;
 }
 .usage-toggle svg {
   transition: transform 0.2s;
@@ -1549,6 +1601,10 @@ html[data-theme="nex"]
   background: var(--bg-warm);
   color: var(--text);
 }
+.task-detail-close:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
 .task-detail-section {
   padding: 16px 20px;
   border-bottom: 1px solid var(--border);
@@ -1824,6 +1880,10 @@ html[data-theme="nex"]
 }
 .thread-panel-close:hover {
   background: var(--bg);
+}
+.thread-panel-close:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .thread-panel-body {
   flex: 1;
@@ -2153,6 +2213,10 @@ html[data-theme="nex"]
 }
 .sidebar-color-swatch:hover {
   transform: scale(1.08);
+}
+.sidebar-color-swatch:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 .sidebar-color-swatch.is-active {
   box-shadow: 0 0 0 2px var(--accent, var(--text));

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -302,7 +302,9 @@
   background: var(--bg);
   font-size: 12px;
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    border-color var(--duration-base, 0.15s);
 }
 .reaction-pill:hover {
   background: var(--accent-bg);
@@ -675,7 +677,9 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    border-color var(--duration-base, 0.15s);
   text-align: left;
   font-family: var(--font-sans);
   color: var(--text);
@@ -1218,7 +1222,7 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   color: var(--text);
 }
 .message-hover-btn:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
   outline-offset: 1px;
 }
 
@@ -1251,7 +1255,7 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   color: var(--text);
 }
 .thread-collapse-toggle:focus-visible {
-  outline: 2px solid var(--accent);
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
   outline-offset: 1px;
 }
 .thread-collapse-chevron {
@@ -1259,4 +1263,14 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
 }
 .thread-group-collapsed .thread-collapse-toggle {
   color: var(--accent);
+}
+
+/* ─── Feed loading / empty states ─── */
+.messages-loading-label {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  color: var(--empty-state-color, var(--text-tertiary));
+  font-size: var(--empty-state-size, 13px);
 }

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -614,8 +614,8 @@
 .pack-card:focus-visible,
 .pack-filter-chip:focus-visible,
 .pack-detail-close:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 /* ─── Pack Library (Step 2) ─── */

--- a/web/src/styles/pam.css
+++ b/web/src/styles/pam.css
@@ -154,10 +154,13 @@
   font: inherit;
 }
 
-.pam-menu-item:hover,
+.pam-menu-item:hover {
+  background: var(--wk-amber-bg);
+}
 .pam-menu-item:focus-visible {
   background: var(--wk-amber-bg);
-  outline: none;
+  outline: var(--focus-ring-width) solid var(--wk-amber);
+  outline-offset: -2px;
 }
 
 .pam-menu-item[disabled] {

--- a/web/src/styles/search.css
+++ b/web/src/styles/search.css
@@ -95,6 +95,11 @@
 .search-result:hover {
   background: var(--bg-warm);
 }
+.search-result:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: -2px;
+  background: var(--bg-warm);
+}
 .search-result:last-child {
   border-bottom: none;
 }
@@ -290,13 +295,19 @@
   font-weight: 500;
   color: var(--text-secondary);
   cursor: pointer;
-  transition: all 0.15s;
+  transition:
+    background var(--duration-base, 0.15s),
+    color var(--duration-base, 0.15s);
 }
 .channel-wizard-tab:first-child {
   border-right: 1px solid var(--border);
 }
 .channel-wizard-tab:hover {
   background: var(--bg-warm);
+}
+.channel-wizard-tab:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: -2px;
 }
 .channel-wizard-tab.active {
   background: var(--accent-bg);

--- a/web/src/styles/wiki-shell.css
+++ b/web/src/styles/wiki-shell.css
@@ -64,7 +64,8 @@
 }
 
 .wiki-tab:focus-visible {
-  outline: 2px solid var(--accent, #1264a3);
+  outline: var(--focus-ring-width, 2px) solid
+    var(--focus-ring-color, var(--accent, #1264a3));
   outline-offset: -2px;
 }
 

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,56 +1,56 @@
-import animate from 'tailwindcss-animate'
+import animate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     container: {
       center: true,
-      padding: '2rem',
-      screens: { '2xl': '1400px' },
+      padding: "2rem",
+      screens: { "2xl": "1400px" },
     },
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
         },
         destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
         },
         popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
         },
         card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
         },
       },
       borderRadius: {
-        lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 2px)',
-        sm: 'calc(var(--radius) - 4px)',
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
       },
     },
   },
   plugins: [animate],
-}
+};

--- a/web/tests/fixtures/wikilinks.json
+++ b/web/tests/fixtures/wikilinks.json
@@ -1,10 +1,19 @@
 [
-  {"input": "[[slug]]",            "expected": {"slug": "slug", "display": "slug"}},
-  {"input": "[[slug|Display]]",    "expected": {"slug": "slug", "display": "Display"}},
-  {"input": "[[people/nazz]]",     "expected": {"slug": "people/nazz", "display": "people/nazz"}},
-  {"input": "[[people/nazz|Nazz]]","expected": {"slug": "people/nazz", "display": "Nazz"}},
-  {"input": "[[ ]]",               "expected": null},
-  {"input": "[[a|b|c]]",           "expected": null},
-  {"input": "[[../../etc]]",       "expected": null},
-  {"input": "[[/absolute]]",       "expected": null}
+  { "input": "[[slug]]", "expected": { "slug": "slug", "display": "slug" } },
+  {
+    "input": "[[slug|Display]]",
+    "expected": { "slug": "slug", "display": "Display" }
+  },
+  {
+    "input": "[[people/nazz]]",
+    "expected": { "slug": "people/nazz", "display": "people/nazz" }
+  },
+  {
+    "input": "[[people/nazz|Nazz]]",
+    "expected": { "slug": "people/nazz", "display": "Nazz" }
+  },
+  { "input": "[[ ]]", "expected": null },
+  { "input": "[[a|b|c]]", "expected": null },
+  { "input": "[[../../etc]]", "expected": null },
+  { "input": "[[/absolute]]", "expected": null }
 ]


### PR DESCRIPTION
## Summary

- **Focus ring system**: Add `--focus-ring-color`, `--focus-ring-width`, `--focus-ring-offset` tokens in `global.css` and a universal `:focus-visible` baseline so every interactive element (sidebar buttons, nav items, agents, search results, tabs, dropdowns, reaction pills, task detail controls) gets a consistent keyboard focus indicator.
- **Fix suppressed focus rings**: `kbd.css` `.status-bar-shortcut:focus-visible` previously set `outline: none`, killing keyboard nav. Restored with proper ring. `pam.css` menu items similarly fixed.
- **Scope `transition: all`**: Replaced `transition: all 0.15s/0.2s` with specific property lists (`background`, `color`, `border-color`) across `.sidebar-item`, `.sidebar-agent`, `.sidebar-icon-btn`, `.sidebar-btn`, `.agent-panel-close`, `.reaction-pill`, `.thread-list-item`, `.provider-option`, `.channel-wizard-tab` to prevent unintended dimension transitions on hover that could cause layout shift.
- **Empty/loading state utilities**: Add `.empty-state`, `.empty-state--padded`, `.messages-loading-label` CSS classes. Replace inline-style loading states in `MessageFeed`, `SettingsApp`, `SkillPreviewBody` with shared classes.
- **Spacing + typography tokens**: Define `--space-1..6`, `--text-xs..2xl`, `--duration-fast/base/slow`, `--empty-state-color/size` tokens for future normalization without forcing a sweep of existing code.
- **Biome auto-fixes**: Quote normalization, arrow function rewrites, brace style in `index.html`, theme files, modal, test, and config files (no behavior change).

## Test plan

- [ ] Tab through the sidebar — every nav item, agent row, and icon button shows a visible purple focus ring
- [ ] Tab through the message feed toolbar — hover action buttons and thread toggles show focus rings
- [ ] Tab through the status bar — the `?` shortcuts button shows focus ring
- [ ] Tab through the wiki tab bar — active/inactive tabs show focus ring without layout shift
- [ ] Hover over sidebar items and agents — no size/layout change, only background/color transitions
- [ ] Open settings runtimes panel while loading — shows centered text via `.app-panel-loading`
- [ ] All 905 web unit tests green (`bash scripts/test-web.sh`)
- [ ] `bunx tsc --noEmit` clean (excluding test files with vitest resolution)
- [ ] `bunx biome check --write` — no new errors (5 pre-existing errors in themes/e2e remain)
- [ ] Complexity baseline passes (`bash scripts/check-complexity-baseline.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)