### PR TITLE
docs(provider): clarify opencode is cloud-only, recommend ollama for custom endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ if I say yes. If I am not logged in, just open https://wuphf.team.
 | `--no-open` | Don't auto-open the browser |
 | `--pack <name>` | Pick an agent pack (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`, `revops`) |
 | `--opus-ceo` | Upgrade CEO from Sonnet to Opus |
-| `--provider <name>` | LLM provider override (`claude-code`, `codex`, `opencode`) |
+| `--provider <name>` | LLM provider override (`claude-code`, `codex`, `opencode`, `ollama`) |
 | `--collab` | Start in collaborative mode — all agents see all messages (this is the default) |
 | `--unsafe` | Bypass agent permission checks (local dev only) |
 | `--web-port <n>` | Change the web UI port (default 7891) |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,22 @@ if I say yes. If I am not logged in, just open https://wuphf.team.
 
 `--legacy-tui` is deprecated, slated for removal, and retained only while the desktop replacement lands.
 
+### Opencode and custom endpoints
+
+`--provider opencode` shells out to the `opencode` CLI binary. WUPHF does not
+own that provider's HTTP path, and `provider_endpoints.opencode.base_url` is not
+consulted.
+
+For custom OpenAI-compatible endpoints such as LiteLLM, OmniRoute, or local
+proxies, use `--provider ollama` and set `WUPHF_OLLAMA_BASE_URL` or
+`provider_endpoints.ollama.base_url`:
+
+```bash
+WUPHF_OLLAMA_BASE_URL="http://127.0.0.1:20128/v1" \
+WUPHF_OLLAMA_MODEL="openai/gpt-5.4-mini" \
+wuphf --provider ollama --memory-backend none --no-open
+```
+
 `--no-nex` still lets Telegram and any other local integration keep working. To switch back to CEO-routed delegation after launch, use `/focus` inside the office.
 
 ## Memory: Notebooks and the Wiki

--- a/internal/operations/company_seed_test.go
+++ b/internal/operations/company_seed_test.go
@@ -37,6 +37,7 @@ func TestSeedCompanyContext(t *testing.T) {
 
 	tests := []struct {
 		name                string
+		setup               func(t *testing.T) // optional per-case setup (e.g. env scrubbing)
 		input               func(wikiRoot string) CompanySeedInput
 		wantCompanyMD       bool
 		wantOwnerMD         bool
@@ -122,6 +123,14 @@ func TestSeedCompanyContext(t *testing.T) {
 		},
 		{
 			name: "pdftotext not found",
+			// extractPDF resolves pdftotext via exec.LookPath, which reads PATH
+			// from the environment on every call. Scrub PATH for this case so
+			// the not-installed branch fires regardless of whether the host
+			// (a developer Mac with poppler installed via Homebrew, say) has
+			// pdftotext available.
+			setup: func(t *testing.T) {
+				t.Setenv("PATH", "")
+			},
 			input: func(wikiRoot string) CompanySeedInput {
 				return CompanySeedInput{
 					WikiRoot:  wikiRoot,
@@ -136,6 +145,9 @@ func TestSeedCompanyContext(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.setup != nil {
+				tc.setup(t)
+			}
 			wikiRoot := t.TempDir()
 			input := tc.input(wikiRoot)
 


### PR DESCRIPTION
## Summary
Documents that `--provider opencode` shells out to the `opencode` CLI binary and that `provider_endpoints.opencode.base_url` is not consulted on that path. Recommends `--provider ollama` with `WUPHF_OLLAMA_BASE_URL` for users who want a custom OpenAI-compatible endpoint. Also fixes a `TestSeedCompanyContext/pdftotext_not_found` subtest that fails on macOS dev boxes with `poppler` installed.

## Why this matters
- Issue: [#582](https://github.com/nex-crm/wuphf/issues/582) - "provider opencode routes to OpenCode.ai directly, ignores base_url override". The reporter explicitly offers two acceptable resolutions: (1) make opencode respect `provider_endpoints.opencode.base_url`, or (2) clarify in docs that opencode is a CLI-subprocess provider with no base_url override and recommend ollama for custom endpoints. This PR ships option 2.
- `internal/provider/opencode.go` registers `KindOpencode` with `CreateOpencodeCLIStreamFn`, which shells out to the `opencode` binary. WUPHF makes no HTTP requests to opencode.ai - the `https://opencode.ai/zen/...` URL the reporter saw is emitted by the opencode binary itself. Option 1 would require the opencode CLI to support endpoint override, which is upstream-unknown.
- The reporter already confirmed in the issue that `--provider ollama` with `WUPHF_OLLAMA_BASE_URL` works for custom OpenAI-compatible endpoints (LiteLLM, OmniRoute, local proxies). The docs change makes this discoverable.

## Changes
- `README.md` adds an `Opencode and custom endpoints` subsection in the providers area. Explains the CLI-subprocess shape and points users at `--provider ollama` for custom endpoints, with the reporter's working snippet as a code block.
- `internal/operations/company_seed_test.go` - adds an optional `setup func(t *testing.T)` field to `TestSeedCompanyContext`, used only by the `pdftotext not found` case to `t.Setenv("PATH", "")`. The case relies on `extractPDF`'s `exec.LookPath("pdftotext")` returning an error, but on a Mac with `poppler` installed `pdftotext` IS on PATH and the not-installed warning never fires. Scrubbing PATH in the per-case setup makes the test deterministic on any host.

## Testing
- `bash scripts/test-go.sh ./internal/operations` -> ok, including the previously flaky `pdftotext_not_found` subtest.
- Full pre-push hook suite green: build, complexity-baseline, file-size, smoke, vhs, web-unit (1438 tests), go-unit.

Fixes #582

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring custom endpoints, including support for the new provider option and integration with Ollama for OpenAI‑compatible services.
* **Tests**
  * Improved test coverage for document-processing edge cases to make missing-tool scenarios deterministic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->