### PR TITLE
feat(team): A4 per-turn manifest HeadlessEvent with tool-call index

### DIFF
--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -160,6 +160,8 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	var firstToolAt time.Time
 	textStarted := false
 	turnID := newHeadlessTurnID()
+	var turnToolNames []string
+	var turnTextLen int
 
 	result, parseErr := provider.ReadClaudeJSONStream(teedStdout, func(event provider.ClaudeStreamEvent) {
 		if firstEventAt.IsZero() {
@@ -179,6 +181,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
 			relay.OnText(event.Text)
+			turnTextLen += len(event.Text)
 			emitHeadlessText(agentStream, turnID, HeadlessProviderClaude, slug, taskID, event.Text, "claude.text")
 		case "tool_use":
 			relay.Flush()
@@ -188,6 +191,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			}
 			appendHeadlessClaudeLog(slug, fmt.Sprintf("tool_use: %s %s", event.ToolName, truncate(event.ToolInput, 120)))
 			l.updateHeadlessProgress(slug, "active", "tool_use", fmt.Sprintf("running %s", strings.TrimSpace(event.ToolName)), metrics)
+			turnToolNames = append(turnToolNames, event.ToolName)
 			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderClaude, slug, taskID, event.ToolName, event.ToolInput, "claude.tool_use")
 		case "tool_result":
 			appendHeadlessClaudeLog(slug, "tool_result: "+truncate(event.Text, 140))
@@ -211,6 +215,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", detail, metrics, claudeUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
 		return fmt.Errorf("%w: %s", err, detail)
 	}
 	if parseErr != nil {
@@ -224,6 +229,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", parseErr.Error(), metrics, claudeUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 
@@ -243,6 +249,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, summary, "", metrics, claudeUsageToTokenUsage(result.Usage))
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
 	if l.broker != nil {
 		l.broker.RecordAgentUsage(slug, l.headlessClaudeModel(slug), result.Usage)
 	}

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -215,7 +215,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", detail, metrics, claudeUsageToTokenUsage(result.Usage))
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, detail, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
 		return fmt.Errorf("%w: %s", err, detail)
 	}
 	if parseErr != nil {
@@ -229,7 +229,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", parseErr.Error(), metrics, claudeUsageToTokenUsage(result.Usage))
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, parseErr.Error(), turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 
@@ -249,7 +249,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderClaude, slug, taskID, summary, "", metrics, claudeUsageToTokenUsage(result.Usage))
-	emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderClaude, slug, taskID, "", turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(result.Usage))
 	if l.broker != nil {
 		l.broker.RecordAgentUsage(slug, l.headlessClaudeModel(slug), result.Usage)
 	}

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -166,6 +166,8 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	var firstToolAt time.Time
 	textStarted := false
 	turnID := newHeadlessTurnID()
+	var turnToolNames []string
+	var turnTextLen int
 	result, parseErr := provider.ReadCodexJSONStream(teedStdout, func(event provider.CodexStreamEvent) {
 		if firstEventAt.IsZero() {
 			firstEventAt = time.Now()
@@ -182,6 +184,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
 			relay.OnText(event.Text)
+			turnTextLen += len(event.Text)
 			emitHeadlessText(agentStream, turnID, HeadlessProviderCodex, slug, taskID, event.Text, event.RawType)
 		case "tool_use":
 			relay.Flush()
@@ -192,6 +195,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			line := fmt.Sprintf("tool_use: %s %s", event.ToolName, truncate(event.ToolInput, 120))
 			appendHeadlessCodexLog(slug, line)
 			l.updateHeadlessProgress(slug, "active", "tool_use", fmt.Sprintf("running %s", strings.TrimSpace(event.ToolName)), metrics)
+			turnToolNames = append(turnToolNames, event.ToolName)
 			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderCodex, slug, taskID, event.ToolName, event.ToolInput, event.RawType)
 		case "tool_result":
 			line := "tool_result: " + truncate(event.Text, 140)
@@ -218,6 +222,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			appendHeadlessCodexLog(slug, "stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 			emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", detail, metrics, codexUsageToTokenUsage(result.Usage))
+			emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 			if isCodexAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -238,12 +243,14 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			err.Error(),
 		))
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", err.Error(), metrics, codexUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 		return err
 	}
 	if parseErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", parseErr.Error(), metrics, codexUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 	metrics.TotalMs = time.Since(startedAt).Milliseconds()
@@ -262,6 +269,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, summary, "", metrics, codexUsageToTokenUsage(result.Usage))
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 	if l.broker != nil && (result.Usage.InputTokens != 0 || result.Usage.OutputTokens != 0 || result.Usage.CacheReadTokens != 0 || result.Usage.CacheCreationTokens != 0 || result.Usage.CostUSD != 0) {
 		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
 	}

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -222,7 +222,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			appendHeadlessCodexLog(slug, "stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 			emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", detail, metrics, codexUsageToTokenUsage(result.Usage))
-			emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
+			emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, detail, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 			if isCodexAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -243,14 +243,14 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			err.Error(),
 		))
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", err.Error(), metrics, codexUsageToTokenUsage(result.Usage))
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, err.Error(), turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 		return err
 	}
 	if parseErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(parseErr.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", parseErr.Error(), metrics, codexUsageToTokenUsage(result.Usage))
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, parseErr.Error(), turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 		return parseErr
 	}
 	metrics.TotalMs = time.Since(startedAt).Milliseconds()
