### PR TITLE
docs(transport): correct ShareTransport.Send no-op rationale

### DIFF
--- a/internal/team/share_transport.go
+++ b/internal/team/share_transport.go
@@ -167,14 +167,22 @@ func (s *ShareTransport) onHumanAdmit(ctx context.Context, sessionID, slug, disp
 	}
 }
 
-// Send is a no-op for the human-share adapter. Office-wide messages reach
-// admitted humans through the existing broker channels (the shared web UI
-// polls /api/* routes on the same broker), so there is no external network for
-// the adapter to push to. Returning nil keeps the OfficeBoundTransport contract
-// honest: the adapter accepts the message and trusts the broker to deliver via
-// its existing channel-message machinery. This is a conscious contract choice,
-// not an oversight — a future push transport (WebSocket, SSE) for share-
-// admitted humans would replace this no-op with real delivery.
+// Send is a no-op for the human-share adapter — and that is the correct
+// architecture, not a TODO. Admitted humans already receive office-wide
+// messages in real-time through the broker's existing SSE fan-out: the
+// broker's handleEvents (broker_sse.go) accepts the human session cookie,
+// publishMessage (broker_publish.go) fans every channelMessage to all
+// subscribers without filtering humans out, the share HTTP server proxies
+// /api/* including text/event-stream through to the broker
+// (cmd/wuphf/share.go), and the React app subscribes via useBrokerEvents
+// (web/src/hooks/useBrokerEvents.ts). Doing real delivery here would
+// duplicate that path.
+//
+// Returning nil keeps the OfficeBoundTransport contract honest: the adapter
+// accepts the outbound message and trusts the broker SSE channel to deliver.
+// If a future deployment ever needs out-of-band push (e.g. native mobile
+// admitted humans without the React EventSource), that work belongs in the
+// broker's SSE layer or a sibling adapter — not here.
 func (s *ShareTransport) Send(_ context.Context, _ transport.Outbound) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

Doc-only fix for a misleading comment in \`internal/team/share_transport.go:170\`. The prior text described real-time delivery to admitted humans as a *"future push transport (WebSocket, SSE) ... would replace this no-op"* — implying a feature gap. **No gap exists.**

## What I traced

Admitted humans already receive office-wide messages in real-time, just at a different layer than the adapter:

| Layer | File | Behavior |
|---|---|---|
| Broker SSE | \`internal/team/broker_sse.go:24\` (\`handleEvents\`) | Accepts human-session cookies; subscribes to messages, actions, activity, office changes, wiki/notebook/entity events, etc. |
| Fan-out | \`internal/team/broker_publish.go:39\` (\`publishMessage\`) | Sends every \`channelMessage\` to every subscriber. Human actors are NOT filtered out (only notebook events get filtered, at \`broker_sse.go:126\`). |
| Share proxy | \`cmd/wuphf/share.go:762\` | Proxies \`/api/*\` through to the broker. Detects \`Accept: text/event-stream\` and uses a timeout-free client so SSE stays open across hours-long sessions. |
| Web client | \`web/src/hooks/useBrokerEvents.ts:83\` | The React app subscribes via \`EventSource(\"/events\")\`. The share-admitted SPA mounts the same RootRoute → \`useBrokerEvents\` after \`JoinPage\` completes admit. |

So implementing a real \`Send\` would duplicate the existing fan-out. The no-op is the correct architecture.

## Why this stacked on #708

Originally scoped as one of two transport-contract leftovers from the presence epic (#673/#699). On reading the actual code (rather than my prior memo), the gap dissolved — what's left is a comment that misleads the next reader into building a duplicate feature. Replacing it is small enough to land while #708 is still in review; rebasing onto main once #708 merges is trivial.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./internal/team/...\`
- [x] \`golangci-lint run ./internal/team/...\` (0 issues)
- [ ] No behavior change → no manual test needed.

## What this closes on the epic

After #723 (telegram Host-driven dispatcher) and this PR land, the transport-contract migration epic is **fully done**: all four phase-4 slices merged (A/B/C/D), per-member presence end-to-end (#673 + #699), the telegram outbound contract honored, and the share Send rationale documented honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to clarify message delivery mechanisms and system transport behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->