### PR TITLE
feat(notebook+onboarding): auto-write notebook entries on broker events + company context wiki seed

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -188,6 +188,60 @@ Tracking work that is deliberately deferred from the current branch. Each item n
 
 ---
 
+### 18. Wiki worker queue depth monitoring + alert thresholds (post-PR 1 notebook auto-writer)
+
+**What:** Instrument `wiki_worker.go` to emit queue depth and time-in-queue metrics, plus a warn log at 80% of the 64-buffer capacity. Track the dropped-event counter from `auto_notebook_writer.go` alongside.
+
+**Why:** PR 1 of the notebook-wiki-promise effort adds a new write source (every agent message + every task transition) that competes with real wiki, artifact, fact, lint, playbook, and learning writes through the same shared queue. Codex flagged this as the most likely operational failure mode. Without observability we discover starvation only when a real wiki write fails or times out.
+
+**Pros:** Confirms PR 1 didn't quietly DoS real wiki writes. Gives a concrete signal for tuning the auto-writer's enqueue capacity or for triggering the OV7B event-log migration (TODO #20).
+
+**Cons:** Adds a small metrics surface; needs to land somewhere in the existing analytics path.
+
+**Context:** PR 1 design doc: `~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md`. Eng review: same dir, dated 2026-05-05. Decision OV7A locked the per-event commit model with bounded enqueue; finding #8 from the Codex outside voice is the underlying concern.
+
+**Depends on / blocked by:** PR 1 must ship first (introduces the new write source).
+
+**Trigger to revisit:** First week of real PR 1 traffic, OR if any real wiki write ever times out.
+
+---
+
+### 19. Premise #3 closure design pass: memory workflow gate auto-satisfaction or removal
+
+**What:** Fresh `/office-hours` design pass on closing the memory workflow gate semantically. Today the gate requires `lookup + capture + promote` all satisfied to mark a task complete (`memory_workflow.go:398`). The eng review had originally planned to satisfy it inline from the auto-writer, but Codex flagged two killers: (a) the gate needs all three steps, not just capture; (b) calling `RecordTaskMemoryCapture` inline holds `b.mu` and would deadlock with the broker API path.
+
+**Why:** Premise #3 of the notebook-wiki-promise design says "kill the narrow `process_research` filter so the gate applies to all tasks, auto-satisfied by the writer." With OV3A we deferred this from PR 1 because the implementation path was wrong. Two possible exit ramps: (1) auto-satisfy all three steps deterministically with proper locking (raw helper holding existing lock + queueing the file write async); (2) kill the gate entirely — once writes are deterministic the gate is dead weight, but we lose its override-tracking and partial-error surfaces.
+
+**Pros:** Closes premise #3 honestly. Either direction simplifies the broker.
+
+**Cons:** A real design pass, not a one-line filter removal. Potentially touches `memory_workflow.go`, `broker_tasks_memory_workflow.go`, and `memory_workflow_reconciler.go`.
+
+**Context:** Notebook-wiki-promise design doc PR 8 row was originally "5-line filter removal at memory_workflow.go:212-227." Codex outside voice (2026-05-05) showed why that's wrong. Locked decisions OV3A, OV3B (rejected), OV3D (deadlock).
+
+**Depends on / blocked by:** PR 1 + PR 2 should ship first so we can observe the writer's real behavior before deciding which exit ramp is right.
+
+**Trigger to revisit:** After PRs 1, 2, 3 ship and the auto-writer behavior is observable in real WUPHF traffic.
+
+---
+
+### 20. Evaluate event-log architecture migration after notebook-wiki-promise PR 1 screenshot test
+
+**What:** After PR 1 ships and one full WUPHF session populates shelves, evaluate whether the per-event direct-commit model (OV7A) creates the predicted problems: wiki worker queue saturation, NotebookSignalScanner garbage on noisy files, PR 3 clustering quality. If yes, plan migration to the alternative architecture (OV7B): append-only event log per agent (`agents/{slug}/notebook/.events.jsonl`) plus a renderer pass that materializes markdown files on cadence or on-demand.
+
+**Why:** Codex outside voice (2026-05-05, finding #11) argued the event-log architecture is fundamentally simpler than per-event commits and avoids problems PRs 3-6 will have to unwind. We chose OV7A for PR 1 because it gives instant visible shelf fill (the screenshot is the demand test). If the prediction holds, the migration option needs to be alive, not re-derived from scratch.
+
+**Pros:** Far fewer git commits (1/min batched vs 1/event). Lighter long-term cost as agent activity scales. Cleaner separation between durable raw stream and rendered surface.
+
+**Cons:** Bigger refactor than designing it right once. Migration must preserve existing markdown files or accept that historical writes stay in the original layout.
+
+**Context:** Notebook-wiki-promise design 2026-05-05. OV7A vs OV7B in the eng review. Codex flagged OV7B as the simpler architecture; we picked OV7A for the demo path with this TODO as the safety net.
+
+**Depends on / blocked by:** PR 1 must ship and one full session must populate shelves. TODO #18's queue-depth metric is a leading signal.
+
+**Trigger to revisit:** After the screenshot post in founder channel + one week of PR 1 production traffic, OR if TODO #18 alerts fire repeatedly, OR if PR 3 ranking quality is poor.
+
+---
+
 ## Deferred
 
 Items with known fixes but out of scope for this branch. Each names the trigger that would unblock revisiting.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,10 @@ type Config struct {
 	CompanyGoals        string `json:"company_goals,omitempty"`
 	CompanySize         string `json:"company_size,omitempty"`
 	CompanyPriority     string `json:"company_priority,omitempty"`
+	OwnerName           string `json:"owner_name,omitempty"`
+	OwnerRole           string `json:"owner_role,omitempty"`
+	CompanyWebsite      string `json:"company_website,omitempty"`
+	PendingCompanySeed  bool   `json:"pending_company_seed,omitempty"`
 
 	OpenclawBridges    []OpenclawBridgeBinding `json:"openclaw_bridges,omitempty"`
 	OpenclawGatewayURL string                  `json:"openclaw_gateway_url,omitempty"`
@@ -616,6 +620,16 @@ func CompanyContextBlock() string {
 	}
 	if priority := strings.TrimSpace(cfg.CompanyPriority); priority != "" {
 		sb.WriteString(fmt.Sprintf("Immediate priority: %s\n", priority))
+	}
+	if website := strings.TrimSpace(cfg.CompanyWebsite); website != "" {
+		sb.WriteString(fmt.Sprintf("Website: %s\n", website))
+	}
+	if name := strings.TrimSpace(cfg.OwnerName); name != "" {
+		sb.WriteString(fmt.Sprintf("Owner: %s", name))
+		if role := strings.TrimSpace(cfg.OwnerRole); role != "" {
+			sb.WriteString(fmt.Sprintf(" (%s)", role))
+		}
+		sb.WriteString("\n")
 	}
 	sb.WriteString("\n")
 	return sb.String()

--- a/internal/onboarding/completer.go
+++ b/internal/onboarding/completer.go
@@ -1,0 +1,13 @@
+package onboarding
+
+import (
+	"context"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+type cliCompleter struct{}
+
+func (c cliCompleter) Complete(_ context.Context, prompt string) (string, error) {
+	return provider.RunConfiguredOneShot("", prompt, "")
+}

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/operations"
 )
 
@@ -33,6 +37,9 @@ type CompleteFunc func(task string, skipTask bool, blueprintID string, selectedA
 // return operation-appropriate first-task suggestions and falls back to the
 // generic compatibility templates when no blueprint-specific set exists.
 //
+// wikiRoot is the absolute path to the wiki directory used by the scan
+// handler to write extracted company context articles.
+//
 // authMiddleware wraps each handler. Pass the broker's requireAuth so local
 // processes and cross-origin callers cannot POST /onboarding/complete (which
 // seeds the team and fires the first CEO turn) without the broker token.
@@ -48,7 +55,9 @@ type CompleteFunc func(task string, skipTask bool, blueprintID string, selectedA
 //	GET  /onboarding/templates
 //	POST /onboarding/checklist/{id}/done
 //	POST /onboarding/checklist/dismiss
-func RegisterRoutes(mux *http.ServeMux, completeFn CompleteFunc, packSlug string, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
+//	POST /onboarding/scan
+//	POST /onboarding/upload-context
+func RegisterRoutes(mux *http.ServeMux, completeFn CompleteFunc, packSlug string, authMiddleware func(http.HandlerFunc) http.HandlerFunc, wikiRoot string) {
 	if authMiddleware == nil {
 		authMiddleware = func(h http.HandlerFunc) http.HandlerFunc { return h }
 	}
@@ -63,6 +72,8 @@ func RegisterRoutes(mux *http.ServeMux, completeFn CompleteFunc, packSlug string
 	// Pattern must be registered after the more-specific /dismiss route so
 	// that /dismiss is not swallowed by the /{id}/done prefix match.
 	mux.HandleFunc("/onboarding/checklist/", authMiddleware(HandleChecklistDone))
+	mux.HandleFunc("/onboarding/scan", authMiddleware(makeHandleScan(wikiRoot)))
+	mux.HandleFunc("/onboarding/upload-context", authMiddleware(handleUploadContext))
 }
 
 // HandleState handles GET /onboarding/state.
@@ -156,14 +167,30 @@ func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn CompleteF
 	}
 
 	var body struct {
-		Task      string   `json:"task"`
-		SkipTask  bool     `json:"skip_task"`
-		Blueprint string   `json:"blueprint"`
-		Agents    []string `json:"agents"`
+		Task          string   `json:"task"`
+		SkipTask      bool     `json:"skip_task"`
+		Blueprint     string   `json:"blueprint"`
+		Agents        []string `json:"agents"`
+		Website       string   `json:"website"`
+		ScanCompleted bool     `json:"scan_completed"`
+		OwnerName     string   `json:"owner_name"`
+		OwnerRole     string   `json:"owner_role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
 		return
+	}
+
+	if body.Website != "" || body.OwnerName != "" || !body.ScanCompleted {
+		if cfg, err := config.Load(); err == nil {
+			if w := strings.TrimSpace(body.Website); w != "" {
+				cfg.CompanyWebsite = w
+			}
+			cfg.OwnerName = strings.TrimSpace(body.OwnerName)
+			cfg.OwnerRole = strings.TrimSpace(body.OwnerRole)
+			cfg.PendingCompanySeed = !body.ScanCompleted
+			_ = config.Save(cfg)
+		}
 	}
 
 	s, err := Load()
@@ -514,6 +541,117 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 		})
 	}
 	return s
+}
+
+// OSScanRequest is the request body for POST /onboarding/scan.
+type OSScanRequest struct {
+	WebsiteURL string   `json:"website_url"`
+	FilePaths  []string `json:"file_paths"`
+	OwnerName  string   `json:"owner_name"`
+	OwnerRole  string   `json:"owner_role"`
+}
+
+// OSScanResponse is the response body for POST /onboarding/scan.
+type OSScanResponse struct {
+	Facts           []string `json:"facts"`
+	ArticlesWritten []string `json:"articles_written"`
+	Warnings        []string `json:"warnings,omitempty"`
+}
+
+// makeHandleScan returns a handler for POST /onboarding/scan that runs the
+// company context seeding pipeline and writes wiki articles.
+func makeHandleScan(wikiRoot string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var req OSScanRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		// Security: file path prefix guard — only files staged under the
+		// wuphf-upload temp prefix are permitted.
+		uploadPrefix := filepath.Join(os.TempDir(), "wuphf-upload-")
+		for _, p := range req.FilePaths {
+			if !strings.HasPrefix(filepath.Clean(p), uploadPrefix) {
+				http.Error(w, "invalid file path", http.StatusBadRequest)
+				return
+			}
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+		defer cancel()
+		input := operations.CompanySeedInput{
+			WebsiteURL: req.WebsiteURL,
+			FilePaths:  req.FilePaths,
+			OwnerName:  req.OwnerName,
+			OwnerRole:  req.OwnerRole,
+			Completer:  cliCompleter{},
+			WikiRoot:   wikiRoot,
+		}
+		result, err := operations.SeedCompanyContext(ctx, input)
+		if err != nil {
+			if ctx.Err() != nil {
+				http.Error(w, "scan timeout", http.StatusRequestTimeout)
+				return
+			}
+			http.Error(w, "scan failed", http.StatusInternalServerError)
+			return
+		}
+		resp := OSScanResponse{
+			Facts:           result.Facts,
+			ArticlesWritten: result.ArticlesWritten,
+			Warnings:        result.Warnings,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// handleUploadContext handles POST /onboarding/upload-context.
+// Accepts a multipart form with a "files" field and saves each uploaded file
+// to a temp directory so /onboarding/scan can reference it by path.
+func handleUploadContext(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		http.Error(w, "parse form failed", http.StatusBadRequest)
+		return
+	}
+	files := r.MultipartForm.File["files"]
+	if len(files) == 0 {
+		http.Error(w, "no files uploaded", http.StatusBadRequest)
+		return
+	}
+	var paths []string
+	for _, fh := range files {
+		f, err := fh.Open()
+		if err != nil {
+			continue
+		}
+		// Create temp dir with wuphf-upload- prefix so the scan handler's
+		// path prefix guard accepts it.
+		dir, err := os.MkdirTemp("", "wuphf-upload-")
+		if err != nil {
+			f.Close()
+			continue
+		}
+		dst := filepath.Join(dir, filepath.Base(fh.Filename))
+		out, err := os.Create(dst)
+		if err != nil {
+			f.Close()
+			continue
+		}
+		_, _ = io.Copy(out, f)
+		out.Close()
+		f.Close()
+		paths = append(paths, dst)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string][]string{"paths": paths})
 }
 
 // HandleChecklistDismiss handles POST /onboarding/checklist/dismiss.

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -503,7 +503,7 @@ func TestHandleChecklistDismiss(t *testing.T) {
 func TestRegisterRoutesRegistersAllPaths(t *testing.T) {
 	withTempHome(t, func(_ string) {
 		mux := http.NewServeMux()
-		RegisterRoutes(mux, nil, "", nil)
+		RegisterRoutes(mux, nil, "", nil, t.TempDir())
 
 		routes := []struct {
 			method string

--- a/internal/operations/company_seed.go
+++ b/internal/operations/company_seed.go
@@ -1,0 +1,369 @@
+package operations
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+)
+
+// Completer is the minimal interface for one LLM completion call.
+// Defined locally to avoid import cycle with internal/provider.
+type Completer interface {
+	Complete(ctx context.Context, prompt string) (string, error)
+}
+
+// CompanySeedInput configures a SeedCompanyContext run.
+type CompanySeedInput struct {
+	WebsiteURL string
+	FilePaths  []string
+	OwnerName  string
+	OwnerRole  string
+	Completer  Completer
+	WikiRoot   string
+}
+
+// CompanySeedResult summarizes what SeedCompanyContext did.
+type CompanySeedResult struct {
+	Profile         CompanyProfile
+	ArticlesWritten []string
+	Facts           []string
+	Warnings        []string
+}
+
+// SeedCompanyContext fetches or reads content, runs LLM extraction, and
+// writes wiki articles under WikiRoot/team/about/.
+func SeedCompanyContext(ctx context.Context, input CompanySeedInput) (*CompanySeedResult, error) {
+	result := &CompanySeedResult{}
+	var contentBuf strings.Builder
+
+	// 1. Fetch URL
+	if input.WebsiteURL != "" {
+		u, err := url.Parse(input.WebsiteURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			result.Warnings = append(result.Warnings, "skipped URL: must be http or https")
+		} else {
+			text, err := fetchURL(ctx, input.WebsiteURL)
+			if err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("URL fetch failed: %v", err))
+			} else {
+				contentBuf.WriteString(text)
+				contentBuf.WriteString("\n")
+			}
+		}
+	}
+
+	// 2. Extract file content
+	for _, path := range input.FilePaths {
+		data, err := os.ReadFile(path)
+		defer os.Remove(path)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("read file %s: %v", path, err))
+			continue
+		}
+		var text string
+		if strings.HasSuffix(strings.ToLower(path), ".pdf") {
+			text, err = extractPDF(ctx, path)
+			if err != nil {
+				result.Warnings = append(result.Warnings, err.Error())
+				continue
+			}
+		} else {
+			text = string(data)
+		}
+		if len(text) > 8*1024 {
+			text = text[:8*1024]
+		}
+		contentBuf.WriteString(text)
+		contentBuf.WriteString("\n")
+	}
+
+	// 3. Build wiki dirs
+	if err := os.MkdirAll(filepath.Join(input.WikiRoot, "team", "about"), 0o755); err != nil {
+		return nil, fmt.Errorf("operations: mkdir team/about: %w", err)
+	}
+
+	// 4. Write README (skip if exists)
+	readmePath := filepath.Join(input.WikiRoot, "team", "about", "README.md")
+	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
+		if err := atomicWrite(input.WikiRoot, "team/about/README.md", []byte(aboutReadmeContent)); err != nil {
+			return nil, err
+		}
+	}
+
+	// 5. Write owner.md (skip if both empty) — does not depend on content.
+	if strings.TrimSpace(input.OwnerName) != "" || strings.TrimSpace(input.OwnerRole) != "" {
+		ownerMD := buildOwnerMD(input.OwnerName, input.OwnerRole)
+		if err := atomicWrite(input.WikiRoot, "team/about/owner.md", []byte(ownerMD)); err != nil {
+			return nil, err
+		}
+		result.ArticlesWritten = append(result.ArticlesWritten, "team/about/owner.md")
+	}
+
+	// If no content, return early (README and owner written as applicable)
+	content := contentBuf.String()
+	if strings.TrimSpace(content) == "" && input.Completer == nil {
+		return result, nil
+	}
+
+	// 6. LLM extraction (skip if no completer or no content)
+	if input.Completer != nil && strings.TrimSpace(content) != "" {
+		if len(content) > 32*1024 {
+			content = content[:32*1024]
+		}
+		raw, err := runExtraction(ctx, input.Completer, content)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("LLM extraction failed: %v", err))
+		} else {
+			profile, facts, err := parseExtraction(raw)
+			if err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("LLM parse failed: %v", err))
+			} else {
+				result.Profile = profile
+				result.Facts = facts
+				if input.WebsiteURL != "" {
+					result.Profile.Website = input.WebsiteURL
+				}
+			}
+		}
+	}
+
+	// 7. Write company.md
+	if result.Profile.Name != "" || result.Profile.Description != "" {
+		companyMD := buildCompanyMD(result.Profile)
+		if err := atomicWrite(input.WikiRoot, "team/about/company.md", []byte(companyMD)); err != nil {
+			return nil, err
+		}
+		result.ArticlesWritten = append(result.ArticlesWritten, "team/about/company.md")
+	}
+
+	return result, nil
+}
+
+// fetchURL retrieves the text content of the given URL by walking the HTML
+// parse tree and collecting text from block-level nodes. Truncates to 4096 bytes.
+func fetchURL(ctx context.Context, urlStr string) (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return "", fmt.Errorf("fetch URL build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "wuphf-seed/1.0")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch URL: %w", err)
+	}
+	defer resp.Body.Close()
+
+	doc, err := html.Parse(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("parse HTML: %w", err)
+	}
+
+	var buf bytes.Buffer
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			switch n.Data {
+			case "p", "h1", "h2", "h3", "h4", "h5", "h6", "li":
+				var textBuf bytes.Buffer
+				collectText(n, &textBuf)
+				line := strings.TrimSpace(textBuf.String())
+				if line != "" {
+					buf.WriteString(line)
+					buf.WriteString("\n")
+				}
+				return
+			case "script", "style", "noscript":
+				return
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(doc)
+
+	text := buf.String()
+	if len(text) > 4096 {
+		text = text[:4096]
+	}
+	return text, nil
+}
+
+// collectText recursively extracts text nodes from the HTML tree.
+func collectText(n *html.Node, buf *bytes.Buffer) {
+	if n.Type == html.TextNode {
+		buf.WriteString(n.Data)
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		collectText(c, buf)
+	}
+}
+
+// extractPDF extracts text from a PDF file using pdftotext (poppler).
+func extractPDF(ctx context.Context, path string) (string, error) {
+	if _, err := exec.LookPath("pdftotext"); err != nil {
+		return "", fmt.Errorf("skipped %s: pdftotext not installed; install poppler (brew install poppler on macOS)", path)
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "pdftotext", "-layout", path, "-")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("pdftotext %s: %w", path, err)
+	}
+	reader := io.LimitReader(bytes.NewReader(out), 8192)
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return "", fmt.Errorf("read pdftotext output: %w", err)
+	}
+	return string(data), nil
+}
+
+// runExtraction calls the LLM completer with a structured extraction prompt.
+func runExtraction(ctx context.Context, completer Completer, content string) (string, error) {
+	prompt := `Extract company context from the content below. Output ONLY valid JSON with
+no markdown fences, no explanation, no commentary before or after:
+{"company_name":"...","description":"...","industry":"...","audience":"...",
+ "goals":"...","key_facts":["fact 1","fact 2",...]}
+key_facts: max 8 short factual bullets. Empty string for unknown fields.
+
+Content:
+` + content
+	return completer.Complete(ctx, prompt)
+}
+
+type extractionPayload struct {
+	CompanyName string   `json:"company_name"`
+	Description string   `json:"description"`
+	Industry    string   `json:"industry"`
+	Audience    string   `json:"audience"`
+	Goals       string   `json:"goals"`
+	KeyFacts    []string `json:"key_facts"`
+}
+
+// parseExtraction strips JSON fences from the raw LLM output and unmarshals it.
+func parseExtraction(raw string) (CompanyProfile, []string, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimPrefix(raw, "```json")
+	raw = strings.TrimPrefix(raw, "```")
+	raw = strings.TrimSuffix(raw, "```")
+	raw = strings.TrimSpace(raw)
+
+	var payload extractionPayload
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return CompanyProfile{}, nil, fmt.Errorf("unmarshal extraction: %w", err)
+	}
+
+	profile := CompanyProfile{
+		Name:        payload.CompanyName,
+		Description: payload.Description,
+		Industry:    payload.Industry,
+		Audience:    payload.Audience,
+	}
+	if payload.Goals != "" {
+		profile.Notes = []string{payload.Goals}
+	}
+
+	return profile, payload.KeyFacts, nil
+}
+
+// atomicWrite writes data to wikiRoot/relPath using a temp-dir-then-rename
+// pattern so partial writes are never visible. Follows the same pattern as
+// makeWikiTempDir in wiki_materialize.go.
+func atomicWrite(wikiRoot, relPath string, data []byte) error {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Errorf("operations: atomicWrite token: %w", err)
+	}
+	name := fmt.Sprintf(".wiki.tmp.%s", hex.EncodeToString(buf))
+	tempDir := filepath.Join(wikiRoot, name)
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return fmt.Errorf("operations: atomicWrite tempdir %q: %w", tempDir, err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	stagePath := filepath.Join(tempDir, relPath)
+	if err := os.MkdirAll(filepath.Dir(stagePath), 0o755); err != nil {
+		return fmt.Errorf("operations: atomicWrite stage dir: %w", err)
+	}
+	if err := os.WriteFile(stagePath, data, 0o644); err != nil {
+		return fmt.Errorf("operations: atomicWrite write stage: %w", err)
+	}
+
+	finalPath := filepath.Join(wikiRoot, relPath)
+	if err := os.Rename(stagePath, finalPath); err != nil {
+		return fmt.Errorf("operations: atomicWrite rename to %q: %w", finalPath, err)
+	}
+	return nil
+}
+
+// buildCompanyMD renders a markdown article for the company profile.
+func buildCompanyMD(profile CompanyProfile) string {
+	var sb strings.Builder
+	name := strings.TrimSpace(profile.Name)
+	if name == "" {
+		name = "Company"
+	}
+	sb.WriteString(fmt.Sprintf("# %s\n\n", name))
+	if d := strings.TrimSpace(profile.Description); d != "" {
+		sb.WriteString(fmt.Sprintf("%s\n\n", d))
+	}
+	if w := strings.TrimSpace(profile.Website); w != "" {
+		sb.WriteString(fmt.Sprintf("**Website:** %s\n\n", w))
+	}
+	if ind := strings.TrimSpace(profile.Industry); ind != "" {
+		sb.WriteString(fmt.Sprintf("**Industry:** %s\n\n", ind))
+	}
+	if aud := strings.TrimSpace(profile.Audience); aud != "" {
+		sb.WriteString(fmt.Sprintf("**Audience:** %s\n\n", aud))
+	}
+	if len(profile.Notes) > 0 {
+		for _, n := range profile.Notes {
+			if n = strings.TrimSpace(n); n != "" {
+				sb.WriteString(fmt.Sprintf("**Goals:** %s\n\n", n))
+			}
+		}
+	}
+	return sb.String()
+}
+
+// buildOwnerMD renders a markdown article for the workspace owner.
+func buildOwnerMD(name, role string) string {
+	var sb strings.Builder
+	displayName := strings.TrimSpace(name)
+	if displayName == "" {
+		displayName = "Owner"
+	}
+	sb.WriteString(fmt.Sprintf("# %s\n\n", displayName))
+	if r := strings.TrimSpace(role); r != "" {
+		sb.WriteString(fmt.Sprintf("**Role:** %s\n\n", r))
+	}
+	return sb.String()
+}
+
+// aboutReadmeContent is the README placed in the team/about/ wiki section.
+const aboutReadmeContent = `# About This Team
+
+> **For agents reading this section:** The articles here describe the humans
+> and company that own and operate this WUPHF workspace. This is not information
+> about external clients, customers, or contacts — that context lives elsewhere
+> in the wiki. Use this section to understand who you are working for and what
+> their goals are.
+
+- [company.md](company.md) — what this company does
+- [owner.md](owner.md) — who is running this workspace
+`

--- a/internal/operations/company_seed_test.go
+++ b/internal/operations/company_seed_test.go
@@ -1,0 +1,221 @@
+package operations
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type mockCompleter struct{ response string }
+
+func (m mockCompleter) Complete(_ context.Context, _ string) (string, error) {
+	return m.response, nil
+}
+
+func TestSeedCompanyContext(t *testing.T) {
+	validJSON := `{"company_name":"Acme","description":"B2B SaaS","industry":"SaaS","audience":"Ops teams","goals":"Launch Q3","key_facts":["Fact 1","Fact 2"]}`
+
+	tests := []struct {
+		name               string
+		input              func(wikiRoot string) CompanySeedInput
+		wantCompanyMD      bool
+		wantOwnerMD        bool
+		wantReadme         bool
+		wantWarningContains string
+	}{
+		{
+			name: "happy path with owner",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					OwnerName: "Alice",
+					OwnerRole: "CEO",
+					Completer: mockCompleter{response: validJSON},
+					WikiRoot:  wikiRoot,
+					// Provide content via a temp text file so LLM extraction fires.
+					FilePaths: func() []string {
+						f, _ := os.CreateTemp("", "wuphf-seed-*.txt")
+						f.WriteString("Acme is a B2B SaaS company.")
+						f.Close()
+						return []string{f.Name()}
+					}(),
+				}
+			},
+			wantCompanyMD: true,
+			wantOwnerMD:   true,
+			wantReadme:    true,
+		},
+		{
+			name: "JSON fence stripping",
+			input: func(wikiRoot string) CompanySeedInput {
+				fenced := "```json\n" + validJSON + "\n```"
+				return CompanySeedInput{
+					Completer: mockCompleter{response: fenced},
+					WikiRoot:  wikiRoot,
+					FilePaths: func() []string {
+						f, _ := os.CreateTemp("", "wuphf-seed-*.txt")
+						f.WriteString("Acme builds software.")
+						f.Close()
+						return []string{f.Name()}
+					}(),
+				}
+			},
+			wantCompanyMD: true,
+			wantReadme:    true,
+		},
+		{
+			name: "URL scheme rejected",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					WebsiteURL: "file:///etc/passwd",
+					WikiRoot:   wikiRoot,
+				}
+			},
+			wantReadme:          true,
+			wantWarningContains: "must be http or https",
+		},
+		{
+			name: "both URL and files empty no completer",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					WikiRoot: wikiRoot,
+				}
+			},
+			wantReadme:    true,
+			wantCompanyMD: false,
+			wantOwnerMD:   false,
+		},
+		{
+			name: "owner name and role empty",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					Completer: mockCompleter{response: validJSON},
+					WikiRoot:  wikiRoot,
+					FilePaths: func() []string {
+						f, _ := os.CreateTemp("", "wuphf-seed-*.txt")
+						f.WriteString("Some company content.")
+						f.Close()
+						return []string{f.Name()}
+					}(),
+				}
+			},
+			wantReadme:    true,
+			wantCompanyMD: true,
+			wantOwnerMD:   false,
+		},
+		{
+			name: "owner name provided",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					OwnerName: "Alice",
+					OwnerRole: "CEO",
+					WikiRoot:  wikiRoot,
+				}
+			},
+			wantReadme:  true,
+			wantOwnerMD: true,
+		},
+		{
+			name: "pdftotext not found",
+			input: func(wikiRoot string) CompanySeedInput {
+				// Create a fake .pdf file so the extension check triggers.
+				f, _ := os.CreateTemp("", "wuphf-seed-*.pdf")
+				f.WriteString("%PDF fake")
+				f.Close()
+				return CompanySeedInput{
+					WikiRoot:  wikiRoot,
+					FilePaths: []string{f.Name()},
+				}
+			},
+			wantReadme:          true,
+			wantWarningContains: "pdftotext not installed",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			wikiRoot := t.TempDir()
+			input := tc.input(wikiRoot)
+
+			result, err := SeedCompanyContext(context.Background(), input)
+			if err != nil {
+				t.Fatalf("SeedCompanyContext returned error: %v", err)
+			}
+
+			readmePath := filepath.Join(wikiRoot, "team", "about", "README.md")
+			companyPath := filepath.Join(wikiRoot, "team", "about", "company.md")
+			ownerPath := filepath.Join(wikiRoot, "team", "about", "owner.md")
+
+			checkExists := func(path string, want bool, label string) {
+				t.Helper()
+				_, err := os.Stat(path)
+				exists := err == nil
+				if exists != want {
+					t.Errorf("%s: exists=%v, want %v", label, exists, want)
+				}
+			}
+
+			checkExists(readmePath, tc.wantReadme, "README.md")
+			checkExists(companyPath, tc.wantCompanyMD, "company.md")
+			checkExists(ownerPath, tc.wantOwnerMD, "owner.md")
+
+			if tc.wantWarningContains != "" {
+				found := false
+				for _, w := range result.Warnings {
+					if strings.Contains(w, tc.wantWarningContains) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected warning containing %q, got: %v", tc.wantWarningContains, result.Warnings)
+				}
+			}
+
+			// For owner name test, verify content.
+			if tc.name == "owner name provided" && tc.wantOwnerMD {
+				data, err := os.ReadFile(ownerPath)
+				if err != nil {
+					t.Fatalf("read owner.md: %v", err)
+				}
+				content := string(data)
+				if !strings.Contains(content, "Alice") {
+					t.Errorf("owner.md missing name Alice, got: %s", content)
+				}
+				if !strings.Contains(content, "CEO") {
+					t.Errorf("owner.md missing role CEO, got: %s", content)
+				}
+			}
+		})
+	}
+}
+
+func TestSeedCompanyContext_ReadmeSkipIfExists(t *testing.T) {
+	wikiRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(wikiRoot, "team", "about"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	readmePath := filepath.Join(wikiRoot, "team", "about", "README.md")
+	originalContent := "# Original README\n"
+	if err := os.WriteFile(readmePath, []byte(originalContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	input := CompanySeedInput{WikiRoot: wikiRoot}
+	if _, err := SeedCompanyContext(context.Background(), input); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if _, err := SeedCompanyContext(context.Background(), input); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	data, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != originalContent {
+		t.Errorf("README.md was overwritten: got %q, want %q", string(data), originalContent)
+	}
+}

--- a/internal/team/auto_notebook_writer.go
+++ b/internal/team/auto_notebook_writer.go
@@ -92,9 +92,23 @@ type AutoNotebookWriter struct {
 	wiki   autoNotebookWriterClient
 	roster autoNotebookRoster
 	queue  chan autoNotebookEvent
+	// stopCh signals shutdown without closing w.queue. Closing the queue
+	// would race with concurrent Handle() callers that already cleared the
+	// running.Load() fast-path check and panic on send-to-closed-chan.
+	// CodeRabbit-flagged race fixed by leaving the queue intact and tearing
+	// down via this dedicated signal channel instead.
+	stopCh chan struct{}
 
 	mu      sync.Mutex
 	buckets map[string]*autoNotebookDedupeBucket
+
+	// progressMu + progressCond fan out a "something was processed" signal so
+	// tests can wait deterministically on a counter or a notebook entry
+	// without resorting to sleep loops (the repo's check-no-new-sleeps lint
+	// blocks them in tests, and this is the same pattern as scheduler.go's
+	// manual clock — push state changes, never poll real time).
+	progressMu   sync.Mutex
+	progressCond *sync.Cond
 
 	running atomic.Bool
 	done    chan struct{}
@@ -120,13 +134,16 @@ type autoNotebookDedupeBucket struct {
 // processing. Either argument may be nil for tests; nil wiki disables writes,
 // nil roster disables the membership filter.
 func NewAutoNotebookWriter(wiki autoNotebookWriterClient, roster autoNotebookRoster) *AutoNotebookWriter {
-	return &AutoNotebookWriter{
+	w := &AutoNotebookWriter{
 		wiki:    wiki,
 		roster:  roster,
 		queue:   make(chan autoNotebookEvent, autoNotebookQueueSize),
+		stopCh:  make(chan struct{}),
 		buckets: make(map[string]*autoNotebookDedupeBucket),
 		done:    make(chan struct{}),
 	}
+	w.progressCond = sync.NewCond(&w.progressMu)
+	return w
 }
 
 // Start launches the drain goroutine. Idempotent: a second call is a no-op.
@@ -140,14 +157,25 @@ func (w *AutoNotebookWriter) Start(ctx context.Context) {
 	go w.run(ctx)
 }
 
-// Stop closes the queue and waits up to timeout for the drain goroutine to
+// Stop signals the drain goroutine to exit and waits up to timeout for it to
 // finish. Idempotent. Returns even if the deadline elapses with events still
 // in flight — caller may inspect counters to detect drops.
+//
+// Implementation note: w.queue is intentionally NOT closed. Concurrent
+// Handle() callers may already be past the running.Load() fast-path check
+// when Stop runs, and a send-to-closed-chan would panic. Closing stopCh and
+// letting run() bail on it covers shutdown without that hazard. The queue
+// itself becomes garbage once all references are gone.
 func (w *AutoNotebookWriter) Stop(timeout time.Duration) {
 	if w == nil || !w.running.Swap(false) {
 		return
 	}
-	close(w.queue)
+	close(w.stopCh)
+	// Wake any test waiters parked on progressCond so they observe the
+	// stopped state and bail out of WaitForCondition without timing out.
+	w.progressMu.Lock()
+	w.progressCond.Broadcast()
+	w.progressMu.Unlock()
 	if timeout <= 0 {
 		<-w.done
 		return
@@ -188,13 +216,74 @@ func (w *AutoNotebookWriter) Handle(evt autoNotebookEvent) {
 	} else {
 		evt.Timestamp = evt.Timestamp.UTC()
 	}
+	// stopCh closes before the queue would (which it never does); selecting
+	// on it first lets a Handle racing with Stop bail out cleanly instead of
+	// blocking or — worse, with the old close(queue) implementation — sending
+	// on a closed channel.
 	select {
+	case <-w.stopCh:
+		return
+	default:
+	}
+	select {
+	case <-w.stopCh:
 	case w.queue <- evt:
 		w.enqueued.Add(1)
 	default:
 		w.queueSaturated.Add(1)
 		log.Printf("auto_notebook_writer: queue saturated, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
+		w.signalProgress()
 	}
+}
+
+// signalProgress fans out a "something happened" notification so tests can
+// wait deterministically without sleep loops. Cheap: cond.Broadcast on an
+// uncontended mutex is essentially a memory barrier when nobody is parked.
+func (w *AutoNotebookWriter) signalProgress() {
+	w.progressMu.Lock()
+	w.progressCond.Broadcast()
+	w.progressMu.Unlock()
+}
+
+// WaitForCondition blocks until predicate returns true, ctx is cancelled, or
+// the writer stops. Returns ctx.Err() on timeout/cancel and nil on success.
+// Test-only entry point — production code never waits on the writer.
+func (w *AutoNotebookWriter) WaitForCondition(ctx context.Context, predicate func() bool) error {
+	if w == nil {
+		return nil
+	}
+	if predicate() {
+		return nil
+	}
+	cancelWatcher := make(chan struct{})
+	defer close(cancelWatcher)
+	go func() {
+		select {
+		case <-ctx.Done():
+			w.progressMu.Lock()
+			w.progressCond.Broadcast()
+			w.progressMu.Unlock()
+		case <-cancelWatcher:
+		}
+	}()
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	for !predicate() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !w.running.Load() {
+			// Writer has been stopped. Re-check predicate one last time
+			// (a final event may have been processed before shutdown) and
+			// return whatever the predicate says.
+			if predicate() {
+				return nil
+			}
+			return ErrWorkerStopped
+		}
+		w.progressCond.Wait()
+	}
+	return nil
 }
 
 func (w *AutoNotebookWriter) run(ctx context.Context) {
@@ -203,28 +292,29 @@ func (w *AutoNotebookWriter) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case evt, ok := <-w.queue:
-			if !ok {
-				return
-			}
+		case <-w.stopCh:
+			return
+		case evt := <-w.queue:
 			w.process(ctx, evt)
 		}
 	}
 }
 
 func (w *AutoNotebookWriter) process(ctx context.Context, evt autoNotebookEvent) {
+	defer w.signalProgress()
 	body := renderAutoNotebookSection(evt)
 	if autoNotebookContainsSecret(body) {
 		w.redacted.Add(1)
 		log.Printf("auto_notebook_writer: secret pattern matched, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
 		return
 	}
-	// Dedupe key is the raw content + transition delta, not the rendered body
-	// — two events with identical message text but different timestamps render
-	// differently, and we want them to collapse into a single shelf entry per
-	// decision 4A. Including the kind+status pair distinguishes a status churn
-	// from a chat repeat.
-	dedupeBasis := string(evt.Kind) + "|" + evt.BeforeStatus + "→" + evt.AfterStatus + "|" + strings.TrimSpace(evt.Content)
+	// Dedupe key folds in the full transition identity — kind, before/after
+	// status, owning task, and trimmed content — not just content. Without
+	// TaskID two distinct tasks owned by the same agent and sharing a title
+	// (or two consecutive transitions on the same task) would collapse into
+	// one shelf entry. Decision 4A pinned per-(slug, day) sha256(content);
+	// "content" here is the dedupe basis, not the rendered body.
+	dedupeBasis := string(evt.Kind) + "|" + evt.TaskID + "|" + evt.BeforeStatus + "→" + evt.AfterStatus + "|" + strings.TrimSpace(evt.Content)
 	if w.isDuplicate(evt.Slug, evt.Timestamp, dedupeBasis) {
 		w.deduped.Add(1)
 		return

--- a/internal/team/auto_notebook_writer.go
+++ b/internal/team/auto_notebook_writer.go
@@ -1,0 +1,457 @@
+package team
+
+// auto_notebook_writer.go is PR 1 of the notebook-wiki-promise design
+// (~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md).
+//
+// It populates per-agent notebook shelves deterministically: every roster-agent
+// PostMessage and every task transition emits one notebook entry under
+// agents/{slug}/notebook/{YYYY-MM-DD-HHMMSS}-{kind}-{shortHash}.md.
+//
+// Hot-path constraints (locked by eng review 2026-05-05):
+//   - PostMessage stays sub-microsecond. Handle() is a non-blocking enqueue.
+//   - Drop on queue saturation; never block the broker. Counter + warn log.
+//   - In-memory LRU dedupe per (slug, day) keyed by sha256(content). Ring of 50.
+//   - Pre-write secretlint regex scrub. Match → drop with redacted_event counter.
+//   - Roster-membership filter at ingress. Non-agents bypass.
+//   - One file per event (file-as-entry — aligns with NotebookSignalScanner).
+//   - On NotebookWrite error: structured warn + counter + drop. No retry.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// AutoNotebookEventKind identifies which broker hook produced an event. The
+// string values are written into entry filenames and section headers, so they
+// participate in the public format and must stay stable.
+type AutoNotebookEventKind string
+
+const (
+	AutoNotebookEventMessagePosted    AutoNotebookEventKind = "message_posted"
+	AutoNotebookEventTaskTransitioned AutoNotebookEventKind = "task_transitioned"
+)
+
+// autoNotebookQueueSize is the buffered-channel capacity (decision 6A). 256
+// gives ~minutes of headroom under realistic burst loads while keeping the
+// drop-on-saturation tail short enough to surface in logs quickly.
+const autoNotebookQueueSize = 256
+
+// autoNotebookDedupeRing bounds the per-bucket sha256 history. 50 covers a
+// reasonable rolling window of "same content posted twice" without unbounded
+// memory growth on a long-running session (decision 4A).
+const autoNotebookDedupeRing = 50
+
+// autoNotebookContentLimit truncates the blockquote rendered into each entry
+// (decision S1A). The notebook is meant to be a navigable shelf, not a verbatim
+// transcript — full content lives in the broker's message log.
+const autoNotebookContentLimit = 500
+
+// autoNotebookWriteTimeout bounds a single NotebookWrite call so a stuck git
+// process never wedges the writer goroutine.
+const autoNotebookWriteTimeout = 10 * time.Second
+
+// autoNotebookEvent is the in-memory event submitted to the writer's queue.
+// Constructed inline at hook sites; never persisted.
+type autoNotebookEvent struct {
+	Kind         AutoNotebookEventKind
+	Slug         string // owning agent — the notebook shelf the entry lands on
+	Actor        string // who acted; usually equals Slug
+	Channel      string
+	TaskID       string
+	TaskTitle    string
+	BeforeStatus string
+	AfterStatus  string
+	Content      string
+	Timestamp    time.Time
+}
+
+// autoNotebookWriterClient is the slice of WikiWorker the writer needs. Kept as
+// an interface so tests can substitute a fake without spinning the real worker.
+type autoNotebookWriterClient interface {
+	NotebookWrite(ctx context.Context, slug, path, content, mode, commitMsg string) (string, int, error)
+}
+
+// autoNotebookRoster filters events to roster-member senders only (OV6A).
+// Broker satisfies this via IsAgentMemberSlug.
+type autoNotebookRoster interface {
+	IsAgentMemberSlug(slug string) bool
+}
+
+// AutoNotebookWriter ingests broker events and writes notebook entries.
+// Lifecycle mirrors WikiWorker: NewAutoNotebookWriter → Start(ctx) → Stop(timeout).
+// Safe for concurrent Handle() callers.
+type AutoNotebookWriter struct {
+	wiki   autoNotebookWriterClient
+	roster autoNotebookRoster
+	queue  chan autoNotebookEvent
+
+	mu      sync.Mutex
+	buckets map[string]*autoNotebookDedupeBucket
+
+	running atomic.Bool
+	done    chan struct{}
+
+	enqueued       atomic.Int64
+	deduped        atomic.Int64
+	redacted       atomic.Int64
+	nonRoster      atomic.Int64
+	written        atomic.Int64
+	writeFailed    atomic.Int64
+	queueSaturated atomic.Int64
+	noopTransition atomic.Int64
+}
+
+// autoNotebookDedupeBucket is a small ring buffer of recent content hashes,
+// keyed by (slug, YYYY-MM-DD). Day boundaries are natural section breaks in
+// the bookshelf so per-day buckets are the right granularity.
+type autoNotebookDedupeBucket struct {
+	hashes []string
+}
+
+// NewAutoNotebookWriter constructs an idle writer. Call Start to begin
+// processing. Either argument may be nil for tests; nil wiki disables writes,
+// nil roster disables the membership filter.
+func NewAutoNotebookWriter(wiki autoNotebookWriterClient, roster autoNotebookRoster) *AutoNotebookWriter {
+	return &AutoNotebookWriter{
+		wiki:    wiki,
+		roster:  roster,
+		queue:   make(chan autoNotebookEvent, autoNotebookQueueSize),
+		buckets: make(map[string]*autoNotebookDedupeBucket),
+		done:    make(chan struct{}),
+	}
+}
+
+// Start launches the drain goroutine. Idempotent: a second call is a no-op.
+func (w *AutoNotebookWriter) Start(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	if w.running.Swap(true) {
+		return
+	}
+	go w.run(ctx)
+}
+
+// Stop closes the queue and waits up to timeout for the drain goroutine to
+// finish. Idempotent. Returns even if the deadline elapses with events still
+// in flight — caller may inspect counters to detect drops.
+func (w *AutoNotebookWriter) Stop(timeout time.Duration) {
+	if w == nil || !w.running.Swap(false) {
+		return
+	}
+	close(w.queue)
+	if timeout <= 0 {
+		<-w.done
+		return
+	}
+	select {
+	case <-w.done:
+	case <-time.After(timeout):
+	}
+}
+
+// Handle is the broker-side ingress. Roster-filters and validates, then does a
+// non-blocking enqueue. Drops with a counter increment when the queue is full
+// (decision S3A). Always cheap to call from a hot path.
+func (w *AutoNotebookWriter) Handle(evt autoNotebookEvent) {
+	if w == nil || !w.running.Load() {
+		return
+	}
+	evt.Slug = strings.TrimSpace(evt.Slug)
+	if evt.Slug == "" {
+		return
+	}
+	if w.roster != nil && !w.roster.IsAgentMemberSlug(evt.Slug) {
+		w.nonRoster.Add(1)
+		return
+	}
+	if evt.Kind == AutoNotebookEventTaskTransitioned && strings.EqualFold(evt.BeforeStatus, evt.AfterStatus) {
+		w.noopTransition.Add(1)
+		return
+	}
+	if strings.TrimSpace(evt.Content) == "" && evt.Kind == AutoNotebookEventMessagePosted {
+		// A truly empty agent message has nothing worth shelving. Task
+		// transitions still record even with empty content because the
+		// status delta itself is the signal.
+		return
+	}
+	if evt.Timestamp.IsZero() {
+		evt.Timestamp = time.Now().UTC()
+	} else {
+		evt.Timestamp = evt.Timestamp.UTC()
+	}
+	select {
+	case w.queue <- evt:
+		w.enqueued.Add(1)
+	default:
+		w.queueSaturated.Add(1)
+		log.Printf("auto_notebook_writer: queue saturated, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
+	}
+}
+
+func (w *AutoNotebookWriter) run(ctx context.Context) {
+	defer close(w.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-w.queue:
+			if !ok {
+				return
+			}
+			w.process(ctx, evt)
+		}
+	}
+}
+
+func (w *AutoNotebookWriter) process(ctx context.Context, evt autoNotebookEvent) {
+	body := renderAutoNotebookSection(evt)
+	if autoNotebookContainsSecret(body) {
+		w.redacted.Add(1)
+		log.Printf("auto_notebook_writer: secret pattern matched, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
+		return
+	}
+	// Dedupe key is the raw content + transition delta, not the rendered body
+	// — two events with identical message text but different timestamps render
+	// differently, and we want them to collapse into a single shelf entry per
+	// decision 4A. Including the kind+status pair distinguishes a status churn
+	// from a chat repeat.
+	dedupeBasis := string(evt.Kind) + "|" + evt.BeforeStatus + "→" + evt.AfterStatus + "|" + strings.TrimSpace(evt.Content)
+	if w.isDuplicate(evt.Slug, evt.Timestamp, dedupeBasis) {
+		w.deduped.Add(1)
+		return
+	}
+	relPath := autoNotebookEntryPath(evt, body)
+	commitMsg := fmt.Sprintf("notebook: auto-write %s for @%s", evt.Kind, evt.Slug)
+
+	if w.wiki == nil {
+		w.writeFailed.Add(1)
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, autoNotebookWriteTimeout)
+	defer cancel()
+	_, _, err := w.wiki.NotebookWrite(writeCtx, evt.Slug, relPath, body, "create", commitMsg)
+	if err != nil {
+		w.writeFailed.Add(1)
+		log.Printf("auto_notebook_writer: write failed slug=%s path=%s: %v", evt.Slug, relPath, err)
+		return
+	}
+	w.written.Add(1)
+}
+
+// isDuplicate consults the per-(slug, day) ring buffer. A hit returns true and
+// does NOT add the hash again. A miss appends and returns false.
+func (w *AutoNotebookWriter) isDuplicate(slug string, ts time.Time, content string) bool {
+	key := autoNotebookDedupeKey(slug, ts)
+	hash := autoNotebookSha256Hex(content)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	bucket, ok := w.buckets[key]
+	if !ok {
+		bucket = &autoNotebookDedupeBucket{}
+		w.buckets[key] = bucket
+	}
+	for _, h := range bucket.hashes {
+		if h == hash {
+			return true
+		}
+	}
+	bucket.hashes = append(bucket.hashes, hash)
+	if len(bucket.hashes) > autoNotebookDedupeRing {
+		bucket.hashes = bucket.hashes[len(bucket.hashes)-autoNotebookDedupeRing:]
+	}
+	// Cheap GC: drop yesterday's bucket once a new day rolls over so we do not
+	// retain stale day buckets across long-running sessions.
+	w.gcOldBucketsLocked(ts)
+	return false
+}
+
+func (w *AutoNotebookWriter) gcOldBucketsLocked(ts time.Time) {
+	today := ts.UTC().Format("2006-01-02")
+	for k := range w.buckets {
+		if !strings.HasSuffix(k, today) {
+			// Keep buckets whose key day matches today. Drop everything else.
+			// Same-day keys end in today; mismatching keys are old.
+			parts := strings.SplitN(k, "|", 2)
+			if len(parts) != 2 || parts[1] != today {
+				delete(w.buckets, k)
+			}
+		}
+	}
+}
+
+// AutoNotebookCounters is a snapshot of the writer's observability counters.
+// Returned by Counters() for tests and (eventually) the TODO #18 metrics surface.
+type AutoNotebookCounters struct {
+	Enqueued       int64
+	Written        int64
+	Deduped        int64
+	Redacted       int64
+	NonRoster      int64
+	WriteFailed    int64
+	QueueSaturated int64
+	NoopTransition int64
+}
+
+// Counters returns a thread-safe snapshot of the writer's atomic counters.
+func (w *AutoNotebookWriter) Counters() AutoNotebookCounters {
+	if w == nil {
+		return AutoNotebookCounters{}
+	}
+	return AutoNotebookCounters{
+		Enqueued:       w.enqueued.Load(),
+		Written:        w.written.Load(),
+		Deduped:        w.deduped.Load(),
+		Redacted:       w.redacted.Load(),
+		NonRoster:      w.nonRoster.Load(),
+		WriteFailed:    w.writeFailed.Load(),
+		QueueSaturated: w.queueSaturated.Load(),
+		NoopTransition: w.noopTransition.Load(),
+	}
+}
+
+// renderAutoNotebookSection produces the markdown body for one entry. Format
+// is locked by decision S1A: H1 with kind, bullet list of metadata, blockquote
+// of the first autoNotebookContentLimit chars of content. Any markdown-special
+// characters in content are forced into the blockquote so they cannot inject
+// new H2 sections or break the catalog reader.
+func renderAutoNotebookSection(evt autoNotebookEvent) string {
+	ts := evt.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+	var b strings.Builder
+	switch evt.Kind {
+	case AutoNotebookEventTaskTransitioned:
+		fmt.Fprintf(&b, "# task_transitioned — %s → %s\n\n",
+			autoNotebookFallback(evt.BeforeStatus, "(unset)"),
+			autoNotebookFallback(evt.AfterStatus, "(unset)"))
+	case AutoNotebookEventMessagePosted:
+		fmt.Fprintf(&b, "# message_posted in #%s\n\n", autoNotebookFallback(evt.Channel, "general"))
+	default:
+		fmt.Fprintf(&b, "# %s\n\n", string(evt.Kind))
+	}
+	fmt.Fprintf(&b, "- timestamp: %s\n", ts.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- kind: %s\n", evt.Kind)
+	fmt.Fprintf(&b, "- actor: @%s\n", autoNotebookFallback(evt.Actor, evt.Slug))
+	if evt.Channel != "" {
+		fmt.Fprintf(&b, "- channel: #%s\n", evt.Channel)
+	}
+	if evt.TaskID != "" {
+		title := strings.TrimSpace(evt.TaskTitle)
+		if title != "" {
+			fmt.Fprintf(&b, "- task: %s %q\n", evt.TaskID, title)
+		} else {
+			fmt.Fprintf(&b, "- task: %s\n", evt.TaskID)
+		}
+	}
+	if evt.Kind == AutoNotebookEventTaskTransitioned {
+		fmt.Fprintf(&b, "- status: %s → %s\n",
+			autoNotebookFallback(evt.BeforeStatus, "(unset)"),
+			autoNotebookFallback(evt.AfterStatus, "(unset)"))
+	}
+	body := autoNotebookTruncate(strings.TrimSpace(evt.Content), autoNotebookContentLimit)
+	if body != "" {
+		b.WriteString("\n")
+		for _, line := range strings.Split(body, "\n") {
+			b.WriteString("> ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func autoNotebookFallback(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+// autoNotebookTruncate trims s to at most n bytes while preserving valid UTF-8
+// at the cut. Appends a "…" marker when truncation occurs.
+func autoNotebookTruncate(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	cut := n
+	for cut > 0 && (s[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return s[:cut] + "…"
+}
+
+// autoNotebookEntryPath builds agents/{slug}/notebook/{YYYY-MM-DD-HHMMSS}-{kind}-{shortHash}.md.
+// The shortHash mixes timestamp nanoseconds into the digest so two events with
+// identical content but different times still get distinct filenames; dedupe
+// elsewhere (isDuplicate) protects against true duplicates.
+func autoNotebookEntryPath(evt autoNotebookEvent, body string) string {
+	ts := evt.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+	stamp := ts.Format("2006-01-02-150405")
+	mix := fmt.Sprintf("%d|%s|%s", ts.UnixNano(), evt.Kind, body)
+	short := autoNotebookSha256Hex(mix)[:8]
+	kind := strings.ReplaceAll(string(evt.Kind), "_", "-")
+	if kind == "" {
+		kind = "event"
+	}
+	return fmt.Sprintf("agents/%s/notebook/%s-%s-%s.md", evt.Slug, stamp, kind, short)
+}
+
+func autoNotebookDedupeKey(slug string, ts time.Time) string {
+	return slug + "|" + ts.UTC().Format("2006-01-02")
+}
+
+func autoNotebookSha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// autoNotebookSecretPatterns is the OV5A pre-write scrub set. Patterns are
+// high-confidence (typed prefixes, fixed lengths). Generic substring rules like
+// "password=" are intentionally omitted to avoid false-positive drops on agent
+// chatter that happens to mention the word "password".
+var autoNotebookSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                                 // AWS access key
+	regexp.MustCompile(`ASIA[0-9A-Z]{16}`),                                                 // AWS STS access key
+	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{36,}`),                                       // GitHub personal/OAuth/server token
+	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`),                                     // GitHub fine-grained PAT
+	regexp.MustCompile(`sk_live_[A-Za-z0-9]{24,}`),                                         // Stripe secret key (live)
+	regexp.MustCompile(`rk_live_[A-Za-z0-9]{24,}`),                                         // Stripe restricted key (live)
+	regexp.MustCompile(`sk-ant-[A-Za-z0-9_\-]{20,}`),                                       // Anthropic API key
+	regexp.MustCompile(`sk-[A-Za-z0-9]{32,}`),                                              // OpenAI-style secret key
+	regexp.MustCompile(`SG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}`),                       // SendGrid API key
+	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                                     // Slack token
+	regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),                                           // Google API key
+	regexp.MustCompile(`-----BEGIN ((RSA|EC|OPENSSH|DSA|PGP) )?PRIVATE KEY( BLOCK)?-----`), // Private key block
+}
+
+// autoNotebookContainsSecret returns true when any locked secret pattern
+// matches anywhere in s. Errs on the side of dropping ambiguous content;
+// the broker still has the raw message in its log, so nothing is lost.
+func autoNotebookContainsSecret(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, re := range autoNotebookSecretPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/team/auto_notebook_writer_test.go
+++ b/internal/team/auto_notebook_writer_test.go
@@ -1,0 +1,415 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeNotebookClient records each NotebookWrite call. It is intentionally
+// permissive — validation is the WikiWorker's job; here we test the writer's
+// own logic (dedupe, redaction, roster, queue saturation, formatting).
+type fakeNotebookClient struct {
+	mu    sync.Mutex
+	calls []fakeNotebookCall
+	err   error
+}
+
+type fakeNotebookCall struct {
+	Slug    string
+	Path    string
+	Content string
+	Mode    string
+}
+
+func (f *fakeNotebookClient) NotebookWrite(_ context.Context, slug, path, content, mode, _ string) (string, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return "", 0, f.err
+	}
+	f.calls = append(f.calls, fakeNotebookCall{Slug: slug, Path: path, Content: content, Mode: mode})
+	return "deadbeef", len(content), nil
+}
+
+func (f *fakeNotebookClient) snapshot() []fakeNotebookCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeNotebookCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// allowAllRoster mimics a broker where every slug is a registered agent.
+type allowAllRoster struct{}
+
+func (allowAllRoster) IsAgentMemberSlug(string) bool { return true }
+
+// allowSetRoster gates membership on a small set of slugs.
+type allowSetRoster struct {
+	allowed map[string]struct{}
+}
+
+func (r allowSetRoster) IsAgentMemberSlug(slug string) bool {
+	_, ok := r.allowed[strings.TrimSpace(slug)]
+	return ok
+}
+
+func startWriter(t *testing.T, client autoNotebookWriterClient, roster autoNotebookRoster) *AutoNotebookWriter {
+	t.Helper()
+	w := NewAutoNotebookWriter(client, roster)
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+	t.Cleanup(func() {
+		cancel()
+		w.Stop(2 * time.Second)
+	})
+	return w
+}
+
+func waitForCalls(t *testing.T, client *fakeNotebookClient, n int) []fakeNotebookCall {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(client.snapshot()) >= n {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := client.snapshot()
+	if len(calls) < n {
+		t.Fatalf("expected at least %d calls, got %d", n, len(calls))
+	}
+	return calls
+}
+
+func waitForCounter(t *testing.T, get func() int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if get() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("counter never reached %d (got %d)", want, get())
+}
+
+func TestAutoNotebookWriter_HandleEnqueuesAndWrites(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:      AutoNotebookEventMessagePosted,
+		Slug:      "ceo",
+		Actor:     "ceo",
+		Channel:   "general",
+		Content:   "hello team",
+		Timestamp: time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
+	})
+
+	calls := waitForCalls(t, client, 1)
+	if calls[0].Slug != "ceo" {
+		t.Fatalf("slug: got %q want ceo", calls[0].Slug)
+	}
+	if calls[0].Mode != "create" {
+		t.Fatalf("mode: got %q want create", calls[0].Mode)
+	}
+	if !strings.HasPrefix(calls[0].Path, "agents/ceo/notebook/2026-05-05-131415-message-posted-") {
+		t.Fatalf("unexpected path: %q", calls[0].Path)
+	}
+	if !strings.HasSuffix(calls[0].Path, ".md") {
+		t.Fatalf("path missing .md suffix: %q", calls[0].Path)
+	}
+	if !strings.Contains(calls[0].Content, "# message_posted in #general") {
+		t.Fatalf("body missing header:\n%s", calls[0].Content)
+	}
+	if !strings.Contains(calls[0].Content, "> hello team") {
+		t.Fatalf("body missing blockquote:\n%s", calls[0].Content)
+	}
+}
+
+func TestAutoNotebookWriter_RosterFilterDropsNonAgents(t *testing.T) {
+	client := &fakeNotebookClient{}
+	roster := allowSetRoster{allowed: map[string]struct{}{"ceo": {}}}
+	w := startWriter(t, client, roster)
+
+	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "human:nazz", Content: "hi"})
+	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "ceo", Content: "yo"})
+
+	calls := waitForCalls(t, client, 1)
+	if len(calls) != 1 {
+		t.Fatalf("only the agent message should land; got %d", len(calls))
+	}
+	if w.Counters().NonRoster != 1 {
+		t.Fatalf("nonRoster counter: got %d want 1", w.Counters().NonRoster)
+	}
+}
+
+func TestAutoNotebookWriter_DedupeWithinDay(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	evt := autoNotebookEvent{
+		Kind:      AutoNotebookEventMessagePosted,
+		Slug:      "ceo",
+		Channel:   "general",
+		Content:   "shipping pr 1 today",
+		Timestamp: time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
+	}
+	w.Handle(evt)
+	evt2 := evt
+	evt2.Timestamp = evt.Timestamp.Add(2 * time.Second)
+	w.Handle(evt2)
+
+	waitForCalls(t, client, 1)
+	waitForCounter(t, func() int64 { return w.Counters().Deduped }, 1)
+	if got := len(client.snapshot()); got != 1 {
+		t.Fatalf("expected exactly 1 write, got %d", got)
+	}
+}
+
+func TestAutoNotebookWriter_DedupePerDayBucket(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	common := autoNotebookEvent{
+		Kind:    AutoNotebookEventMessagePosted,
+		Slug:    "ceo",
+		Channel: "general",
+		Content: "weekly retro: shipped pr 1",
+	}
+	day1 := common
+	day1.Timestamp = time.Date(2026, 5, 5, 23, 59, 59, 0, time.UTC)
+	day2 := common
+	day2.Timestamp = time.Date(2026, 5, 6, 0, 0, 1, 0, time.UTC)
+
+	w.Handle(day1)
+	w.Handle(day2)
+
+	calls := waitForCalls(t, client, 2)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 writes (different day buckets), got %d", len(calls))
+	}
+}
+
+func TestAutoNotebookWriter_RedactsSecretContent(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	// Build the fake-looking key at runtime so GitHub's secret scanner does
+	// not flag the source line. The pattern still matches the writer's
+	// regex set at the byte level, which is the property under test.
+	fakeKey := "sk" + "_" + "live" + "_" + strings.Repeat("A", 24)
+	w.Handle(autoNotebookEvent{
+		Kind:    AutoNotebookEventMessagePosted,
+		Slug:    "ceo",
+		Channel: "general",
+		Content: "found a stripe key " + fakeKey + " in the logs",
+	})
+
+	waitForCounter(t, func() int64 { return w.Counters().Redacted }, 1)
+	if got := len(client.snapshot()); got != 0 {
+		t.Fatalf("expected zero writes after redaction, got %d", got)
+	}
+}
+
+func TestAutoNotebookWriter_TaskTransitionUsesOwnerShelf(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:         AutoNotebookEventTaskTransitioned,
+		Slug:         "eng",
+		Actor:        "ceo",
+		Channel:      "engineering",
+		TaskID:       "task-42",
+		TaskTitle:    "Ship PR 1",
+		BeforeStatus: "review",
+		AfterStatus:  "done",
+		Content:      "Ship PR 1",
+		Timestamp:    time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
+	})
+
+	calls := waitForCalls(t, client, 1)
+	if calls[0].Slug != "eng" {
+		t.Fatalf("expected owner shelf 'eng', got %q", calls[0].Slug)
+	}
+	if !strings.Contains(calls[0].Content, "review → done") {
+		t.Fatalf("missing transition delta in body:\n%s", calls[0].Content)
+	}
+	if !strings.Contains(calls[0].Content, "task: task-42 \"Ship PR 1\"") {
+		t.Fatalf("missing task ref in body:\n%s", calls[0].Content)
+	}
+	if !strings.Contains(calls[0].Path, "task-transitioned") {
+		t.Fatalf("path missing kind segment: %q", calls[0].Path)
+	}
+}
+
+func TestAutoNotebookWriter_NoopTransitionDropped(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:         AutoNotebookEventTaskTransitioned,
+		Slug:         "eng",
+		BeforeStatus: "in_progress",
+		AfterStatus:  "in_progress",
+	})
+
+	// Counter is updated synchronously in Handle, so no wait needed.
+	if w.Counters().NoopTransition != 1 {
+		t.Fatalf("noopTransition: want 1, got %d", w.Counters().NoopTransition)
+	}
+	if got := len(client.snapshot()); got != 0 {
+		t.Fatalf("no-op transitions must not write; got %d", got)
+	}
+}
+
+func TestAutoNotebookWriter_QueueSaturationDropsNotBlocks(t *testing.T) {
+	// Block the writer goroutine by giving it a slow client. Once the queue
+	// fills, additional Handle() calls must drop without blocking.
+	release := make(chan struct{})
+	client := &slowClient{release: release}
+	w := startWriter(t, client, allowAllRoster{})
+
+	// First N events fill the buffered channel + the in-process slot.
+	for i := 0; i < autoNotebookQueueSize+2; i++ {
+		w.Handle(autoNotebookEvent{
+			Kind:    AutoNotebookEventMessagePosted,
+			Slug:    "ceo",
+			Channel: "general",
+			Content: "msg-" + strings.Repeat("x", i+1), // unique content per call
+		})
+	}
+
+	if w.Counters().QueueSaturated == 0 {
+		t.Fatalf("expected at least one queue-saturated drop")
+	}
+	close(release)
+}
+
+func TestAutoNotebookWriter_HandleAfterStopIsNoop(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := NewAutoNotebookWriter(client, allowAllRoster{})
+	ctx := context.Background()
+	w.Start(ctx)
+	w.Stop(time.Second)
+
+	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "ceo", Content: "after stop"})
+
+	if got := len(client.snapshot()); got != 0 {
+		t.Fatalf("Handle after Stop must drop; got %d writes", got)
+	}
+}
+
+func TestAutoNotebookWriter_WriteFailureCountedNotPropagated(t *testing.T) {
+	client := &fakeNotebookClient{err: errors.New("simulated git contention")}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:    AutoNotebookEventMessagePosted,
+		Slug:    "ceo",
+		Channel: "general",
+		Content: "transient error",
+	})
+
+	waitForCounter(t, func() int64 { return w.Counters().WriteFailed }, 1)
+	if w.Counters().Written != 0 {
+		t.Fatalf("written counter should stay 0; got %d", w.Counters().Written)
+	}
+}
+
+func TestAutoNotebookSecretPatterns(t *testing.T) {
+	t.Parallel()
+	// Build fixtures at runtime so GitHub's secret scanner does not flag the
+	// source. Each value still satisfies the corresponding regex.
+	awsKey := "AKIA" + strings.Repeat("A", 16)
+	ghpKey := "ghp_" + strings.Repeat("a", 36)
+	openaiKey := "sk-" + strings.Repeat("A", 32)
+	slackKey := "xoxb-" + strings.Repeat("1", 10) + "-abcde"
+	cases := []struct {
+		name string
+		in   string
+		hit  bool
+	}{
+		{"aws access key", awsKey, true},
+		{"github pat", ghpKey, true},
+		{"openai key", openaiKey, true},
+		{"slack token", slackKey, true},
+		{"private key block", "-----BEGIN RSA PRIVATE KEY-----", true},
+		{"plain word password", "password is fine to mention", false},
+		{"normal sentence", "shipping notebook auto-writer pr1", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autoNotebookContainsSecret(tc.in); got != tc.hit {
+				t.Fatalf("autoNotebookContainsSecret(%q) = %v, want %v", tc.in, got, tc.hit)
+			}
+		})
+	}
+}
+
+func TestAutoNotebookTruncate(t *testing.T) {
+	t.Parallel()
+	// Ascii within limit
+	if got := autoNotebookTruncate("hello", 10); got != "hello" {
+		t.Fatalf("short string changed: %q", got)
+	}
+	// Ascii over limit
+	if got := autoNotebookTruncate("abcdefghij", 5); got != "abcde…" {
+		t.Fatalf("ascii truncate: got %q", got)
+	}
+	// UTF-8 boundary
+	got := autoNotebookTruncate("héllo", 3)
+	// "h" (1 byte) + "é" (2 bytes) = 3 bytes; cut at 3 lands cleanly.
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncation marker; got %q", got)
+	}
+	for i, r := range got {
+		if r == 0xFFFD {
+			t.Fatalf("invalid utf-8 introduced at byte %d in %q", i, got)
+		}
+	}
+}
+
+func TestRenderAutoNotebookSection_MarkdownEscape(t *testing.T) {
+	body := renderAutoNotebookSection(autoNotebookEvent{
+		Kind:      AutoNotebookEventMessagePosted,
+		Slug:      "ceo",
+		Actor:     "ceo",
+		Channel:   "general",
+		Content:   "## not a section\n# definitely not\n- list",
+		Timestamp: time.Date(2026, 5, 5, 13, 0, 0, 0, time.UTC),
+	})
+	// Each content line should be blockquoted, never promoted to a header.
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		if strings.HasPrefix(line, "##") {
+			t.Fatalf("content line was promoted to H2 header:\n%s", body)
+		}
+	}
+	if !strings.Contains(body, "> ## not a section") {
+		t.Fatalf("expected blockquoted content line; body:\n%s", body)
+	}
+}
+
+// slowClient simulates a NotebookWrite that blocks until release is closed.
+type slowClient struct {
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (s *slowClient) NotebookWrite(ctx context.Context, slug, path, content, mode, msg string) (string, int, error) {
+	s.calls.Add(1)
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return "", 0, ctx.Err()
+	}
+	return "deadbeef", len(content), nil
+}

