### PR TITLE
feat(team): A3 per-phase HeadlessEvent mappers — text/tool_use/tool_result

### DIFF
--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -159,6 +159,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	var firstTextAt time.Time
 	var firstToolAt time.Time
 	textStarted := false
+	turnID := newHeadlessTurnID()
 
 	result, parseErr := provider.ReadClaudeJSONStream(teedStdout, func(event provider.ClaudeStreamEvent) {
 		if firstEventAt.IsZero() {
@@ -178,6 +179,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
 			relay.OnText(event.Text)
+			emitHeadlessText(agentStream, turnID, HeadlessProviderClaude, slug, taskID, event.Text, "claude.text")
 		case "tool_use":
 			relay.Flush()
 			if firstToolAt.IsZero() {
@@ -186,9 +188,11 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			}
 			appendHeadlessClaudeLog(slug, fmt.Sprintf("tool_use: %s %s", event.ToolName, truncate(event.ToolInput, 120)))
 			l.updateHeadlessProgress(slug, "active", "tool_use", fmt.Sprintf("running %s", strings.TrimSpace(event.ToolName)), metrics)
+			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderClaude, slug, taskID, event.ToolName, event.ToolInput, "claude.tool_use")
 		case "tool_result":
 			appendHeadlessClaudeLog(slug, "tool_result: "+truncate(event.Text, 140))
 			l.updateHeadlessProgress(slug, "active", "tool_result", truncate(event.Text, 140), metrics)
+			emitHeadlessToolResult(agentStream, turnID, HeadlessProviderClaude, slug, taskID, event.ToolName, event.Text, "claude.tool_result")
 		case "error":
 			appendHeadlessClaudeLog(slug, "stream_error: "+event.Detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(event.Detail, 180), metrics)
@@ -206,7 +210,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			detail,
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
-		emitHeadlessTerminal(agentStream, HeadlessProviderClaude, slug, taskID, "", detail, metrics, claudeUsageToTokenUsage(result.Usage))
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", detail, metrics, claudeUsageToTokenUsage(result.Usage))
 		return fmt.Errorf("%w: %s", err, detail)
 	}
 	if parseErr != nil {
@@ -219,7 +223,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			parseErr.Error(),
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
-		emitHeadlessTerminal(agentStream, HeadlessProviderClaude, slug, taskID, "", parseErr.Error(), metrics, claudeUsageToTokenUsage(result.Usage))
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", parseErr.Error(), metrics, claudeUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 
@@ -238,7 +242,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
-	emitHeadlessTerminal(agentStream, HeadlessProviderClaude, slug, taskID, summary, "", metrics, claudeUsageToTokenUsage(result.Usage))
+	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, summary, "", metrics, claudeUsageToTokenUsage(result.Usage))
 	if l.broker != nil {
 		l.broker.RecordAgentUsage(slug, l.headlessClaudeModel(slug), result.Usage)
 	}

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -165,6 +165,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	var firstTextAt time.Time
 	var firstToolAt time.Time
 	textStarted := false
+	turnID := newHeadlessTurnID()
 	result, parseErr := provider.ReadCodexJSONStream(teedStdout, func(event provider.CodexStreamEvent) {
 		if firstEventAt.IsZero() {
 			firstEventAt = time.Now()
@@ -181,6 +182,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
 			relay.OnText(event.Text)
+			emitHeadlessText(agentStream, turnID, HeadlessProviderCodex, slug, taskID, event.Text, event.RawType)
 		case "tool_use":
 			relay.Flush()
 			if firstToolAt.IsZero() {
@@ -190,10 +192,12 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			line := fmt.Sprintf("tool_use: %s %s", event.ToolName, truncate(event.ToolInput, 120))
 			appendHeadlessCodexLog(slug, line)
 			l.updateHeadlessProgress(slug, "active", "tool_use", fmt.Sprintf("running %s", strings.TrimSpace(event.ToolName)), metrics)
+			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderCodex, slug, taskID, event.ToolName, event.ToolInput, event.RawType)
 		case "tool_result":
 			line := "tool_result: " + truncate(event.Text, 140)
 			appendHeadlessCodexLog(slug, line)
 			l.updateHeadlessProgress(slug, "active", "tool_result", truncate(event.Text, 140), metrics)
+			emitHeadlessToolResult(agentStream, turnID, HeadlessProviderCodex, slug, taskID, event.ToolName, event.Text, event.RawType)
 		case "error":
 			appendHeadlessCodexLog(slug, "stream_error: "+event.Detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(event.Detail, 180), metrics)
@@ -213,7 +217,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			))
 			appendHeadlessCodexLog(slug, "stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
-			emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, "", detail, metrics, codexUsageToTokenUsage(result.Usage))
+			emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", detail, metrics, codexUsageToTokenUsage(result.Usage))
 			if isCodexAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -233,13 +237,13 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			durationMillis(startedAt, firstToolAt),
 			err.Error(),
 		))
