### PR TITLE
feat(skills): view full SKILL.md + Skills section in wiki

### DIFF
--- a/internal/team/broker_human.go
+++ b/internal/team/broker_human.go
@@ -128,6 +128,12 @@ func (b *Broker) handleWikiWriteHuman(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	// Keep in-memory skill state consistent after a human edits a SKILL.md
+	// directly via the wiki editor. The reconcile runs asynchronously so it
+	// does not block the HTTP response.
+	if strings.HasPrefix(body.Path, "team/skills/") && strings.HasSuffix(body.Path, ".md") {
+		go b.reconcileSkillStatusFromDisk()
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"path":          body.Path,
 		"commit_sha":    sha,

--- a/web/src/components/apps/SkillsApp.test.tsx
+++ b/web/src/components/apps/SkillsApp.test.tsx
@@ -109,7 +109,7 @@ describe("<SkillsApp> SidePanel editor", () => {
     render(wrap(<SkillsApp />));
 
     const viewFull = await screen.findByRole("button", {
-      name: /View full SKILL\.md/i,
+      name: /View SKILL\.md/i,
     });
     fireEvent.click(viewFull);
 
@@ -141,7 +141,7 @@ describe("<SkillsApp> SidePanel editor", () => {
     render(wrap(<SkillsApp />));
 
     const viewFull = await screen.findByRole("button", {
-      name: /View full SKILL\.md/i,
+      name: /View SKILL\.md/i,
     });
     fireEvent.click(viewFull);
 
@@ -193,7 +193,7 @@ describe("<SkillsApp> SidePanel editor", () => {
     render(wrap(<SkillsApp />));
 
     const viewFull = await screen.findByRole("button", {
-      name: /View full SKILL\.md/i,
+      name: /View SKILL\.md/i,
     });
     fireEvent.click(viewFull);
 

--- a/web/src/components/apps/SkillsApp.tsx
+++ b/web/src/components/apps/SkillsApp.tsx
@@ -1393,20 +1393,6 @@ function SkillCard({
             </div>
           ) : null}
           <ProposedPreviewBody skill={skill} />
-          <button
-            type="button"
-            onClick={() => onPreview(skill)}
-            className="btn-text"
-            style={{
-              padding: "2px 0",
-              fontSize: 12,
-              color: "var(--accent, #1264a3)",
-              marginBottom: 8,
-            }}
-            aria-label={`View full SKILL.md for ${skill.name}`}
-          >
-            View full SKILL.md →
-          </button>
           <SkillProvenance articles={sourceArticles} />
         </>
       ) : null}
@@ -1416,6 +1402,21 @@ function SkillCard({
           Source: {skill.source}
         </div>
       ) : null}
+
+      <button
+        type="button"
+        onClick={() => onPreview(skill)}
+        className="btn-text"
+        style={{
+          padding: "2px 0",
+          fontSize: 12,
+          color: "var(--accent, #1264a3)",
+          marginBottom: 4,
+        }}
+        aria-label={`View SKILL.md for ${skill.name}`}
+      >
+        View SKILL.md →
+      </button>
 
       <div
         style={{

--- a/web/src/components/apps/skills/SkillPreviewBody.tsx
+++ b/web/src/components/apps/skills/SkillPreviewBody.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { patchSkill, type Skill } from "../../../api/client";
 import { fetchArticle } from "../../../api/wiki";
@@ -284,15 +284,31 @@ function SkillFullContent({
 }) {
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  // Capture fallback in a ref so changing it never re-triggers a fresh fetch;
+  // it is only used as an error fallback, not a fetch trigger.
+  const fallbackRef = useRef(fallbackContent);
+  useEffect(() => {
+    fallbackRef.current = fallbackContent;
+  }, [fallbackContent]);
 
   useEffect(() => {
+    let cancelled = false;
     setLoading(true);
     setContent(null);
     fetchArticle(`team/skills/${skillName}.md`)
-      .then((article) => setContent(article.content))
-      .catch(() => setContent(fallbackContent ?? null))
-      .finally(() => setLoading(false));
-  }, [skillName, fallbackContent]);
+      .then((article) => {
+        if (!cancelled) setContent(article.content);
+      })
+      .catch(() => {
+        if (!cancelled) setContent(fallbackRef.current ?? null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [skillName]);
 
   if (loading) {
     return (

--- a/web/src/components/apps/skills/SkillPreviewBody.tsx
+++ b/web/src/components/apps/skills/SkillPreviewBody.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { patchSkill, type Skill } from "../../../api/client";
+import { fetchArticle } from "../../../api/wiki";
 import { showNotice } from "../../ui/Toast";
 import { OwnersChip } from "./OwnersChip";
 import { STATUS_BADGE_CLASS } from "./status";
@@ -104,7 +105,10 @@ export function SkillPreviewBody({
           onSave={handleSave}
         />
       ) : (
-        <SkillReadonlyBody content={skill.content} />
+        <SkillFullContent
+          skillName={skill.name}
+          fallbackContent={skill.content}
+        />
       )}
     </section>
   );
@@ -271,30 +275,69 @@ function SkillBodyEditor({
   );
 }
 
-function SkillReadonlyBody({ content }: { content?: string }) {
-  if (!content) {
+function SkillFullContent({
+  skillName,
+  fallbackContent,
+}: {
+  skillName: string;
+  fallbackContent?: string;
+}) {
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    setContent(null);
+    fetchArticle(`team/skills/${skillName}.md`)
+      .then((article) => setContent(article.content))
+      .catch(() => setContent(fallbackContent ?? null))
+      .finally(() => setLoading(false));
+  }, [skillName, fallbackContent]);
+
+  if (loading) {
     return (
-      <div style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
-        No body content available.
+      <div
+        style={{
+          color: "var(--text-tertiary)",
+          fontSize: 13,
+          padding: "12px 0",
+        }}
+      >
+        Loading SKILL.md…
       </div>
     );
   }
+
   return (
-    <pre
-      style={{
-        background: "var(--bg-warm, var(--neutral-50))",
-        border: "1px solid var(--border)",
-        borderRadius: 6,
-        padding: 12,
-        fontSize: 12,
-        fontFamily: "var(--font-mono)",
-        whiteSpace: "pre-wrap",
-        wordBreak: "break-word",
-        margin: 0,
-      }}
-    >
-      {content}
-    </pre>
+    <>
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 500,
+          color: "var(--text-secondary)",
+          marginBottom: 6,
+        }}
+      >
+        SKILL.md
+      </div>
+      <pre
+        style={{
+          background: "var(--bg-warm, var(--neutral-50))",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          padding: 12,
+          fontSize: 12,
+          fontFamily: "var(--font-mono)",
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          margin: 0,
+          maxHeight: "70vh",
+          overflowY: "auto",
+        }}
+      >
+        {content ?? "No content available."}
+      </pre>
+    </>
   );
 }
 

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 
+import { getSkillsList } from "../../api/client";
 import {
   type DiscoveredSection,
   fetchCatalog,
@@ -13,7 +14,7 @@ import WikiArticle from "./WikiArticle";
 import WikiAudit from "./WikiAudit";
 import WikiCatalog from "./WikiCatalog";
 import WikiLint from "./WikiLint";
-import WikiSidebar from "./WikiSidebar";
+import WikiSidebar, { type SidebarSkill } from "./WikiSidebar";
 import "../../styles/wiki.css";
 
 // Reserved pseudo-path for the audit view. Never collides with a real
@@ -44,11 +45,11 @@ export default function Wiki({
   const [catalog, setCatalog] = useState<WikiCatalogEntry[]>([]);
   const [sections, setSections] = useState<DiscoveredSection[]>([]);
   const [loading, setLoading] = useState(true);
+  const [sidebarSkills, setSidebarSkills] = useState<SidebarSkill[]>([]);
 
   useEffect(() => {
     let cancelled = false;
-    // Parallel fetch: catalog and sections are independent so we pay one
-    // round-trip of latency, not two.
+    // Parallel fetch: catalog, sections, and skills are all independent.
     Promise.all([fetchCatalog(), fetchSections()])
       .then(([c, s]) => {
         if (cancelled) return;
@@ -61,6 +62,22 @@ export default function Wiki({
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  useEffect(() => {
+    getSkillsList("all")
+      .then((res) => {
+        setSidebarSkills(
+          (res.skills ?? []).map((s) => ({
+            name: s.name,
+            title: s.title,
+            status: s.status,
+          })),
+        );
+      })
+      .catch(() => {
+        // Skills section is additive — a failure here should not break the wiki.
+      });
   }, []);
 
   const refreshCatalog = useCallback(() => {
@@ -100,6 +117,7 @@ export default function Wiki({
           onNavigate={(path) => onNavigate(path)}
           onNavigateAudit={() => onNavigate(AUDIT_PATH)}
           onNavigateLint={() => onNavigate(LINT_PATH)}
+          skills={sidebarSkills}
         />
         {isAudit ? (
           <WikiAudit onNavigate={(path) => onNavigate(path)} />

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -49,7 +49,7 @@ export default function Wiki({
 
   useEffect(() => {
     let cancelled = false;
-    // Parallel fetch: catalog, sections, and skills are all independent.
+    // Parallel fetch: catalog and sections are independent.
     Promise.all([fetchCatalog(), fetchSections()])
       .then(([c, s]) => {
         if (cancelled) return;
@@ -65,8 +65,10 @@ export default function Wiki({
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
     getSkillsList("all")
       .then((res) => {
+        if (cancelled) return;
         setSidebarSkills(
           (res.skills ?? []).map((s) => ({
             name: s.name,
@@ -78,6 +80,9 @@ export default function Wiki({
       .catch(() => {
         // Skills section is additive — a failure here should not break the wiki.
       });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const refreshCatalog = useCallback(() => {

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -5,6 +5,12 @@ import { useEffect, useMemo, useState } from "react";
 import type { DiscoveredSection, WikiCatalogEntry } from "../../api/wiki";
 import { resolveGroupOrder } from "../../lib/groupOrder";
 
+export interface SidebarSkill {
+  name: string;
+  title?: string;
+  status?: string;
+}
+
 /** Left-rail thematic dir groups + Tools section + search. */
 
 interface WikiSidebarProps {
@@ -23,6 +29,8 @@ interface WikiSidebarProps {
   onNavigateAudit?: () => void;
   /** Optional lint opener — rendered as a footer link when provided. */
   onNavigateLint?: () => void;
+  /** Skills to show as a dedicated Skills section below wiki sections. */
+  skills?: SidebarSkill[];
 }
 
 // Sections first seen within this window render a "new" indicator. 7 days
@@ -37,6 +45,7 @@ export default function WikiSidebar({
   onNavigate,
   onNavigateAudit,
   onNavigateLint,
+  skills,
 }: WikiSidebarProps) {
   const [query, setQuery] = useState("");
   const [bannerSlug, setBannerSlug] = useState<string | null>(null);
@@ -140,6 +149,13 @@ export default function WikiSidebar({
               );
             })}
       </div>
+      {skills && skills.length > 0 ? (
+        <SkillsNavSection
+          skills={skills}
+          currentPath={currentPath}
+          onNavigate={onNavigate}
+        />
+      ) : null}
       {onNavigateAudit ? (
         <div className="wk-sidebar-audit">
           <button
@@ -485,6 +501,101 @@ function branchContainsCurrent(
   return (
     node.articles.some((item) => articlePathKey(item.path) === currentKey) ||
     node.folders.some((child) => branchContainsCurrent(child, currentKey))
+  );
+}
+
+function SkillsNavSection({
+  skills,
+  currentPath,
+  onNavigate,
+}: {
+  skills: SidebarSkill[];
+  currentPath?: string | null;
+  onNavigate: (path: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  const currentKey = articlePathKey(currentPath ?? "");
+
+  const activeSkills = skills.filter((s) => !s.status || s.status === "active");
+  const otherSkills = skills.filter((s) => s.status && s.status !== "active");
+  const sorted = [
+    ...activeSkills.sort((a, b) => (a.name || "").localeCompare(b.name || "")),
+    ...otherSkills.sort((a, b) => (a.name || "").localeCompare(b.name || "")),
+  ];
+
+  return (
+    <div
+      className="wk-section-group"
+      data-section-slug="skills"
+      style={{
+        borderTop: "1px solid var(--border-subtle, var(--neutral-200))",
+        paddingTop: 8,
+        marginTop: 4,
+      }}
+    >
+      <h3
+        className="wk-section-header wk-section-schema"
+        style={{ cursor: "pointer" }}
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <span className="wk-section-title">Skills</span>
+        <span className="wk-section-count">{skills.length}</span>
+        <span
+          aria-hidden="true"
+          style={{
+            marginLeft: "auto",
+            fontSize: 10,
+            transition: "transform 0.15s",
+            transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+          }}
+        >
+          {"▶"}
+        </span>
+      </h3>
+      {expanded ? (
+        <ul className="wk-tree" aria-label="Skills">
+          {sorted.map((skill) => {
+            const path = `team/skills/${skill.name}.md`;
+            const current = currentKey === articlePathKey(path);
+            return (
+              <li
+                key={skill.name}
+                className={
+                  current ? "current wk-tree-article" : "wk-tree-article"
+                }
+              >
+                <a
+                  href={`#/wiki/${encodeURI(path)}`}
+                  className="wk-tree-article-link"
+                  title={skill.name}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    onNavigate(path);
+                  }}
+                >
+                  <span className="wk-tree-file-dot" aria-hidden="true" />
+                  <span className="wk-tree-article-title">
+                    {skill.title || skill.name}
+                  </span>
+                  {skill.status && skill.status !== "active" ? (
+                    <span
+                      style={{
+                        fontSize: 10,
+                        color: "var(--text-tertiary)",
+                        marginLeft: 4,
+                      }}
+                    >
+                      {skill.status}
+                    </span>
+                  ) : null}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </div>
   );
 }
 

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -148,14 +148,14 @@ export default function WikiSidebar({
                 </div>
               );
             })}
+        {skills && skills.length > 0 ? (
+          <SkillsNavSection
+            skills={skills}
+            currentPath={currentPath}
+            onNavigate={onNavigate}
+          />
+        ) : null}
       </div>
-      {skills && skills.length > 0 ? (
-        <SkillsNavSection
-          skills={skills}
-          currentPath={currentPath}
-          onNavigate={onNavigate}
-        />
-      ) : null}
       {onNavigateAudit ? (
         <div className="wk-sidebar-audit">
           <button
@@ -516,23 +516,17 @@ function SkillsNavSection({
   const [expanded, setExpanded] = useState(true);
   const currentKey = articlePathKey(currentPath ?? "");
 
-  const activeSkills = skills.filter((s) => !s.status || s.status === "active");
-  const otherSkills = skills.filter((s) => s.status && s.status !== "active");
-  const sorted = [
-    ...activeSkills.sort((a, b) => (a.name || "").localeCompare(b.name || "")),
-    ...otherSkills.sort((a, b) => (a.name || "").localeCompare(b.name || "")),
-  ];
+  const sorted = useMemo(() => {
+    const active = skills.filter((s) => !s.status || s.status === "active");
+    const other = skills.filter((s) => s.status && s.status !== "active");
+    return [
+      ...active.sort((a, b) => (a.name || "").localeCompare(b.name || "")),
+      ...other.sort((a, b) => (a.name || "").localeCompare(b.name || "")),
+    ];
+  }, [skills]);
 
   return (
-    <div
-      className="wk-section-group"
-      data-section-slug="skills"
-      style={{
-        borderTop: "1px solid var(--border-subtle, var(--neutral-200))",
-        paddingTop: 8,
-        marginTop: 4,
-      }}
-    >
+    <div className="wk-section-group" data-section-slug="skills">
       <h3
         className="wk-section-header wk-section-schema"
         style={{ cursor: "pointer" }}


### PR DESCRIPTION
## Summary

- **Skills App**: Every skill card (active, disabled, archived, proposed) now has a "View SKILL.md →" button. Clicking it opens the side panel showing the complete SKILL.md file (frontmatter + body) fetched directly from the wiki at `team/skills/{name}.md`. Previously only proposed skills had any panel access.
- **Wiki sidebar**: New collapsible "Skills" section appears below the regular wiki sections. Lists all skills (active first, then others with a status tag). Clicking any skill opens it as a full wiki article — same `WikiArticle` view with history, edit button, and backlinks — allowing free editing of the SKILL.md from the wiki.
- **Backend**: When a human saves edits to `team/skills/*.md` via the wiki editor, `reconcileSkillStatusFromDisk()` runs asynchronously so the broker's in-memory skill state stays consistent.

## Test plan

- [ ] Open Skills App → click "View SKILL.md →" on an active skill → side panel shows full SKILL.md with frontmatter
- [ ] Open Skills App → click "View SKILL.md →" on a disabled/archived skill → same behaviour
- [ ] Open Skills App → click "View SKILL.md →" on a proposed skill → body editor unchanged; full panel still opens
- [ ] Open Wiki → Skills section appears in sidebar with skill list
- [ ] Click a skill in wiki sidebar → opens article view with content, history, and edit button
- [ ] Edit a skill SKILL.md via wiki editor → save → reload Skills App → in-memory state reflects changes within 30s
- [ ] 1057 web tests pass; Go team tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a collapsible "Skills" section in the wiki sidebar with status-based grouping and alphabetical ordering; highlights current skill.
  * Wiki now loads a global skills list on startup to populate the sidebar.

* **New Features (Content)**
  * Skill preview now fetches and displays full SKILL.md content asynchronously with a loading indicator and sensible fallback when unavailable.

* **Style**
  * Clarified skill card button label and tightened vertical spacing.

* **Tests**
  * Updated UI tests to match label and editor behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->