--- a/internal/team/auto_notebook_writer_test.go
+++ b/internal/team/auto_notebook_writer_test.go
@@ -71,32 +71,25 @@ func startWriter(t *testing.T, client autoNotebookWriterClient, roster autoNoteb
 	return w
 }
 
-func waitForCalls(t *testing.T, client *fakeNotebookClient, n int) []fakeNotebookCall {
+func waitForCalls(t *testing.T, w *AutoNotebookWriter, client *fakeNotebookClient, n int) []fakeNotebookCall {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(client.snapshot()) >= n {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := w.WaitForCondition(ctx, func() bool {
+		return len(client.snapshot()) >= n
+	}); err != nil {
+		t.Fatalf("waiting for %d calls: %v (got %d)", n, err, len(client.snapshot()))
 	}
-	calls := client.snapshot()
-	if len(calls) < n {
-		t.Fatalf("expected at least %d calls, got %d", n, len(calls))
-	}
-	return calls
+	return client.snapshot()
 }
 
-func waitForCounter(t *testing.T, get func() int64, want int64) {
+func waitForCounter(t *testing.T, w *AutoNotebookWriter, get func() int64, want int64) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if get() >= want {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := w.WaitForCondition(ctx, func() bool { return get() >= want }); err != nil {
+		t.Fatalf("counter never reached %d: %v (got %d)", want, err, get())
 	}
-	t.Fatalf("counter never reached %d (got %d)", want, get())
 }
 
 func TestAutoNotebookWriter_HandleEnqueuesAndWrites(t *testing.T) {
@@ -112,7 +105,7 @@ func TestAutoNotebookWriter_HandleEnqueuesAndWrites(t *testing.T) {
 		Timestamp: time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
 	})
 
-	calls := waitForCalls(t, client, 1)
+	calls := waitForCalls(t, w, client, 1)
 	if calls[0].Slug != "ceo" {
 		t.Fatalf("slug: got %q want ceo", calls[0].Slug)
 	}
@@ -141,7 +134,7 @@ func TestAutoNotebookWriter_RosterFilterDropsNonAgents(t *testing.T) {
 	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "human:nazz", Content: "hi"})
 	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "ceo", Content: "yo"})
 
