### PR TITLE
feat(web): theme switcher menu with named options

### DIFF
--- a/web/src/components/layout/ChannelHeader.test.tsx
+++ b/web/src/components/layout/ChannelHeader.test.tsx
@@ -18,18 +18,37 @@ afterEach(() => {
 });
 
 describe("<ChannelHeader>", () => {
-  it("labels the theme toggle with the next theme action", () => {
-    useAppStore.setState({ theme: "nex-dark" });
+  it("opens the theme switcher and switches to Nex Dark", () => {
+    useAppStore.setState({ theme: "nex" });
 
     render(<ChannelHeader />);
 
-    const button = screen.getByRole("button", {
-      name: "Switch theme to Noir Gold",
+    const trigger = screen.getByRole("button", {
+      name: /Theme: Nex Light\. Open theme switcher\./,
     });
-    expect(button).toHaveAttribute("title", "Switch theme to Noir Gold");
+    fireEvent.click(trigger);
 
-    fireEvent.click(button);
+    const dark = screen.getByRole("menuitemradio", { name: /Nex Dark/ });
+    fireEvent.click(dark);
 
-    expect(useAppStore.getState().theme).toBe("noir-gold");
+    expect(useAppStore.getState().theme).toBe("nex-dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe(
+      "nex-dark",
+    );
+  });
+
+  it("marks the active theme as checked", () => {
+    useAppStore.setState({ theme: "noir-gold" });
+
+    render(<ChannelHeader />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Theme: Noir Gold\. Open theme switcher\./,
+      }),
+    );
+
+    const noir = screen.getByRole("menuitemradio", { name: /Noir Gold/ });
+    expect(noir).toHaveAttribute("aria-checked", "true");
   });
 });

--- a/web/src/components/layout/ChannelHeader.tsx
+++ b/web/src/components/layout/ChannelHeader.tsx
@@ -1,20 +1,8 @@
 import { useChannels } from "../../hooks/useChannels";
 import { appTitle } from "../../lib/constants";
 import { useCurrentRoute } from "../../routes/useCurrentRoute";
-import type { Theme } from "../../stores/app";
 import { useAppStore } from "../../stores/app";
-
-function nextTheme(t: Theme): Theme {
-  if (t === "noir-gold") return "nex";
-  if (t === "nex") return "nex-dark";
-  return "noir-gold";
-}
-
-function themeLabel(t: Theme): string {
-  if (t === "noir-gold") return "Noir Gold";
-  if (t === "nex-dark") return "Nex Dark";
-  return "Nex Light";
-}
+import { ThemeSwitcher } from "./ThemeSwitcher";
 
 function headerTitleAndDesc(
   route: ReturnType<typeof useCurrentRoute>,
@@ -58,12 +46,9 @@ function headerTitleAndDesc(
 export function ChannelHeader() {
   const route = useCurrentRoute();
   const setSearchOpen = useAppStore((s) => s.setSearchOpen);
-  const theme = useAppStore((s) => s.theme);
-  const setTheme = useAppStore((s) => s.setTheme);
   const { data: channels = [] } = useChannels();
 
   const { title, desc } = headerTitleAndDesc(route, channels);
-  const targetTheme = nextTheme(theme);
 
   return (
     <div className="channel-header">
@@ -72,64 +57,7 @@ export function ChannelHeader() {
         {desc ? <span className="channel-desc">{desc}</span> : null}
       </div>
       <div className="channel-actions">
-        <button
-          type="button"
-          className="sidebar-btn"
-          title={`Switch theme to ${themeLabel(targetTheme)}`}
-          aria-label={`Switch theme to ${themeLabel(targetTheme)}`}
-          onClick={() => setTheme(targetTheme)}
-        >
-          {targetTheme === "noir-gold" ? (
-            // Sparkle / star — switch to the gold theme
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M12 3l1.8 5.5H19l-4.6 3.4 1.8 5.6L12 14l-4.2 3.5 1.8-5.6L5 8.5h5.2L12 3z" />
-            </svg>
-          ) : targetTheme === "nex" ? (
-            // Sun — switch to the light theme
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <circle cx="12" cy="12" r="4" />
-              <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
-            </svg>
-          ) : (
-            // Moon — switch to the dark theme
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-            </svg>
-          )}
-        </button>
+        <ThemeSwitcher />
         <button
           type="button"
           className="sidebar-btn"

--- a/web/src/components/layout/ThemeSwitcher.tsx
+++ b/web/src/components/layout/ThemeSwitcher.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { Theme } from "../../stores/app";
+import { useAppStore } from "../../stores/app";
+
+interface ThemeOption {
+  id: Theme;
+  name: string;
+  desc: string;
+  swatch: { primary: string; accent: string; surface: string };
+}
+
+const THEME_OPTIONS: ThemeOption[] = [
+  {
+    id: "nex",
+    name: "Nex Light",
+    desc: "Clean light. Cyan accents.",
+    swatch: { primary: "#612a92", accent: "#9f4dbf", surface: "#ffffff" },
+  },
+  {
+    id: "nex-dark",
+    name: "Nex Dark",
+    desc: "Low-glare dark.",
+    swatch: { primary: "#0f0f12", accent: "#9f4dbf", surface: "#1a1a1f" },
+  },
+  {
+    id: "noir-gold",
+    name: "Noir Gold",
+    desc: "Black, gold leaf.",
+    swatch: { primary: "#0a0a0a", accent: "#d4af37", surface: "#161616" },
+  },
+];
+
+interface ThemeSwitcherProps {
+  className?: string;
+}
+
+export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
+  const theme = useAppStore((s) => s.theme);
+  const setTheme = useAppStore((s) => s.setTheme);
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function onPointerDown(e: PointerEvent) {
+      const node = wrapRef.current;
+      if (node && e.target instanceof Node && !node.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  function pick(t: Theme) {
+    setTheme(t);
+    setOpen(false);
+  }
+
+  const current = THEME_OPTIONS.find((o) => o.id === theme) ?? THEME_OPTIONS[0];
+
+  return (
+    <div
+      ref={wrapRef}
+      className={`theme-switcher${className ? ` ${className}` : ""}`}
+    >
+      <button
+        type="button"
+        className="sidebar-btn theme-switcher-trigger"
+        title={`Theme: ${current.name}`}
+        aria-label={`Theme: ${current.name}. Open theme switcher.`}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span
+          className="theme-switcher-swatch"
+          aria-hidden="true"
+          style={{
+            background: `linear-gradient(135deg, ${current.swatch.primary} 0%, ${current.swatch.primary} 50%, ${current.swatch.accent} 50%, ${current.swatch.accent} 100%)`,
+          }}
+        />
+        <svg
+          aria-hidden="true"
+          focusable="false"
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M2 4l3 3 3-3" />
+        </svg>
+      </button>
+
+      {open ? (
+        <div
+          className="theme-switcher-menu"
+          role="menu"
+          aria-label="Theme switcher"
+        >
+          <div className="theme-switcher-title">Theme</div>
+          <div className="theme-switcher-options">
+            {THEME_OPTIONS.map((opt) => {
+              const isActive = opt.id === theme;
+              return (
+                <button
+                  key={opt.id}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={isActive}
+                  className={`theme-switcher-option${isActive ? " is-active" : ""}`}
+                  onClick={() => pick(opt.id)}
+                >
+                  <span
+                    className="theme-switcher-option-swatch"
+                    aria-hidden="true"
+                    style={{
+                      background: `linear-gradient(135deg, ${opt.swatch.primary} 0%, ${opt.swatch.primary} 50%, ${opt.swatch.accent} 50%, ${opt.swatch.accent} 100%)`,
+                      borderColor: opt.swatch.surface,
+                    }}
+                  />
+                  <span className="theme-switcher-option-text">
+                    <span className="theme-switcher-option-name">
+                      {opt.name}
+                    </span>
+                    <span className="theme-switcher-option-desc">
+                      {opt.desc}
+                    </span>
+                  </span>
+                  {isActive ? (
+                    <span
+                      className="theme-switcher-option-check"
+                      aria-hidden="true"
+                    >
+                      {"✓"}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/layout/ThemeSwitcher.tsx
+++ b/web/src/components/layout/ThemeSwitcher.tsx
@@ -1,35 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
-import type { Theme } from "../../stores/app";
+import { type Theme, THEMES } from "../../lib/themes";
 import { useAppStore } from "../../stores/app";
-
-interface ThemeOption {
-  id: Theme;
-  name: string;
-  desc: string;
-  swatch: { primary: string; accent: string; surface: string };
-}
-
-const THEME_OPTIONS: ThemeOption[] = [
-  {
-    id: "nex",
-    name: "Nex Light",
-    desc: "Clean light. Cyan accents.",
-    swatch: { primary: "#612a92", accent: "#9f4dbf", surface: "#ffffff" },
-  },
-  {
-    id: "nex-dark",
-    name: "Nex Dark",
-    desc: "Low-glare dark.",
-    swatch: { primary: "#0f0f12", accent: "#9f4dbf", surface: "#1a1a1f" },
-  },
-  {
-    id: "noir-gold",
-    name: "Noir Gold",
-    desc: "Black, gold leaf.",
-    swatch: { primary: "#0a0a0a", accent: "#d4af37", surface: "#161616" },
-  },
-];
 
 interface ThemeSwitcherProps {
   className?: string;
@@ -66,7 +38,7 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
     setOpen(false);
   }
 
-  const current = THEME_OPTIONS.find((o) => o.id === theme) ?? THEME_OPTIONS[0];
+  const current = THEMES.find((o) => o.id === theme) ?? THEMES[0];
 
   return (
     <div
@@ -113,7 +85,7 @@ export function ThemeSwitcher({ className }: ThemeSwitcherProps) {
         >
           <div className="theme-switcher-title">Theme</div>
           <div className="theme-switcher-options">
-            {THEME_OPTIONS.map((opt) => {
+            {THEMES.map((opt) => {
               const isActive = opt.id === theme;
               return (
                 <button

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -1,0 +1,73 @@
+/**
+ * Theme registry — single source of truth for every theme the app ships.
+ *
+ * Adding a theme means:
+ *   1. Drop the CSS file under `web/public/themes/<id>.css`.
+ *   2. Append an entry to `THEMES` below.
+ *
+ * The `Theme` union, the switcher menu, and the loader in `RootRoute` all
+ * derive their behaviour from this list.
+ */
+
+export interface ThemeSwatch {
+  /** Dominant chrome color used for the half of the corner badge. */
+  primary: string;
+  /** Accent color used for the other half of the corner badge. */
+  accent: string;
+  /** Body surface color, used as the swatch border so it reads against any bg. */
+  surface: string;
+}
+
+export interface ThemeDef {
+  id: string;
+  name: string;
+  desc: string;
+  swatch: ThemeSwatch;
+  /** Public path served by Vite — loaded into a `<link>` tag at runtime. */
+  cssPath: string;
+}
+
+export const THEMES = [
+  {
+    id: "nex",
+    name: "Nex Light",
+    desc: "Clean light. Cyan accents.",
+    swatch: { primary: "#612a92", accent: "#9f4dbf", surface: "#ffffff" },
+    cssPath: "/themes/nex.css",
+  },
+  {
+    id: "nex-dark",
+    name: "Nex Dark",
+    desc: "Low-glare dark.",
+    swatch: { primary: "#0f0f12", accent: "#9f4dbf", surface: "#1a1a1f" },
+    cssPath: "/themes/nex-dark.css",
+  },
+  {
+    id: "noir-gold",
+    name: "Noir Gold",
+    desc: "Black, gold leaf.",
+    swatch: { primary: "#0a0a0a", accent: "#d4af37", surface: "#161616" },
+    cssPath: "/themes/noir-gold.css",
+  },
+] as const satisfies readonly ThemeDef[];
+
+export type Theme = (typeof THEMES)[number]["id"];
+
+export const DEFAULT_THEME: Theme = "nex";
+
+const THEME_IDS: ReadonlySet<string> = new Set(THEMES.map((t) => t.id));
+
+/** Type guard for unknown values that might be persisted theme ids. */
+export function isTheme(v: unknown): v is Theme {
+  return typeof v === "string" && THEME_IDS.has(v);
+}
+
+/** Resolve a theme id to its definition, falling back to the default. */
+export function getTheme(id: Theme): (typeof THEMES)[number] {
+  const found = THEMES.find((t) => t.id === id);
+  if (found) return found;
+  // Manifest is non-empty and `id` is a member of the union, so this branch
+  // is unreachable in practice; the explicit fallback keeps the return type
+  // narrow for callers.
+  return THEMES[0];
+}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -33,6 +33,7 @@ import WikiTabs from "../components/wiki/WikiTabs";
 import { useBrokerEvents } from "../hooks/useBrokerEvents";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { rootRoute, router } from "../lib/router";
+import { getTheme } from "../lib/themes";
 import { useAppStore } from "../stores/app";
 import { type AppPanelId, isAppPanelId } from "./routeRegistry";
 import { type CurrentRoute, useCurrentRoute } from "./useCurrentRoute";
@@ -556,16 +557,17 @@ export default function RootRoute() {
   useBrokerEvents(apiReady);
 
   useEffect(() => {
+    const href = getTheme(theme).cssPath;
     const existing = document.getElementById(
       "theme-css",
     ) as HTMLLinkElement | null;
     if (existing) {
-      existing.href = `/themes/${theme}.css`;
+      existing.href = href;
     } else {
       const el = document.createElement("link");
       el.id = "theme-css";
       el.rel = "stylesheet";
-      el.href = `/themes/${theme}.css`;
+      el.href = href;
       document.head.appendChild(el);
     }
   }, [theme]);

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -5,8 +5,9 @@ import {
   computePillState,
   type PillState,
 } from "../lib/agentEventTimer";
+import { DEFAULT_THEME, isTheme, type Theme } from "../lib/themes";
 
-export type Theme = "nex" | "nex-dark" | "noir-gold";
+export type { Theme };
 
 /**
  * Snapshot payload for the SSE "activity" event. Lane A may not yet emit
@@ -52,9 +53,9 @@ export const MAX_AGENT_HISTORY = 8;
 const _storedTheme = ((): Theme => {
   try {
     const v = localStorage.getItem("wuphf-theme");
-    if (v === "nex" || v === "nex-dark" || v === "noir-gold") return v;
+    if (isTheme(v)) return v;
   } catch {}
-  return "nex";
+  return DEFAULT_THEME;
 })();
 if (typeof document !== "undefined") {
   document.documentElement.setAttribute("data-theme", _storedTheme);

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2701,3 +2701,98 @@ html[data-theme="nex"]
     height: 92vh;
   }
 }
+
+/* ═══════════════════════════════════════
+   Theme Switcher (base — theme files re-skin)
+   ═══════════════════════════════════════ */
+.theme-switcher {
+  position: relative;
+  display: inline-flex;
+}
+.theme-switcher-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 6px;
+}
+.theme-switcher-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  border: 1px solid var(--border-dark);
+  flex-shrink: 0;
+}
+.theme-switcher-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 240px;
+  background: var(--bg-card, #fff);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-md);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.18);
+  z-index: 50;
+  overflow: hidden;
+}
+.theme-switcher-title {
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border);
+}
+.theme-switcher-options {
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+}
+.theme-switcher-option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  text-align: left;
+  cursor: pointer;
+  color: var(--text);
+  width: 100%;
+  font: inherit;
+}
+.theme-switcher-option:hover,
+.theme-switcher-option:focus-visible {
+  background: var(--bg-warm);
+  outline: none;
+}
+.theme-switcher-option.is-active {
+  background: var(--accent-bg);
+}
+.theme-switcher-option-swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 4px;
+  border: 1px solid var(--border-dark);
+  flex-shrink: 0;
+}
+.theme-switcher-option-text {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+.theme-switcher-option-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.theme-switcher-option-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.theme-switcher-option-check {
+  color: var(--accent);
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary

Replaces the cycling theme button in the channel header with a popover menu that lists each theme by name and swatch.

- New `ThemeSwitcher` component with a swatch-button trigger and a labeled menu (Nex Light, Nex Dark, Noir Gold).
- Active theme is marked with a check; click-outside and Escape close the menu.
- `ChannelHeader` drops the `nextTheme` cycle helper and renders `<ThemeSwitcher />`.
- Base styles for the switcher live in `web/src/styles/layout.css` and use existing tokens so themes can re-skin if they want.

## Why

Cycling through three themes to land on the right one was clunky. Naming each theme up-front lets users see what they are switching to before they commit.

## Test plan

- [x] `bash scripts/test-web.sh web/src/components/layout web/src/stores` (126 tests, all green)
- [x] Manually verified the menu opens, closes on outside click and Escape, and switches between Nex Light / Nex Dark / Noir Gold with the active row checked.

## Notes

- Pre-existing typecheck errors on `main` in `web/src/components/wiki/editor/RichWikiEditor.tsx` (32 errors from removed `@milkdown/*` packages) are not from this branch and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a theme switcher UI with a dropdown and visual swatches to pick app themes.

* **Refactor**
  * Moved theme selection out of the channel header into a standalone theme switcher for clearer UI and reuse.

* **Styles**
  * Added styling for the theme switcher, swatches, and dropdown menu.

* **Chores**
  * Introduced a centralized theme registry and ensured theme stylesheet wiring updates correctly.

* **Tests**
  * Expanded tests for opening the menu, selecting themes, and reflecting active theme in UI and state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->