@@ -269,7 +269,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, summary, "", metrics, codexUsageToTokenUsage(result.Usage))
-	emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 	if l.broker != nil && (result.Usage.InputTokens != 0 || result.Usage.OutputTokens != 0 || result.Usage.CacheReadTokens != 0 || result.Usage.CacheCreationTokens != 0 || result.Usage.CostUSD != 0) {
 		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
 	}

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -285,7 +285,7 @@ func emitHeadlessToolResult(stream *agentStreamBuffer, turnID, provider, slug, t
 // event emitted during the turn. Both may be zero for turns that produced
 // no tools or no text — the manifest is still emitted so consumers see a
 // consistent turn boundary.
-func emitHeadlessManifest(stream *agentStreamBuffer, turnID, provider, slug, taskID string, toolNames []string, textLen int, metrics headlessProgressMetrics, usage *headlessTokenUsage) {
+func emitHeadlessManifest(stream *agentStreamBuffer, turnID, provider, slug, taskID, errDetail string, toolNames []string, textLen int, metrics headlessProgressMetrics, usage *headlessTokenUsage) {
 	if stream == nil {
 		return
 	}
@@ -300,13 +300,17 @@ func emitHeadlessManifest(stream *agentStreamBuffer, turnID, provider, slug, tas
 		calls = append(calls, HeadlessManifestEntry{ToolName: name, Count: count})
 	}
 	sort.Slice(calls, func(i, j int) bool { return calls[i].ToolName < calls[j].ToolName })
+	status := "idle"
+	if strings.TrimSpace(errDetail) != "" {
+		status = "error"
+	}
 	pushHeadlessEvent(stream, HeadlessEvent{
 		Type:      HeadlessEventTypeManifest,
 		Provider:  provider,
 		Agent:     slug,
 		TurnID:    strings.TrimSpace(turnID),
 		TaskID:    strings.TrimSpace(taskID),
-		Status:    "idle",
+		Status:    status,
 		ToolCalls: calls,
 		TextLen:   textLen,
 		Metrics:   headlessProgressEventMetrics(metrics, usage),

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -73,7 +73,7 @@ type HeadlessEvent struct {
 	Metrics   *HeadlessEventMetrics   `json:"metrics,omitempty"`
 	RawType   string                  `json:"raw_type,omitempty"`
 	ToolCalls []HeadlessManifestEntry `json:"tool_calls,omitempty"`
-	TextLen   int                     `json:"text_len,omitempty"`
+	TextLen   *int                    `json:"text_len,omitempty"`
 }
 
 // HeadlessManifestEntry is one tool in a manifest event's ToolCalls list.
@@ -312,7 +312,7 @@ func emitHeadlessManifest(stream *agentStreamBuffer, turnID, provider, slug, tas
 		TaskID:    strings.TrimSpace(taskID),
 		Status:    status,
 		ToolCalls: calls,
-		TextLen:   textLen,
+		TextLen:   &textLen,
 		Metrics:   headlessProgressEventMetrics(metrics, usage),
 	})
 }

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -29,10 +30,10 @@ import (
 //   - Kind: always "headless_event". Lets a JSON.parse-then-discriminate
 //     consumer skip provider-native events without a structural sniff.
 //   - Type: phase of the turn — "status", "text", "tool_use",
-//     "tool_result", "idle", "error". A2-MVP emits only "idle" and
-//     "error"; the remaining types are reserved so the wire shape does
-//     not churn when later slices wire up per-runner mappers for the
-//     intermediate phases.
+//     "tool_result", "idle", "error", "manifest". A2-MVP emitted only
+//     "idle" and "error"; A3 wired the intermediate phases; A4 adds
+//     "manifest" — a per-turn completion summary emitted after the
+//     terminal idle/error event.
 //   - Provider: "claude" | "codex" | "opencode" | "openai-compat".
 //   - Agent: the speaker slug (the agent the turn belongs to).
 //   - TurnID, TaskID, ParentID: correlation IDs. TurnID groups events
@@ -48,24 +49,38 @@ import (
 //   - StartedAt: RFC3339 timestamp from the runner's clock so ordering
 //     survives reordering at the SSE boundary and replay timing is
 //     reconstructable.
-//   - Metrics: turn-level latency and token totals. Populated on idle.
+//   - Metrics: turn-level latency and token totals. Populated on idle
+//     and manifest.
 //   - RawType: the underlying provider event type for debug tooling.
-//     Empty for runner-synthesized events like idle.
+//     Empty for runner-synthesized events like idle and manifest.
+//   - ToolCalls: populated only on manifest events. Sorted list of
+//     distinct tools called during the turn with per-tool call counts.
+//   - TextLen: populated only on manifest events. Total byte length of
+//     all text chunks emitted during the turn.
 type HeadlessEvent struct {
-	Kind      string                `json:"kind"`
-	Type      string                `json:"type"`
-	Provider  string                `json:"provider,omitempty"`
-	Agent     string                `json:"agent,omitempty"`
-	TurnID    string                `json:"turn_id,omitempty"`
-	TaskID    string                `json:"task_id,omitempty"`
-	ParentID  string                `json:"parent_id,omitempty"`
-	ToolName  string                `json:"tool_name,omitempty"`
-	Text      string                `json:"text,omitempty"`
-	Detail    string                `json:"detail,omitempty"`
-	Status    string                `json:"status,omitempty"`
-	StartedAt string                `json:"started_at,omitempty"`
-	Metrics   *HeadlessEventMetrics `json:"metrics,omitempty"`
-	RawType   string                `json:"raw_type,omitempty"`
+	Kind      string                  `json:"kind"`
+	Type      string                  `json:"type"`
+	Provider  string                  `json:"provider,omitempty"`
+	Agent     string                  `json:"agent,omitempty"`
+	TurnID    string                  `json:"turn_id,omitempty"`
+	TaskID    string                  `json:"task_id,omitempty"`
+	ParentID  string                  `json:"parent_id,omitempty"`
+	ToolName  string                  `json:"tool_name,omitempty"`
+	Text      string                  `json:"text,omitempty"`
+	Detail    string                  `json:"detail,omitempty"`
+	Status    string                  `json:"status,omitempty"`
+	StartedAt string                  `json:"started_at,omitempty"`
+	Metrics   *HeadlessEventMetrics   `json:"metrics,omitempty"`
+	RawType   string                  `json:"raw_type,omitempty"`
+	ToolCalls []HeadlessManifestEntry `json:"tool_calls,omitempty"`
+	TextLen   int                     `json:"text_len,omitempty"`
+}
+
+// HeadlessManifestEntry is one tool in a manifest event's ToolCalls list.
+// Count is the number of times that tool was called during the turn.
+type HeadlessManifestEntry struct {
+	ToolName string `json:"tool_name"`
+	Count    int    `json:"count"`
 }
 
 // HeadlessEventMetrics carries turn-level timing and token totals. All
@@ -90,6 +105,7 @@ const (
 	HeadlessEventTypeToolResult = "tool_result"
 	HeadlessEventTypeIdle       = "idle"
 	HeadlessEventTypeError      = "error"
+	HeadlessEventTypeManifest   = "manifest"
 
 	HeadlessProviderClaude       = "claude"
 	HeadlessProviderCodex        = "codex"
@@ -254,6 +270,46 @@ func emitHeadlessToolResult(stream *agentStreamBuffer, turnID, provider, slug, t
 		Text:     text,
 		Status:   "active",
 		RawType:  rawType,
+	})
+}
+
+// emitHeadlessManifest pushes a manifest HeadlessEvent after the terminal
+// idle/error event. It is the machine-readable per-turn completion record:
+// which tools were called (deduplicated with counts), how many text bytes
+// were produced, and the same metrics as the idle event. Downstream
+// consumers — task details view, notebook auto-writer, cost analytics —
+// can query a single event type rather than replaying the full turn stream.
+//
+// toolNames is the ordered sequence of tool names as called; duplicates are
+// collapsed into a count. textLen is the sum of len(chunk) for every text
+// event emitted during the turn. Both may be zero for turns that produced
+// no tools or no text — the manifest is still emitted so consumers see a
+// consistent turn boundary.
+func emitHeadlessManifest(stream *agentStreamBuffer, turnID, provider, slug, taskID string, toolNames []string, textLen int, metrics headlessProgressMetrics, usage *headlessTokenUsage) {
+	if stream == nil {
+		return
+	}
+	counts := make(map[string]int, len(toolNames))
+	for _, name := range toolNames {
+		if name = strings.TrimSpace(name); name != "" {
+			counts[name]++
+		}
+	}
+	calls := make([]HeadlessManifestEntry, 0, len(counts))
+	for name, count := range counts {
+		calls = append(calls, HeadlessManifestEntry{ToolName: name, Count: count})
+	}
+	sort.Slice(calls, func(i, j int) bool { return calls[i].ToolName < calls[j].ToolName })
+	pushHeadlessEvent(stream, HeadlessEvent{
+		Type:      HeadlessEventTypeManifest,
+		Provider:  provider,
+		Agent:     slug,
+		TurnID:    strings.TrimSpace(turnID),
+		TaskID:    strings.TrimSpace(taskID),
+		Status:    "idle",
+		ToolCalls: calls,
+		TextLen:   textLen,
+		Metrics:   headlessProgressEventMetrics(metrics, usage),
 	})
 }
 

--- a/internal/team/headless_event_test.go
+++ b/internal/team/headless_event_test.go
@@ -223,7 +223,7 @@ func TestEmitHeadlessManifestAggregatesAndSorts(t *testing.T) {
 	// Read called 3 times, Edit called 1 time, Bash called 2 times — expect
 	// Bash×2, Edit×1, Read×3 in alphabetical order.
 	toolNames := []string{"Read", "Bash", "Edit", "Read", "Bash", "Read"}
-	emitHeadlessManifest(stream, "turn-m1", HeadlessProviderClaude, "ceo", "task-99",
+	emitHeadlessManifest(stream, "turn-m1", HeadlessProviderClaude, "ceo", "task-99", "",
 		toolNames, 1420, metrics, &headlessTokenUsage{InputTokens: 500, OutputTokens: 300})
 
 	lines := stream.recentTask("task-99")
@@ -270,6 +270,26 @@ func TestEmitHeadlessManifestAggregatesAndSorts(t *testing.T) {
 	}
 }
 
+// TestEmitHeadlessManifestErrorTurnStatus verifies that a non-empty errDetail
+// flips the manifest status to "error" so consumers can distinguish failed
+// turns without also reading the preceding idle/error event.
+func TestEmitHeadlessManifestErrorTurnStatus(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+	emitHeadlessManifest(stream, "turn-err", HeadlessProviderCodex, "eng", "task-e", "auth: 401",
+		nil, 0, headlessProgressMetrics{TotalMs: 300}, nil)
+	lines := stream.recentTask("task-e")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 manifest event, got %d", len(lines))
+	}
+	var ev HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ev.Status != "error" {
+		t.Fatalf("status: want error on non-empty errDetail, got %q", ev.Status)
+	}
+}
+
 // TestEmitHeadlessManifestEmptyTools verifies a turn with no tool calls
 // still emits a manifest with zero-length ToolCalls (omitted from wire
 // JSON due to omitempty) but still carries TextLen and Metrics.
@@ -277,7 +297,7 @@ func TestEmitHeadlessManifestEmptyTools(t *testing.T) {
 	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
 	metrics := headlessProgressMetrics{TotalMs: 500}
 
-	emitHeadlessManifest(stream, "turn-m2", HeadlessProviderCodex, "eng", "task-1",
+	emitHeadlessManifest(stream, "turn-m2", HeadlessProviderCodex, "eng", "task-1", "",
 		nil, 850, metrics, nil)
 
 	lines := stream.recentTask("task-1")
@@ -312,7 +332,7 @@ func TestEmitHeadlessManifestNilStreamIsSafe(t *testing.T) {
 			t.Fatalf("emitHeadlessManifest on nil stream panicked: %v", r)
 		}
 	}()
-	emitHeadlessManifest(nil, "t", HeadlessProviderClaude, "ceo", "task-1",
+	emitHeadlessManifest(nil, "t", HeadlessProviderClaude, "ceo", "task-1", "",
 		[]string{"Read"}, 100, headlessProgressMetrics{}, nil)
 }
 

--- a/internal/team/headless_event_test.go
+++ b/internal/team/headless_event_test.go
@@ -212,6 +212,110 @@ func TestNewHeadlessTurnIDIsUnique(t *testing.T) {
 	}
 }
 
+// TestEmitHeadlessManifestAggregatesAndSorts pins the per-turn manifest
+// emit contract: tool names are deduplicated with per-tool counts, the
+// list is sorted alphabetically so wire output is deterministic, and the
+// event carries the same turn/task correlation IDs as per-phase events.
+func TestEmitHeadlessManifestAggregatesAndSorts(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+	metrics := headlessProgressMetrics{TotalMs: 2000, FirstTextMs: 80}
+
+	// Read called 3 times, Edit called 1 time, Bash called 2 times — expect
+	// Bash×2, Edit×1, Read×3 in alphabetical order.
+	toolNames := []string{"Read", "Bash", "Edit", "Read", "Bash", "Read"}
+	emitHeadlessManifest(stream, "turn-m1", HeadlessProviderClaude, "ceo", "task-99",
+		toolNames, 1420, metrics, &headlessTokenUsage{InputTokens: 500, OutputTokens: 300})
+
+	lines := stream.recentTask("task-99")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 manifest event, got %d: %v", len(lines), lines)
+	}
+	var ev HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ev.Kind != HeadlessEventKind {
+		t.Fatalf("kind: want %q, got %q", HeadlessEventKind, ev.Kind)
+	}
+	if ev.Type != HeadlessEventTypeManifest {
+		t.Fatalf("type: want manifest, got %q", ev.Type)
+	}
+	if ev.TurnID != "turn-m1" {
+		t.Fatalf("turn_id: want turn-m1, got %q", ev.TurnID)
+	}
+	if ev.Status != "idle" {
+		t.Fatalf("status: want idle, got %q", ev.Status)
+	}
+	if ev.TextLen != 1420 {
+		t.Fatalf("text_len: want 1420, got %d", ev.TextLen)
+	}
+	if ev.Metrics == nil || ev.Metrics.TotalMs != 2000 || ev.Metrics.InputTokens != 500 {
+		t.Fatalf("metrics: %+v", ev.Metrics)
+	}
+
+	// Verify dedup + sort
+	want := []HeadlessManifestEntry{
+		{ToolName: "Bash", Count: 2},
+		{ToolName: "Edit", Count: 1},
+		{ToolName: "Read", Count: 3},
+	}
+	if len(ev.ToolCalls) != len(want) {
+		t.Fatalf("tool_calls length: want %d, got %d: %+v", len(want), len(ev.ToolCalls), ev.ToolCalls)
+	}
+	for i, w := range want {
+		g := ev.ToolCalls[i]
+		if g.ToolName != w.ToolName || g.Count != w.Count {
+			t.Fatalf("tool_calls[%d]: want %+v, got %+v", i, w, g)
+		}
+	}
+}
+
+// TestEmitHeadlessManifestEmptyTools verifies a turn with no tool calls
+// still emits a manifest with zero-length ToolCalls (omitted from wire
+// JSON due to omitempty) but still carries TextLen and Metrics.
+func TestEmitHeadlessManifestEmptyTools(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+	metrics := headlessProgressMetrics{TotalMs: 500}
+
+	emitHeadlessManifest(stream, "turn-m2", HeadlessProviderCodex, "eng", "task-1",
+		nil, 850, metrics, nil)
+
+	lines := stream.recentTask("task-1")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 manifest event even with no tools, got %d", len(lines))
+	}
+	var ev HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ev.Type != HeadlessEventTypeManifest {
+		t.Fatalf("type: want manifest, got %q", ev.Type)
+	}
+	if len(ev.ToolCalls) != 0 {
+		t.Fatalf("ToolCalls must be empty for no-tool turn, got %+v", ev.ToolCalls)
+	}
+	if ev.TextLen != 850 {
+		t.Fatalf("text_len: want 850, got %d", ev.TextLen)
+	}
+	// Verify omitempty strips tool_calls from JSON
+	raw := strings.TrimRight(lines[0], "\n")
+	if strings.Contains(raw, `"tool_calls"`) {
+		t.Fatalf("tool_calls must be omitted from JSON when empty: %s", raw)
+	}
+}
+
+// TestEmitHeadlessManifestNilStreamIsSafe verifies the nil-stream guard
+// so runners don't need a conditional around every emit call.
+func TestEmitHeadlessManifestNilStreamIsSafe(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("emitHeadlessManifest on nil stream panicked: %v", r)
+		}
+	}()
+	emitHeadlessManifest(nil, "t", HeadlessProviderClaude, "ceo", "task-1",
+		[]string{"Read"}, 100, headlessProgressMetrics{}, nil)
+}
+
 // TestHeadlessProgressEventMetricsDropsSentinels pins the "-1 means
 // not measured" sentinel handling. Sentinels must not leak onto the
 // wire as negative numbers — JSON omitempty zeros are how the frontend

