### PR TITLE
refactor(transport): host-driven outbound dispatcher for telegram

### DIFF
--- a/internal/team/broker_outbound_dispatch.go
+++ b/internal/team/broker_outbound_dispatch.go
@@ -1,0 +1,87 @@
+package team
+
+// broker_outbound_dispatch.go owns the per-transport outbound dispatcher loop
+// that the launcher runs alongside Run for adapters that publish to an
+// external surface (Telegram today, future channel-bound adapters tomorrow).
+//
+// This honors the transport.Transport contract intent — "The Host calls Send
+// from a per-transport worker goroutine (not the broker's hot path)" — by
+// moving the polling lifecycle out of each adapter and into a shared loop the
+// Host owns. Adapters supply two thin functions:
+//
+//   formatter(channelMessage) (transport.Outbound, bool)
+//       Adapter-specific conversion. Returns ok=false to skip a message
+//       (e.g. the channel slug has no chat mapped). No side effects.
+//
+//   sender(ctx, transport.Outbound) error
+//       The adapter's Transport.Send method (passed by value as a method
+//       expression: t.Send) — actually delivers to the wire.
+//
+// The dispatcher polls broker.ExternalQueue(name) every interval, formats
+// each message, and calls sender. Send errors are logged and the loop
+// continues to the next message — at-least-once delivery semantics already
+// live in the broker's ExternalQueue (which marks messages as delivered on
+// dequeue), so a transient send failure drops the message rather than
+// retrying. This matches the prior in-adapter behavior.
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// outboundDispatchInterval is the polling cadence. Matches the prior
+// in-adapter loop (2s) so behavior is byte-identical at the SLO level for
+// the existing telegram path. If we ever need pushed delivery (lower
+// latency), the broker grows a per-provider notify channel and the
+// dispatcher selects on it instead of a ticker.
+const outboundDispatchInterval = 2 * time.Second
+
+// runOutboundDispatcher polls the broker's outbound queue for `name` and
+// hands each message to the adapter via formatter+sender. Returns when ctx
+// is cancelled. The caller is responsible for goroutine lifecycle (typically
+// launcher_transports.go starts this in a goroutine alongside Transport.Run).
+//
+// formatter must be safe to call from a single goroutine (no caller locking
+// is provided around it). sender is the adapter's Send method; the
+// dispatcher passes ctx through so a Send blocking past adapter timeout can
+// be unwound on shutdown.
+func runOutboundDispatcher(
+	ctx context.Context,
+	broker *Broker,
+	name string,
+	formatter func(channelMessage) (transport.Outbound, bool),
+	sender func(context.Context, transport.Outbound) error,
+) error {
+	if broker == nil {
+		return nil
+	}
+	ticker := time.NewTicker(outboundDispatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+		msgs := broker.ExternalQueue(name)
+		if len(msgs) > 0 {
+			log.Printf("[transport] %s: outbound queue: %d message(s)", name, len(msgs))
+		}
+		for _, msg := range msgs {
+			out, ok := formatter(msg)
+			if !ok {
+				continue
+			}
+			if err := sender(ctx, out); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				log.Printf("[transport] %s: outbound send error for %q: %v", name, out.Binding.ChannelSlug, err)
+				continue
+			}
+		}
+	}
+}

