### PR TITLE
feat(web): agent profile pages with skills and recent activity (phase 5 pr 5)

### DIFF
--- a/internal/team/broker_tasks_http.go
+++ b/internal/team/broker_tasks_http.go
@@ -62,10 +62,31 @@ func (b *Broker) handleAgentLogs(w http.ResponseWriter, r *http.Request) {
 			limit = n
 		}
 	}
-	tasks, err := agent.ListRecentTasks(root, limit)
+	agentFilter := strings.TrimSpace(r.URL.Query().Get("agent"))
+
+	// When filtering by agent we over-fetch so the limit applies after the
+	// filter, not before — otherwise a busy office with many other agents can
+	// exhaust the window before the requested agent's runs appear.
+	scanLimit := limit
+	if agentFilter != "" {
+		scanLimit = 500
+	}
+	tasks, err := agent.ListRecentTasks(root, scanLimit)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	if agentFilter != "" {
+		filtered := tasks[:0]
+		for _, t := range tasks {
+			if t.AgentSlug == agentFilter {
+				filtered = append(filtered, t)
+				if len(filtered) == limit {
+					break
+				}
+			}
+		}
+		tasks = filtered
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(AgentLogTasksResponse{Tasks: tasks})

--- a/web/src/api/tasks.ts
+++ b/web/src/api/tasks.ts
@@ -248,9 +248,10 @@ export interface TaskLogEntry {
   completed_at?: number;
 }
 
-export function listAgentLogTasks(opts?: { limit?: number }) {
+export function listAgentLogTasks(opts?: { limit?: number; agentSlug?: string }) {
   const params: Record<string, string> = {};
   if (opts?.limit) params.limit = String(opts.limit);
+  if (opts?.agentSlug) params.agent = opts.agentSlug;
   return get<{ tasks: TaskLogSummary[] }>("/agent-logs", params);
 }
 

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -528,7 +528,7 @@ export function AgentPanel() {
 
   return (
     <div ref={panelRef} style={{ display: "contents" }}>
-      <AgentPanelView agent={agent} onClose={close} />
+      <AgentPanelView key={activeAgentSlug} agent={agent} onClose={close} />
     </div>
   );
 }

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -21,6 +21,7 @@ import { confirm } from "../ui/ConfirmDialog";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
 import { showNotice } from "../ui/Toast";
+import { AgentProfilePanel } from "./AgentProfilePanel";
 
 /**
  * Stable identity key for the AgentPanel "close on route change" effect.
@@ -189,6 +190,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
   const [view, setView] = useState<"stream" | "logs">("stream");
   const [toggling, setToggling] = useState(false);
   const [removing, setRemoving] = useState(false);
+  const [showProfile, setShowProfile] = useState(false);
   const defaultHarness = useDefaultHarness();
 
   // Derive the per-channel enabled state. An agent is "enabled" in the
@@ -199,6 +201,11 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
   const { data: channelMembers = [] } = useChannelMembers(currentChannel);
   const channelEntry = channelMembers.find((m) => m.slug === agent.slug);
   const enabled = Boolean(channelEntry) && channelEntry?.disabled !== true;
+
+  // All hooks called. Now it is safe to branch on profile mode.
+  if (showProfile) {
+    return <AgentProfilePanel agent={agent} onClose={onClose} />;
+  }
 
   // Broker rejects remove / disable for any `built_in` member (lead agent).
   // Use `!== true` (not `!agent.built_in`) so an absent field isn't silently
@@ -432,6 +439,14 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
           onClick={() => setView(view === "logs" ? "stream" : "logs")}
         >
           {view === "logs" ? "Live stream" : "View logs"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => setShowProfile(true)}
+          aria-label={`View full profile for ${agent.name || agent.slug}`}
+        >
+          Profile
         </button>
       </div>
 

--- a/web/src/components/agents/AgentProfilePanel.test.tsx
+++ b/web/src/components/agents/AgentProfilePanel.test.tsx
@@ -176,6 +176,8 @@ describe("<AgentProfilePanel>", () => {
   });
 
   it("renders recent runs when log tasks are available", async () => {
+    // The API is called with agentSlug so the server filters; the mock
+    // returns only the current agent's runs, matching real server behavior.
     listAgentLogTasksMock.mockResolvedValue({
       tasks: [
         {
@@ -185,13 +187,6 @@ describe("<AgentProfilePanel>", () => {
           hasError: false,
           sizeBytes: 1000,
         },
-        {
-          taskId: "task-other",
-          agentSlug: "reviewer",
-          toolCallCount: 2,
-          hasError: false,
-          sizeBytes: 500,
-        },
       ],
     });
 
@@ -200,8 +195,11 @@ describe("<AgentProfilePanel>", () => {
     await waitFor(() => {
       expect(screen.getByText("task-abc-123")).toBeInTheDocument();
     });
-    // Other agent's run should not appear
-    expect(screen.queryByText("task-other")).not.toBeInTheDocument();
+    // Verify the API was called with the agent-scoped params
+    expect(listAgentLogTasksMock).toHaveBeenCalledWith({
+      limit: 8,
+      agentSlug: "planner",
+    });
     // "See all activity" link should render
     expect(screen.getByText("See all activity")).toBeInTheDocument();
   });

--- a/web/src/components/agents/AgentProfilePanel.test.tsx
+++ b/web/src/components/agents/AgentProfilePanel.test.tsx
@@ -1,0 +1,310 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Hoist all mocks before imports so vitest can intercept module resolution.
+const getSkillsListMock = vi.hoisted(() => vi.fn());
+const getChannelsMock = vi.hoisted(() => vi.fn());
+const getOfficeTasksMock = vi.hoisted(() => vi.fn());
+const listAgentLogTasksMock = vi.hoisted(() => vi.fn());
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    getSkillsList: getSkillsListMock,
+    getChannels: getChannelsMock,
+  };
+});
+
+vi.mock("../../api/tasks", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/tasks")>("../../api/tasks");
+  return {
+    ...actual,
+    getOfficeTasks: getOfficeTasksMock,
+    listAgentLogTasks: listAgentLogTasksMock,
+  };
+});
+
+vi.mock("../../hooks/useConfig", () => ({
+  useDefaultHarness: () => "claude-code",
+}));
+
+vi.mock("../../lib/router", () => ({
+  router: { navigate: navigateMock },
+}));
+
+vi.mock("../../lib/harness", () => ({
+  resolveHarness: (_provider: unknown, fallback: string) => fallback,
+}));
+
+vi.mock("../ui/PixelAvatar", () => ({
+  PixelAvatar: ({ slug }: { slug: string }) => (
+    <span data-testid={`avatar-${slug}`} />
+  ),
+}));
+
+vi.mock("../ui/HarnessBadge", () => ({
+  HarnessBadge: () => null,
+}));
+
+import type { OfficeMember } from "../../api/client";
+import { AgentProfilePanel } from "./AgentProfilePanel";
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: ReactNode, qc = makeQC()) {
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+const baseAgent: OfficeMember = {
+  slug: "planner",
+  name: "Planner",
+  role: "Plans tasks and coordinates agents",
+  status: "active",
+  provider: { kind: "claude-code", model: "claude-3-5-sonnet" },
+  built_in: false,
+};
+
+describe("<AgentProfilePanel>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSkillsListMock.mockResolvedValue({ skills: [] });
+    getChannelsMock.mockResolvedValue({ channels: [] });
+    getOfficeTasksMock.mockResolvedValue({ tasks: [] });
+    listAgentLogTasksMock.mockResolvedValue({ tasks: [] });
+  });
+
+  it("renders agent name, status badge, and close button", async () => {
+    const onClose = vi.fn();
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={onClose} />));
+
+    expect(screen.getByText("Planner")).toBeInTheDocument();
+    expect(screen.getByLabelText("Close agent profile")).toBeInTheDocument();
+    // Status badge should say "active"
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("renders agent role description", async () => {
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+    expect(
+      screen.getByText("Plans tasks and coordinates agents"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={onClose} />));
+
+    await user.click(screen.getByLabelText("Close agent profile"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders empty-state messages when all data is missing", async () => {
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("No skills yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No channels")).toBeInTheDocument();
+    expect(screen.getByText("No recent tasks")).toBeInTheDocument();
+  });
+
+  it("renders skills owned by this agent", async () => {
+    getSkillsListMock.mockResolvedValue({
+      skills: [
+        {
+          name: "plan-sprint",
+          title: "Plan Sprint",
+          status: "active",
+          owner_agents: ["planner"],
+        },
+        {
+          name: "review-pr",
+          title: "Review PR",
+          status: "active",
+          owner_agents: ["reviewer"],
+        },
+        {
+          name: "pending-skill",
+          title: "Pending Skill",
+          status: "proposed",
+          owner_agents: ["planner"],
+        },
+      ],
+    });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("Plan Sprint")).toBeInTheDocument();
+    });
+    // Skill owned by a different agent should NOT appear
+    expect(screen.queryByText("Review PR")).not.toBeInTheDocument();
+    // Proposed skill shows a "pending" badge
+    expect(screen.getByText("Pending Skill")).toBeInTheDocument();
+    expect(screen.getByText("pending")).toBeInTheDocument();
+  });
+
+  it("renders channels the agent is a member of", async () => {
+    getChannelsMock.mockResolvedValue({
+      channels: [
+        { slug: "general", name: "general", members: ["planner", "ceo"] },
+        { slug: "engineering", name: "engineering", members: ["planner"] },
+        { slug: "marketing", name: "marketing", members: ["ceo"] },
+      ],
+    });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("#general")).toBeInTheDocument();
+    });
+    expect(screen.getByText("#engineering")).toBeInTheDocument();
+    // marketing doesn't include "planner"
+    expect(screen.queryByText("#marketing")).not.toBeInTheDocument();
+  });
+
+  it("renders recent runs when log tasks are available", async () => {
+    listAgentLogTasksMock.mockResolvedValue({
+      tasks: [
+        {
+          taskId: "task-abc-123",
+          agentSlug: "planner",
+          toolCallCount: 5,
+          hasError: false,
+          sizeBytes: 1000,
+        },
+        {
+          taskId: "task-other",
+          agentSlug: "reviewer",
+          toolCallCount: 2,
+          hasError: false,
+          sizeBytes: 500,
+        },
+      ],
+    });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("task-abc-123")).toBeInTheDocument();
+    });
+    // Other agent's run should not appear
+    expect(screen.queryByText("task-other")).not.toBeInTheDocument();
+    // "See all activity" link should render
+    expect(screen.getByText("See all activity")).toBeInTheDocument();
+  });
+
+  it("renders recent tasks for the agent", async () => {
+    getOfficeTasksMock.mockResolvedValue({
+      tasks: [
+        {
+          id: "t1",
+          title: "Build feature X",
+          status: "in_progress",
+          owner: "planner",
+          updated_at: "2026-05-07T10:00:00Z",
+        },
+        {
+          id: "t2",
+          title: "Unrelated task",
+          status: "open",
+          owner: "reviewer",
+          updated_at: "2026-05-07T09:00:00Z",
+        },
+      ],
+    });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("Build feature X")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Unrelated task")).not.toBeInTheDocument();
+  });
+
+  it("renders permissions section with correct role for non-lead agent", async () => {
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      // permissions section
+      expect(screen.getByText("team member")).toBeInTheDocument();
+    });
+    // removable: yes
+    expect(screen.getAllByText("yes").length).toBeGreaterThan(0);
+  });
+
+  it("renders permissions section with correct role for built-in (lead) agent", async () => {
+    const leadAgent: OfficeMember = {
+      ...baseAgent,
+      slug: "ceo",
+      name: "CEO",
+      built_in: true,
+    };
+    render(wrap(<AgentProfilePanel agent={leadAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("lead agent")).toBeInTheDocument();
+    });
+    // removable: no
+    const noEls = screen.getAllByText("no");
+    expect(noEls.length).toBeGreaterThan(0);
+  });
+
+  it("handles missing optional fields on agent gracefully", async () => {
+    const minimalAgent: OfficeMember = {
+      slug: "bare",
+      name: "Bare",
+      role: "",
+      status: undefined,
+    };
+    render(wrap(<AgentProfilePanel agent={minimalAgent} onClose={vi.fn()} />));
+
+    // Should not throw; name renders
+    expect(screen.getByText("Bare")).toBeInTheDocument();
+    // Status defaults to "idle"
+    expect(screen.getByText("idle")).toBeInTheDocument();
+    // Role description section (the `<p>` text) should not render when role is empty
+    expect(
+      screen.queryByText("Plans tasks and coordinates agents"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("navigates to activity app when 'See all activity' is clicked", async () => {
+    const user = userEvent.setup();
+    listAgentLogTasksMock.mockResolvedValue({
+      tasks: [
+        {
+          taskId: "task-1",
+          agentSlug: "planner",
+          toolCallCount: 3,
+          hasError: false,
+          sizeBytes: 100,
+        },
+      ],
+    });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("See all activity")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("See all activity"));
+    expect(navigateMock).toHaveBeenCalledWith({
+      to: "/apps/$appId",
+      params: { appId: "activity" },
+    });
+  });
+});

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -335,7 +335,8 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
 
   const { data: channels = [] } = useQuery({
     queryKey: ["channels"],
-    queryFn: () => getChannels().then((r) => r.channels ?? []),
+    queryFn: () => getChannels(),
+    select: (data) => data.channels ?? [],
     refetchInterval: 30_000,
   });
 

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Xmark } from "iconoir-react";
 
@@ -135,13 +134,6 @@ function RecentRunsSection({
 }: RecentRunsSectionProps) {
   const agentRuns = runs.filter((r) => r.agentSlug === agentSlug).slice(0, 8);
 
-  function handleRunClick(taskId: string) {
-    // Navigate to the activity app; task detail opens from there.
-    void router.navigate({ to: "/apps/$appId", params: { appId: "activity" } });
-    // Shallow timeout so panel can close before navigation
-    void taskId;
-  }
-
   if (loading) {
     return (
       <div className="agent-profile-section">
@@ -166,7 +158,12 @@ function RecentRunsSection({
               <button
                 type="button"
                 className="agent-profile-run-btn"
-                onClick={() => handleRunClick(r.taskId)}
+                onClick={() =>
+                  void router.navigate({
+                    to: "/apps/$appId",
+                    params: { appId: "activity" },
+                  })
+                }
               >
                 <span className="agent-profile-run-id">{r.taskId}</span>
                 <span className="agent-profile-run-meta">
@@ -346,26 +343,11 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
     refetchInterval: 30_000,
   });
 
-  const [runs, setRuns] = useState<TaskLogSummary[]>([]);
-  const [runsLoading, setRunsLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    setRunsLoading(true);
-    listAgentLogTasks({ limit: 100 })
-      .then((data) => {
-        if (!cancelled) {
-          setRuns(data.tasks ?? []);
-          setRunsLoading(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setRunsLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const { data: runs = [], isLoading: runsLoading } = useQuery({
+    queryKey: ["agent-log-tasks", { limit: 100 }],
+    queryFn: () => listAgentLogTasks({ limit: 100 }).then((r) => r.tasks ?? []),
+    refetchInterval: 30_000,
+  });
 
   const statusClass = agent.status === "active" ? "active pulse" : "lurking";
 

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -335,8 +335,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
 
   const { data: channels = [] } = useQuery({
     queryKey: ["channels"],
-    queryFn: () => getChannels(),
-    select: (data) => data.channels ?? [],
+    queryFn: () => getChannels().then((r) => r.channels ?? []),
     refetchInterval: 30_000,
   });
 

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -282,7 +282,7 @@ function PermissionsSection({ agent }: { agent: OfficeMember }) {
         <div className="agent-profile-perm-row">
           <span className="agent-profile-perm-label">built-in</span>
           <span className="agent-profile-perm-value">
-            {agent.built_in ? "yes" : "no"}
+            {isLead ? "yes" : "no"}
           </span>
         </div>
       </div>

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -122,17 +122,12 @@ function ChannelsSection({
 }
 
 interface RecentRunsSectionProps {
-  agentSlug: string;
   runs: TaskLogSummary[];
   loading: boolean;
 }
 
-function RecentRunsSection({
-  agentSlug,
-  runs,
-  loading,
-}: RecentRunsSectionProps) {
-  const agentRuns = runs.filter((r) => r.agentSlug === agentSlug).slice(0, 8);
+function RecentRunsSection({ runs, loading }: RecentRunsSectionProps) {
+  const agentRuns = runs;
 
   if (loading) {
     return (
@@ -344,8 +339,11 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
   });
 
   const { data: runs = [], isLoading: runsLoading } = useQuery({
-    queryKey: ["agent-log-tasks", { limit: 100 }],
-    queryFn: () => listAgentLogTasks({ limit: 100 }).then((r) => r.tasks ?? []),
+    queryKey: ["agent-log-tasks", agent.slug],
+    queryFn: () =>
+      listAgentLogTasks({ limit: 8, agentSlug: agent.slug }).then(
+        (r) => r.tasks ?? [],
+      ),
     refetchInterval: 30_000,
   });
 
@@ -414,7 +412,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
         ) : null}
 
         {/* Current task */}
-        {agent.task ? (
+        {agent.task && agent.status === "active" ? (
           <div className="agent-profile-section">
             <SectionTitle>current task</SectionTitle>
             <p className="agent-profile-current-task">{agent.task}</p>
@@ -431,11 +429,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
         <ChannelsSection agentSlug={agent.slug} channels={channels} />
 
         {/* Recent runs */}
-        <RecentRunsSection
-          agentSlug={agent.slug}
-          runs={runs}
-          loading={runsLoading}
-        />
+        <RecentRunsSection runs={runs} loading={runsLoading} />
 
         {/* Recent tasks (artifacts) */}
         <RecentArtifactsSection agentSlug={agent.slug} tasks={allTasks} />

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -1,0 +1,466 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Xmark } from "iconoir-react";
+
+import type { OfficeMember, Skill } from "../../api/client";
+import { getChannels, getSkillsList } from "../../api/client";
+import {
+  getOfficeTasks,
+  listAgentLogTasks,
+  type Task,
+  type TaskLogSummary,
+} from "../../api/tasks";
+import { useDefaultHarness } from "../../hooks/useConfig";
+import type { HarnessKind } from "../../lib/harness";
+import { resolveHarness } from "../../lib/harness";
+import { router } from "../../lib/router";
+import { HarnessBadge } from "../ui/HarnessBadge";
+import { PixelAvatar } from "../ui/PixelAvatar";
+
+interface AgentProfilePanelProps {
+  agent: OfficeMember;
+  onClose: () => void;
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return <div className="agent-profile-section-title">{children}</div>;
+}
+
+function EmptyRow({ label }: { label: string }) {
+  return <div className="agent-profile-empty">{label}</div>;
+}
+
+function StatusBadge({ status }: { status: string | undefined }) {
+  const s = (status || "idle").toLowerCase();
+  let cls = "agent-profile-status-badge";
+  if (s === "active") cls += " active";
+  else if (s === "paused") cls += " paused";
+  return (
+    <span className={cls}>
+      <span className="agent-profile-status-dot" />
+      {s}
+    </span>
+  );
+}
+
+function SkillsSection({
+  agentSlug,
+  skills,
+}: {
+  agentSlug: string;
+  skills: Skill[];
+}) {
+  const owned = skills.filter(
+    (sk) =>
+      Array.isArray(sk.owner_agents) && sk.owner_agents.includes(agentSlug),
+  );
+  const active = owned.filter(
+    (sk) => sk.status === "active" || sk.status === "proposed",
+  );
+
+  return (
+    <div className="agent-profile-section">
+      <SectionTitle>skills</SectionTitle>
+      {active.length === 0 ? (
+        <EmptyRow label="No skills yet" />
+      ) : (
+        <ul className="agent-profile-list">
+          {active.map((sk) => (
+            <li key={sk.name} className="agent-profile-list-item">
+              <span className="agent-profile-skill-name">
+                {sk.title || sk.name}
+              </span>
+              {sk.status === "proposed" && (
+                <span className="badge badge-yellow agent-profile-badge">
+                  pending
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ChannelsSection({
+  agentSlug,
+  channels,
+}: {
+  agentSlug: string;
+  channels: { slug: string; name: string; members?: string[] }[];
+}) {
+  const memberOf = channels.filter(
+    (ch) => Array.isArray(ch.members) && ch.members.includes(agentSlug),
+  );
+
+  return (
+    <div className="agent-profile-section">
+      <SectionTitle>channels</SectionTitle>
+      {memberOf.length === 0 ? (
+        <EmptyRow label="No channels" />
+      ) : (
+        <div className="agent-profile-chips">
+          {memberOf.map((ch) => (
+            <button
+              key={ch.slug}
+              type="button"
+              className="agent-profile-chip"
+              onClick={() =>
+                void router.navigate({
+                  to: "/channels/$channelSlug",
+                  params: { channelSlug: ch.slug },
+                })
+              }
+            >
+              #{ch.name || ch.slug}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface RecentRunsSectionProps {
+  agentSlug: string;
+  runs: TaskLogSummary[];
+  loading: boolean;
+}
+
+function RecentRunsSection({
+  agentSlug,
+  runs,
+  loading,
+}: RecentRunsSectionProps) {
+  const agentRuns = runs.filter((r) => r.agentSlug === agentSlug).slice(0, 8);
+
+  function handleRunClick(taskId: string) {
+    // Navigate to the activity app; task detail opens from there.
+    void router.navigate({ to: "/apps/$appId", params: { appId: "activity" } });
+    // Shallow timeout so panel can close before navigation
+    void taskId;
+  }
+
+  if (loading) {
+    return (
+      <div className="agent-profile-section">
+        <SectionTitle>recent runs</SectionTitle>
+        <EmptyRow label="Loading..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className="agent-profile-section">
+      <SectionTitle>recent runs</SectionTitle>
+      {agentRuns.length === 0 ? (
+        <EmptyRow label="No runs yet" />
+      ) : (
+        <ul className="agent-profile-list">
+          {agentRuns.map((r) => (
+            <li
+              key={r.taskId}
+              className="agent-profile-list-item agent-profile-run-item"
+            >
+              <button
+                type="button"
+                className="agent-profile-run-btn"
+                onClick={() => handleRunClick(r.taskId)}
+              >
+                <span className="agent-profile-run-id">{r.taskId}</span>
+                <span className="agent-profile-run-meta">
+                  {r.toolCallCount} tool call{r.toolCallCount === 1 ? "" : "s"}
+                  {r.hasError ? " ⚠" : ""}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {agentRuns.length > 0 && (
+        <button
+          type="button"
+          className="agent-profile-see-all"
+          onClick={() =>
+            void router.navigate({
+              to: "/apps/$appId",
+              params: { appId: "activity" },
+            })
+          }
+        >
+          See all activity
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface RecentTasksSectionProps {
+  agentSlug: string;
+  tasks: Task[];
+}
+
+function RecentArtifactsSection({ agentSlug, tasks }: RecentTasksSectionProps) {
+  const agentTasks = tasks
+    .filter((t) => t.owner === agentSlug)
+    .sort((a, b) => {
+      const ta = a.updated_at ?? a.created_at ?? "";
+      const tb = b.updated_at ?? b.created_at ?? "";
+      return tb.localeCompare(ta);
+    })
+    .slice(0, 5);
+
+  return (
+    <div className="agent-profile-section">
+      <SectionTitle>recent tasks</SectionTitle>
+      {agentTasks.length === 0 ? (
+        <EmptyRow label="No recent tasks" />
+      ) : (
+        <ul className="agent-profile-list">
+          {agentTasks.map((t) => (
+            <li key={t.id} className="agent-profile-list-item">
+              <button
+                type="button"
+                className="agent-profile-task-btn"
+                onClick={() =>
+                  void router.navigate({
+                    to: "/tasks/$taskId",
+                    params: { taskId: t.id },
+                  })
+                }
+              >
+                <span className="agent-profile-task-title">{t.title}</span>
+                <span
+                  className={`badge ${taskStatusBadgeClass(t.status)} agent-profile-badge`}
+                >
+                  {normalizeTaskStatus(t.status)}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function normalizeTaskStatus(raw: string): string {
+  const s = raw.toLowerCase().replace(/[\s-]+/g, "_");
+  if (s === "completed") return "done";
+  if (s === "in_progress") return "in progress";
+  return s;
+}
+
+function taskStatusBadgeClass(raw: string): string {
+  const s = raw.toLowerCase();
+  if (s === "done" || s === "completed") return "badge-green";
+  if (s === "blocked") return "badge-yellow";
+  if (s === "canceled" || s === "cancelled") return "badge-muted";
+  return "badge-accent";
+}
+
+function PermissionsSection({ agent }: { agent: OfficeMember }) {
+  const isLead = agent.built_in === true || agent.slug === "ceo";
+
+  return (
+    <div className="agent-profile-section">
+      <SectionTitle>permissions</SectionTitle>
+      <div className="agent-profile-permissions">
+        <div className="agent-profile-perm-row">
+          <span className="agent-profile-perm-label">role</span>
+          <span className="agent-profile-perm-value">
+            {isLead ? "lead agent" : "team member"}
+          </span>
+        </div>
+        <div className="agent-profile-perm-row">
+          <span className="agent-profile-perm-label">removable</span>
+          <span className="agent-profile-perm-value">
+            {isLead ? "no" : "yes"}
+          </span>
+        </div>
+        <div className="agent-profile-perm-row">
+          <span className="agent-profile-perm-label">built-in</span>
+          <span className="agent-profile-perm-value">
+            {agent.built_in ? "yes" : "no"}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProviderSection({
+  agent,
+  defaultHarness,
+}: {
+  agent: OfficeMember;
+  defaultHarness: HarnessKind;
+}) {
+  const harness = resolveHarness(agent.provider, defaultHarness);
+  const providerLabel =
+    typeof agent.provider === "string"
+      ? agent.provider
+      : agent.provider?.model
+        ? `${agent.provider.kind ?? harness} / ${agent.provider.model}`
+        : agent.provider?.kind || harness;
+
+  return (
+    <div className="agent-profile-section">
+      <SectionTitle>runtime</SectionTitle>
+      <div className="agent-profile-permissions">
+        <div className="agent-profile-perm-row">
+          <span className="agent-profile-perm-label">harness</span>
+          <span className="agent-profile-perm-value">{harness}</span>
+        </div>
+        {providerLabel && providerLabel !== harness && (
+          <div className="agent-profile-perm-row">
+            <span className="agent-profile-perm-label">provider</span>
+            <span className="agent-profile-perm-value">{providerLabel}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
+  const defaultHarness = useDefaultHarness();
+
+  const { data: skills = [] } = useQuery({
+    queryKey: ["skills-list"],
+    queryFn: () => getSkillsList("all").then((r) => r.skills ?? []),
+    refetchInterval: 30_000,
+  });
+
+  const { data: channels = [] } = useQuery({
+    queryKey: ["channels"],
+    queryFn: () => getChannels().then((r) => r.channels ?? []),
+    refetchInterval: 30_000,
+  });
+
+  const { data: allTasks = [] } = useQuery({
+    queryKey: ["office-tasks-profile"],
+    queryFn: () =>
+      getOfficeTasks({ includeDone: true }).then((r) => r.tasks ?? []),
+    refetchInterval: 30_000,
+  });
+
+  const [runs, setRuns] = useState<TaskLogSummary[]>([]);
+  const [runsLoading, setRunsLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    setRunsLoading(true);
+    listAgentLogTasks({ limit: 100 })
+      .then((data) => {
+        if (!cancelled) {
+          setRuns(data.tasks ?? []);
+          setRunsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRunsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const statusClass = agent.status === "active" ? "active pulse" : "lurking";
+
+  return (
+    <div className="agent-panel agent-profile-panel">
+      {/* Header */}
+      <div className="agent-panel-header">
+        <div className="agent-panel-identity">
+          <div className="agent-panel-avatar avatar-with-harness">
+            <PixelAvatar
+              slug={agent.slug}
+              size={36}
+              className="pixel-avatar-panel"
+            />
+            <HarnessBadge
+              kind={resolveHarness(agent.provider, defaultHarness)}
+              size={18}
+              className="harness-badge-on-avatar"
+            />
+          </div>
+          <div
+            style={{
+              minWidth: 0,
+              flex: 1,
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
+            <div
+              style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+            >
+              <span className="agent-panel-name">
+                {agent.name || agent.slug}
+              </span>
+              <span
+                className={`status-dot ${statusClass}`}
+                style={{ marginLeft: -2 }}
+              />
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <StatusBadge status={agent.status} />
+            </div>
+          </div>
+        </div>
+        <button
+          type="button"
+          className="agent-panel-close"
+          onClick={onClose}
+          aria-label="Close agent profile"
+        >
+          <Xmark width={20} height={20} />
+        </button>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="agent-profile-body">
+        {/* Role / description */}
+        {agent.role ? (
+          <div className="agent-profile-section">
+            <SectionTitle>role</SectionTitle>
+            <p className="agent-profile-role-text">{agent.role}</p>
+          </div>
+        ) : null}
+
+        {/* Current task */}
+        {agent.task ? (
+          <div className="agent-profile-section">
+            <SectionTitle>current task</SectionTitle>
+            <p className="agent-profile-current-task">{agent.task}</p>
+          </div>
+        ) : null}
+
+        {/* Provider / runtime */}
+        <ProviderSection agent={agent} defaultHarness={defaultHarness} />
+
+        {/* Skills */}
+        <SkillsSection agentSlug={agent.slug} skills={skills} />
+
+        {/* Channels */}
+        <ChannelsSection agentSlug={agent.slug} channels={channels} />
+
+        {/* Recent runs */}
+        <RecentRunsSection
+          agentSlug={agent.slug}
+          runs={runs}
+          loading={runsLoading}
+        />
+
+        {/* Recent tasks (artifacts) */}
+        <RecentArtifactsSection agentSlug={agent.slug} tasks={allTasks} />
+
+        {/* Permissions */}
+        <PermissionsSection agent={agent} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -13,6 +13,7 @@ import {
   messageRemarkPlugins,
 } from "../../lib/messageMarkdown";
 import { useChannelSlug } from "../../routes/useCurrentRoute";
+import { useAppStore } from "../../stores/app";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
 import { RedactedBadge } from "../ui/RedactedBadge";
@@ -45,6 +46,7 @@ export function MessageBubble({
 }: MessageBubbleProps) {
   const currentChannel = useChannelSlug() ?? "general";
   const { data: members = [] } = useOfficeMembers();
+  const setActiveAgentSlug = useAppStore((s) => s.setActiveAgentSlug);
   const isHuman =
     message.from === "you" ||
     message.from === "human" ||
@@ -111,46 +113,61 @@ export function MessageBubble({
       data-author-slug={message.from}
     >
       {/* Avatar */}
-      <div
-        className={`message-avatar${isHuman ? "" : " avatar-with-harness"}`}
-        style={
-          isHuman
-            ? {
-                background: "var(--bg-warm)",
-                color: "var(--text-secondary)",
-                fontSize: 12,
-                fontWeight: 600,
-              }
-            : undefined
-        }
-      >
-        {isLocalUser ? (
-          "You"
-        ) : teamMemberDisplayName ? (
-          teamMemberDisplayName.slice(0, 1).toUpperCase()
-        ) : (
-          <>
-            <PixelAvatar slug={message.from} size={24} />
-            {harness ? (
-              <HarnessBadge
-                kind={harness}
-                size={14}
-                className="harness-badge-on-avatar"
-              />
-            ) : null}
-          </>
-        )}
-      </div>
+      {!isHuman ? (
+        <button
+          type="button"
+          className="message-avatar avatar-with-harness message-avatar-btn"
+          data-agent-slug={message.from}
+          aria-label={`View profile of ${agent?.name || message.from}`}
+          onClick={() => setActiveAgentSlug(message.from)}
+        >
+          <PixelAvatar slug={message.from} size={24} />
+          {harness ? (
+            <HarnessBadge
+              kind={harness}
+              size={14}
+              className="harness-badge-on-avatar"
+            />
+          ) : null}
+        </button>
+      ) : (
+        <div
+          className="message-avatar"
+          style={{
+            background: "var(--bg-warm)",
+            color: "var(--text-secondary)",
+            fontSize: 12,
+            fontWeight: 600,
+          }}
+        >
+          {isLocalUser
+            ? "You"
+            : teamMemberDisplayName
+              ? teamMemberDisplayName.slice(0, 1).toUpperCase()
+              : null}
+        </div>
+      )}
 
       {/* Content */}
       <div className="message-content">
         {/* Header */}
         <div className="message-header">
-          <span className="message-author">
-            {isLocalUser
-              ? "You"
-              : teamMemberDisplayName || agent?.name || message.from}
-          </span>
+          {!isHuman ? (
+            <button
+              type="button"
+              className="message-author message-author-btn"
+              data-agent-slug={message.from}
+              onClick={() => setActiveAgentSlug(message.from)}
+            >
+              {agent?.name || message.from}
+            </button>
+          ) : (
+            <span className="message-author">
+              {isLocalUser
+                ? "You"
+                : teamMemberDisplayName || agent?.name || message.from}
+            </span>
+          )}
           {isHuman ? (
             <span className="badge badge-neutral">human</span>
           ) : agent?.role ? (

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -118,7 +118,7 @@ export function MessageBubble({
           type="button"
           className="message-avatar avatar-with-harness message-avatar-btn"
           data-agent-slug={message.from}
-          aria-label={`View profile of ${agent?.name || message.from}`}
+          aria-label={`Open agent panel for ${agent?.name || message.from}`}
           onClick={() => setActiveAgentSlug(message.from)}
         >
           <PixelAvatar slug={message.from} size={24} />
@@ -157,6 +157,7 @@ export function MessageBubble({
               type="button"
               className="message-author message-author-btn"
               data-agent-slug={message.from}
+              aria-label={`Open agent panel for ${agent?.name || message.from}`}
               onClick={() => setActiveAgentSlug(message.from)}
             >
               {agent?.name || message.from}

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -537,6 +537,232 @@
   height: 320px;
 }
 
+/* ─── Agent Profile Panel ─── */
+.agent-profile-panel {
+  /* Inherits .agent-panel layout; adds a scrollable body */
+}
+
+.agent-profile-body {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.agent-profile-section {
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.agent-profile-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  margin-bottom: 8px;
+  font-family: var(--font-mono);
+}
+
+.agent-profile-empty {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-style: italic;
+  padding: 2px 0;
+}
+
+.agent-profile-role-text,
+.agent-profile-current-task {
+  font-size: 13px;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+/* Status badge */
+.agent-profile-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  color: var(--text-tertiary);
+  text-transform: lowercase;
+}
+
+.agent-profile-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--neutral-400);
+  flex-shrink: 0;
+}
+
+.agent-profile-status-badge.active .agent-profile-status-dot {
+  background: var(--green);
+}
+
+.agent-profile-status-badge.paused .agent-profile-status-dot {
+  background: var(--yellow);
+}
+
+/* List (skills, runs, tasks) */
+.agent-profile-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agent-profile-list-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text);
+  min-height: 26px;
+}
+
+.agent-profile-skill-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-profile-badge {
+  font-size: 9px;
+  padding: 1px 6px;
+  flex-shrink: 0;
+}
+
+/* Channels chips */
+.agent-profile-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.agent-profile-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: var(--radius-full);
+  font-size: 11px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+  font-family: var(--font-sans);
+}
+
+.agent-profile-chip:hover {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* Run items */
+.agent-profile-run-item {
+  width: 100%;
+}
+
+.agent-profile-run-btn,
+.agent-profile-task-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 3px 0;
+  text-align: left;
+  transition: color 0.15s;
+  font-family: var(--font-sans);
+  color: var(--text);
+}
+
+.agent-profile-run-btn:hover,
+.agent-profile-task-btn:hover {
+  color: var(--accent);
+}
+
+.agent-profile-run-id {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+
+.agent-profile-run-meta {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.agent-profile-task-title {
+  font-size: 12px;
+  color: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.agent-profile-see-all {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--accent);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-family: var(--font-sans);
+  transition: opacity 0.15s;
+}
+
+.agent-profile-see-all:hover {
+  opacity: 0.75;
+}
+
+/* Permissions / runtime grid */
+.agent-profile-permissions {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.agent-profile-perm-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.agent-profile-perm-label {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  min-width: 72px;
+  flex-shrink: 0;
+}
+
+.agent-profile-perm-value {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ─── Responsive ─── */
 @media (max-width: 768px) {
   .agent-panel {

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -573,6 +573,7 @@
 
 .agent-profile-role-text,
 .agent-profile-current-task {
+  margin: 0;
   font-size: 13px;
   color: var(--text-secondary);
   line-height: 1.5;

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -608,6 +608,8 @@
 /* List (skills, runs, tasks) */
 .agent-profile-list {
   list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -155,7 +155,7 @@
 .message-avatar-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 50%;
+  border-radius: 8px;
   opacity: 1;
 }
 .message-author-btn {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -142,6 +142,32 @@
   font-size: 13px;
   font-weight: 600;
 }
+
+/* Clickable avatar / author for agent messages — opens profile panel */
+.message-avatar-btn {
+  cursor: pointer;
+  border: none;
+  transition: opacity 0.15s;
+}
+.message-avatar-btn:hover {
+  opacity: 0.75;
+}
+.message-author-btn {
+  font-size: 13px;
+  font-weight: 600;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--text);
+  font-family: var(--font-sans);
+  transition: color 0.15s;
+}
+.message-author-btn:hover {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
 .message-time {
   font-size: 11px;
   color: var(--text-tertiary);

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -152,6 +152,12 @@
 .message-avatar-btn:hover {
   opacity: 0.75;
 }
+.message-avatar-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 50%;
+  opacity: 1;
+}
 .message-author-btn {
   font-size: 13px;
   font-weight: 600;

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -145,6 +145,9 @@
 
 /* Clickable avatar / author for agent messages — opens profile panel */
 .message-avatar-btn {
+  background: transparent;
+  padding: 0;
+  border-radius: 8px;
   cursor: pointer;
   border: none;
   transition: opacity 0.15s;
@@ -155,7 +158,6 @@
 .message-avatar-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 8px;
   opacity: 1;
 }
 .message-author-btn {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -174,6 +174,11 @@
   text-decoration: underline;
   text-underline-offset: 2px;
 }
+.message-author-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
 .message-time {
   font-size: 11px;
   color: var(--text-tertiary);


### PR DESCRIPTION
## Summary

- Adds `AgentProfilePanel` component — a right-rail slide-in panel that renders a full agent profile with 8 sections: status badge, role/description, runtime/provider, owned skills, channels the agent belongs to, recent runs (linked to activity app), recent tasks, and permissions summary
- Adds a **Profile** button to `AgentPanel`'s primary actions row; clicking it switches the panel in-place to the profile view (no navigation, no new route)
- Makes message **avatar** and **author name** clickable for agent messages — both now open the agent panel (which the user can then navigate to Profile from)
- All sections handle missing data gracefully with empty-state copy

## Entry points

| Surface | How |
|---|---|
| Roster/sidebar | Click agent → panel opens → click **Profile** |
| Message avatar | Click avatar on any agent message → panel opens |
| Message author name | Click author name on any agent message → panel opens |

## Sections rendered

- **Status** — active / idle / paused badge with coloured dot
- **Role** — full role description text
- **Current task** — live task text when agent is active
- **Runtime** — harness (claude-code/codex/…) and model
- **Skills** — skills owned by this agent (active + proposed), with pending badge
- **Channels** — clickable chips navigating to each channel
- **Recent runs** — up to 8 log tasks with tool-call count and error flag; "See all activity" links to the activity app
- **Recent tasks** — up to 5 tasks owned by this agent, linked to task detail
- **Permissions** — role classification, removable flag, built-in flag (read-only in this PR)

## Test plan

- [ ] Render full-data agent profile — all sections populated
- [ ] Render minimal agent (no role, no tasks, no channels, no skills) — empty states shown, no crash
- [ ] Click Profile in AgentPanel → profile replaces quick-panel view
- [ ] Click message avatar → agent panel opens
- [ ] Click message author name → agent panel opens
- [ ] "See all activity" navigates to `/apps/activity`
- [ ] Channel chip navigates to `/channels/:slug`
- [ ] Vitest: `bash scripts/test-web.sh web/src/components/agents` — 14/14 pass

## Checks

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — no errors on changed files
- [x] `bunx secretlint` — clean
- [x] `bash scripts/test-web.sh web/src/components/agents` — 14/14
- [x] `bash scripts/check-complexity-baseline.sh` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Agent Profile view showing skills, channels, recent activity, tasks, permissions, runtime/provider info, and a close action; Agent panel gains a "Profile" action and agent-origin avatars/names are now interactive to open profiles or set the active agent.

* **Style**
  * Added styles for the Agent Profile UI and accessible, keyboard-focusable agent avatar/author controls.

* **Tests**
  * Comprehensive tests for profile rendering, interactions, filtering, empty states, and navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->