--- a/internal/team/headless_event_test.go
+++ b/internal/team/headless_event_test.go
@@ -246,8 +246,12 @@ func TestEmitHeadlessManifestAggregatesAndSorts(t *testing.T) {
 	if ev.Status != "idle" {
 		t.Fatalf("status: want idle, got %q", ev.Status)
 	}
-	if ev.TextLen != 1420 {
-		t.Fatalf("text_len: want 1420, got %d", ev.TextLen)
+	if ev.TextLen == nil || *ev.TextLen != 1420 {
+		v := 0
+		if ev.TextLen != nil {
+			v = *ev.TextLen
+		}
+		t.Fatalf("text_len: want 1420, got %d", v)
 	}
 	if ev.Metrics == nil || ev.Metrics.TotalMs != 2000 || ev.Metrics.InputTokens != 500 {
 		t.Fatalf("metrics: %+v", ev.Metrics)
@@ -314,8 +318,12 @@ func TestEmitHeadlessManifestEmptyTools(t *testing.T) {
 	if len(ev.ToolCalls) != 0 {
 		t.Fatalf("ToolCalls must be empty for no-tool turn, got %+v", ev.ToolCalls)
 	}
-	if ev.TextLen != 850 {
-		t.Fatalf("text_len: want 850, got %d", ev.TextLen)
+	if ev.TextLen == nil || *ev.TextLen != 850 {
+		v := 0
+		if ev.TextLen != nil {
+			v = *ev.TextLen
+		}
+		t.Fatalf("text_len: want 850, got %d", v)
 	}
 	// Verify omitempty strips tool_calls from JSON
 	raw := strings.TrimRight(lines[0], "\n")
@@ -334,6 +342,32 @@ func TestEmitHeadlessManifestNilStreamIsSafe(t *testing.T) {
 	}()
 	emitHeadlessManifest(nil, "t", HeadlessProviderClaude, "ceo", "task-1", "",
 		[]string{"Read"}, 100, headlessProgressMetrics{}, nil)
+}
+
+// TestEmitHeadlessManifestFiltersEmptyToolNames verifies that blank or
+// whitespace-only tool names in the accumulator slice are silently
+// dropped before counting. Opencode normalises missing names to "tool"
+// before appending, but other callers could pass raw provider names
+// that arrive empty; the filter ensures they don't inflate the count.
+func TestEmitHeadlessManifestFiltersEmptyToolNames(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+	toolNames := []string{"Read", "", "  ", "Edit", ""}
+	emitHeadlessManifest(stream, "turn-f1", HeadlessProviderClaude, "ceo", "task-f", "",
+		toolNames, 0, headlessProgressMetrics{}, nil)
+	lines := stream.recentTask("task-f")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 manifest event, got %d", len(lines))
+	}
+	var ev HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(ev.ToolCalls) != 2 {
+		t.Fatalf("want 2 tool entries (Read, Edit), got %d: %+v", len(ev.ToolCalls), ev.ToolCalls)
+	}
+	if ev.ToolCalls[0].ToolName != "Edit" || ev.ToolCalls[1].ToolName != "Read" {
+		t.Fatalf("expected alphabetical [Edit, Read], got %+v", ev.ToolCalls)
+	}
 }
 
 // TestHeadlessProgressEventMetricsDropsSentinels pins the "-1 means

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -143,6 +143,8 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	// agent's turn into its own row. Format mirrors agent.nextTaskID.
 	taskID := fmt.Sprintf("%s-%d", slug, time.Now().UnixMilli())
 	turnID := newHeadlessTurnID()
+	var turnToolNames []string
+	var turnTextLen int
 
 	loop := openAICompatToolLoop{
 		streamFn:    streamFn,
@@ -155,11 +157,13 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		agentSlug:   slug,
 		onText: func(chunk string) {
 			state.onText(chunk)
+			turnTextLen += len(chunk)
 			emitHeadlessText(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, chunk, kind+".text")
 		},
 		onToolUse: func(name, rawInput string) {
 			state.onToolUseChunk(name, rawInput)
 			l.updateHeadlessProgress(slug, "active", "tool", "running "+name, metrics)
+			turnToolNames = append(turnToolNames, name)
 			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, name, rawInput, kind+".tool_use")
 		},
 		onError: state.onError,
@@ -195,6 +199,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", err.Error(), metrics, claudeUsageToTokenUsage(turnUsage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
 		return err
 	}
 	if streamErr != "" {
@@ -206,6 +211,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(streamErr, 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", streamErr, metrics, claudeUsageToTokenUsage(turnUsage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
 		// Post any partial output (e.g. the cap-hit marker the loop
 		// produced when maxIters tripped) before propagating the error,
 		// so the user sees something on-channel rather than a silent
@@ -246,6 +252,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, summary, "", metrics, claudeUsageToTokenUsage(turnUsage))
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
 
 	state.flushLiveChat()
 	if text != "" && state.shouldPostFinalText() {

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -199,7 +199,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", err.Error(), metrics, claudeUsageToTokenUsage(turnUsage))
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, err.Error(), turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
 		return err
 	}
 	if streamErr != "" {
@@ -211,7 +211,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		))
 		l.updateHeadlessProgress(slug, "error", "error", truncate(streamErr, 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", streamErr, metrics, claudeUsageToTokenUsage(turnUsage))
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, streamErr, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
 		// Post any partial output (e.g. the cap-hit marker the loop
 		// produced when maxIters tripped) before propagating the error,
 		// so the user sees something on-channel rather than a silent
@@ -252,7 +252,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, summary, "", metrics, claudeUsageToTokenUsage(turnUsage))
-	emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpenAICompat, slug, activeTaskID, "", turnToolNames, turnTextLen, metrics, claudeUsageToTokenUsage(turnUsage))
 
 	state.flushLiveChat()
 	if text != "" && state.shouldPostFinalText() {

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -191,7 +191,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			}
 			l.updateHeadlessProgress(slug, "active", "tool", "running "+detail, metrics)
 			pushStream("[tool] " + detail)
-			turnToolNames = append(turnToolNames, ev.ToolName)
+			turnToolNames = append(turnToolNames, detail)
 			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, ev.ToolName, "", "opencode.tool_use")
 		case "tool_result":
 			if d := strings.TrimSpace(ev.Detail); d != "" {
@@ -222,7 +222,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			appendHeadlessCodexLog(slug, "opencode_stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 			emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", detail, metrics, nil)
-			emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
+			emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, detail, turnToolNames, turnTextLen, metrics, nil)
 			if isOpencodeAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -242,14 +242,14 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			err.Error(),
 		))
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", err.Error(), metrics, nil)
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, err.Error(), turnToolNames, turnTextLen, metrics, nil)
 		return err
 	}
 	if scanErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(scanErr.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", scanErr.Error(), metrics, nil)
-		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, scanErr.Error(), turnToolNames, turnTextLen, metrics, nil)
 		return scanErr
 	}
 