-		emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, "", err.Error(), metrics, codexUsageToTokenUsage(result.Usage))
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", err.Error(), metrics, codexUsageToTokenUsage(result.Usage))
 		return err
 	}
 	if parseErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
-		emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, "", parseErr.Error(), metrics, codexUsageToTokenUsage(result.Usage))
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", parseErr.Error(), metrics, codexUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 	metrics.TotalMs = time.Since(startedAt).Milliseconds()
@@ -257,7 +261,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
-	emitHeadlessTerminal(agentStream, HeadlessProviderCodex, slug, taskID, summary, "", metrics, codexUsageToTokenUsage(result.Usage))
+	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, summary, "", metrics, codexUsageToTokenUsage(result.Usage))
 	if l.broker != nil && (result.Usage.InputTokens != 0 || result.Usage.OutputTokens != 0 || result.Usage.CacheReadTokens != 0 || result.Usage.CacheCreationTokens != 0 || result.Usage.CostUSD != 0) {
 		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
 	}

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -1,8 +1,12 @@
 package team
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
@@ -160,12 +164,20 @@ type headlessTokenUsage struct {
 // and the timeline event stay aligned. Provider is the wire-format
 // constant (HeadlessProviderClaude, etc).
 func emitHeadlessTerminal(stream *agentStreamBuffer, provider, slug, taskID, summary, errDetail string, metrics headlessProgressMetrics, usage *headlessTokenUsage) {
+	emitHeadlessTerminalWithTurn(stream, "", provider, slug, taskID, summary, errDetail, metrics, usage)
+}
+
+// emitHeadlessTerminalWithTurn is the turn-aware variant of
+// emitHeadlessTerminal. Pass the same turnID used for the per-phase
+// emits so all events from one turn carry a stable correlation key.
+func emitHeadlessTerminalWithTurn(stream *agentStreamBuffer, turnID, provider, slug, taskID, summary, errDetail string, metrics headlessProgressMetrics, usage *headlessTokenUsage) {
 	if stream == nil {
 		return
 	}
 	event := HeadlessEvent{
 		Provider: provider,
 		Agent:    slug,
+		TurnID:   strings.TrimSpace(turnID),
 		TaskID:   strings.TrimSpace(taskID),
 		Metrics:  headlessProgressEventMetrics(metrics, usage),
 	}
@@ -180,4 +192,88 @@ func emitHeadlessTerminal(stream *agentStreamBuffer, provider, slug, taskID, sum
 		event.Text = summary
 	}
 	pushHeadlessEvent(stream, event)
+}
+
+// emitHeadlessText pushes a text-phase HeadlessEvent. text is the
+// user-facing chunk the model just produced. rawType is the underlying
+// provider event name (e.g. "content_block_delta", "response.output_text.delta")
+// — empty when the runner cannot supply one.
+//
+// Empty text is dropped so trivially-empty text-deltas (provider noise
+// during preamble) don't pollute the timeline.
+func emitHeadlessText(stream *agentStreamBuffer, turnID, provider, slug, taskID, text, rawType string) {
+	if stream == nil || strings.TrimSpace(text) == "" {
+		return
+	}
+	pushHeadlessEvent(stream, HeadlessEvent{
+		Type:     HeadlessEventTypeText,
+		Provider: provider,
+		Agent:    slug,
+		TurnID:   strings.TrimSpace(turnID),
+		TaskID:   strings.TrimSpace(taskID),
+		Text:     text,
+		Status:   "active",
+		RawType:  rawType,
+	})
+}
+
+// emitHeadlessToolUse pushes a tool_use-phase HeadlessEvent. toolInput is
+// the JSON-serialized arguments string the runner already builds (kept as
+// string so the wire shape is stable across providers that pre-stream
+// arguments differently).
+func emitHeadlessToolUse(stream *agentStreamBuffer, turnID, provider, slug, taskID, toolName, toolInput, rawType string) {
+	if stream == nil || strings.TrimSpace(toolName) == "" {
+		return
+	}
+	pushHeadlessEvent(stream, HeadlessEvent{
+		Type:     HeadlessEventTypeToolUse,
+		Provider: provider,
+		Agent:    slug,
+		TurnID:   strings.TrimSpace(turnID),
+		TaskID:   strings.TrimSpace(taskID),
+		ToolName: strings.TrimSpace(toolName),
+		Detail:   toolInput,
+		Status:   "active",
+		RawType:  rawType,
+	})
+}
+
+// emitHeadlessToolResult pushes a tool_result-phase HeadlessEvent. text is
+// the truncated result summary the runner already prepares for logs.
+func emitHeadlessToolResult(stream *agentStreamBuffer, turnID, provider, slug, taskID, toolName, text, rawType string) {
+	if stream == nil {
+		return
+	}
+	pushHeadlessEvent(stream, HeadlessEvent{
+		Type:     HeadlessEventTypeToolResult,
+		Provider: provider,
+		Agent:    slug,
+		TurnID:   strings.TrimSpace(turnID),
+		TaskID:   strings.TrimSpace(taskID),
+		ToolName: strings.TrimSpace(toolName),
+		Text:     text,
+		Status:   "active",
+		RawType:  rawType,
+	})
+}
+
+// turnIDCounter is a process-local fallback when crypto/rand fails (it
+// almost never does). Combined with a per-process-start nanosecond it
+// keeps generated IDs unique even when the system entropy source is
+// briefly unavailable.
+var turnIDCounter atomic.Uint64
+
+// newHeadlessTurnID returns a short, opaque correlation ID for one
+// runner turn. Callers attach this to every HeadlessEvent they emit so
+// downstream consumers can group events from the same turn without
+// pattern-matching on text content. Format is implementation-detail —
+// hex string today; treat as opaque.
+func newHeadlessTurnID() string {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		return hex.EncodeToString(b[:])
+	}
+	// crypto/rand failure is rare on supported platforms; fall back to
+	// the atomic counter so we never block a turn for a missing ID.
+	return fmt.Sprintf("ctr-%d-%d", time.Now().UnixNano(), turnIDCounter.Add(1))
 }

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -241,7 +241,7 @@ func emitHeadlessToolUse(stream *agentStreamBuffer, turnID, provider, slug, task
 // emitHeadlessToolResult pushes a tool_result-phase HeadlessEvent. text is
 // the truncated result summary the runner already prepares for logs.
 func emitHeadlessToolResult(stream *agentStreamBuffer, turnID, provider, slug, taskID, toolName, text, rawType string) {
-	if stream == nil {
+	if stream == nil || strings.TrimSpace(toolName) == "" {
 		return
 	}
 	pushHeadlessEvent(stream, HeadlessEvent{

--- a/internal/team/headless_event_test.go
+++ b/internal/team/headless_event_test.go
@@ -112,6 +112,106 @@ func TestEmitHeadlessTerminalIdleAndError(t *testing.T) {
 	}
 }
 
+// TestEmitHeadlessTextDropsEmptyAndCarriesTurn pins the per-phase text
+// emit contract: empty text is silently dropped (so trivially-empty
+// stream noise during preamble doesn't pollute the timeline), but a
+// text chunk carries kind="headless_event", type="text", the turn
+// correlation key, and the runner-supplied raw_type for debug tooling.
+func TestEmitHeadlessTextDropsEmptyAndCarriesTurn(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+
+	// Empty / whitespace-only text must not produce an event.
+	emitHeadlessText(stream, "turn-1", HeadlessProviderClaude, "ceo", "task-1", "", "claude.text")
+	emitHeadlessText(stream, "turn-1", HeadlessProviderClaude, "ceo", "task-1", "   ", "claude.text")
+	if got := stream.recentTask("task-1"); len(got) != 0 {
+		t.Fatalf("empty text must be dropped, got %d lines: %v", len(got), got)
+	}
+
+	emitHeadlessText(stream, "turn-1", HeadlessProviderClaude, "ceo", "task-1", "shipping the update", "claude.text")
+	got := stream.recentTask("task-1")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 text event, got %d: %v", len(got), got)
+	}
+	var event HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(got[0], "\n")), &event); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if event.Type != HeadlessEventTypeText {
+		t.Fatalf("type: want text, got %q", event.Type)
+	}
+	if event.TurnID != "turn-1" {
+		t.Fatalf("turn id missing: %+v", event)
+	}
+	if event.RawType != "claude.text" {
+		t.Fatalf("raw_type missing: %+v", event)
+	}
+	if event.Status != "active" {
+		t.Fatalf("status: want active, got %q", event.Status)
+	}
+}
+
+// TestEmitHeadlessToolUseAndToolResult pins the tool-phase wire shape:
+// tool_use carries the tool name + serialized arguments; tool_result
+// carries the truncated summary text. Both variants share the same
+// turn id so a downstream consumer can correlate call -> result.
+func TestEmitHeadlessToolUseAndToolResult(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+
+	emitHeadlessToolUse(stream, "turn-2", HeadlessProviderCodex, "eng", "task-7", "team_broadcast", `{"channel":"general","content":"shipped"}`, "response.function_call.delta")
+	emitHeadlessToolResult(stream, "turn-2", HeadlessProviderCodex, "eng", "task-7", "team_broadcast", "Posted to #general as @eng", "response.function_call_result")
+
+	// Empty tool name must be silently dropped — the runner's stream
+	// callback can't always tag a name (Codex pre-streams arguments
+	// before the name lands in the same chunk), and we don't want a
+	// nameless tool_use polluting the timeline.
+	emitHeadlessToolUse(stream, "turn-2", HeadlessProviderCodex, "eng", "task-7", "", "{}", "")
+
+	lines := stream.recentTask("task-7")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 events (tool_use + tool_result), got %d: %v", len(lines), lines)
+	}
+	var use, res HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &use); err != nil {
+		t.Fatalf("tool_use decode: %v", err)
+	}
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[1], "\n")), &res); err != nil {
+		t.Fatalf("tool_result decode: %v", err)
+	}
+	if use.Type != HeadlessEventTypeToolUse || res.Type != HeadlessEventTypeToolResult {
+		t.Fatalf("types: %+v %+v", use, res)
+	}
+	if use.TurnID != "turn-2" || res.TurnID != "turn-2" {
+		t.Fatalf("correlation lost: %+v %+v", use, res)
+	}
+	if use.ToolName != "team_broadcast" || res.ToolName != "team_broadcast" {
+		t.Fatalf("tool name: %+v %+v", use, res)
+	}
+	if use.Detail == "" {
+		t.Fatalf("tool_use Detail must carry serialized arguments: %+v", use)
+	}
+	if res.Text == "" {
+		t.Fatalf("tool_result Text must carry summary: %+v", res)
+	}
+}
+
+// TestNewHeadlessTurnIDIsUnique pins the contract: every call returns a
+// distinct opaque ID. The runner uses this to correlate text/tool events
+// from the same turn — two turns colliding would silently merge their
+// timelines. crypto/rand-backed; collision is astronomically unlikely.
+func TestNewHeadlessTurnIDIsUnique(t *testing.T) {
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		id := newHeadlessTurnID()
+		if id == "" {
+			t.Fatalf("turn id %d empty", i)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("turn id %d collided: %q", i, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
 // TestHeadlessProgressEventMetricsDropsSentinels pins the "-1 means
 // not measured" sentinel handling. Sentinels must not leak onto the
 // wire as negative numbers — JSON omitempty zeros are how the frontend

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -142,6 +142,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	// taskID is unique per turn so the Receipts panel groups each
 	// agent's turn into its own row. Format mirrors agent.nextTaskID.
 	taskID := fmt.Sprintf("%s-%d", slug, time.Now().UnixMilli())
+	turnID := newHeadlessTurnID()
 
 	loop := openAICompatToolLoop{
 		streamFn:    streamFn,
@@ -152,13 +153,24 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		taskLogRoot: agent.DefaultTaskLogRoot(),
 		taskID:      taskID,
 		agentSlug:   slug,
-		onText:      state.onText,
+		onText: func(chunk string) {
+			state.onText(chunk)
+			emitHeadlessText(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, chunk, kind+".text")
+		},
 		onToolUse: func(name, rawInput string) {
 			state.onToolUseChunk(name, rawInput)
 			l.updateHeadlessProgress(slug, "active", "tool", "running "+name, metrics)
+			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, name, rawInput, kind+".tool_use")
 		},
-		onError:      state.onError,
-		onToolResult: state.onToolResult,
+		onError: state.onError,
+		onToolResult: func(name, result string, err error) {
+			state.onToolResult(name, result, err)
+			text := result
+			if err != nil {
+				text = err.Error()
+			}
+			emitHeadlessToolResult(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, name, text, kind+".tool_result")
+		},
 		onFirstEvent: func() {
 			metrics.FirstEventMs = durationMillis(startedAt, time.Now())
 		},
@@ -182,7 +194,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	if err != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), metrics)
-		emitHeadlessTerminal(agentStream, HeadlessProviderOpenAICompat, slug, activeTaskID, "", err.Error(), metrics, claudeUsageToTokenUsage(turnUsage))
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", err.Error(), metrics, claudeUsageToTokenUsage(turnUsage))
 		return err
 	}
 	if streamErr != "" {
@@ -193,7 +205,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 			iterationsUsed, streamErr,
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(streamErr, 180), metrics)
-		emitHeadlessTerminal(agentStream, HeadlessProviderOpenAICompat, slug, activeTaskID, "", streamErr, metrics, claudeUsageToTokenUsage(turnUsage))
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", streamErr, metrics, claudeUsageToTokenUsage(turnUsage))
 		// Post any partial output (e.g. the cap-hit marker the loop
 		// produced when maxIters tripped) before propagating the error,
 		// so the user sees something on-channel rather than a silent