-	calls := waitForCalls(t, client, 1)
+	calls := waitForCalls(t, w, client, 1)
 	if len(calls) != 1 {
 		t.Fatalf("only the agent message should land; got %d", len(calls))
 	}
@@ -166,8 +159,8 @@ func TestAutoNotebookWriter_DedupeWithinDay(t *testing.T) {
 	evt2.Timestamp = evt.Timestamp.Add(2 * time.Second)
 	w.Handle(evt2)
 
-	waitForCalls(t, client, 1)
-	waitForCounter(t, func() int64 { return w.Counters().Deduped }, 1)
+	waitForCalls(t, w, client, 1)
+	waitForCounter(t, w, func() int64 { return w.Counters().Deduped }, 1)
 	if got := len(client.snapshot()); got != 1 {
 		t.Fatalf("expected exactly 1 write, got %d", got)
 	}
@@ -191,7 +184,7 @@ func TestAutoNotebookWriter_DedupePerDayBucket(t *testing.T) {
 	w.Handle(day1)
 	w.Handle(day2)
 
-	calls := waitForCalls(t, client, 2)
+	calls := waitForCalls(t, w, client, 2)
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 writes (different day buckets), got %d", len(calls))
 	}
@@ -212,7 +205,7 @@ func TestAutoNotebookWriter_RedactsSecretContent(t *testing.T) {
 		Content: "found a stripe key " + fakeKey + " in the logs",
 	})
 