@@ -271,7 +271,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, summary, "", metrics, nil)
-	emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", turnToolNames, turnTextLen, metrics, nil)
 	relay.Flush()
 	if text != "" {
 		appendHeadlessCodexLog(slug, "opencode_result: "+text)

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -149,6 +149,8 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	textStarted := false
 	var lastError string
 	turnID := newHeadlessTurnID()
+	var turnToolNames []string
+	var turnTextLen int
 	pushStream := func(line string) {
 		if agentStream != nil && strings.TrimSpace(line) != "" {
 			agentStream.PushTask(taskID, line)
@@ -175,6 +177,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			}
 			pushStream(ev.Text)
 			relay.OnText(ev.Text)
+			turnTextLen += len(ev.Text)
 			emitHeadlessText(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, ev.Text, "opencode.text")
 		case "tool_use":
 			relay.Flush()
@@ -188,6 +191,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			}
 			l.updateHeadlessProgress(slug, "active", "tool", "running "+detail, metrics)
 			pushStream("[tool] " + detail)
+			turnToolNames = append(turnToolNames, ev.ToolName)
 			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, ev.ToolName, "", "opencode.tool_use")
 		case "tool_result":
 			if d := strings.TrimSpace(ev.Detail); d != "" {
@@ -218,6 +222,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			appendHeadlessCodexLog(slug, "opencode_stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 			emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", detail, metrics, nil)
+			emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
 			if isOpencodeAuthError(detail) && l.broker != nil {
 				sysTarget := target
 				if strings.TrimSpace(sysTarget) == "" {
@@ -237,12 +242,14 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			err.Error(),
 		))
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", err.Error(), metrics, nil)
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
 		return err
 	}
 	if scanErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(scanErr.Error(), 180), metrics)
 		emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, "", scanErr.Error(), metrics, nil)