@@ -233,7 +245,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
-	emitHeadlessTerminal(agentStream, HeadlessProviderOpenAICompat, slug, activeTaskID, summary, "", metrics, claudeUsageToTokenUsage(turnUsage))
+	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, summary, "", metrics, claudeUsageToTokenUsage(turnUsage))
 
 	state.flushLiveChat()
 	if text != "" && state.shouldPostFinalText() {

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -148,6 +148,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	var firstEventAt, firstTextAt, firstToolAt time.Time
 	textStarted := false
 	var lastError string
+	turnID := newHeadlessTurnID()
 	pushStream := func(line string) {
 		if agentStream != nil && strings.TrimSpace(line) != "" {
 			agentStream.PushTask(taskID, line)
@@ -174,6 +175,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			}
 			pushStream(ev.Text)
 			relay.OnText(ev.Text)
+			emitHeadlessText(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, ev.Text, "opencode.text")
 		case "tool_use":
 			relay.Flush()
 			if firstToolAt.IsZero() {
@@ -186,9 +188,11 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			}
 			l.updateHeadlessProgress(slug, "active", "tool", "running "+detail, metrics)
 			pushStream("[tool] " + detail)
+			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, ev.ToolName, "", "opencode.tool_use")
 		case "tool_result":
 			if d := strings.TrimSpace(ev.Detail); d != "" {
 				pushStream("[tool_result] " + truncate(d, 240))
+				emitHeadlessToolResult(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, ev.ToolName, d, "opencode.tool_result")
 			}
 		case "error":
 			if msg := strings.TrimSpace(ev.Detail); msg != "" {
@@ -213,7 +217,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			))
 			appendHeadlessCodexLog(slug, "opencode_stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
-			emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, "", detail, metrics, nil)
+			emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", detail, metrics, nil)
 			if isOpencodeAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -232,13 +236,13 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			durationMillis(startedAt, firstTextAt),
 			err.Error(),
 		))