-	waitForCounter(t, func() int64 { return w.Counters().Redacted }, 1)
+	waitForCounter(t, w, func() int64 { return w.Counters().Redacted }, 1)
 	if got := len(client.snapshot()); got != 0 {
 		t.Fatalf("expected zero writes after redaction, got %d", got)
 	}
@@ -235,7 +228,7 @@ func TestAutoNotebookWriter_TaskTransitionUsesOwnerShelf(t *testing.T) {
 		Timestamp:    time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
 	})
 
-	calls := waitForCalls(t, client, 1)
+	calls := waitForCalls(t, w, client, 1)
 	if calls[0].Slug != "eng" {
 		t.Fatalf("expected owner shelf 'eng', got %q", calls[0].Slug)
 	}
@@ -318,7 +311,7 @@ func TestAutoNotebookWriter_WriteFailureCountedNotPropagated(t *testing.T) {
 		Content: "transient error",
 	})
 
-	waitForCounter(t, func() int64 { return w.Counters().WriteFailed }, 1)
+	waitForCounter(t, w, func() int64 { return w.Counters().WriteFailed }, 1)
 	if w.Counters().Written != 0 {
 		t.Fatalf("written counter should stay 0; got %d", w.Counters().Written)
 	}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -630,6 +630,11 @@ func (b *Broker) Stop() {
 //
 // Caller must hold b.mu. Roster filtering happens here (lock-free predicate)
 // because the writer cannot re-enter b.mu — see isAgentMemberSlugLocked.
+//
+// No-op transitions (beforeStatus == afterStatus) are short-circuited at the
+// source: the writer would also drop them via NoopTransition, but pruning
+// here avoids the enqueue + roster lookup on a path where many of the
+// existing call sites can legitimately be called with no actual delta.
 func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, actor string) {
 	if b == nil || b.autoNotebookWriter == nil || task == nil {
 		return
@@ -638,6 +643,11 @@ func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, ac
 	if owner == "" {
 		// No owner means no shelf to land on. Skipping here avoids feeding
 		// the writer an event it would just drop and keeps counters clean.
+		return
+	}
+	beforeTrimmed := strings.TrimSpace(beforeStatus)
+	afterTrimmed := strings.TrimSpace(task.Status)
+	if strings.EqualFold(beforeTrimmed, afterTrimmed) {
 		return
 	}
 	if !b.isAgentMemberSlugLocked(owner) {
@@ -650,11 +660,40 @@ func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, ac
 		Channel:      normalizeChannelSlug(task.Channel),
 		TaskID:       task.ID,
 		TaskTitle:    task.Title,
-		BeforeStatus: strings.TrimSpace(beforeStatus),
-		AfterStatus:  strings.TrimSpace(task.Status),
+		BeforeStatus: beforeTrimmed,
+		AfterStatus:  afterTrimmed,
 		Content:      strings.TrimSpace(task.Title),
 		Timestamp:    time.Now().UTC(),
 	})
+}
+
+// pendingTaskTransition captures a status delta that an under-mutex helper
+// (e.g. unblockDependentsLocked) wants to publish, but only AFTER the caller
+// has persisted via saveLocked. Without this two-step, a saveLocked failure
+// would still leak notebook entries for transitions the broker rolled back.
+type pendingTaskTransition struct {
+	taskID       string
+	beforeStatus string
+}
+
+// flushPendingAutoNotebookTransitionsLocked publishes a batch of cascade
+// transitions to the writer using the current status of each task in
+// b.tasks. Caller holds b.mu and has just successfully saveLocked'd. The
+// per-event no-op guard inside emitTaskTransitionAutoNotebook handles the
+// case where a subsequent mutation reverted the status back to its prior
+// value before we got here.
+func (b *Broker) flushPendingAutoNotebookTransitionsLocked(pending []pendingTaskTransition, actor string) {
+	if b == nil || len(pending) == 0 {
+		return
+	}
+	for _, p := range pending {
+		for i := range b.tasks {
+			if b.tasks[i].ID == p.taskID {
+				b.emitTaskTransitionAutoNotebook(&b.tasks[i], p.beforeStatus, actor)
+				break
+			}
+		}
+	}
 }
 
 // IsAgentMemberSlug returns true when `slug` matches a registered office

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -100,6 +100,7 @@ type Broker struct {
 	wikiSectionsSubscribers map[int]chan WikiSectionsUpdatedEvent
 	wikiWorker              *WikiWorker
 	wikiOnce                sync.Once
+	autoNotebookWriter      *AutoNotebookWriter
 	wikiIndex               *WikiIndex
 	wikiExtractor           *Extractor
 	wikiDLQ                 *DLQ
@@ -584,6 +585,7 @@ func (b *Broker) Stop() {
 	pbSynth := b.playbookSynthesizer
 	pamDisp := b.pamDispatcher
 	compressor := b.wikiCompressor
+	autoWriter := b.autoNotebookWriter
 	b.mu.Unlock()
 	if synth != nil {
 		synth.Stop()
@@ -596,6 +598,9 @@ func (b *Broker) Stop() {
 	}
 	if compressor != nil {
 		compressor.Stop()
+	}
+	if autoWriter != nil {
+		autoWriter.Stop(2 * time.Second)
 	}
 }
 
@@ -616,6 +621,79 @@ func (b *Broker) Stop() {
 // Returns an error if the port cannot be bound (e.g. already in use).
 // Web UI server (ServeWebUI, cacheControlMiddleware, webUIProxyHandler)
 // moved to broker_web_proxy.go.
+
+// emitTaskTransitionAutoNotebook is the canonical seam for the OV2A locked
+// hook: a single after-saveLocked task-transition event, emitted from
+// MutateTask, BlockTask, ResumeTask, EnsureTask, and the self-healing path.
+// Caller passes the pre-mutation status snapshot; the writer records the
+// before/after pair and routes the entry to the task owner's shelf.
+//
+// Caller must hold b.mu. Roster filtering happens here (lock-free predicate)
+// because the writer cannot re-enter b.mu — see isAgentMemberSlugLocked.
+func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, actor string) {
+	if b == nil || b.autoNotebookWriter == nil || task == nil {
+		return
+	}
+	owner := strings.TrimSpace(task.Owner)
+	if owner == "" {
+		// No owner means no shelf to land on. Skipping here avoids feeding
+		// the writer an event it would just drop and keeps counters clean.
+		return
+	}
+	if !b.isAgentMemberSlugLocked(owner) {
+		return
+	}
+	b.autoNotebookWriter.Handle(autoNotebookEvent{
+		Kind:         AutoNotebookEventTaskTransitioned,
+		Slug:         owner,
+		Actor:        strings.TrimSpace(actor),
+		Channel:      normalizeChannelSlug(task.Channel),
+		TaskID:       task.ID,
+		TaskTitle:    task.Title,
+		BeforeStatus: strings.TrimSpace(beforeStatus),
+		AfterStatus:  strings.TrimSpace(task.Status),
+		Content:      strings.TrimSpace(task.Title),
+		Timestamp:    time.Now().UTC(),
+	})
+}
+
+// IsAgentMemberSlug returns true when `slug` matches a registered office
+// member and is not a human/system slug. Acquires b.mu — DO NOT call from a
+// path that already holds it; use isAgentMemberSlugLocked instead.
+func (b *Broker) IsAgentMemberSlug(slug string) bool {
+	if b == nil {
+		return false
+	}
+	slug = normalizeActorSlug(slug)
+	if slug == "" || isHumanMessageSender(slug) {
+		return false
+	}
+	switch slug {
+	case "system", "nex":
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.findMemberLocked(slug) != nil
+}
+
+// isAgentMemberSlugLocked is the hook-site variant: it assumes b.mu is held.
+// Used by the auto-notebook writer hooks to filter senders without re-entering
+// the broker's mutex (which would deadlock).
+func (b *Broker) isAgentMemberSlugLocked(slug string) bool {
+	if b == nil {
+		return false
+	}
+	slug = normalizeActorSlug(slug)
+	if slug == "" || isHumanMessageSender(slug) {
+		return false
+	}
+	switch slug {
+	case "system", "nex":
+		return false
+	}
+	return b.findMemberLocked(slug) != nil
+}
 
 // senderMayAutoPromoteLocked reports whether a `from` value is allowed to have
 // its @slug body text auto-promoted into the tagged array. Allowlist shape:

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/brokeraddr"
 	"github.com/nex-crm/wuphf/internal/channel"
+	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/workspace"
 )
@@ -349,6 +351,12 @@ func (b *Broker) ChannelStore() *channel.Store {
 // Start launches the broker on the configured localhost port.
 func (b *Broker) Start() error {
 	b.ensureWikiWorker()
+	// Seed company context from previous onboarding skip, if pending.
+	if cfg, err := config.Load(); err == nil && cfg.PendingCompanySeed {
+		cfg.PendingCompanySeed = false
+		_ = config.Save(cfg)
+		go b.runCompanySeedJob(cfg)
+	}
 	b.ensureWikiSectionsCache()
 	b.ensureReviewLog()
 	b.ensureEntitySynthesizer()
@@ -516,7 +524,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/admin/pause", b.withAuth(b.handleAdminPause))
 	// Onboarding: state/progress/complete + prereqs/templates/validate-key + checklist.
 	// completeFn posts the first task as a human message and seeds the team.
-	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn, b.packSlug, b.requireAuth)
+	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn, b.packSlug, b.requireAuth, filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki"))
 	// Workspace wipes: POST /workspace/reset (narrow) and /workspace/shred (full).
 	// After a successful wipe, b.Reset clears live in-memory broker state so the
 	// broker stays up without repersisting stale messages back onto disk.
@@ -904,6 +912,17 @@ func (b *Broker) PostInboundSurfaceMessage(from, channel, content, provider stri
 		return channelMessage{}, err
 	}
 	return msg, nil
+}
+
+// Purge clears all tasks from the broker's in-memory state and flushes
+// the empty list to disk. Tests that inject task fixtures with StartOnPort
+// should call this in t.Cleanup to prevent in-progress fixtures from leaking
+// via background saves or shared notification paths after the test exits.
+func (b *Broker) Purge() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.tasks = nil
+	_ = b.saveLocked()
 }
 
 func (b *Broker) Reset() {

--- a/internal/team/broker_auto_notebook_writer_bench_test.go
+++ b/internal/team/broker_auto_notebook_writer_bench_test.go
@@ -7,34 +7,32 @@ import (
 	"time"
 )
 
+// benchNotebookClient is a no-op writer client used by the benchmark — git
+// commits would otherwise dominate runtime and the writer's queue would
+// saturate, pushing the benchmark onto the drop path instead of the enqueue
+// path it is trying to measure.
+type benchNotebookClient struct{}
+
+func (benchNotebookClient) NotebookWrite(context.Context, string, string, string, string, string) (string, int, error) {
+	return "deadbeef", 0, nil
+}
+
 // BenchmarkPostMessage_WithAutoNotebook measures the added latency of the
 // auto-notebook writer hook on the PostMessage hot path. Target: <1ms p50
-// per the eng review test plan (T1A). The writer runs but its internal
-// goroutine processes events asynchronously, so this benchmark exercises the
-// enqueue cost only — exactly the surface that mattered to the eng review.
+// per the eng review test plan (T1A). Uses a no-op writer client so the
+// benchmark stays on the steady-state enqueue path; the consumer drains
+// fast enough that QueueSaturated stays at 0 even at large b.N. Asserted
+// after the loop so a regression that re-introduces drops fails loudly.
 func BenchmarkPostMessage_WithAutoNotebook(b *testing.B) {
-	root := filepath.Join(b.TempDir(), "wiki")
-	backup := filepath.Join(b.TempDir(), "wiki.bak")
-	repo := NewRepoAt(root, backup)
-	if err := repo.Init(context.Background()); err != nil {
-		b.Fatalf("repo init: %v", err)
-	}
-
 	br := NewBrokerAt(filepath.Join(b.TempDir(), "broker-state.json"))
-	worker := NewWikiWorker(repo, br)
 	ctx, cancel := context.WithCancel(context.Background())
-	worker.Start(ctx)
-	defer func() {
-		cancel()
-		<-worker.Done()
-	}()
+	defer cancel()
 
-	writer := NewAutoNotebookWriter(worker, nil)
+	writer := NewAutoNotebookWriter(benchNotebookClient{}, nil)
 	writer.Start(ctx)
 	defer writer.Stop(2 * time.Second)
 
 	br.mu.Lock()
-	br.wikiWorker = worker
 	br.autoNotebookWriter = writer
 	br.mu.Unlock()
 
@@ -47,6 +45,10 @@ func BenchmarkPostMessage_WithAutoNotebook(b *testing.B) {
 		if _, err := br.PostMessage("ceo", "general", "benchmark traffic", nil, ""); err != nil {
 			b.Fatalf("PostMessage: %v", err)
 		}
+	}
+	b.StopTimer()
+	if got := writer.Counters().QueueSaturated; got != 0 {
+		b.Fatalf("benchmark drifted into saturated-drop path; QueueSaturated=%d", got)
 	}
 }
 

--- a/internal/team/broker_auto_notebook_writer_bench_test.go
+++ b/internal/team/broker_auto_notebook_writer_bench_test.go
@@ -1,0 +1,67 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// BenchmarkPostMessage_WithAutoNotebook measures the added latency of the
+// auto-notebook writer hook on the PostMessage hot path. Target: <1ms p50
+// per the eng review test plan (T1A). The writer runs but its internal
+// goroutine processes events asynchronously, so this benchmark exercises the
+// enqueue cost only — exactly the surface that mattered to the eng review.
+func BenchmarkPostMessage_WithAutoNotebook(b *testing.B) {
+	root := filepath.Join(b.TempDir(), "wiki")
+	backup := filepath.Join(b.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		b.Fatalf("repo init: %v", err)
+	}
+
+	br := NewBrokerAt(filepath.Join(b.TempDir(), "broker-state.json"))
+	worker := NewWikiWorker(repo, br)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	defer func() {
+		cancel()
+		<-worker.Done()
+	}()
+
+	writer := NewAutoNotebookWriter(worker, nil)
+	writer.Start(ctx)
+	defer writer.Stop(2 * time.Second)
+
+	br.mu.Lock()
+	br.wikiWorker = worker
+	br.autoNotebookWriter = writer
+	br.mu.Unlock()
+
+	if !br.IsAgentMemberSlug("ceo") {
+		b.Skip("default manifest missing 'ceo'")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := br.PostMessage("ceo", "general", "benchmark traffic", nil, ""); err != nil {
+			b.Fatalf("PostMessage: %v", err)
+		}
+	}
+}
+
+// BenchmarkPostMessage_WithoutAutoNotebook is the baseline — same broker
+// without the writer attached. Compare these two to attribute the writer's
+// cost on the hot path.
+func BenchmarkPostMessage_WithoutAutoNotebook(b *testing.B) {
+	br := NewBrokerAt(filepath.Join(b.TempDir(), "broker-state.json"))
+	if !br.IsAgentMemberSlug("ceo") {
+		b.Skip("default manifest missing 'ceo'")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := br.PostMessage("ceo", "general", "benchmark traffic", nil, ""); err != nil {
+			b.Fatalf("PostMessage: %v", err)
+		}
+	}
+}

--- a/internal/team/broker_auto_notebook_writer_test.go
+++ b/internal/team/broker_auto_notebook_writer_test.go
@@ -1,0 +1,179 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// brokerWithAutoNotebookWriter wires a real WikiWorker on a temp git repo and
+// installs an AutoNotebookWriter on the broker. Returns a teardown that cancels
+// the worker's context and stops the writer.
+func brokerWithAutoNotebookWriter(t *testing.T) (*Broker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("repo init: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	// Roster filtering happens at the broker hook sites under b.mu; the writer
+	// gets nil here so calling Handle from inside a b.mu critical section does
+	// not re-enter the broker mutex.
+	writer := NewAutoNotebookWriter(worker, nil)
+	writer.Start(ctx)
+
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.autoNotebookWriter = writer
+	b.mu.Unlock()
+
+	return b, func() {
+		writer.Stop(2 * time.Second)
+		cancel()
+		<-worker.Done()
+	}
+}
+
+func waitForNotebookEntry(t *testing.T, b *Broker, slug string) []NotebookEntry {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, err := b.wikiWorker.NotebookList(slug)
+		if err == nil && len(entries) > 0 {
+			return entries
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("no notebook entries appeared for slug=%s", slug)
+	return nil
+}
+
+// Real broker + real WikiWorker. PostMessage from the ceo agent must produce a
+// notebook entry under agents/ceo/notebook/ within seconds.
+func TestAutoNotebookWriter_PostMessage_LandsOnShelf(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'; cannot exercise integration path")
+	}
+
+	if _, err := b.PostMessage("ceo", "general", "shipping pr 1 of the auto-notebook writer", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	entries := waitForNotebookEntry(t, b, "ceo")
+	if !strings.Contains(entries[0].Path, "agents/ceo/notebook/") {
+		t.Fatalf("entry not on ceo shelf: %q", entries[0].Path)
+	}
+	if !strings.Contains(entries[0].Path, "message-posted") {
+		t.Fatalf("expected message-posted in filename: %q", entries[0].Path)
+	}
+}
+
+// Human-authored messages must NOT populate the agent shelf. The roster filter
+// (decision OV6A) gates this at the writer's ingress.
+func TestAutoNotebookWriter_HumanMessage_DoesNotLandOnShelf(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+
+	if _, err := b.PostMessage("human", "general", "hi from a human", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	// Give the writer a chance to (incorrectly) write something. We expect no
+	// entries at all on any shelf.
+	time.Sleep(150 * time.Millisecond)
+
+	slugs, err := b.wikiWorker.AgentsWithNotebooks()
+	if err != nil {
+		t.Fatalf("AgentsWithNotebooks: %v", err)
+	}
+	for _, s := range slugs {
+		entries, _ := b.wikiWorker.NotebookList(s)
+		if len(entries) > 0 {
+			t.Fatalf("human message produced an entry on %s shelf", s)
+		}
+	}
+	// Roster filter runs at the broker hook site (lock-free predicate) before
+	// the writer ever sees the event, so the writer's NonRoster counter stays
+	// 0. The "no entries on any shelf" assertion above is the binding check.
+}
+
+// Two consecutive identical messages collapse to one shelf entry via the LRU.
+func TestAutoNotebookWriter_DuplicatePostMessageDeduped(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'")
+	}
+
+	if _, err := b.PostMessage("ceo", "general", "exactly the same thing", nil, ""); err != nil {
+		t.Fatalf("PostMessage 1: %v", err)
+	}
+	waitForNotebookEntry(t, b, "ceo")
+	if _, err := b.PostMessage("ceo", "general", "exactly the same thing", nil, ""); err != nil {
+		t.Fatalf("PostMessage 2: %v", err)
+	}
+
+	// Wait a beat to ensure the second event has been processed and (we hope)
+	// dropped by dedupe.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if b.autoNotebookWriter.Counters().Deduped >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if b.autoNotebookWriter.Counters().Deduped < 1 {
+		t.Fatalf("expected dedupe to fire on identical repost")
+	}
+	entries, _ := b.wikiWorker.NotebookList("ceo")
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 entry after dedupe; got %d", len(entries))
+	}
+}
+
+// Task transitions populate the owner's shelf, distinct kind in filename.
+func TestAutoNotebookWriter_TaskMutationLandsOnOwnerShelf(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'")
+	}
+
+	resp, err := b.MutateTask(TaskPostRequest{
+		Action:    "create",
+		Channel:   "general",
+		Title:     "Ship PR 1",
+		Owner:     "ceo",
+		CreatedBy: "ceo",
+	})
+	if err != nil {
+		t.Fatalf("MutateTask create: %v", err)
+	}
+	taskID := resp.Task.ID
+	if taskID == "" {
+		t.Fatalf("created task missing id")
+	}
+
+	entries := waitForNotebookEntry(t, b, "ceo")
+	var transitionEntry *NotebookEntry
+	for i := range entries {
+		if strings.Contains(entries[i].Path, "task-transitioned") {
+			transitionEntry = &entries[i]
+			break
+		}
+	}
+	if transitionEntry == nil {
+		t.Fatalf("expected task-transitioned entry on ceo shelf; got entries: %v", entries)
+	}
+}

--- a/internal/team/broker_auto_notebook_writer_test.go
+++ b/internal/team/broker_auto_notebook_writer_test.go
@@ -44,16 +44,19 @@ func brokerWithAutoNotebookWriter(t *testing.T) (*Broker, func()) {
 
 func waitForNotebookEntry(t *testing.T, b *Broker, slug string) []NotebookEntry {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		entries, err := b.wikiWorker.NotebookList(slug)
-		if err == nil && len(entries) > 0 {
-			return entries
-		}
-		time.Sleep(20 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := b.autoNotebookWriter.WaitForCondition(ctx, func() bool {
+		entries, listErr := b.wikiWorker.NotebookList(slug)
+		return listErr == nil && len(entries) > 0
+	}); err != nil {
+		t.Fatalf("no notebook entries appeared for slug=%s: %v", slug, err)
 	}
-	t.Fatalf("no notebook entries appeared for slug=%s", slug)
-	return nil
+	entries, err := b.wikiWorker.NotebookList(slug)
+	if err != nil {
+		t.Fatalf("NotebookList(%s): %v", slug, err)
+	}
+	return entries
 }
 
 // Real broker + real WikiWorker. PostMessage from the ceo agent must produce a
@@ -85,27 +88,35 @@ func TestAutoNotebookWriter_HumanMessage_DoesNotLandOnShelf(t *testing.T) {
 	b, teardown := brokerWithAutoNotebookWriter(t)
 	defer teardown()
 
+	// Post a sentinel agent message AFTER the human one so we have a
+	// deterministic signal that the writer pipeline drained: when the agent
+	// entry lands on the ceo shelf, every prior PostMessage hook has already
+	// run to completion. If the human PostMessage incorrectly produced a
+	// shelf entry, NotebookList for any non-ceo agent will be non-empty.
 	if _, err := b.PostMessage("human", "general", "hi from a human", nil, ""); err != nil {
-		t.Fatalf("PostMessage: %v", err)
+		t.Fatalf("PostMessage human: %v", err)
 	}
-
-	// Give the writer a chance to (incorrectly) write something. We expect no
-	// entries at all on any shelf.
-	time.Sleep(150 * time.Millisecond)
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'; cannot drain via agent sentinel")
+	}
+	if _, err := b.PostMessage("ceo", "general", "drain sentinel", nil, ""); err != nil {
+		t.Fatalf("PostMessage ceo sentinel: %v", err)
+	}
+	waitForNotebookEntry(t, b, "ceo")
 
 	slugs, err := b.wikiWorker.AgentsWithNotebooks()
 	if err != nil {
 		t.Fatalf("AgentsWithNotebooks: %v", err)
 	}
 	for _, s := range slugs {
+		if s == "ceo" {
+			continue
+		}
 		entries, _ := b.wikiWorker.NotebookList(s)
 		if len(entries) > 0 {
 			t.Fatalf("human message produced an entry on %s shelf", s)
 		}
 	}
-	// Roster filter runs at the broker hook site (lock-free predicate) before
-	// the writer ever sees the event, so the writer's NonRoster counter stays
-	// 0. The "no entries on any shelf" assertion above is the binding check.
 }
 
 // Two consecutive identical messages collapse to one shelf entry via the LRU.
@@ -124,17 +135,12 @@ func TestAutoNotebookWriter_DuplicatePostMessageDeduped(t *testing.T) {
 		t.Fatalf("PostMessage 2: %v", err)
 	}
 
-	// Wait a beat to ensure the second event has been processed and (we hope)
-	// dropped by dedupe.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if b.autoNotebookWriter.Counters().Deduped >= 1 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if b.autoNotebookWriter.Counters().Deduped < 1 {
-		t.Fatalf("expected dedupe to fire on identical repost")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := b.autoNotebookWriter.WaitForCondition(ctx, func() bool {
+		return b.autoNotebookWriter.Counters().Deduped >= 1
+	}); err != nil {
+		t.Fatalf("expected dedupe to fire on identical repost: %v", err)
 	}
 	entries, _ := b.wikiWorker.NotebookList("ceo")
 	if len(entries) != 1 {

--- a/internal/team/broker_company_seed.go
+++ b/internal/team/broker_company_seed.go
@@ -1,0 +1,53 @@
+package team
+
+import (
+	"context"
+	"log"
+	"path/filepath"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/operations"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+type brokerCompleter struct{}
+
+func (c brokerCompleter) Complete(_ context.Context, prompt string) (string, error) {
+	return provider.RunConfiguredOneShot("", prompt, "")
+}
+
+func (b *Broker) runCompanySeedJob(cfg config.Config) {
+	wikiRoot := filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki")
+	input := operations.CompanySeedInput{
+		WebsiteURL: cfg.CompanyWebsite,
+		OwnerName:  cfg.OwnerName,
+		OwnerRole:  cfg.OwnerRole,
+		Completer:  brokerCompleter{},
+		WikiRoot:   wikiRoot,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	result, err := operations.SeedCompanyContext(ctx, input)
+	if err != nil {
+		log.Printf("broker: company seed failed: %v", err)
+		return
+	}
+	for _, w := range result.Warnings {
+		log.Printf("broker: company seed warning: %s", w)
+	}
+	log.Printf("broker: company seed complete, wrote %d articles", len(result.ArticlesWritten))
+	// Persist extracted profile fields back to config.
+	if c, err := config.Load(); err == nil {
+		if result.Profile.Name != "" {
+			c.CompanyName = result.Profile.Name
+		}
+		if result.Profile.Description != "" {
+			c.CompanyDescription = result.Profile.Description
+		}
+		if len(result.Profile.Notes) > 0 && result.Profile.Notes[0] != "" {
+			c.CompanyGoals = result.Profile.Notes[0]
+		}
+		_ = config.Save(c)
+	}
+}

--- a/internal/team/broker_messages.go
+++ b/internal/team/broker_messages.go
@@ -436,6 +436,20 @@ func (b *Broker) PostMessage(from, channel, content string, tagged []string, rep
 	if err := b.saveLocked(); err != nil {
 		return channelMessage{}, err
 	}
+	// 2A: every roster-agent PostMessage triggers one notebook event. Roster
+	// filter is applied here under b.mu (lock-free predicate); calling Handle
+	// itself never re-enters b.mu, so this is safe to do while still locked.
+	// Handle is non-blocking per decision S3A.
+	if b.autoNotebookWriter != nil && b.isAgentMemberSlugLocked(msg.From) {
+		b.autoNotebookWriter.Handle(autoNotebookEvent{
+			Kind:      AutoNotebookEventMessagePosted,
+			Slug:      msg.From,
+			Actor:     msg.From,
+			Channel:   msg.Channel,
+			Content:   msg.Content,
+			Timestamp: time.Now().UTC(),
+		})
+	}
 	return msg, nil
 }
 

--- a/internal/team/broker_messages_test.go
+++ b/internal/team/broker_messages_test.go
@@ -92,13 +92,10 @@ func TestPostMessage_TriggersAutoNotebookWriter(t *testing.T) {
 	// not produce a writer event.
 	b.PostSystemMessage("general", "system msg", "system")
 
-	// Wait for the agent message to flow through.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(stub.snapshot()) > 0 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	if err := writer.WaitForCondition(waitCtx, func() bool { return len(stub.snapshot()) >= 1 }); err != nil {
+		t.Fatalf("waiting for writer event: %v", err)
 	}
 	calls := stub.snapshot()
 	if len(calls) != 1 {

--- a/internal/team/broker_messages_test.go
+++ b/internal/team/broker_messages_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 )
@@ -49,6 +51,61 @@ func TestPostMessage_SetsTimestampAndChannel(t *testing.T) {
 	all := b.Messages()
 	if len(all) == 0 || all[len(all)-1].ID != got.ID {
 		t.Errorf("posted message not visible in b.Messages()")
+	}
+}
+
+// TestPostMessage_TriggersAutoNotebookWriter pins the locked PR-1 hook (2A):
+// every roster-agent PostMessage feeds exactly one event into the auto-notebook
+// writer, while non-roster senders (humans, system) are filtered at ingress.
+// Uses a stub writer client to keep the assertion focused on the hook seam.
+func TestPostMessage_TriggersAutoNotebookWriter(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.members = append(b.members, officeMember{Slug: "ceo", Name: "CEO", Role: "lead"})
+	for i := range b.channels {
+		if b.channels[i].Slug == "general" {
+			b.channels[i].Members = append(b.channels[i].Members, "ceo", "human")
+		}
+	}
+	b.mu.Unlock()
+
+	stub := &fakeNotebookClient{}
+	// Broker pre-filters via isAgentMemberSlugLocked before calling Handle,
+	// so the writer's roster is unused on the production code path; pass nil
+	// here to avoid re-entering b.mu inside Handle.
+	writer := NewAutoNotebookWriter(stub, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	writer.Start(ctx)
+	t.Cleanup(func() { cancel(); writer.Stop(time.Second) })
+
+	b.mu.Lock()
+	b.autoNotebookWriter = writer
+	b.mu.Unlock()
+
+	if _, err := b.PostMessage("ceo", "general", "agent message", nil, ""); err != nil {
+		t.Fatalf("PostMessage agent: %v", err)
+	}
+	if _, err := b.PostMessage("human", "general", "human message", nil, ""); err != nil {
+		t.Fatalf("PostMessage human: %v", err)
+	}
+	// Process the system path: PostSystemMessage bypasses PostMessage and must
+	// not produce a writer event.
+	b.PostSystemMessage("general", "system msg", "system")
+
+	// Wait for the agent message to flow through.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(stub.snapshot()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := stub.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 notebook write (only the agent message); got %d", len(calls))
+	}
+	if calls[0].Slug != "ceo" {
+		t.Fatalf("expected slug=ceo, got %q", calls[0].Slug)
 	}
 }
 

--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -630,7 +630,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		b.completeSchedulerJobsLocked("request", b.requests[i].ID, b.requests[i].Channel)
 		pendingCascade := b.unblockDependentsLocked(b.requests[i].ID)
 		b.pendingInterview = firstBlockingRequest(b.requests)
-		b.unblockTasksForAnsweredRequestLocked(b.requests[i])
+		pendingCascade = append(pendingCascade, b.unblockTasksForAnsweredRequestLocked(b.requests[i])...)
 
 		// Skill proposal callback: accept activates the skill, reject archives it.
 		if b.requests[i].Kind == "skill_proposal" {
@@ -689,11 +689,12 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 	http.Error(w, "request not found", http.StatusNotFound)
 }
 
-func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
+func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) []pendingTaskTransition {
 	reqID := strings.TrimSpace(req.ID)
 	if reqID == "" {
-		return
+		return nil
 	}
+	var pending []pendingTaskTransition
 	now := time.Now().UTC().Format(time.RFC3339)
 	answerText := strings.TrimSpace(reqAnswerSummary(req.Answered))
 	for i := range b.tasks {
@@ -713,6 +714,7 @@ func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
 		// needs.
 		stillBlocked := b.hasUnresolvedDepsLocked(task)
 		if !stillBlocked {
+			beforeStatus := task.Status
 			task.Blocked = false
 			if strings.EqualFold(strings.TrimSpace(task.Status), "blocked") {
 				if strings.TrimSpace(task.Owner) != "" {
@@ -722,6 +724,10 @@ func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
 				}
 			}
 			b.queueTaskBehindActiveOwnerLaneLocked(task)
+			pending = append(pending, pendingTaskTransition{
+				taskID:       task.ID,
+				beforeStatus: beforeStatus,
+			})
 		}
 		if answerText != "" && !strings.Contains(task.Details, answerText) {
 			task.Details = strings.TrimSpace(task.Details)
@@ -742,6 +748,7 @@ func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
 			)
 		}
 	}
+	return pending
 }
 
 // taskMentionsRequestID returns true when haystack contains needle as a

--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -628,7 +628,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		b.requests[i].RecheckAt = ""
 		b.requests[i].DueAt = ""
 		b.completeSchedulerJobsLocked("request", b.requests[i].ID, b.requests[i].Channel)
-		b.unblockDependentsLocked(b.requests[i].ID)
+		pendingCascade := b.unblockDependentsLocked(b.requests[i].ID)
 		b.pendingInterview = firstBlockingRequest(b.requests)
 		b.unblockTasksForAnsweredRequestLocked(b.requests[i])
 
@@ -678,6 +678,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 			return
 		}
+		b.flushPendingAutoNotebookTransitionsLocked(pendingCascade, "system")
 		b.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -37,6 +37,7 @@ func (b *Broker) BlockTask(taskID, actor, reason string) (teamTask, bool, error)
 		if err := rejectFalseLocalWorktreeBlock(task, reason); err != nil {
 			return *task, false, err
 		}
+		beforeStatus := task.Status
 		if reason != "" {
 			switch existing := strings.TrimSpace(task.Details); {
 			case existing == "":
@@ -60,6 +61,7 @@ func (b *Broker) BlockTask(taskID, actor, reason string) (teamTask, bool, error)
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
+		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
 		return *task, true, nil
 	}
 
@@ -86,6 +88,7 @@ func (b *Broker) ResumeTask(taskID, actor, reason string) (teamTask, bool, error
 		if task.ID != id {
 			continue
 		}
+		beforeStatus := task.Status
 		changed := false
 		if task.Blocked {
 			task.Blocked = false
@@ -120,6 +123,7 @@ func (b *Broker) ResumeTask(taskID, actor, reason string) (teamTask, bool, error
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
+		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
 		return *task, true, nil
 	}
 
@@ -180,6 +184,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		Owner:    strings.TrimSpace(owner),
 	}); existing != nil {
 		now := time.Now().UTC().Format(time.RFC3339)
+		beforeStatus := existing.Status
 		if existing.Details == "" && strings.TrimSpace(details) != "" {
 			existing.Details = strings.TrimSpace(details)
 		}
@@ -206,6 +211,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
+		b.emitTaskTransitionAutoNotebook(existing, beforeStatus, createdBy)
 		return *existing, true, nil
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -243,6 +249,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 	if err := b.saveLocked(); err != nil {
 		return teamTask{}, false, err
 	}
+	b.emitTaskTransitionAutoNotebook(&task, "", createdBy)
 	return task, false, nil
 }
 

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -356,6 +356,7 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) {
 			continue
 		}
 		if !b.hasUnresolvedDepsLocked(&b.tasks[i]) {
+			beforeStatus := b.tasks[i].Status
 			b.tasks[i].Blocked = false
 			if strings.TrimSpace(b.tasks[i].Owner) != "" {
 				b.tasks[i].Status = "in_progress"
@@ -374,6 +375,11 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) {
 				truncateSummary(b.tasks[i].Title+" unblocked by "+completedTaskID, 140),
 				b.tasks[i].ID,
 			)
+			// Caller (MutateTask / lifecycle) holds b.mu and persists via its
+			// own saveLocked, so we don't write here — but every other status
+			// mutation in this PR emits a transition event, and the cascade
+			// path needs to match or PR 3's clustering signal will be skewed.
+			b.emitTaskTransitionAutoNotebook(&b.tasks[i], beforeStatus, "system")
 		}
 	}
 }

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -339,8 +339,14 @@ func (b *Broker) hasUnresolvedDepsLocked(task *teamTask) bool {
 // unblockDependentsLocked checks all blocked tasks and unblocks those whose
 // dependencies are now resolved. For each newly unblocked task, it appends a
 // "task_unblocked" action so the launcher can deliver a notification to the owner.
-func (b *Broker) unblockDependentsLocked(completedTaskID string) {
+//
+// Returns the list of cascade transitions that the caller must publish to the
+// auto-notebook writer AFTER its own saveLocked succeeds. Emitting under
+// b.mu before the persist would leak notebook entries for transitions the
+// broker subsequently rolled back on save failure (CodeRabbit, major).
+func (b *Broker) unblockDependentsLocked(completedTaskID string) []pendingTaskTransition {
 	now := time.Now().UTC().Format(time.RFC3339)
+	var pending []pendingTaskTransition
 	for i := range b.tasks {
 		if !b.tasks[i].Blocked {
 			continue
@@ -375,13 +381,13 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) {
 				truncateSummary(b.tasks[i].Title+" unblocked by "+completedTaskID, 140),
 				b.tasks[i].ID,
 			)
-			// Caller (MutateTask / lifecycle) holds b.mu and persists via its
-			// own saveLocked, so we don't write here — but every other status
-			// mutation in this PR emits a transition event, and the cascade
-			// path needs to match or PR 3's clustering signal will be skewed.
-			b.emitTaskTransitionAutoNotebook(&b.tasks[i], beforeStatus, "system")
+			pending = append(pending, pendingTaskTransition{
+				taskID:       b.tasks[i].ID,
+				beforeStatus: beforeStatus,
+			})
 		}
 	}
+	return pending
 }
 
 type taskReuseMatch struct {

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -447,8 +447,9 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		}
 		// Any terminal status releases waiting dependents. isTerminalTeamTaskStatus
 		// matches hasUnresolvedDepsLocked so cancelled parents do not orphan dependents.
+		var pendingCascade []pendingTaskTransition
 		if isTerminalTeamTaskStatus(task.Status) {
-			b.unblockDependentsLocked(task.ID)
+			pendingCascade = b.unblockDependentsLocked(task.ID)
 		}
 		b.scheduleTaskLifecycleLocked(task)
 		if err := b.syncTaskWorktreeLocked(task); err != nil {
@@ -470,6 +471,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 		}
 		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
+		b.flushPendingAutoNotebookTransitionsLocked(pendingCascade, "system")
 		return TaskResponse{Task: *task}, nil
 	}
 

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -161,6 +161,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			SourceSignalID:   strings.TrimSpace(body.SourceSignalID),
 			SourceDecisionID: strings.TrimSpace(body.SourceDecisionID),
 		}); existing != nil {
+			beforeStatus := existing.Status
 			if details := strings.TrimSpace(body.Details); details != "" {
 				existing.Details = details
 			}
@@ -213,6 +214,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 				rollbackTask()
 				return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 			}
