### PR TITLE
fix(scheduler): strip stale rate-limit marker from task Details on resume

### DIFF
--- a/internal/team/broker_studio.go
+++ b/internal/team/broker_studio.go
@@ -31,7 +31,11 @@ var externalRetryAfterPattern = regexp.MustCompile(`(?i)retry after ([0-9]{4}-[0
 // resumed. Without stripping, a stale timestamp left in Details is detected
 // by externalWorkflowRetryAfter on the next scheduler tick, re-resuming the
 // task and re-delivering it to the CEO — producing an infinite loop.
-var externalRetryAfterLinePattern = regexp.MustCompile(`(?im)^[^\n]*(?:429[^\n]*|retry after [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)[^\n]*$\n?`)
+//
+// The `\b429\b` word boundary keeps the 429-status branch from matching
+// substrings like "4290 items" or "v4.29" that legitimate task Details may
+// contain. The retry-after branch is already tightly anchored to RFC3339.
+var externalRetryAfterLinePattern = regexp.MustCompile(`(?im)^[^\n]*(?:\b429\b[^\n]*|retry after [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)[^\n]*$\n?`)
 
 // stripExternalRetryMarker removes rate-limit lines from a task Details string
 // so stale retry-after timestamps cannot re-trigger the watchdog resume loop.

--- a/internal/team/broker_studio.go
+++ b/internal/team/broker_studio.go
@@ -26,6 +26,20 @@ import (
 // header back to the client. (?i) makes the prefix case-insensitive.
 var externalRetryAfterPattern = regexp.MustCompile(`(?i)retry after ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)`)
 
+// externalRetryAfterLinePattern matches a full line containing a rate-limit
+// marker so it can be stripped from task Details when a blocked task is
+// resumed. Without stripping, a stale timestamp left in Details is detected
+// by externalWorkflowRetryAfter on the next scheduler tick, re-resuming the
+// task and re-delivering it to the CEO — producing an infinite loop.
+var externalRetryAfterLinePattern = regexp.MustCompile(`(?im)^[^\n]*(?:429[^\n]*|retry after [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)[^\n]*$\n?`)
+
+// stripExternalRetryMarker removes rate-limit lines from a task Details string
+// so stale retry-after timestamps cannot re-trigger the watchdog resume loop.
+func stripExternalRetryMarker(details string) string {
+	stripped := externalRetryAfterLinePattern.ReplaceAllString(details, "")
+	return strings.TrimSpace(stripped)
+}
+
 // externalWorkflowRetryAfter extracts a retry-at timestamp from an
 // external workflow provider's error message. Returns (zero, false)
 // when err is nil, when the pattern doesn't match, or when the

--- a/internal/team/broker_studio.go
+++ b/internal/team/broker_studio.go
@@ -26,22 +26,36 @@ import (
 // header back to the client. (?i) makes the prefix case-insensitive.
 var externalRetryAfterPattern = regexp.MustCompile(`(?i)retry after ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)`)
 
-// externalRetryAfterLinePattern matches a full line containing a rate-limit
-// marker so it can be stripped from task Details when a blocked task is
-// resumed. Without stripping, a stale timestamp left in Details is detected
-// by externalWorkflowRetryAfter on the next scheduler tick, re-resuming the
-// task and re-delivering it to the CEO — producing an infinite loop.
+// stripExternalRetryMarker removes rate-limit marker lines from a task Details
+// string so a stale "Retry after <ts>" timestamp cannot re-trigger the
+// watchdog resume loop on the next scheduler tick.
 //
-// The `\b429\b` word boundary keeps the 429-status branch from matching
-// substrings like "4290 items" or "v4.29" that legitimate task Details may
-// contain. The retry-after branch is already tightly anchored to RFC3339.
-var externalRetryAfterLinePattern = regexp.MustCompile(`(?im)^[^\n]*(?:\b429\b[^\n]*|retry after [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)[^\n]*$\n?`)
-
-// stripExternalRetryMarker removes rate-limit lines from a task Details string
-// so stale retry-after timestamps cannot re-trigger the watchdog resume loop.
+// The predicate is externalRetryAfterPattern — the same regex the watchdog uses
+// in externalWorkflowRetryAfter to detect a re-resume condition. Reusing that
+// pattern keeps a single source of truth for marker grammar: if the watchdog
+// would not re-resume from a given line, we do not strip it. This narrows the
+// strip to lines that carry a parseable RFC3339 retry-after timestamp and
+// avoids over-stripping unrelated content (e.g. ticket refs like "SUP-4290",
+// version strings like "v4.29", line counts like "completed 4290 items").
+//
+// Known limitation: when an external provider packs both the rate-limit
+// timestamp and an operator note onto a single line (e.g. "429 ... Retry
+// after <ts>. Owner: refresh OAuth"), the whole line is dropped together. A
+// future refinement could substitute just the marker substring; the loop fix
+// does not require that today.
 func stripExternalRetryMarker(details string) string {
-	stripped := externalRetryAfterLinePattern.ReplaceAllString(details, "")
-	return strings.TrimSpace(stripped)
+	if details == "" {
+		return details
+	}
+	lines := strings.Split(details, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if externalRetryAfterPattern.MatchString(line) {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.TrimSpace(strings.Join(kept, "\n"))
 }
 
 // externalWorkflowRetryAfter extracts a retry-at timestamp from an

--- a/internal/team/broker_studio_test.go
+++ b/internal/team/broker_studio_test.go
@@ -677,12 +677,12 @@ func mustJSON(t *testing.T, value any) string {
 	return string(raw)
 }
 
-// TestStripExternalRetryMarkerScope guards the regex against two failure
-// modes: it must strip real rate-limit markers (the bug we were fixing) but
-// must NOT strip lines that merely contain "429" as a substring inside other
-// numbers/words. The 429 branch is anchored with \b on both sides; this test
-// fixes that contract so a future "make the regex looser" change has to
-// confront the tradeoff explicitly.
+// TestStripExternalRetryMarkerScope locks in the predicate-driven strip
+// behavior: a line is removed only when externalRetryAfterPattern matches it
+// (i.e. it contains a parseable RFC3339 retry-after timestamp — the same
+// condition the watchdog uses to re-resume). The cases here include both
+// happy-path strips and the false-positive substrings that motivated the
+// switch from a bare-`429` matcher to the predicate pattern.
 func TestStripExternalRetryMarkerScope(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -690,17 +690,32 @@ func TestStripExternalRetryMarkerScope(t *testing.T) {
 		want string
 	}{
 		{
-			name: "strips standalone 429 status line",
+			name: "strips 429 line with retry-after timestamp",
 			in:   "429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z.",
 			want: "",
 		},
 		{
-			name: "strips retry-after timestamp line",
+			name: "strips bare retry-after timestamp line",
 			in:   "Retry after 2026-04-15T22:00:29.610Z",
 			want: "",
 		},
 		{
-			name: "preserves 4290 substring",
+			name: "preserves bare 429 line without a timestamp (cannot re-trigger watchdog)",
+			in:   "429 RESOURCE_EXHAUSTED",
+			want: "429 RESOURCE_EXHAUSTED",
+		},
+		{
+			name: "preserves SUP-4290 ticket reference",
+			in:   "Investigate ticket SUP-4290 about login failures",
+			want: "Investigate ticket SUP-4290 about login failures",
+		},
+		{
+			name: "preserves task-4290 lane reference",
+			in:   "queued behind active lane on task-4290",
+			want: "queued behind active lane on task-4290",
+		},
+		{
+			name: "preserves 4290 line count",
 			in:   "completed 4290 items in batch",
 			want: "completed 4290 items in batch",
 		},
@@ -715,9 +730,24 @@ func TestStripExternalRetryMarkerScope(t *testing.T) {
 			want: "see issue 1429 for context",
 		},
 		{
-			name: "strips 429 line but keeps surrounding context",
+			name: "strips marker line but preserves surrounding context",
 			in:   "Original goal: ship the kickoff send.\n429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z.\nNotes follow.",
 			want: "Original goal: ship the kickoff send.\nNotes follow.",
+		},
+		{
+			name: "preserves separate 429 line when timestamp is on its own line",
+			in:   "429 RESOURCE_EXHAUSTED\nRetry after 2026-04-15T22:00:29.610Z",
+			want: "429 RESOURCE_EXHAUSTED",
+		},
+		{
+			name: "documented limitation: same-line operator context is dropped together with marker",
+			in:   "Cannot send: 429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z. Owner: refresh OAuth.",
+			want: "",
+		},
+		{
+			name: "empty in, empty out",
+			in:   "",
+			want: "",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/team/broker_studio_test.go
+++ b/internal/team/broker_studio_test.go
@@ -676,3 +676,55 @@ func mustJSON(t *testing.T, value any) string {
 	}
 	return string(raw)
 }
+
+// TestStripExternalRetryMarkerScope guards the regex against two failure
+// modes: it must strip real rate-limit markers (the bug we were fixing) but
+// must NOT strip lines that merely contain "429" as a substring inside other
+// numbers/words. The 429 branch is anchored with \b on both sides; this test
+// fixes that contract so a future "make the regex looser" change has to
+// confront the tradeoff explicitly.
+func TestStripExternalRetryMarkerScope(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "strips standalone 429 status line",
+			in:   "429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z.",
+			want: "",
+		},
+		{
+			name: "strips retry-after timestamp line",
+			in:   "Retry after 2026-04-15T22:00:29.610Z",
+			want: "",
+		},
+		{
+			name: "preserves 4290 substring",
+			in:   "completed 4290 items in batch",
+			want: "completed 4290 items in batch",
+		},
+		{
+			name: "preserves v4.29 version reference",
+			in:   "rolled out v4.29 upgrade notes",
+			want: "rolled out v4.29 upgrade notes",
+		},
+		{
+			name: "preserves issue reference 1429",
+			in:   "see issue 1429 for context",
+			want: "see issue 1429 for context",
+		},
+		{
+			name: "strips 429 line but keeps surrounding context",
+			in:   "Original goal: ship the kickoff send.\n429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z.\nNotes follow.",
+			want: "Original goal: ship the kickoff send.\nNotes follow.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripExternalRetryMarker(tc.in)
+			if got != tc.want {
+				t.Errorf("stripExternalRetryMarker(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -92,6 +92,10 @@ func (b *Broker) ResumeTask(taskID, actor, reason string) (teamTask, bool, error
 		changed := false
 		if task.Blocked {
 			task.Blocked = false
+			// Strip the stale rate-limit marker so the watchdog's
+			// externalWorkflowRetryAfter check cannot re-enter the
+			// resume loop after the task is re-blocked for a new reason.
+			task.Details = stripExternalRetryMarker(task.Details)
 			changed = true
 		}
 		if strings.EqualFold(strings.TrimSpace(task.Status), "blocked") {

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -90,12 +90,20 @@ func (b *Broker) ResumeTask(taskID, actor, reason string) (teamTask, bool, error
 		}
 		beforeStatus := task.Status
 		changed := false
+		// Strip the stale rate-limit marker on every ResumeTask call, not
+		// only when this call flips Blocked from true to false. A different
+		// code path (e.g. unblockDependentsLocked, capability self-healing)
+		// may have already cleared Blocked while leaving the marker in
+		// Details; without the unconditional strip the watchdog's
+		// externalWorkflowRetryAfter check would still detect the stale
+		// timestamp on its next tick and re-enter the resume loop. The
+		// strip is a no-op when no marker is present.
+		if cleaned := stripExternalRetryMarker(task.Details); cleaned != task.Details {
+			task.Details = cleaned
+			changed = true
+		}
 		if task.Blocked {
 			task.Blocked = false
-			// Strip the stale rate-limit marker so the watchdog's
-			// externalWorkflowRetryAfter check cannot re-enter the
-			// resume loop after the task is re-blocked for a new reason.
-			task.Details = stripExternalRetryMarker(task.Details)
 			changed = true
 		}
 		if strings.EqualFold(strings.TrimSpace(task.Status), "blocked") {
@@ -368,6 +376,11 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) []pendingTaskTr
 		if !b.hasUnresolvedDepsLocked(&b.tasks[i]) {
 			beforeStatus := b.tasks[i].Status
 			b.tasks[i].Blocked = false
+			// Mirror the strip in ResumeTask: if the dependent task was
+			// also rate-limited at some earlier point, the stale marker
+			// in Details would otherwise trigger the watchdog resume loop
+			// even though the dependency completion already unblocked it.
+			b.tasks[i].Details = stripExternalRetryMarker(b.tasks[i].Details)
 			if strings.TrimSpace(b.tasks[i].Owner) != "" {
 				b.tasks[i].Status = "in_progress"
 			} else {

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -918,6 +918,48 @@ func TestBrokerResumeTaskUnblocksAndSchedulesOwnerLane(t *testing.T) {
 	}
 }
 
+// TestBrokerResumeTaskStripsRateLimitMarker guards against the phantom
+// notification loop where the watchdog re-resumes a task indefinitely because
+// a stale "Retry after <ts>" line is left in task.Details after the first
+// resume. The fix: ResumeTask must call stripExternalRetryMarker so the
+// marker cannot be detected on the next scheduler tick.
+func TestBrokerResumeTaskStripsRateLimitMarker(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
+	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
+
+	const rateLimitDetails = "429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z."
+	task, _, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:       "client-loop",
+		Title:         "Retry kickoff send",
+		Details:       rateLimitDetails,
+		Owner:         "builder",
+		CreatedBy:     "operator",
+		TaskType:      "follow_up",
+		ExecutionMode: "live_external",
+	})
+	if err != nil {
+		t.Fatalf("ensure planned task: %v", err)
+	}
+	if _, changed, err := b.BlockTask(task.ID, "watchdog", "Provider cooldown"); err != nil || !changed {
+		t.Fatalf("block task: %v changed=%v", err, changed)
+	}
+
+	resumed, _, err := b.ResumeTask(task.ID, "watchdog", "Retry window passed")
+	if err != nil {
+		t.Fatalf("resume task: %v", err)
+	}
+	if resumed.Blocked {
+		t.Fatalf("expected task to be unblocked after resume, got blocked=true")
+	}
+
+	// The rate-limit marker must be gone so the watchdog's
+	// externalWorkflowRetryAfter check cannot re-trigger the resume loop.
+	if externalRetryAfterPattern.MatchString(resumed.Details) {
+		t.Fatalf("stale rate-limit marker still present in Details after resume: %q", resumed.Details)
+	}
+}
+
 func TestBrokerResumeTaskQueuesBehindExistingExclusiveOwnerLane(t *testing.T) {
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -1011,6 +1011,56 @@ func TestBrokerResumeTaskPreservesDetailsWithoutMarker(t *testing.T) {
 	}
 }
 
+// TestBrokerUnblockDependentsStripsRateLimitMarker covers the second
+// Blocked→false transition path: when a dependency completion clears the
+// blocked flag, a stale rate-limit marker would otherwise survive in
+// Details, the watchdog's externalWorkflowRetryAfter check would re-detect
+// it on the next tick, and ResumeTask's existing strip would fire — but
+// before this test was added, ResumeTask only stripped on the
+// blocked-true→false transition, so a marker present after
+// unblockDependentsLocked would persist indefinitely. The fix strips both
+// at the source (unblockDependentsLocked) and unconditionally in
+// ResumeTask, so either path now closes the loop.
+func TestBrokerUnblockDependentsStripsRateLimitMarker(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
+	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.tasks = []teamTask{
+		{
+			ID: "task-parent", Channel: "client-loop", Title: "Prereq",
+			Owner: "builder", Status: "done", CreatedBy: "operator",
+			TaskType: "feature", ExecutionMode: "local_worktree",
+			ReviewState: "approved", CreatedAt: now, UpdatedAt: now,
+		},
+		{
+			ID: "task-child", Channel: "client-loop", Title: "Dependent kickoff",
+			Owner: "builder", Status: "blocked", Blocked: true,
+			CreatedBy: "operator", TaskType: "feature", ExecutionMode: "live_external",
+			DependsOn: []string{"task-parent"},
+			Details:   "Original goal: ship dependent kickoff.\n429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z.",
+			CreatedAt: now, UpdatedAt: now,
+		},
+	}
+
+	b.mu.Lock()
+	b.unblockDependentsLocked("task-parent")
+	got := append([]teamTask(nil), b.tasks...)
+	b.mu.Unlock()
+
+	child := got[1]
+	if child.Blocked {
+		t.Fatalf("expected child task to be unblocked after dependency completion, got blocked=true")
+	}
+	if externalRetryAfterPattern.MatchString(child.Details) {
+		t.Fatalf("dependency-unblock did not strip the stale rate-limit marker: %q", child.Details)
+	}
+	if !strings.Contains(child.Details, "Original goal: ship dependent kickoff.") {
+		t.Fatalf("dependency-unblock should preserve pre-block context, got %q", child.Details)
+	}
+}
+
 func TestBrokerResumeTaskQueuesBehindExistingExclusiveOwnerLane(t *testing.T) {
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -923,16 +923,22 @@ func TestBrokerResumeTaskUnblocksAndSchedulesOwnerLane(t *testing.T) {
 // a stale "Retry after <ts>" line is left in task.Details after the first
 // resume. The fix: ResumeTask must call stripExternalRetryMarker so the
 // marker cannot be detected on the next scheduler tick.
+//
+// Also asserts pre-block context that does NOT contain a parseable
+// retry-after timestamp survives the resume — over-stripping would silently
+// destroy operator notes on every Blocked→false transition (manual unblocks,
+// dependency releases, capability self-healing, not just cooldown recovery).
 func TestBrokerResumeTaskStripsRateLimitMarker(t *testing.T) {
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
 	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
 
-	const rateLimitDetails = "429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z."
+	const preBlockContext = "Investigate ticket SUP-4290 about login failures"
+	const rateLimitLine = "429 RESOURCE_EXHAUSTED. Retry after 2026-04-15T22:00:29.610Z."
 	task, _, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "client-loop",
 		Title:         "Retry kickoff send",
-		Details:       rateLimitDetails,
+		Details:       preBlockContext + "\n" + rateLimitLine,
 		Owner:         "builder",
 		CreatedBy:     "operator",
 		TaskType:      "follow_up",
@@ -957,6 +963,51 @@ func TestBrokerResumeTaskStripsRateLimitMarker(t *testing.T) {
 	// externalWorkflowRetryAfter check cannot re-trigger the resume loop.
 	if externalRetryAfterPattern.MatchString(resumed.Details) {
 		t.Fatalf("stale rate-limit marker still present in Details after resume: %q", resumed.Details)
+	}
+	// The pre-block operator context must survive — it has no parseable
+	// retry-after timestamp, so over-stripping would be a regression.
+	if !strings.Contains(resumed.Details, preBlockContext) {
+		t.Fatalf("expected resume to preserve pre-block context %q in Details, got %q", preBlockContext, resumed.Details)
+	}
+}
+
+// TestBrokerResumeTaskPreservesDetailsWithoutMarker asserts that a task
+// resume on a non-cooldown path (operator manual unblock, dependency-resolved
+// release, capability self-healing) does not touch Details when there is no
+// rate-limit marker present. Strip is scoped to the actual loop trigger.
+func TestBrokerResumeTaskPreservesDetailsWithoutMarker(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
+	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
+
+	const detailsNoMarker = "queued behind active lane on task-4290; awaiting dependency resolution"
+	task, _, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:   "client-loop",
+		Title:     "Dependent kickoff",
+		Details:   detailsNoMarker,
+		Owner:     "builder",
+		CreatedBy: "operator",
+		TaskType:  "follow_up",
+	})
+	if err != nil {
+		t.Fatalf("ensure planned task: %v", err)
+	}
+	if _, changed, err := b.BlockTask(task.ID, "operator", "Manual hold"); err != nil || !changed {
+		t.Fatalf("block task: %v changed=%v", err, changed)
+	}
+	resumed, _, err := b.ResumeTask(task.ID, "operator", "Manual unblock")
+	if err != nil {
+		t.Fatalf("resume task: %v", err)
+	}
+	// Block/Resume append their own reason text to Details (existing behavior);
+	// what matters here is that strip did not destroy the pre-block context
+	// and that the substring "task-4290" containing "429" survives the
+	// strip's predicate (which requires a parseable retry-after timestamp).
+	if !strings.Contains(resumed.Details, detailsNoMarker) {
+		t.Fatalf("resume dropped pre-block context: got %q", resumed.Details)
+	}
+	if externalRetryAfterPattern.MatchString(resumed.Details) {
+		t.Fatalf("resume should not introduce a retry-after marker: got %q", resumed.Details)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes an infinite-resume notification loop on `task-1` / `client-loop` (33+ observed occurrences in production logs).

`Broker.ResumeTask` cleared `task.Blocked` but left the prior `Retry after <ts>` line in `task.Details`. On the next live-external attempt the CEO agent got 429'd again, re-blocking the task with a fresh `RESOURCE_EXHAUSTED` line. The watchdog's `externalWorkflowRetryAfter` check then re-detected the **stale** timestamp once it expired and called `ResumeTask` again — producing a self-driving loop that re-delivered approval prompts to the CEO.

## Fix

- New `stripExternalRetryMarker` helper in `internal/team/broker_studio.go`, plus the `externalRetryAfterLinePattern` regex it uses (anchored to lines containing `429` or an RFC3339 retry timestamp).
- `Broker.ResumeTask` now calls `stripExternalRetryMarker(task.Details)` whenever it transitions `task.Blocked` from true to false, so a subsequent re-block writes a fresh marker rather than racing the stale one.

## Test plan

- [x] `go test -race -run TestBrokerResumeTaskStripsRateLimitMarker ./internal/team/` — passes (1.7s)
- [x] `gofmt -l` clean on all 3 changed files
- [x] `go vet ./internal/team/...` clean
- [x] `go build ./cmd/wuphf` clean

## Files

- `internal/team/broker_studio.go` — pattern + helper
- `internal/team/broker_tasks_lifecycle.go` — call site in `ResumeTask`
- `internal/team/broker_tasks_test.go` — `TestBrokerResumeTaskStripsRateLimitMarker` regression coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clear stale external rate-limit marker lines when resuming blocked tasks to prevent immediate re-triggering of watchdog resume loops and improve scheduler reliability.

* **Tests**
  * Added regression and unit tests ensuring resume strips only standalone retry-marker lines (preserving other content) and that behavior is correct across various multiline scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->