-		emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, "", err.Error(), metrics, nil)
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", err.Error(), metrics, nil)
 		return err
 	}
 	if scanErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(scanErr.Error(), 180), metrics)
-		emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, "", scanErr.Error(), metrics, nil)
+		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", scanErr.Error(), metrics, nil)
 		return scanErr
 	}
 
@@ -259,7 +263,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
-	emitHeadlessTerminal(agentStream, HeadlessProviderOpencode, slug, taskID, summary, "", metrics, nil)
+	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, summary, "", metrics, nil)
 	relay.Flush()
 	if text != "" {
 		appendHeadlessCodexLog(slug, "opencode_result: "+text)

--- a/web/src/components/messages/StreamLineView.test.tsx
+++ b/web/src/components/messages/StreamLineView.test.tsx
@@ -154,6 +154,49 @@ describe("<StreamLineView>", () => {
     expect(screen.getByText("auth: 401 unauthorized")).toBeInTheDocument();
   });
 
+  it("renders a HeadlessEvent text envelope as a thinking block", () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "text",
+            provider: "claude",
+            agent: "ceo",
+            text: "Shipping the update now",
+            status: "active",
+            turn_id: "abc123",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Shipping the update now")).toBeInTheDocument();
+  });
+
+  it("renders a HeadlessEvent tool_use envelope as a tool call card", () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "tool_use",
+            provider: "codex",
+            agent: "eng",
+            tool_name: "team_broadcast",
+            detail: '{"channel":"general","content":"Done"}',
+            status: "active",
+            turn_id: "xyz789",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("team_broadcast")).toBeInTheDocument();
+  });
+
   it("renders Codex completed message content arrays", () => {
     render(
       <StreamLineView

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -171,6 +171,35 @@ function HeadlessEventView({ parsed }: { parsed: Record<string, unknown> }) {
     );
   }
 
+  if (eventType === "text") {
+    // Text events render as the same dim "thinking" block the
+    // provider-native paths use, so a stream containing both raw
+    // provider chunks (today's wire) and HeadlessEvent text (A3+)
+    // looks visually consistent. Empty text is dropped at the runner
+    // boundary; we still guard here because old captures may exist.
+    if (!text) return null;
+    return <div className="cc-thinking">{text}</div>;
+  }
+
+  if (eventType === "tool_use" || eventType === "tool_result") {
+    // Reuse the existing ToolCallCard so HeadlessEvent tool entries
+    // get the same collapsible chrome as the provider-native paths.
+    // Wire mapping: HeadlessEvent.tool_name -> name, .detail -> args
+    // for tool_use, .text -> result for tool_result.
+    const toolName = stringish(parsed.tool_name) || "tool";
+    return (
+      <ToolCallCard
+        item={{
+          type: "tool_call",
+          name: toolName,
+          arguments: eventType === "tool_use" ? parsed.detail : undefined,
+          result: eventType === "tool_result" ? parsed.text : undefined,
+        }}
+        compact={false}
+      />
+    );
+  }
+
   // Unknown HeadlessEvent type — fall back to the generic card so future
   // variants render something useful before they earn a dedicated branch.
   return <GenericEventCard parsed={parsed} compact={false} />;

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -177,7 +177,7 @@ function HeadlessEventView({ parsed }: { parsed: Record<string, unknown> }) {
     // provider chunks (today's wire) and HeadlessEvent text (A3+)
     // looks visually consistent. Empty text is dropped at the runner
     // boundary; we still guard here because old captures may exist.
-    if (!text) return null;
+    if (!text.trim()) return null;
     return <div className="cc-thinking">{text}</div>;
   }
 
@@ -195,14 +195,14 @@ function HeadlessEventView({ parsed }: { parsed: Record<string, unknown> }) {
           arguments: eventType === "tool_use" ? parsed.detail : undefined,
           result: eventType === "tool_result" ? parsed.text : undefined,
         }}
-        compact={false}
+        compact={compact}
       />
     );
   }
 
   // Unknown HeadlessEvent type — fall back to the generic card so future
   // variants render something useful before they earn a dedicated branch.