+			b.emitTaskTransitionAutoNotebook(existing, beforeStatus, actor)
 			return TaskResponse{Task: *existing}, nil
 		}
 		b.counter++
@@ -261,6 +263,9 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			rollbackTask()
 			return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 		}
+		// Treat creation as a transition from "" → task.Status so the owner's
+		// shelf records the moment a task lands in their lane.
+		b.emitTaskTransitionAutoNotebook(&task, "", actor)
 		return TaskResponse{Task: task}, nil
 	}
 
@@ -290,6 +295,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		reassignTriggered := false
 		cancelTriggered := false
 		cancelPrevOwner := ""
+		beforeStatus := task.Status
 		switch action {
 		case "claim", "assign":
 			if strings.TrimSpace(body.Owner) == "" {
@@ -463,6 +469,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			rollbackTask()
 			return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 		}
+		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
 		return TaskResponse{Task: *task}, nil
 	}
 

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -1129,6 +1129,7 @@ func TestBrokerTaskCompleteRejectsLiveBusinessTheater(t *testing.T) {
 		t.Fatalf("failed to start broker: %v", err)
 	}
 	defer b.Stop()
+	t.Cleanup(func() { b.Purge() })
 	b.mu.Lock()
 	b.tasks = []teamTask{{
 		ID:            "task-1",
@@ -1181,6 +1182,7 @@ func TestBrokerTaskUpdateRollsBackBrokerSideEffectsOnSaveFailure(t *testing.T) {
 		t.Fatalf("failed to start broker: %v", err)
 	}
 	defer b.Stop()
+	t.Cleanup(func() { b.Purge() })
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -67,12 +67,20 @@ func (b *Broker) initWikiWorker() {
 	extractor := NewExtractor(brokerQueryProvider{}, worker, dlq, idx)
 	worker.SetExtractor(extractor)
 
+	// Roster filter is applied at the broker hook sites (under b.mu) via
+	// isAgentMemberSlugLocked, so the writer itself takes nil here — passing
+	// the broker as roster would deadlock when Handle is called from inside a
+	// b.mu critical section.
+	autoWriter := NewAutoNotebookWriter(worker, nil)
+	autoWriter.Start(lifecycleCtx)
+
 	b.mu.Lock()
 	b.wikiWorker = worker
 	b.wikiIndex = idx
 	b.wikiExtractor = extractor
 	b.wikiDLQ = dlq
 	b.readLog = NewReadLog(repo.Root())
+	b.autoNotebookWriter = autoWriter
 	b.mu.Unlock()
 
 	b.ensureNotebookDirsForRoster()

--- a/internal/team/self_healing.go
+++ b/internal/team/self_healing.go
@@ -55,6 +55,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 		Owner:      owner,
 		PipelineID: "incident",
 	}); existing != nil {
+		beforeStatus := existing.Status
 		if existing.Details == "" {
 			existing.Details = details
 		} else if err := appendTaskDetailLocked(existing, selfHealingIncidentUpdate(reason, detail)); err != nil {
@@ -87,6 +88,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, true, err
 		}
+		b.emitTaskTransitionAutoNotebook(existing, beforeStatus, createdBy)
 		return *existing, true, nil
 	}
 
@@ -123,6 +125,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 	if err := b.saveLocked(); err != nil {
 		return teamTask{}, false, err
 	}
+	b.emitTaskTransitionAutoNotebook(&task, "", createdBy)
 	return task, false, nil
 }
 

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -38,8 +38,20 @@ const (
 	InitNexRegister      InitPhase = "nex_register"
 	InitBlueprintChoice  InitPhase = "blueprint_choice"
 	InitPackChoice       InitPhase = "pack_choice" // legacy alias
+	InitCompanyURL       InitPhase = "company_url"
+	InitCompanyFiles     InitPhase = "company_files"
+	InitOwnerName        InitPhase = "owner_name"
+	InitOwnerRole        InitPhase = "owner_role"
+	InitCompanyScan      InitPhase = "company_scan"
+	InitCompanyDone      InitPhase = "company_done"
 	InitDone             InitPhase = "done"
 )
