### PR TITLE
fix(web): profile panel run rows display-only + normalizeStatus null guard

### DIFF
--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -150,22 +150,13 @@ function RecentRunsSection({ runs, loading }: RecentRunsSectionProps) {
               key={r.taskId}
               className="agent-profile-list-item agent-profile-run-item"
             >
-              <button
-                type="button"
-                className="agent-profile-run-btn"
-                onClick={() =>
-                  void router.navigate({
-                    to: "/apps/$appId",
-                    params: { appId: "activity" },
-                  })
-                }
-              >
+              <div className="agent-profile-run-row">
                 <span className="agent-profile-run-id">{r.taskId}</span>
                 <span className="agent-profile-run-meta">
                   {r.toolCallCount} tool call{r.toolCallCount === 1 ? "" : "s"}
                   {r.hasError ? " ⚠" : ""}
                 </span>
-              </button>
+              </div>
             </li>
           ))}
         </ul>

--- a/web/src/lib/officeStatus.ts
+++ b/web/src/lib/officeStatus.ts
@@ -7,6 +7,7 @@ import { formatRelativeTime } from "./format";
  * ArtifactsApp. Both files previously carried their own copy.
  */
 export function normalizeStatus(raw: string): string {
+  if (!raw) return "";
   const s = raw.toLowerCase().replace(/[\s-]+/g, "_");
   if (s === "completed") return "done";
   if (s === "in_review") return "review";

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -672,24 +672,26 @@
   width: 100%;
 }
 
-.agent-profile-run-btn,
+.agent-profile-run-row,
 .agent-profile-task-btn {
   display: flex;
   align-items: center;
   justify-content: space-between;
   width: 100%;
   gap: 8px;
-  background: transparent;
-  border: none;
-  cursor: pointer;
   padding: 3px 0;
-  text-align: left;
-  transition: color 0.15s;
   font-family: var(--font-sans);
   color: var(--text);
 }
 
-.agent-profile-run-btn:hover,
+.agent-profile-task-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.15s;
+}
+
 .agent-profile-task-btn:hover {
   color: var(--accent);
 }


### PR DESCRIPTION
## Summary

Follow-up fixes for two open CodeRabbit comments from PRs #712 and #734 that were missed before merge.

- **AgentProfilePanel** (`web/src/components/agents/AgentProfilePanel.tsx`): per-run buttons in `RecentRunsSection` navigated to the same `/apps/activity` URL as the "See all activity" button, making the per-row click misleading — it implied a specific run detail view that doesn't exist. Converts run rows to non-interactive `<div>` elements. Renames `.agent-profile-run-btn` → `.agent-profile-run-row` in CSS and splits interactive-only styles (`cursor`, `hover`, `transition`) to the task button selector only.

- **officeStatus** (`web/src/lib/officeStatus.ts`): `normalizeStatus` calls `raw.toLowerCase()` without a null/undefined guard. Adds `if (!raw) return ""` early return, matching the defensive pattern in `normalizeTaskStatus`.

## Test plan

- [ ] `bash scripts/test-web.sh web/src/components/agents/AgentProfilePanel.test.tsx` — 12/12 pass
- [ ] Verify agent profile panel renders run rows as non-clickable text (no pointer cursor, no hover color change)
- [ ] Verify "See all activity" button still navigates to `/apps/activity`
- [ ] Verify `normalizeStatus("")`, `normalizeStatus(null as any)` return `""` without throwing

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved status handling for empty or invalid input.

* **Refactor**
  * Agent profile recent runs are now displayed as non-interactive rows with task and error information instead of navigable buttons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->