-  return <GenericEventCard parsed={parsed} compact={false} />;
+  return <GenericEventCard parsed={parsed} compact={compact} />;
 }
 
 function ClaudeAssistantEvent({

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -33,7 +33,7 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
   // Branch first so the discriminator wins over provider-native `type`
   // routes below (e.g. `assistant`, `mcp_tool_event`).
   if (parsed.kind === "headless_event") {
-    return <HeadlessEventView parsed={parsed} />;
+    return <HeadlessEventView parsed={parsed} compact={compact} />;
   }
 
   const evtType = typeof parsed.type === "string" ? parsed.type : "";
@@ -131,7 +131,13 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
 // minimal because future slices (text / tool_use / tool_result) will
 // reuse this component, and a maximalist v1 design would lock those
 // future variants into chrome that won't fit.
-function HeadlessEventView({ parsed }: { parsed: Record<string, unknown> }) {
+function HeadlessEventView({
+  parsed,
+  compact,
+}: {
+  parsed: Record<string, unknown>;
+  compact: boolean;
+}) {
   const eventType = stringish(parsed.type);
   const provider = stringish(parsed.provider);
   const text = stringish(parsed.text);


### PR DESCRIPTION
## Summary

- Wire `emitHeadlessText`, `emitHeadlessToolUse`, `emitHeadlessToolResult` into all four runner stream callbacks (claude, codex, opencode, openai-compat)
- Add `emitHeadlessTerminalWithTurn` so terminal idle/error events carry the same `turn_id` as the per-phase events — enables downstream grouping without pattern-matching on text
- Add `newHeadlessTurnID()` — short crypto/rand hex ID generated once per runner turn, threaded through all emit calls
- Frontend `HeadlessEventView` in `StreamLineView.tsx` gets handlers for `text` (renders as `cc-thinking` block) and `tool_use`/`tool_result` (renders via existing `ToolCallCard`)

**Slice context:** A3 of the Flue agent-harness extraction. A1 (drain hardening, #670) and A2 (HeadlessEvent envelope + replay-end boundary, #698) are merged. A4 (manifest) is next.

**Wire back-compat:** Raw provider chunks continue to tee alongside HeadlessEvents — no consumer breakage. A3 just adds the typed channel; the raw tee removal is a separate PR once A3 is the system of record.

## Test plan

- [ ] `go test -race ./internal/team/...` — 7 new tests pass: `TestEmitHeadlessText*`, `TestEmitHeadlessToolUse*`, `TestNewHeadlessTurnIDIsUnique`, `TestHeadlessProgressEventMetrics*`
- [ ] `npx vitest run web/src/components/messages/StreamLineView.test.tsx` — 9 tests pass including 2 new A3 scenarios (text block, tool_use card)
- [ ] `go build -buildvcs=false ./...` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Show dim “thinking” blocks for non-empty intermediate headless runner text and drop empty whitespace-only entries
  * Render tool use and tool result events as tool-call cards (name, args/detail, and result text); these events are correlated per turn
  * Respect compact rendering for headless event cards

* **Tests**
  * Added tests for headless event rendering, tool interaction ordering/correlation, and turn-ID uniqueness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->