+		emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
 		return scanErr
 	}
 
@@ -264,6 +271,7 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, summary, "", metrics, nil)
+	emitHeadlessManifest(agentStream, turnID, HeadlessProviderOpencode, slug, taskID, turnToolNames, turnTextLen, metrics, nil)
 	relay.Flush()
 	if text != "" {
 		appendHeadlessCodexLog(slug, "opencode_result: "+text)

--- a/web/src/components/messages/StreamLineView.test.tsx
+++ b/web/src/components/messages/StreamLineView.test.tsx
@@ -224,7 +224,7 @@ describe("<StreamLineView>", () => {
     expect(screen.getByText("Bash ×2")).toBeInTheDocument();
     expect(screen.getByText("Read ×3")).toBeInTheDocument();
     // Text byte stat
-    expect(screen.getByText("1,420 chars")).toBeInTheDocument();
+    expect(screen.getByText("1,420 bytes")).toBeInTheDocument();
     // Token stat (500 + 300 = 800)
     expect(screen.getByText("800 tok")).toBeInTheDocument();
   });

--- a/web/src/components/messages/StreamLineView.test.tsx
+++ b/web/src/components/messages/StreamLineView.test.tsx
@@ -197,6 +197,60 @@ describe("<StreamLineView>", () => {
     expect(screen.getByText("team_broadcast")).toBeInTheDocument();
   });
 
+  it("renders a HeadlessEvent manifest with tool badges and stats", () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "manifest",
+            provider: "claude",
+            agent: "ceo",
+            turn_id: "abc123",
+            status: "idle",
+            text_len: 1420,
+            tool_calls: [
+              { tool_name: "Bash", count: 2 },
+              { tool_name: "Read", count: 3 },
+            ],
+            metrics: { total_ms: 2000, input_tokens: 500, output_tokens: 300 },
+          },
+        }}
+      />,
+    );
+    // Tool badges appear with count suffix when count > 1
+    expect(screen.getByText("Bash ×2")).toBeInTheDocument();
+    expect(screen.getByText("Read ×3")).toBeInTheDocument();
+    // Text byte stat
+    expect(screen.getByText("1,420 chars")).toBeInTheDocument();
+    // Token stat (500 + 300 = 800)
+    expect(screen.getByText("800 tok")).toBeInTheDocument();
+  });
+
+  it("renders a HeadlessEvent manifest with no tools as null", () => {
+    const { container } = render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "manifest",
+            provider: "codex",
+            agent: "eng",
+            turn_id: "t1",
+            status: "idle",
+            text_len: 0,
+          },
+        }}
+      />,
+    );
+    // Zero tools + zero textLen → hasStats false → renders nothing
+    expect(container.firstChild).toBeNull();
+  });
+
   it("renders Codex completed message content arrays", () => {
     render(
       <StreamLineView

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -241,11 +241,11 @@ function HeadlessEventView({
             );
           })}
           {textLen !== null && textLen > 0 && (
-            <span className="stream-manifest-stat">{textLen.toLocaleString()} chars</span>
+            <span className="stream-manifest-stat">{textLen.toLocaleString("en-US")} bytes</span>
           )}
           {inputTokens !== null && outputTokens !== null && (
             <span className="stream-manifest-stat">
-              {(inputTokens + outputTokens).toLocaleString()} tok
+              {(inputTokens + outputTokens).toLocaleString("en-US")} tok
             </span>
           )}
         </div>

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -125,12 +125,9 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
 }
 
 // HeadlessEventView renders the typed HeadlessEvent envelope emitted by