+
+// companyScanDoneMsg is emitted when the company context scan completes.
+type companyScanDoneMsg struct{ result *operations.CompanySeedResult }
+
+// companyScanErrMsg is emitted when the company context scan fails.
+type companyScanErrMsg struct{ err error }
 
 // InitFlowModel is the state machine for the /init onboarding flow.
 type InitFlowModel struct {
@@ -48,6 +60,14 @@ type InitFlowModel struct {
 	provider  string
 	memory    string
 	blueprint string
+
+	companyURL   string
+	companyFiles string // comma-separated file paths
+	ownerName    string
+	ownerRole    string
+	scanResult   *operations.CompanySeedResult
+	scanErr      error
+	scanRunning  bool
 
 	// Text input buffer for key / email entry
 	keyInput []rune
@@ -120,10 +140,40 @@ func (f InitFlowModel) Update(msg tea.Msg) (InitFlowModel, tea.Cmd) {
 			return f.advanceAfterMemoryChoice()
 		case InitBlueprintChoice, InitPackChoice:
 			f.blueprint = m.Value
-			return f.finish()
+			f.phase = InitCompanyURL
+			return f, f.emitPhase(InitCompanyURL)
 		}
 
+	case companyScanDoneMsg:
+		if f.phase == InitCompanyScan {
+			f.scanRunning = false
+			f.scanResult = m.result
+			f.phase = InitCompanyDone
+			return f, f.emitPhase(InitCompanyDone)
+		}
+		return f, nil // late message after skip — ignore
+
+	case companyScanErrMsg:
+		if f.phase == InitCompanyScan {
+			f.scanRunning = false
+			f.scanErr = m.err
+			return f.finish()
+		}
+		return f, nil // late message after skip — ignore
+
 	case tea.KeyMsg:
+		if f.phase == InitCompanyScan && m.String() == "s" {
+			cfg, _ := config.Load()
+			cfg.PendingCompanySeed = true
+			_ = config.Save(cfg)
+			return f.finish()
+		}
+		if f.phase == InitCompanyDone {
+			if m.Type == tea.KeyEnter || m.String() == " " {
+				return f.finish()
+			}
+			return f, nil
+		}
 		if f.requiresTextInput() {
 			return f.updateTextInput(m)
 		}
@@ -162,7 +212,8 @@ func (f InitFlowModel) advanceAfterMemoryChoice() (InitFlowModel, tea.Cmd) {
 
 func (f InitFlowModel) requiresTextInput() bool {
 	switch f.phase {
-	case InitAPIKey, InitGBrainOpenAIKey, InitGBrainAnthropKey, InitNexRegister:
+	case InitAPIKey, InitGBrainOpenAIKey, InitGBrainAnthropKey, InitNexRegister,
+		InitCompanyURL, InitCompanyFiles, InitOwnerName, InitOwnerRole:
 		return true
 	}
 	return false
@@ -261,6 +312,53 @@ func (f InitFlowModel) submitTextInput(value string) (InitFlowModel, tea.Cmd) {
 		f.apiKey = strings.TrimSpace(config.ResolveAPIKey(""))
 		f.phase = InitBlueprintChoice
 		return f, f.emitPhase(InitBlueprintChoice)
+
+	case InitCompanyURL:
+		f.companyURL = value
+		f.keyInput = nil
+		f.keyError = ""
+		f.phase = InitCompanyFiles
+		return f, f.emitPhase(InitCompanyFiles)
+
+	case InitCompanyFiles:
+		f.companyFiles = value
+		f.keyInput = nil
+		f.keyError = ""
+		// If both URL and files are empty, skip all company phases.
+		if f.companyURL == "" && f.companyFiles == "" {
+			return f.finish()
+		}
+		f.phase = InitOwnerName
+		return f, f.emitPhase(InitOwnerName)
+
+	case InitOwnerName:
+		f.ownerName = value
+		f.keyInput = nil
+		f.keyError = ""
+		f.phase = InitOwnerRole
+		return f, f.emitPhase(InitOwnerRole)
+
+	case InitOwnerRole:
+		f.ownerRole = value
+		f.keyInput = nil
+		f.keyError = ""
+		f.phase = InitCompanyScan
+		f.scanRunning = true
+		wikiRoot := filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki")
+		return f, tea.Batch(
+			f.emitPhase(InitCompanyScan),
+			runCompanyScan(
+				operations.CompanySeedInput{
+					WebsiteURL: f.companyURL,
+					FilePaths:  splitFilePaths(f.companyFiles),
+					OwnerName:  f.ownerName,
+					OwnerRole:  f.ownerRole,
+					Completer:  cliCompleter{},
+					WikiRoot:   wikiRoot,
+				},
+				saveCompanyProfile,
+			),
+		)
 	}
 	return f, nil
 }
@@ -421,6 +519,14 @@ func (f InitFlowModel) renderAPIKeyInput() string {
 		label = "Anthropic Key (Enter to skip): "
 	case InitNexRegister:
 		label = "Email: "
+	case InitCompanyURL:
+		label = "URL (Enter to skip): "
+	case InitCompanyFiles:
+		label = "Files (Enter to skip): "
+	case InitOwnerName:
+		label = "Name: "
+	case InitOwnerRole:
+		label = "Role: "
 	default:
 		label = "API Key: "
 	}
@@ -674,6 +780,18 @@ func (f InitFlowModel) phaseText() (heading, instructions string) {
 		return "Register with Nex", "Enter your email to create or connect your Nex identity. This enables shared memory, entity briefs, and integrations."
 	case InitBlueprintChoice, InitPackChoice:
 		return "Choose Operation Template", "Select the blueprint or template that will seed your startup."
+	case InitCompanyURL:
+		return "Company Website URL?", "Company website URL? (optional, press Enter to skip)"
+	case InitCompanyFiles:
+		return "Context Documents?", "Context documents? (comma-separated paths, Enter to skip)"
+	case InitOwnerName:
+		return "Your Name?", "Your name?"
+	case InitOwnerRole:
+		return "Your Role?", "Your role? (e.g. founder, CTO)"
+	case InitCompanyScan:
+		return "Scanning Company Context", "Scanning company context... (press s to skip to background)"
+	case InitCompanyDone:
+		return "Company Context Ready", "Company context written to wiki. Press Enter to continue."
 	case InitDone:
 		blueprintName := blueprintDisplayName(f.blueprint)
 		memoryName := config.MemoryBackendLabel(f.memory)

--- a/internal/tui/init_flow_company.go
+++ b/internal/tui/init_flow_company.go
@@ -1,0 +1,93 @@
+package tui
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/operations"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// cliCompleter implements operations.Completer using the configured LLM provider.
+type cliCompleter struct{}
+
+func (c cliCompleter) Complete(_ context.Context, prompt string) (string, error) {
+	return provider.RunConfiguredOneShot("", prompt, "")
+}
+
+// runCompanyScan launches operations.SeedCompanyContext as a tea.Cmd.
+// It clears PendingCompanySeed before running to prevent a double-seed if
+// the broker starts concurrently. On success it calls cfgSave to persist
+// the extracted profile, then emits companyScanDoneMsg. On failure it
+// emits companyScanErrMsg.
+func runCompanyScan(
+	input operations.CompanySeedInput,
+	cfgSave func(operations.CompanyProfile, string, string),
+) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		// Clear PendingCompanySeed before running to avoid a double-run if
+		// the broker starts concurrently.
+		if cfg, err := config.Load(); err == nil && cfg.PendingCompanySeed {
+			cfg.PendingCompanySeed = false
+			_ = config.Save(cfg)
+		}
+		result, err := operations.SeedCompanyContext(ctx, input)
+		if err != nil {
+			return companyScanErrMsg{err: err}
+		}
+		cfgSave(result.Profile, input.OwnerName, input.OwnerRole)
+		return companyScanDoneMsg{result: result}
+	}
+}
+
+// saveCompanyProfile writes the extracted company profile fields back to config.
+func saveCompanyProfile(profile operations.CompanyProfile, ownerName, ownerRole string) {
+	cfg, err := config.Load()
+	if err != nil {
+		return
+	}
+	if profile.Name != "" {
+		cfg.CompanyName = profile.Name
+	}
+	if profile.Description != "" {
+		cfg.CompanyDescription = profile.Description
+	}
+	if len(profile.Notes) > 0 && profile.Notes[0] != "" {
+		cfg.CompanyGoals = profile.Notes[0]
+	}
+	if profile.Website != "" {
+		cfg.CompanyWebsite = profile.Website
+	}
+	cfg.OwnerName = ownerName
+	cfg.OwnerRole = ownerRole
+	_ = config.Save(cfg)
+}
+
+// splitFilePaths splits a comma-separated list of file paths and expands
+// leading ~/ to the user home directory.
+func splitFilePaths(input string) []string {
+	if strings.TrimSpace(input) == "" {
+		return nil
+	}
+	parts := strings.Split(input, ",")
+	out := make([]string, 0, len(parts))
+	home, _ := os.UserHomeDir()
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		if home != "" && strings.HasPrefix(p, "~/") {
+			p = home + p[1:]
+		}
+		out = append(out, p)
+	}
+	return out
+}

--- a/web/src/api/onboarding.ts
+++ b/web/src/api/onboarding.ts
@@ -1,0 +1,5 @@
+export interface OSScanResponse {
+  facts: string[];
+  articles_written: string[];
+  warnings?: string[];
+}

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -24,11 +24,13 @@ import {
 } from "./wizard/runtime-helpers";
 import { WelcomeStep } from "./wizard/Step1Welcome";
 import { TemplatesStep } from "./wizard/Step2Templates";
+import { AnalysisStep } from "./wizard/Step3bAnalysis";
 import { IdentityStep } from "./wizard/Step3Identity";
 import { TeamStep } from "./wizard/Step4Team";
 import { SetupStep } from "./wizard/Step5Setup";
 import { TaskStep } from "./wizard/Step6Task";
 import { ReadyStep } from "./wizard/Step7Ready";
+import type { OSScanResponse } from "../../api/onboarding";
 import type {
   BlueprintAgent,
   BlueprintTemplate,
@@ -135,6 +137,10 @@ export function Wizard({ onComplete }: WizardProps) {
   const [company, setCompany] = useState("");
   const [description, setDescription] = useState("");
   const [priority, setPriority] = useState("");
+  const [website, setWebsite] = useState("");
+  const [ownerName, setOwnerName] = useState("");
+  const [ownerRole, setOwnerRole] = useState("");
+  const [scanResult, setScanResult] = useState<OSScanResponse | null>(null);
   // Optional in-wizard Nex registration. Mirrors the TUI's InitNexRegister
   // phase — we POST /nex/register which shells out to `nex-cli setup <email>`.
   // If nex-cli isn't installed we flip to `fallback` (external link to
@@ -609,6 +615,10 @@ export function Wizard({ onComplete }: WizardProps) {
           company,
           description,
           priority,
+          website,
+          owner_name: ownerName,
+          owner_role: ownerRole,
+          scan_completed: scanResult !== null,
           runtime: primaryRuntime,
           runtime_priority: runtimePriority,
           memory_backend: "markdown",
@@ -633,6 +643,10 @@ export function Wizard({ onComplete }: WizardProps) {
       company,
       description,
       priority,
+      website,
+      ownerName,
+      ownerRole,
+      scanResult,
       runtimePriority,
       selectedBlueprint,
       agents,
@@ -771,14 +785,41 @@ export function Wizard({ onComplete }: WizardProps) {
             nexEmail={nexEmail}
             nexSignupStatus={nexSignupStatus}
             nexSignupError={nexSignupError}
+            website={website}
+            ownerName={ownerName}
+            ownerRole={ownerRole}
             onChangeCompany={setCompany}
             onChangeDescription={setDescription}
             onChangePriority={setPriority}
             onChangeNexEmail={setNexEmail}
             onSubmitNexSignup={submitNexSignup}
             onOpenNexSignup={openNexSignup}
-            onNext={nextStep}
+            onChangeWebsite={setWebsite}
+            onChangeOwnerName={setOwnerName}
+            onChangeOwnerRole={setOwnerRole}
+            onNext={() => {
+              if (website.trim() || ownerName.trim()) {
+                setStep("analysis");
+              } else {
+                nextStep();
+              }
+            }}
             onBack={prevStep}
+          />
+        )}
+
+        {step === "analysis" && (
+          <AnalysisStep
+            website={website}
+            ownerName={ownerName}
+            ownerRole={ownerRole}
+            onDone={(result) => {
+              setScanResult(result);
+              setStep("templates");
+            }}
+            onSkip={() => {
+              setStep("templates");
+            }}
           />
         )}
 

--- a/web/src/components/onboarding/wizard/Step3Identity.test.tsx
+++ b/web/src/components/onboarding/wizard/Step3Identity.test.tsx
@@ -10,6 +10,9 @@ interface Overrides {
   nexEmail?: string;
   nexSignupStatus?: "hidden" | "open" | "submitting" | "ok" | "fallback";
   nexSignupError?: string;
+  website?: string;
+  ownerName?: string;
+  ownerRole?: string;
 }
 
 function renderIdentity(
@@ -21,6 +24,9 @@ function renderIdentity(
     onChangeNexEmail: (v: string) => void;
     onSubmitNexSignup: () => void;
     onOpenNexSignup: () => void;
+    onChangeWebsite: (v: string) => void;
+    onChangeOwnerName: (v: string) => void;
+    onChangeOwnerRole: (v: string) => void;
     onNext: () => void;
     onBack: () => void;
   }> = {},
@@ -32,12 +38,18 @@ function renderIdentity(
     nexEmail: "",
     nexSignupStatus: "hidden" as const,
     nexSignupError: "",
+    website: "",
+    ownerName: "",
+    ownerRole: "",
     onChangeCompany: callbacks.onChangeCompany ?? (() => {}),
     onChangeDescription: callbacks.onChangeDescription ?? (() => {}),
     onChangePriority: callbacks.onChangePriority ?? (() => {}),
     onChangeNexEmail: callbacks.onChangeNexEmail ?? (() => {}),
     onSubmitNexSignup: callbacks.onSubmitNexSignup ?? (() => {}),
     onOpenNexSignup: callbacks.onOpenNexSignup ?? (() => {}),
+    onChangeWebsite: callbacks.onChangeWebsite ?? (() => {}),
+    onChangeOwnerName: callbacks.onChangeOwnerName ?? (() => {}),
+    onChangeOwnerRole: callbacks.onChangeOwnerRole ?? (() => {}),
     onNext: callbacks.onNext ?? (() => {}),
     onBack: callbacks.onBack ?? (() => {}),
     ...overrides,
@@ -53,26 +65,26 @@ function renderIdentity(
 describe("IdentityStep", () => {
   it("disables Continue when company or description are empty", () => {
     const { rerenderWith } = renderIdentity({ company: "", description: "" });
-    const cta = screen.getByRole("button", { name: /Choose a blueprint/i });
+    const cta = screen.getByRole("button", { name: /Continue/i });
     expect(cta).toBeDisabled();
 
     rerenderWith({ company: "Acme", description: "" });
     expect(
-      screen.getByRole("button", { name: /Choose a blueprint/i }),
+      screen.getByRole("button", { name: /Continue/i }),
     ).toBeDisabled();
   });
 
   it("enables Continue once both company and description are non-empty", () => {
     renderIdentity({ company: "Acme", description: "We sell things" });
     expect(
-      screen.getByRole("button", { name: /Choose a blueprint/i }),
+      screen.getByRole("button", { name: /Continue/i }),
     ).toBeEnabled();
   });
 
   it("treats whitespace-only inputs as empty (trim gate)", () => {
     renderIdentity({ company: "   ", description: "  " });
     expect(
-      screen.getByRole("button", { name: /Choose a blueprint/i }),
+      screen.getByRole("button", { name: /Continue/i }),
     ).toBeDisabled();
   });
 

--- a/web/src/components/onboarding/wizard/Step3Identity.tsx
+++ b/web/src/components/onboarding/wizard/Step3Identity.tsx
@@ -9,12 +9,18 @@ interface IdentityStepProps {
   nexEmail: string;
   nexSignupStatus: NexSignupStatus;
   nexSignupError: string;
+  website: string;
+  ownerName: string;
+  ownerRole: string;
   onChangeCompany: (v: string) => void;
   onChangeDescription: (v: string) => void;
   onChangePriority: (v: string) => void;
   onChangeNexEmail: (v: string) => void;
   onSubmitNexSignup: () => void;
   onOpenNexSignup: () => void;
+  onChangeWebsite: (v: string) => void;
+  onChangeOwnerName: (v: string) => void;
+  onChangeOwnerRole: (v: string) => void;
   onNext: () => void;
   onBack: () => void;
 }
@@ -26,12 +32,18 @@ export function IdentityStep({
   nexEmail,
   nexSignupStatus,
   nexSignupError,
+  website,
+  ownerName,
+  ownerRole,
   onChangeCompany,
   onChangeDescription,
   onChangePriority,
   onChangeNexEmail,
   onSubmitNexSignup,
   onOpenNexSignup,
+  onChangeWebsite,
+  onChangeOwnerName,
+  onChangeOwnerRole,
   onNext,
   onBack,
 }: IdentityStepProps) {
@@ -80,6 +92,47 @@ export function IdentityStep({
             onChange={(e) => onChangePriority(e.target.value)}
           />
         </div>
+        <div className="form-group">
+          <label className="label" htmlFor="wiz-website">
+            Company website <span className="label-optional">(optional)</span>
+          </label>
+          <input
+            className="input"
+            id="wiz-website"
+            type="url"
+            placeholder="https://acme.com"
+            autoComplete="url"
+            value={website}
+            onChange={(e) => onChangeWebsite(e.target.value)}
+          />
+        </div>
+        <div className="form-group form-group-row">
+          <div className="form-group">
+            <label className="label" htmlFor="wiz-owner-name">
+              Your name <span className="label-optional">(optional)</span>
+            </label>
+            <input
+              className="input"
+              id="wiz-owner-name"
+              placeholder="Nazz Mohammad"
+              autoComplete="name"
+              value={ownerName}
+              onChange={(e) => onChangeOwnerName(e.target.value)}
+            />
+          </div>
+          <div className="form-group">
+            <label className="label" htmlFor="wiz-owner-role">
+              Your role <span className="label-optional">(optional)</span>
+            </label>
+            <input
+              className="input"
+              id="wiz-owner-role"
+              placeholder="Founder, CTO..."
+              value={ownerRole}
+              onChange={(e) => onChangeOwnerRole(e.target.value)}
+            />
+          </div>
+        </div>
       </div>
 
       {nexSignupStatus === "hidden" ? (
@@ -112,7 +165,7 @@ export function IdentityStep({
           disabled={!canContinue}
           type="button"
         >
-          Choose a blueprint
+          Continue
           <ArrowIcon />
           <EnterHint />
         </button>

--- a/web/src/components/onboarding/wizard/Step3bAnalysis.tsx
+++ b/web/src/components/onboarding/wizard/Step3bAnalysis.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react";
+import type { OSScanResponse } from "../../../api/onboarding";
+
+interface AnalysisStepProps {
+  website: string;
+  ownerName: string;
+  ownerRole: string;
+  onDone: (result: OSScanResponse) => void;
+  onSkip: () => void;
+}
+
+type ScanStatus = "scanning" | "done-flash" | "revealing";
+
+export function AnalysisStep({
+  website,
+  ownerName,
+  ownerRole,
+  onDone,
+  onSkip,
+}: AnalysisStepProps) {
+  const [status, setStatus] = useState<ScanStatus>("scanning");
+  const [result, setResult] = useState<OSScanResponse | null>(null);
+  const [showContinue, setShowContinue] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function runScan() {
+      try {
+        const res = await fetch("/onboarding/scan", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            website_url: website,
+            file_paths: [],
+            owner_name: ownerName,
+            owner_role: ownerRole,
+          }),
+        });
+        if (!res.ok || cancelled) {
+          onSkip();
+          return;
+        }
+        const data: OSScanResponse = await res.json();
+        if (cancelled) return;
+        setResult(data);
+        setStatus("done-flash");
+        setTimeout(() => {
+          if (!cancelled) setStatus("revealing");
+        }, 200);
+      } catch {
+        if (!cancelled) onSkip();
+      }
+    }
+    void runScan();
+    return () => {
+      cancelled = true;
+    };
+  }, []); // only run once on mount
+
+  const items = result
+    ? [...(result.articles_written ?? []), ...(result.facts ?? [])]
+    : [];
+
+  useEffect(() => {
+    if (status !== "revealing") return;
+    const t = setTimeout(() => setShowContinue(true), items.length * 120 + 350);
+    return () => clearTimeout(t);
+  }, [status, items.length]);
+
+  return (
+    <div className="wizard-step">
+      <div className="wizard-panel">
+        {status === "scanning" && (
+          <div className="analysis-scanning">
+            <span className="analysis-spinner" aria-label="Scanning" />
+            <p className="analysis-status-text">Analyzing your company...</p>
+          </div>
+        )}
+        {status === "done-flash" && (
+          <p className="analysis-status-text analysis-done-flash">Done.</p>
+        )}
+        {status === "revealing" && result && (
+          <div className="analysis-reveal">
+            {result.articles_written?.map((article, i) => (
+              <div
+                key={article}
+                className="reveal-item"
+                style={{ ["--i" as string]: i } as React.CSSProperties}
+              >
+                <span className="reveal-check">✓</span>
+                <span className="reveal-article">{article}</span>
+                <span className="unread-dot" aria-hidden="true" />
+              </div>
+            ))}
+            {result.facts?.map((fact, i) => (
+              <div
+                key={fact}
+                className="reveal-item"
+                style={
+                  {
+                    ["--i" as string]:
+                      (result.articles_written?.length ?? 0) + i,
+                  } as React.CSSProperties
+                }
+              >
+                <span className="reveal-fact">{fact}</span>
+              </div>
+            ))}
+            {showContinue && (
+              <p className="analysis-caption">Your agents already know this.</p>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="wizard-nav">
+        <button className="btn btn-ghost" onClick={onSkip} type="button">
+          Skip
+        </button>
+        {showContinue && (
+          <button
+            className="btn btn-primary"
+            onClick={() => result && onDone(result)}
+            type="button"
+          >
+            Continue
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/wizard/types.ts
+++ b/web/src/components/onboarding/wizard/types.ts
@@ -37,6 +37,7 @@ export type WizardStep =
   | "welcome"
   | "templates"
   | "identity"
+  | "analysis"
   | "team"
   | "setup"
   | "task"

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -913,3 +913,99 @@
   color: var(--text-secondary);
   margin-top: 2px;
 }
+
+/* Company scan AnalysisStep */
+.analysis-scanning {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 0;
+}
+
+.analysis-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--border);
+  border-top-color: var(--purple, #7c3aed);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.analysis-status-text {
+  font-size: 15px;
+  color: var(--text-secondary, #666);
+}
+
+.analysis-done-flash {
+  color: var(--text, #1a1a1a);
+  font-weight: 500;
+}
+
+.analysis-reveal {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 0;
+}
+
+.analysis-caption {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--text-secondary, #888);
+  font-style: italic;
+}
+
+.reveal-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  animation: reveal-item 0.3s ease-out both;
+  animation-delay: calc(var(--i) * 120ms);
+}
+
+@keyframes reveal-item {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.reveal-check {
+  color: var(--green, #22c55e);
+  font-weight: 600;
+}
+
+.reveal-article {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--text-secondary, #555);
+}
+
+.reveal-fact {
+  color: var(--text-secondary, #555);
+}
+
+.unread-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--purple, #7c3aed);
+  flex-shrink: 0;
+}
+
+.label-optional {
+  font-size: 11px;
+  color: var(--text-tertiary, #999);
+  font-weight: normal;
+  margin-left: 4px;
+}
+
+.form-group-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}


### PR DESCRIPTION
## Summary

**Notebook auto-writer (PR 1)**
- Broker writes per-agent notebook entries automatically on key events (task assigned, request created, answer delivered, task completed) — agents get a persistent scratch space without any prompt engineering
- `WikiArchiver.Sweep` moves zero-read articles older than the cutoff to `.archive/` and replaces them with tombstones
- Fixes: cascade transitions deferred until after `saveLocked`; `request-answer` unblocks included in pending cascade; broker `Purge()` helper for test cleanup

**Company context scan (new)**
- Web wizard identity step gains optional website URL + owner name/role fields
- New `AnalysisStep` between identity and templates: fires `POST /onboarding/scan`, shows spinner → "Done." flash → staggered reveal checklist with extracted facts and article names
- Skip button sets `PendingCompanySeed: true`; broker clears and runs the seed job on next startup
- `SeedCompanyContext` pipeline: HTML fetch via `golang.org/x/net/html` (no regex), `pdftotext` PDF extraction, LLM extraction with JSON-fence stripping, atomic temp-dir-then-rename wiki writes to `team/about/company.md` + `owner.md` + `README.md`
- SSRF guard (scheme validation) and path-traversal guard (upload prefix check) on the scan handler
- TUI: 6 new init phases with `s`-to-skip and late `companyScanDoneMsg` guard
- Config: `OwnerName`, `OwnerRole`, `CompanyWebsite`, `PendingCompanySeed` fields; `CompanyContextBlock()` extended

## Test plan

- [ ] Web wizard: fill identity with website URL → AnalysisStep appears, shows reveal checklist, Continue advances to templates
- [ ] Web wizard: both website and owner fields empty → AnalysisStep skipped, goes straight to templates
- [ ] Web wizard: click Skip during scan → wizard advances immediately, `pending_company_seed: true` in config
- [ ] Broker start with `pending_company_seed: true` → `team/about/company.md` written, flag cleared
- [ ] TUI: `wuphf init`, fill website URL → scan runs, wiki articles written
- [ ] TUI: press `s` during scan → advances to done, `pending_company_seed: true`
- [ ] Go unit tests: `bash scripts/test-go.sh ./internal/operations/... ./internal/onboarding/... ./internal/tui/... ./internal/team/...`
- [ ] Web tests: `bash scripts/test-web.sh web/src/components/onboarding/wizard/Step3Identity.test.tsx`
- [ ] `team/about/README.md` written once (idempotent on second scan)
- [ ] Notebook entries appear in wiki after broker processes a completed task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Company context setup during onboarding: Collect website URL, company description, and owner information to personalize the system
  * Automatic notebook entries: Agent messages and task status changes are now recorded automatically in per-agent notebooks
  * Enhanced onboarding: Upload company documents and scan them for automated context extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->