### PR TITLE
fix(agents): resolve channels query cache conflict in AgentProfilePanel

### DIFF
--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -335,7 +335,8 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
 
   const { data: channels = [] } = useQuery({
     queryKey: ["channels"],
-    queryFn: () => getChannels().then((r) => r.channels ?? []),
+    queryFn: () => getChannels(),
+    select: (data) => data.channels ?? [],
     refetchInterval: 30_000,
   });
 


### PR DESCRIPTION
## Bug

`AgentProfilePanel` crashed with **`TypeError: channels.filter is not a function`** when opening any agent profile page.

## Root cause

`useChannels` (used elsewhere in the shell) and `AgentProfilePanel` share the React Query cache key `["channels"]`. `useChannels` stores the raw API response `{ channels: [...] }` in the cache and applies its array-extraction via `select:`. `AgentProfilePanel` was using a `queryFn` that transformed inline (`.then(r => r.channels ?? [])`), so it received the **raw object** from the already-populated cache instead of the array — and `Object.filter` does not exist.

## Fix

Switch `AgentProfilePanel`'s query to store the same raw response and use `select:` for extraction, consistent with `useChannels`:

```diff
- queryFn: () => getChannels().then((r) => r.channels ?? []),
+ queryFn: () => getChannels(),
+ select: (data) => data.channels ?? [],
```

`select` is applied per-subscriber without affecting the shared cache — both hooks now coexist correctly.

## Test

Verified via browser test on `feat/agent-profile-pages` Vite dev server:
- Click agent in sidebar → peek panel → Profile
- Profile panel renders with channels section showing `#general`
- No runtime error

🤖 Generated with [Claude Code](https://claude.com/claude-code)