-// each runner at terminal phases (idle / error). The wire shape comes
-// from internal/team/headless_event.go (HeadlessEvent struct). A2-MVP
-// only emits idle and error; the rendering branches keep the layout
-// minimal because future slices (text / tool_use / tool_result) will
-// reuse this component, and a maximalist v1 design would lock those
-// future variants into chrome that won't fit.
+// each runner. The wire shape comes from internal/team/headless_event.go
+// (HeadlessEvent struct). A4 adds the "manifest" type — a per-turn
+// completion summary with tool-call counts and text byte stats.
 function HeadlessEventView({
   parsed,
   compact,
@@ -203,6 +200,53 @@ function HeadlessEventView({
         }}
         compact={compact}
       />
+    );
+  }
+
+  if (eventType === "manifest") {
+    // manifest is a per-turn completion record emitted after idle/error.
+    // Render as a compact summary row: tool badges + text bytes + tokens.
+    const toolCalls = Array.isArray(parsed.tool_calls)
+      ? (parsed.tool_calls as Array<Record<string, unknown>>)
+      : [];
+    const textLen =
+      typeof parsed.text_len === "number" ? parsed.text_len : null;
+    const inputTokens =
+      metrics && typeof metrics.input_tokens === "number"
+        ? metrics.input_tokens
+        : null;
+    const outputTokens =
+      metrics && typeof metrics.output_tokens === "number"
+        ? metrics.output_tokens
+        : null;
+    const hasStats = toolCalls.length > 0 || (textLen !== null && textLen > 0) || inputTokens !== null;
+    if (!hasStats) return null;
+    return (
+      <div className="stream-card stream-card-manifest">
+        <div className="stream-card-header">
+          <span className="stream-card-phase stream-phase-manifest">turn</span>
+          {provider && <span className="stream-card-agent">{provider}</span>}
+        </div>
+        <div className="stream-manifest-stats">
+          {toolCalls.map((tc) => {
+            const name = stringish(tc.tool_name) || "tool";
+            const count = typeof tc.count === "number" ? tc.count : 1;
+            return (
+              <span key={name} className="stream-manifest-tool-badge">
+                {count > 1 ? `${name} ×${count}` : name}
+              </span>
+            );
+          })}
+          {textLen !== null && textLen > 0 && (
+            <span className="stream-manifest-stat">{textLen.toLocaleString()} chars</span>
+          )}
+          {inputTokens !== null && outputTokens !== null && (
+            <span className="stream-manifest-stat">
+              {(inputTokens + outputTokens).toLocaleString()} tok
+            </span>
+          )}
+        </div>
+      </div>
     );
   }
 

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -219,7 +219,10 @@ function HeadlessEventView({
       metrics && typeof metrics.output_tokens === "number"
         ? metrics.output_tokens
         : null;
-    const hasStats = toolCalls.length > 0 || (textLen !== null && textLen > 0) || inputTokens !== null;
+    const hasStats =
+      toolCalls.length > 0 ||
+      (textLen !== null && textLen > 0) ||
+      (inputTokens !== null && outputTokens !== null);
     if (!hasStats) return null;
     return (
       <div className="stream-card stream-card-manifest">

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -990,6 +990,35 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   white-space: pre-wrap;
 }
 
+.stream-card-manifest {
+  opacity: 0.8;
+}
+.stream-phase-manifest {
+  color: var(--text-tertiary);
+  background: var(--bg-secondary, var(--bg));
+}
+.stream-manifest-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+.stream-manifest-tool-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  white-space: nowrap;
+}
+.stream-manifest-stat {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
 /* ─── Composer ─── */
 .composer {
   padding: 12px 24px 16px;


### PR DESCRIPTION
## Summary

- Adds a new `"manifest"` HeadlessEvent type emitted after every turn's terminal `idle`/`error` event across all four headless runners (Claude, Codex, Opencode, OpenAI-compat)
- The manifest is the **machine-readable per-turn completion record**: tools called with per-tool call counts (sorted alphabetically), total text bytes produced, and the same latency+token metrics as the `idle` event
- Frontend `HeadlessEventView` in `StreamLineView.tsx` renders the manifest as a compact turn-summary row: tool badges (`Bash ×2`, `Read ×3`), char count, token total; zero-stat manifests suppress rendering

**Slice context:** A4 of the Flue agent-harness extraction. A1 (drain hardening, #670), A2 (HeadlessEvent envelope + replay-end boundary, #698), and A3 (per-phase text/tool_use/tool_result mappers + emitHeadlessTerminalWithTurn, #714) are all merged. A4 is the manifest summary slice.

**Wire additions (all backward-compatible, omitempty):**
- `HeadlessEventTypeManifest = "manifest"` constant
- `HeadlessManifestEntry{ToolName, Count}` struct
- `HeadlessEvent.ToolCalls []HeadlessManifestEntry`
- `HeadlessEvent.TextLen int`
- `emitHeadlessManifest()` helper in `headless_event.go`

**Runner changes:** Each runner accumulates `turnToolNames []string` and `turnTextLen int` during the event loop and calls `emitHeadlessManifest` after `emitHeadlessTerminalWithTurn` on all exit paths (success, `cmd.Wait` error, `parseErr`/`scanErr`) — error turns still surface their tool index.

**Wire back-compat:** `idle` and `error` events are unchanged. `manifest` is additive.

## Test plan

- [ ] `go test -count=1 ./internal/team/...` — 3 new tests: `TestEmitHeadlessManifestAggregatesAndSorts`, `TestEmitHeadlessManifestEmptyTools`, `TestEmitHeadlessManifestNilStreamIsSafe`
- [ ] `bash scripts/test-web.sh web/src/components/messages/StreamLineView.test.tsx` — 2 new tests: manifest badges+stats render, zero-stat renders null (11 total pass)
- [ ] `bunx tsc --noEmit` — clean
- [ ] `go build -buildvcs=false ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit per-turn "manifest" events summarizing tool-call counts, total streamed character counts, and metrics; UI displays a manifest card with tool badges (e.g., "Bash ×2") and formatted char/token stats, hidden when empty.

* **Tests**
  * Added unit and component tests for manifest emission, deterministic aggregation, error/idle statuses, nil-stream safety, and UI rendering.

* **Style**
  * Added CSS utilities for manifest summary styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->