--- a/internal/team/broker_outbound_dispatch_test.go
+++ b/internal/team/broker_outbound_dispatch_test.go
@@ -106,9 +106,13 @@ func TestOutboundDispatcherFormatsAndSendsEachQueuedMessage(t *testing.T) {
 func TestOutboundDispatcherLogsButContinuesOnSendError(t *testing.T) {
 	b := newTestBroker(t)
 	seedSurfaceMessage(t, b, "general", "fail-me")
-	// Second message arrives on a later poll cycle.
+	// Second message is enqueued only after the first fail completes — see
+	// the failedOnce signal below — so its arrival on a later poll cycle is
+	// guaranteed by ordering, not by sleep duration.
 
-	var deliveredOK atomic.Int32
+	failedOnce := make(chan struct{})
+	delivered := make(chan struct{}, 1)
+	var failedOnceClosed atomic.Bool
 	formatter := func(msg channelMessage) (transport.Outbound, bool) {
 		return transport.Outbound{
 			Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: msg.Channel},
@@ -117,9 +121,14 @@ func TestOutboundDispatcherLogsButContinuesOnSendError(t *testing.T) {
 	}
 	sender := func(_ context.Context, out transport.Outbound) error {
 		if out.Text == "fail-me" {
+			// Close-once guard so a second fail (e.g. requeue under load)
+			// does not panic on the closed channel.
+			if failedOnceClosed.CompareAndSwap(false, true) {
+				close(failedOnce)
+			}
 			return errors.New("simulated transient send failure")
 		}
-		deliveredOK.Add(1)
+		delivered <- struct{}{}
 		return nil
 	}
 
@@ -131,19 +140,20 @@ func TestOutboundDispatcherLogsButContinuesOnSendError(t *testing.T) {
 		close(loopDone)
 	}()
 
-	// Wait for the first poll-and-fail cycle, then queue a deliverable
-	// message. The dispatcher must still be alive to pick it up.
-	time.Sleep(outboundDispatchInterval + 200*time.Millisecond)
+	// Wait for the first poll-and-fail to complete deterministically before
+	// seeding the deliverable message. Decouples the test from the
+	// production polling cadence.
+	select {
+	case <-failedOnce:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatcher did not call sender for fail-me within 5s")
+	}
 	seedSurfaceMessage(t, b, "general", "deliver-me")
 
-	deadline := time.After(3 * outboundDispatchInterval)
-	for deliveredOK.Load() != 1 {
-		select {
-		case <-deadline:
-			t.Fatalf("dispatcher stopped after a send error (deliveredOK=%d)", deliveredOK.Load())
-		default:
-			time.Sleep(50 * time.Millisecond)
-		}
+	select {
+	case <-delivered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("dispatcher stopped after a send error (deliver-me never sent)")
 	}
 	cancel()
 	<-loopDone

--- a/internal/team/broker_outbound_dispatch_test.go
+++ b/internal/team/broker_outbound_dispatch_test.go
@@ -1,0 +1,160 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// seedSurfaceMessage posts a system message to a channel that's marked as a
+// telegram surface so b.ExternalQueue("telegram") will return it on the next
+// poll. Using "telegram" as the provider keeps the dispatcher under test
+// independent of the real adapter.
+func seedSurfaceMessage(t *testing.T, b *Broker, channel, content string) {
+	t.Helper()
+	b.mu.Lock()
+	for i := range b.channels {
+		if b.channels[i].Slug == channel {
+			b.channels[i].Surface = &channelSurface{Provider: "telegram"}
+			break
+		}
+	}
+	b.counter++
+	b.messages = append(b.messages, channelMessage{
+		ID:        "msg-test-" + content,
+		From:      "system",
+		Channel:   channel,
+		Kind:      "system",
+		Content:   content,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+	b.mu.Unlock()
+}
+
+// TestOutboundDispatcherFormatsAndSendsEachQueuedMessage asserts the dispatcher
+// loop calls formatter+sender once per queued message and applies the
+// formatter's ok=false skip semantics. Uses a channel-rendezvous instead of
+// a sleep so the test is deterministic.
+func TestOutboundDispatcherFormatsAndSendsEachQueuedMessage(t *testing.T) {
+	b := newTestBroker(t)
+	seedSurfaceMessage(t, b, "general", "alpha")
+	seedSurfaceMessage(t, b, "general", "beta")
+	// Skip-shaped: formatter returns ok=false for messages whose content is
+	// "skip-me". Verifies the dispatcher honors the skip and does not call
+	// sender for that message.
+	seedSurfaceMessage(t, b, "general", "skip-me")
+
+	var sentMu sync.Mutex
+	sent := []string{}
+	done := make(chan struct{})
+	var sendCalls atomic.Int32
+
+	formatter := func(msg channelMessage) (transport.Outbound, bool) {
+		if msg.Content == "skip-me" {
+			return transport.Outbound{}, false
+		}
+		return transport.Outbound{
+			Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: msg.Channel},
+			Text:    msg.Content,
+		}, true
+	}
+	sender := func(_ context.Context, out transport.Outbound) error {
+		sentMu.Lock()
+		sent = append(sent, out.Text)
+		sentMu.Unlock()
+		// Signal as soon as we've seen both expected messages so the test
+		// can stop the dispatcher without waiting on the next ticker tick.
+		if sendCalls.Add(1) == 2 {
+			close(done)
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() { _ = runOutboundDispatcher(ctx, b, "telegram", formatter, sender) }()
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("dispatcher did not deliver expected messages within timeout (sent=%v)", sent)
+	}
+	cancel()
+
+	sentMu.Lock()
+	defer sentMu.Unlock()
+	if len(sent) != 2 {
+		t.Fatalf("sent count: got %d (%v), want 2 (skip-me filtered)", len(sent), sent)
+	}
+	want := map[string]bool{"alpha": true, "beta": true}
+	for _, s := range sent {
+		if !want[s] {
+			t.Errorf("unexpected sent text: %q", s)
+		}
+	}
+}
+
+// TestOutboundDispatcherLogsButContinuesOnSendError asserts a transient
+// sender error does not stop the dispatcher loop — subsequent messages on
+// later ticks are still delivered. Mirrors the at-least-once-with-drop
+// semantics the prior in-adapter loop had.
+func TestOutboundDispatcherLogsButContinuesOnSendError(t *testing.T) {
+	b := newTestBroker(t)
+	seedSurfaceMessage(t, b, "general", "fail-me")
+	// Second message arrives on a later poll cycle.
+
+	var deliveredOK atomic.Int32
+	formatter := func(msg channelMessage) (transport.Outbound, bool) {
+		return transport.Outbound{
+			Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: msg.Channel},
+			Text:    msg.Content,
+		}, true
+	}
+	sender := func(_ context.Context, out transport.Outbound) error {
+		if out.Text == "fail-me" {
+			return errors.New("simulated transient send failure")
+		}
+		deliveredOK.Add(1)
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	loopDone := make(chan struct{})
+	go func() {
+		_ = runOutboundDispatcher(ctx, b, "telegram", formatter, sender)
+		close(loopDone)
+	}()
+
+	// Wait for the first poll-and-fail cycle, then queue a deliverable
+	// message. The dispatcher must still be alive to pick it up.
+	time.Sleep(outboundDispatchInterval + 200*time.Millisecond)
+	seedSurfaceMessage(t, b, "general", "deliver-me")
+
+	deadline := time.After(3 * outboundDispatchInterval)
+	for deliveredOK.Load() != 1 {
+		select {
+		case <-deadline:
+			t.Fatalf("dispatcher stopped after a send error (deliveredOK=%d)", deliveredOK.Load())
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	cancel()
+	<-loopDone
+}
+
+// TestOutboundDispatcherNilBrokerIsNoop asserts a nil broker returns
+// immediately rather than spinning forever — defensive guard for misconfigured
+// callers (the launcher today always passes a real broker).
+func TestOutboundDispatcherNilBrokerIsNoop(t *testing.T) {
+	err := runOutboundDispatcher(context.Background(), nil, "telegram", nil, nil)
+	if err != nil {
+		t.Errorf("nil broker should return nil, got %v", err)
+	}
+}

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -47,14 +47,27 @@ func RegisterTransports(b *Broker) (func(), error) {
 			host := &brokerTransportHost{broker: b}
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan struct{})
+			dispatchDone := make(chan struct{})
 			stops = append(stops, func() {
 				cancel()
-				<-done // wait for Run to return before broker.Stop()
+				<-done         // wait for Run to return before broker.Stop()
+				<-dispatchDone // and the outbound dispatcher's goroutine
 			})
 			go func() {
 				defer close(done)
 				if err := t.Run(ctx, host); err != nil && ctx.Err() == nil {
 					log.Printf("[transport] telegram: exited with error: %v", err)
+				}
+			}()
+			// Host-driven outbound dispatcher. Runs alongside Run rather than
+			// inside it so the goroutine lifecycle is owned by the Host, per the
+			// Transport.Send contract intent. FormatOutbound + Send live on the
+			// adapter; the dispatcher just polls the broker queue and wires the
+			// two together.
+			go func() {
+				defer close(dispatchDone)
+				if err := runOutboundDispatcher(ctx, b, t.Name(), t.FormatOutbound, t.Send); err != nil && ctx.Err() == nil {
+					log.Printf("[transport] telegram: outbound dispatcher exited: %v", err)
 				}
 			}()
 			log.Printf("[transport] telegram: started (%d group(s), dm=%v)", len(t.ChatMap), t.DMChannel != "")

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -139,9 +139,16 @@ func (t *TelegramTransport) Health() transport.Health {
 	}
 }
 
-// Run starts the bidirectional bridge and blocks until ctx is cancelled. Inbound
-// Telegram messages are delivered to the office via host; outbound broker messages
-// are polled from the broker queue and sent via Send. Implements transport.Transport.
+// Run starts the bidirectional bridge and blocks until ctx is cancelled.
+// Inbound Telegram messages are delivered to the office via host; outbound
+// delivery is now driven by the Host-side dispatcher in
+// broker_outbound_dispatch.go (started by launcher_transports.go alongside
+// this Run), so the prior drainOutbound goroutine is gone — the contract
+// intent of "Host calls Send from a per-transport worker goroutine" is honest
+// once again. typingLoop continues to run inside Run because it is a passive
+// presence ping (driven by tagged-agent state on the broker), not a per-message
+// outbound action — keeping it adapter-side avoids leaking telegram-specific
+// "is anyone tagged" polling onto the Host. Implements transport.Transport.
 func (t *TelegramTransport) Run(ctx context.Context, host transport.Host) error {
 	if t.BotToken == "" {
 		return fmt.Errorf("telegram bot token is empty")
@@ -153,9 +160,8 @@ func (t *TelegramTransport) Run(ctx context.Context, host transport.Host) error 
 	ctx2, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	errCh := make(chan error, 2)
+	errCh := make(chan error, 1)
 	go func() { errCh <- t.pollInbound(ctx2, host) }()
-	go func() { errCh <- t.drainOutbound(ctx2) }()
 	go t.typingLoop(ctx2)
 
 	select {
@@ -180,12 +186,40 @@ func (t *TelegramTransport) Start(ctx context.Context) error {
 // Send delivers one outbound message to the Telegram chat mapped to
 // msg.Binding.ChannelSlug. Returns an error if no chat is mapped for that slug
 // or if the Telegram API call fails. Implements transport.Transport.
+//
+// A "typing" action is sent immediately before the message body so chats see
+// the same UX they got under the prior in-adapter outbound loop: a brief
+// typing bubble, then the formatted message. Sending typing fails silently —
+// it is a UX nicety, not a delivery prerequisite, and surfacing the error
+// would just translate every Send into two error paths.
 func (t *TelegramTransport) Send(ctx context.Context, msg transport.Outbound) error {
 	chatID := t.chatIDForSlug(msg.Binding.ChannelSlug)
 	if chatID == "" {
 		return fmt.Errorf("telegram: no chat mapped for channel %q", msg.Binding.ChannelSlug)
 	}
+	if chatIDInt, parseErr := strconv.ParseInt(chatID, 10, 64); parseErr == nil {
+		_ = SendTypingAction(ctx, t.BotToken, chatIDInt)
+	}
 	return t.sendMessageHTML(ctx, chatID, msg.Text)
+}
+
+// FormatOutbound converts a broker channelMessage to a transport.Outbound for
+// the per-transport dispatcher (broker_outbound_dispatch.go). Returns ok=false
+// when no Telegram chat is mapped for the message's channel slug — a missing
+// mapping is a routine skip, not a send failure. The dispatcher logs the skip
+// at Info level and moves on. No side effects: typing indicator + API call
+// happen inside Send so this function stays pure for the dispatcher's
+// convert-then-send loop.
+func (t *TelegramTransport) FormatOutbound(msg channelMessage) (transport.Outbound, bool) {
+	ch := normalizeChannelSlug(msg.Channel)
+	if t.chatIDForSlug(ch) == "" {
+		log.Printf("[telegram] outbound skip: no chat for channel %q", ch)
+		return transport.Outbound{}, false
+	}
+	return transport.Outbound{
+		Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: ch},
+		Text:    formatTelegramOutbound(msg),
+	}, true
 }
 
 // chatIDForSlug returns the Telegram chat_id string for the given office channel
@@ -307,56 +341,6 @@ func (t *TelegramTransport) routeInbound(ctx context.Context, host transport.Hos
 		return fmt.Errorf("telegram receive message: %w", err)
 	}
 	return nil
-}
-
-// drainOutbound periodically checks the broker's external queue and sends
-// messages to the appropriate Telegram chats.
-func (t *TelegramTransport) drainOutbound(ctx context.Context) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(2 * time.Second):
-		}
-
-		// Rebuild reverse map each cycle (picks up dynamically added DM chats)
-		t.chatMapMu.RLock()
-		slugToChat := make(map[string]string, len(t.ChatMap))
-		for chatID, slug := range t.ChatMap {
-			if chatID == "0" {
-				continue // skip the placeholder DM entry
-			}
-			slugToChat[slug] = chatID
-		}
-		t.chatMapMu.RUnlock()
-
-		msgs := t.Broker.ExternalQueue("telegram")
-		if len(msgs) > 0 {
-			log.Printf("[telegram] outbound queue: %d message(s)", len(msgs))
-		}
-		for _, msg := range msgs {
-			ch := normalizeChannelSlug(msg.Channel)
-			chatID, ok := slugToChat[ch]
-			if !ok {
-				log.Printf("[telegram] outbound skip: no chat for channel %q", ch)
-				continue
-			}
-			// Send typing indicator before the message (Telegram-specific UX).
-			if chatIDInt, err := strconv.ParseInt(chatID, 10, 64); err == nil {
-				_ = SendTypingAction(ctx, t.BotToken, chatIDInt)
-			}
-			out := transport.Outbound{
-				Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: ch},
-				Text:    formatTelegramOutbound(msg),
-			}
-			if err := t.Send(ctx, out); err != nil {
-				// Transient send failure — message was already dequeued,
-				// so we log and move on.
-				log.Printf("[telegram] outbound send error for %q: %v", ch, err)
-				continue
-			}
-		}
-	}
 }
 
 // typingLoop periodically sends "typing" actions to Telegram chats when

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -190,18 +190,31 @@ func (t *TelegramTransport) Start(ctx context.Context) error {
 // A "typing" action is sent immediately before the message body so chats see
 // the same UX they got under the prior in-adapter outbound loop: a brief
 // typing bubble, then the formatted message. Sending typing fails silently —
-// it is a UX nicety, not a delivery prerequisite, and surfacing the error
-// would just translate every Send into two error paths.
+// it is a UX nicety, not a delivery prerequisite. The typing call is bounded
+// by typingActionMaxLatency rather than the parent ctx because the parent's
+// own timeout is sized for the actual message API call (see
+// SendTypingAction's 30s timeout) — without the tighter cap, a hung
+// chat-action endpoint would gate every Send by the full upstream timeout
+// and serialize into queue backlog on the per-tick dispatcher.
 func (t *TelegramTransport) Send(ctx context.Context, msg transport.Outbound) error {
 	chatID := t.chatIDForSlug(msg.Binding.ChannelSlug)
 	if chatID == "" {
 		return fmt.Errorf("telegram: no chat mapped for channel %q", msg.Binding.ChannelSlug)
 	}
 	if chatIDInt, parseErr := strconv.ParseInt(chatID, 10, 64); parseErr == nil {
-		_ = SendTypingAction(ctx, t.BotToken, chatIDInt)
+		typingCtx, cancelTyping := context.WithTimeout(ctx, typingActionMaxLatency)
+		_ = SendTypingAction(typingCtx, t.BotToken, chatIDInt)
+		cancelTyping()
 	}
 	return t.sendMessageHTML(ctx, chatID, msg.Text)
 }
+
+// typingActionMaxLatency caps the per-Send typing call so a degraded
+// chat-action endpoint cannot gate message delivery. 2s is generous for
+// Telegram's chat-action under healthy conditions and short enough that a
+// stalled action does not cascade into outbound-queue backlog under the
+// per-tick dispatcher cadence.
+const typingActionMaxLatency = 2 * time.Second
 
 // FormatOutbound converts a broker channelMessage to a transport.Outbound for
 // the per-transport dispatcher (broker_outbound_dispatch.go). Returns ok=false


### PR DESCRIPTION
## Summary

Closes leftover transport-contract item (3): `telegram.go:333` polled `Broker.ExternalQueue("telegram")` from inside its own goroutine, contradicting the Transport.Send contract doc which states *"The Host calls Send from a per-transport worker goroutine (not the broker's hot path)."* This PR moves the polling lifecycle into a generic Host-side dispatcher the launcher owns, while keeping all telegram-specific bits (formatting, slug→chat lookup, typing indicator) on the adapter.

## What changed

**`internal/team/broker_outbound_dispatch.go`** (new) — `runOutboundDispatcher(ctx, broker, name, formatter, sender)`. Polls `broker.ExternalQueue(name)` every 2s, runs each msg through the adapter's `formatter` (returns `ok=false` to skip), then calls `sender`. Logs send errors and continues — at-least-once-with-drop matches the prior in-adapter semantics, since `ExternalQueue` already marks messages delivered on dequeue. Future channel-bound adapters wire in by passing two thin functions instead of writing their own polling loop.

**`internal/team/telegram.go`**
- `Run`: drops the `drainOutbound` goroutine. The errCh size shrinks from 2 to 1 (only `pollInbound` remains).
- `Send`: sends a typing indicator before the message body so chats see the same UX (brief typing bubble → message). Typing failures are silent — UX nicety, not a delivery prerequisite.
- `FormatOutbound` (new): converts `channelMessage` → `transport.Outbound`. Returns `ok=false` when no chat is mapped (routine skip, not an error). No side effects.
- `typingLoop` stays adapter-side because it polls the broker's tagged-agent state, not the outbound queue — leaking that semantic to the Host would couple the generic dispatcher to telegram-specific "is anyone tagged" logic.

**`internal/team/launcher_transports.go`** — starts `runOutboundDispatcher` in its own goroutine alongside `Run`, with proper teardown ordering: `cancel()` → wait `Run` → wait dispatcher → `broker.Stop()`.

## Tests

`internal/team/broker_outbound_dispatch_test.go` (new), 3 cases:
- `TestOutboundDispatcherFormatsAndSendsEachQueuedMessage` — happy path, including `ok=false` skip semantics. Channel-rendezvous on `sendCalls.Add(1) == 2` so the assertion is deterministic (no sleep).
- `TestOutboundDispatcherLogsButContinuesOnSendError` — a transient sender error does not stop the loop; subsequent messages on later ticks still get delivered.
- `TestOutboundDispatcherNilBrokerIsNoop` — defensive guard for misconfigured callers.

## Why this slice (and what's NOT in it)

After PR #699 closed presence end-to-end, two transport-contract leftovers remained:
1. ✅ **This PR** — telegram outbound dispatch contract honored. Pure refactor; no user-visible behavior change.
2. **`ShareTransport.Send` push channel** — separate work, will stack on #708 (which stacks on #706) since they touch `cmd/wuphf/share.go` heavily and need to settle first.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/team/...` (0 issues)
- [x] `go test ./internal/team` (229s, ok)
- [x] All 3 new dispatcher tests pass
- [ ] Manual: launch `wuphf-dev` with a connected Telegram channel; tag an agent; observe typing indicator → reply lands in the chat exactly as before. No log noise from dropped messages.

**Note on race-mode flake:** `bash scripts/test-go.sh` (race enabled) intermittently flags a data race in `internal/team/headless_codex_queue.go:566` (`Launcher.beginHeadlessCodexTurn`) and a slow `TestExtractionSurvivesReboot` timeout. Both reproduce on a clean origin/main worktree (with this PR's changes stashed), so they are pre-existing flakes — not introduced by this refactor. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved outbound message delivery architecture for enhanced reliability and consistency in message handling.
  * Enhanced typing indicator behavior to provide more timely user feedback during message transmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->