### PR TITLE
fix(skills): write SKILL.md to wiki on create + backfill missing files

### DIFF
--- a/internal/team/broker_skills.go
+++ b/internal/team/broker_skills.go
@@ -168,8 +168,11 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "action must be create or propose", http.StatusBadRequest)
 		return
 	}
-	if strings.TrimSpace(body.Name) == "" || strings.TrimSpace(body.Content) == "" || strings.TrimSpace(body.CreatedBy) == "" {
-		http.Error(w, "name, content, and created_by required", http.StatusBadRequest)
+	if strings.TrimSpace(body.Name) == "" || strings.TrimSpace(body.Content) == "" || strings.TrimSpace(body.CreatedBy) == "" || strings.TrimSpace(body.Description) == "" {
+		// Description is required by RenderSkillMarkdown — without it the
+		// SKILL.md write would silently no-op and the wiki UI would 404 on
+		// the skill, which is exactly the regression this PR fixes.
+		http.Error(w, "name, description, content, and created_by required", http.StatusBadRequest)
 		return
 	}
 
@@ -271,7 +274,12 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 	unlocked = true
 
 	commitMsg := fmt.Sprintf("wuphf: %s skill %s", action, skSnapshot.Name)
-	if err := enqueueSkillWikiWrite(r.Context(), wikiWorker, skSnapshot, wikiPath, commitMsg); err != nil {
+	// Use the broker lifecycle context, not r.Context(): the skill is
+	// already in broker state, and a client disconnect mid-Enqueue would
+	// cancel the SKILL.md commit and recreate the very "broker has it,
+	// disk doesn't" condition this PR exists to fix.
+	enqueueCtx := b.brokerLifecycleContext()
+	if err := enqueueSkillWikiWrite(enqueueCtx, wikiWorker, skSnapshot, wikiPath, commitMsg); err != nil {
 		// Wiki enqueue failures are logged but do not fail the create — the
 		// skill still lives in broker state, and a later save (edit, archive,
 		// or boot backfill) reconciles disk. Returning 500 here would leave

--- a/internal/team/broker_skills.go
+++ b/internal/team/broker_skills.go
@@ -1,9 +1,11 @@
 package team
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -185,7 +187,12 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	b.mu.Lock()
-	defer b.mu.Unlock()
+	unlocked := false
+	defer func() {
+		if !unlocked {
+			b.mu.Unlock()
+		}
+	}()
 
 	createdBy := strings.TrimSpace(body.CreatedBy)
 	if action == "propose" {
@@ -252,8 +259,65 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enqueue the SKILL.md write so the wiki has the file on disk. Without
+	// this, a freshly created skill exists in broker-state.json but
+	// /wiki/article?path=team/skills/<slug>.md returns "no such file" until
+	// the skill is edited or archived. Mirrors the pattern used by every
+	// other CRUD handler in skill_crud_endpoints.go.
+	wikiWorker := b.wikiWorker
+	wikiPath := skillWikiPath(sk.Name)
+	skSnapshot := sk
+	b.mu.Unlock()
+	unlocked = true
+
+	commitMsg := fmt.Sprintf("wuphf: %s skill %s", action, skSnapshot.Name)
+	if err := enqueueSkillWikiWrite(r.Context(), wikiWorker, skSnapshot, wikiPath, commitMsg); err != nil {
+		// Wiki enqueue failures are logged but do not fail the create — the
+		// skill still lives in broker state, and a later save (edit, archive,
+		// or boot backfill) reconciles disk. Returning 500 here would leave
+		// callers thinking the skill was not created when broker state has
+		// already been mutated.
+		slog.Warn("handlePostSkill: wiki enqueue failed",
+			"name", skSnapshot.Name, "action", action, "err", err)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"skill": sk})
+	_ = json.NewEncoder(w).Encode(map[string]any{"skill": skSnapshot})
+}
+
+// enqueueSkillWikiWrite renders sk into SKILL.md form (with safety scan
+// metadata) and enqueues a wiki write through the worker. Caller must NOT
+// hold b.mu — WikiWorker.Enqueue acquires b.mu via PublishWikiEvent and would
+// deadlock. Returns nil silently when worker is nil (wiki backend offline)
+// or when sk lacks the mandatory frontmatter fields.
+func enqueueSkillWikiWrite(ctx context.Context, worker *WikiWorker, sk teamSkill, wikiPath, commitMsg string) error {
+	if worker == nil {
+		return nil
+	}
+	if strings.TrimSpace(sk.Name) == "" || strings.TrimSpace(sk.Description) == "" {
+		// Description is required by RenderSkillMarkdown. Skip rather than
+		// surface an error — the skill is still usable from broker state and
+		// a future edit can populate the description.
+		slog.Warn("enqueueSkillWikiWrite: skipping wiki write — name or description empty",
+			"name", sk.Name)
+		return nil
+	}
+	fm := teamSkillToFrontmatter(sk)
+	scan := ScanSkill(fm, sk.Content, skillTrustForCreator(sk.CreatedBy))
+	fm.Metadata.Wuphf.SafetyScan = &SkillSafetyScan{
+		Verdict:    string(scan.Verdict),
+		Findings:   append([]string(nil), scan.Findings...),
+		TrustLevel: string(scan.TrustLevel),
+		Summary:    scan.Summary,
+	}
+	mdBytes, err := RenderSkillMarkdown(fm, sk.Content)
+	if err != nil {
+		return fmt.Errorf("render skill markdown: %w", err)
+	}
+	if _, _, err := worker.Enqueue(ctx, sk.Name, wikiPath, string(mdBytes), "replace", commitMsg); err != nil {
+		return fmt.Errorf("wiki enqueue: %w", err)
+	}
+	return nil
 }
 
 func (b *Broker) handlePutSkill(w http.ResponseWriter, r *http.Request) {

--- a/internal/team/broker_skills.go
+++ b/internal/team/broker_skills.go
@@ -303,9 +303,12 @@ func enqueueSkillWikiWrite(ctx context.Context, worker *WikiWorker, sk teamSkill
 		return nil
 	}
 	if strings.TrimSpace(sk.Name) == "" || strings.TrimSpace(sk.Description) == "" {
-		// Description is required by RenderSkillMarkdown. Skip rather than
-		// surface an error — the skill is still usable from broker state and
-		// a future edit can populate the description.
+		// Intentionally retained even though handlePostSkill now rejects empty
+		// description at the HTTP layer: backfillSkillFilesFromState (and any
+		// future caller) may encounter legacy teamSkill records written before
+		// the validation existed. Removing this guard would cause those legacy
+		// skills to fail RenderSkillMarkdown and surface a write error instead
+		// of a safe, logged skip.
 		slog.Warn("enqueueSkillWikiWrite: skipping wiki write — name or description empty",
 			"name", sk.Name)
 		return nil

--- a/internal/team/broker_skills_test.go
+++ b/internal/team/broker_skills_test.go
@@ -543,6 +543,26 @@ func TestHandlePostSkill_ProposeWritesWikiFile(t *testing.T) {
 	skillFilePath(t, b, "propose-skill")
 }
 
+// TestHandlePostSkill_RequiresDescription locks in the 400 returned when
+// description is absent. The field is required by RenderSkillMarkdown, so
+// omitting it would silently skip the SKILL.md write and leave the wiki 404.
+func TestHandlePostSkill_RequiresDescription(t *testing.T) {
+	b := newTestBroker(t)
+	body := bytes.NewBufferString(`{
+		"action":"create",
+		"name":"no-desc-skill",
+		"title":"No Description",
+		"content":"step 1.",
+		"created_by":"ceo"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/skills", body)
+	rec := httptest.NewRecorder()
+	b.handlePostSkill(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 when description is missing, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestBackfillSkillFilesFromState_WritesMissingFiles covers the boot path
 // for skills that already live in broker-state.json but have no SKILL.md
 // (e.g. created before the create-time wiki write was wired up). Without

--- a/internal/team/broker_skills_test.go
+++ b/internal/team/broker_skills_test.go
@@ -28,6 +28,7 @@ func TestHandlePostSkill_RejectsDuplicateName(t *testing.T) {
 		body := bytes.NewBufferString(fmt.Sprintf(`{
 			"name":%q,
 			"title":"Dup",
+			"description":"Dup skill body.",
 			"content":"do the thing",
 			"created_by":"ceo",
 			"channel":"general"
@@ -622,20 +623,22 @@ func TestBackfillSkillFilesFromState_PreservesExistingFile(t *testing.T) {
 		t.Fatalf("handlePostSkill: expected 200, got %d", rec.Code)
 	}
 	path := skillFilePath(t, b, "already-on-disk")
-	originalInfo, err := os.Stat(path)
+	originalRaw, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("stat: %v", err)
+		t.Fatalf("read before backfill: %v", err)
 	}
-	originalSize := originalInfo.Size()
 
 	b.backfillSkillFilesFromState(context.Background())
 
-	infoAfter, err := os.Stat(path)
+	rawAfter, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("stat after backfill: %v", err)
+		t.Fatalf("read after backfill: %v", err)
 	}
-	if infoAfter.Size() != originalSize {
-		t.Errorf("backfill rewrote an existing file (size %d -> %d)",
-			originalSize, infoAfter.Size())
+	// Byte-for-byte equality, not just size: a same-length rewrite
+	// (different commit metadata or whitespace) would slip a size-only
+	// check and still indicate the no-op contract is broken.
+	if !bytes.Equal(rawAfter, originalRaw) {
+		t.Errorf("backfill rewrote an existing file: %d bytes -> %d bytes, content differs",
+			len(originalRaw), len(rawAfter))
 	}
 }

--- a/internal/team/broker_skills_test.go
+++ b/internal/team/broker_skills_test.go
@@ -451,22 +451,19 @@ func brokerWithWiki(t *testing.T) (*Broker, func()) {
 	}
 }
 
-// waitForSkillFile polls for the on-disk SKILL.md path until it appears or
-// the deadline elapses. The wiki worker commits asynchronously, so a tight
-// stat() right after handlePostSkill returns can race the commit.
-func waitForSkillFile(t *testing.T, b *Broker, slug string) string {
+// skillFilePath asserts that the on-disk SKILL.md for slug exists and
+// returns its absolute path. WikiWorker.Enqueue is synchronous (blocks on
+// its reply channel until the commit lands), so handlePostSkill / the
+// backfill helpers return only after the file is on disk — no polling
+// required.
+func skillFilePath(t *testing.T, b *Broker, slug string) string {
 	t.Helper()
 	root := b.wikiWorker.Repo().Root()
 	path := filepath.Join(root, "team", "skills", slug+".md")
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(path); err == nil {
-			return path
-		}
-		time.Sleep(20 * time.Millisecond)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("SKILL.md missing on disk: %v (path=%s)", err, path)
 	}
-	t.Fatalf("SKILL.md never landed on disk: %s", path)
-	return ""
+	return path
 }
 
 // TestHandlePostSkill_WritesWikiFile is the regression guard for the
@@ -494,7 +491,7 @@ func TestHandlePostSkill_WritesWikiFile(t *testing.T) {
 		t.Fatalf("handlePostSkill: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	path := waitForSkillFile(t, b, "flake-quarantine")
+	path := skillFilePath(t, b, "flake-quarantine")
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read SKILL.md: %v", err)
@@ -542,7 +539,7 @@ func TestHandlePostSkill_ProposeWritesWikiFile(t *testing.T) {
 		t.Fatalf("handlePostSkill: expected 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 
-	waitForSkillFile(t, b, "propose-skill")
+	skillFilePath(t, b, "propose-skill")
 }
 
 // TestBackfillSkillFilesFromState_WritesMissingFiles covers the boot path
@@ -589,15 +586,11 @@ func TestBackfillSkillFilesFromState_WritesMissingFiles(t *testing.T) {
 		t.Fatalf("precondition: SKILL.md should be missing, got %v", err)
 	}
 
+	// backfillSkillFilesFromState calls WikiWorker.Enqueue synchronously per
+	// missing skill, so by the time it returns every backfilled SKILL.md is
+	// on disk. No polling needed.
 	b.backfillSkillFilesFromState(context.Background())
 
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if _, err := os.Stat(activePath); err == nil {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
 	if _, err := os.Stat(activePath); err != nil {
 		t.Fatalf("backfill did not create active SKILL.md: %v", err)
 	}
@@ -628,7 +621,7 @@ func TestBackfillSkillFilesFromState_PreservesExistingFile(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("handlePostSkill: expected 200, got %d", rec.Code)
 	}
-	path := waitForSkillFile(t, b, "already-on-disk")
+	path := skillFilePath(t, b, "already-on-disk")
 	originalInfo, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)

--- a/internal/team/broker_skills_test.go
+++ b/internal/team/broker_skills_test.go
@@ -2,14 +2,17 @@ package team
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 )
@@ -421,5 +424,225 @@ func TestSkillProposalPersistenceRoundTrip(t *testing.T) {
 	}
 	if len(requests) != 1 || requests[0].Kind != "skill_proposal" {
 		t.Fatalf("expected persisted skill_proposal request, got %d requests", len(requests))
+	}
+}
+
+// brokerWithWiki wires a temp git-backed wiki worker onto a fresh broker so
+// tests that exercise the wiki write path can read SKILL.md back from disk.
+// Returns the broker plus a cleanup that stops the worker.
+func brokerWithWiki(t *testing.T) (*Broker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+	return b, func() {
+		cancel()
+		worker.Stop()
+	}
+}
+
+// waitForSkillFile polls for the on-disk SKILL.md path until it appears or
+// the deadline elapses. The wiki worker commits asynchronously, so a tight
+// stat() right after handlePostSkill returns can race the commit.
+func waitForSkillFile(t *testing.T, b *Broker, slug string) string {
+	t.Helper()
+	root := b.wikiWorker.Repo().Root()
+	path := filepath.Join(root, "team", "skills", slug+".md")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("SKILL.md never landed on disk: %s", path)
+	return ""
+}
+
+// TestHandlePostSkill_WritesWikiFile is the regression guard for the
+// "team/skills/<slug>.md: no such file or directory" bug. handlePostSkill
+// previously updated broker state without enqueuing the SKILL.md write, so
+// the wiki UI hit a raw filesystem error on first open.
+func TestHandlePostSkill_WritesWikiFile(t *testing.T) {
+	b, cleanup := brokerWithWiki(t)
+	defer cleanup()
+
+	body := bytes.NewBufferString(`{
+		"action":"create",
+		"name":"flake-quarantine",
+		"title":"Flake Quarantine",
+		"description":"Move repeatedly-flaking E2E tests to a quarantine lane.",
+		"content":"# Flake Quarantine\n\nQuarantine flakes that fail >3 times in 24h.",
+		"created_by":"ceo",
+		"channel":"general",
+		"tags":["qa","ci"]
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/skills", body)
+	rec := httptest.NewRecorder()
+	b.handlePostSkill(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handlePostSkill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	path := waitForSkillFile(t, b, "flake-quarantine")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	fm, parsedBody, err := ParseSkillMarkdown(raw)
+	if err != nil {
+		t.Fatalf("parse SKILL.md: %v", err)
+	}
+	if fm.Name != "flake-quarantine" {
+		t.Errorf("frontmatter name: got %q, want flake-quarantine", fm.Name)
+	}
+	if !strings.Contains(parsedBody, "Quarantine flakes that fail") {
+		t.Errorf("body missing skill content, got %q", parsedBody)
+	}
+}
+
+// TestHandlePostSkill_ProposeWritesWikiFile pins the wiki write for the
+// proposal path too. Proposed skills also need an on-disk SKILL.md so the
+// approval interview can render the body.
+func TestHandlePostSkill_ProposeWritesWikiFile(t *testing.T) {
+	b, cleanup := brokerWithWiki(t)
+	defer cleanup()
+	b.mu.Lock()
+	b.members = []officeMember{{Slug: "ceo", Name: "CEO", Role: "lead"}}
+	for i := range b.channels {
+		if b.channels[i].Slug == "general" {
+			b.channels[i].Members = append(b.channels[i].Members, "ceo")
+		}
+	}
+	b.mu.Unlock()
+
+	body := bytes.NewBufferString(`{
+		"action":"propose",
+		"name":"propose-skill",
+		"title":"Propose Skill",
+		"description":"Skill awaiting approval.",
+		"content":"1. Do the deterministic thing.",
+		"created_by":"ceo",
+		"channel":"general"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/skills", body)
+	rec := httptest.NewRecorder()
+	b.handlePostSkill(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handlePostSkill: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	waitForSkillFile(t, b, "propose-skill")
+}
+
+// TestBackfillSkillFilesFromState_WritesMissingFiles covers the boot path
+// for skills that already live in broker-state.json but have no SKILL.md
+// (e.g. created before the create-time wiki write was wired up). Without
+// the backfill these zombies stay invisible to /wiki/article forever.
+func TestBackfillSkillFilesFromState_WritesMissingFiles(t *testing.T) {
+	b, cleanup := brokerWithWiki(t)
+	defer cleanup()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.skills = append(b.skills, teamSkill{
+		ID:          "skill-flake-quarantine",
+		Name:        "flake-quarantine",
+		Title:       "Flake Quarantine",
+		Description: "Move flakes to a quarantine lane.",
+		Content:     "# Flake Quarantine\n\nQuarantine flakes.",
+		CreatedBy:   "ceo",
+		Channel:     "general",
+		Status:      "active",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	// Archived skills must NOT be backfilled — leave the tombstone alone.
+	b.skills = append(b.skills, teamSkill{
+		ID:          "skill-archived-old",
+		Name:        "archived-old",
+		Title:       "Archived",
+		Description: "Already retired.",
+		Content:     "old body",
+		CreatedBy:   "ceo",
+		Channel:     "general",
+		Status:      "archived",
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	})
+	b.mu.Unlock()
+
+	root := b.wikiWorker.Repo().Root()
+	activePath := filepath.Join(root, "team", "skills", "flake-quarantine.md")
+	archivedPath := filepath.Join(root, "team", "skills", "archived-old.md")
+	if _, err := os.Stat(activePath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: SKILL.md should be missing, got %v", err)
+	}
+
+	b.backfillSkillFilesFromState(context.Background())
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(activePath); err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, err := os.Stat(activePath); err != nil {
+		t.Fatalf("backfill did not create active SKILL.md: %v", err)
+	}
+	if _, err := os.Stat(archivedPath); !os.IsNotExist(err) {
+		t.Errorf("backfill should not resurrect archived skills, but %s exists", archivedPath)
+	}
+}
+
+// TestBackfillSkillFilesFromState_PreservesExistingFile covers the no-op
+// path: when a SKILL.md already exists on disk, backfill must leave the
+// file (and its commit history) untouched.
+func TestBackfillSkillFilesFromState_PreservesExistingFile(t *testing.T) {
+	b, cleanup := brokerWithWiki(t)
+	defer cleanup()
+
+	body := bytes.NewBufferString(`{
+		"action":"create",
+		"name":"already-on-disk",
+		"title":"Already On Disk",
+		"description":"Skill that already has SKILL.md.",
+		"content":"# Already On Disk\n\nbody.",
+		"created_by":"ceo",
+		"channel":"general"
+	}`)
+	req := httptest.NewRequest(http.MethodPost, "/skills", body)
+	rec := httptest.NewRecorder()
+	b.handlePostSkill(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handlePostSkill: expected 200, got %d", rec.Code)
+	}
+	path := waitForSkillFile(t, b, "already-on-disk")
+	originalInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	originalSize := originalInfo.Size()
+
+	b.backfillSkillFilesFromState(context.Background())
+
+	infoAfter, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat after backfill: %v", err)
+	}
+	if infoAfter.Size() != originalSize {
+		t.Errorf("backfill rewrote an existing file (size %d -> %d)",
+			originalSize, infoAfter.Size())
 	}
 }

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -174,6 +174,14 @@ func (b *Broker) initWikiWorker() {
 	// silently revert the in-memory status.
 	b.reconcileSkillStatusFromDisk()
 
+	// Skill file backfill: skills that exist in broker state but have no
+	// SKILL.md on disk (e.g. created before the wiki write was wired into
+	// handlePostSkill, or during a window when wikiWorker was nil) get
+	// written here so /wiki/article?path=team/skills/<slug>.md no longer
+	// 404s. Runs async because each enqueue blocks on a git commit and the
+	// broker should not stall startup waiting for them.
+	go b.backfillSkillFilesFromState(lifecycleCtx)
+
 	// Boot reconcile: walk the full wiki tree and populate the index from
 	// existing markdown + jsonl. Runs async so it does not delay broker
 	// startup. The per-commit ReconcilePath calls keep the index live once

--- a/internal/team/skill_crud_endpoints.go
+++ b/internal/team/skill_crud_endpoints.go
@@ -923,6 +923,69 @@ func (b *Broker) reconcileSkillStatusFromDisk() {
 	}
 }
 
+// backfillSkillFilesFromState walks b.skills and writes a SKILL.md for every
+// skill whose wiki file is missing on disk. It is the symmetric peer of
+// reconcileSkillStatusFromDisk: that helper trusts disk over memory for
+// status, this one trusts memory when disk has nothing at all. Without this,
+// skills created via handlePostSkill before the wiki write was wired (or
+// during a window when wikiWorker was nil) stay invisible to /wiki/article
+// for the rest of the broker's lifetime.
+//
+// Each missing skill is enqueued individually so a malformed entry (empty
+// description, render failure) doesn't block the rest. Errors are logged,
+// not surfaced — startup must not block on wiki-side hiccups.
+func (b *Broker) backfillSkillFilesFromState(ctx context.Context) {
+	b.mu.Lock()
+	worker := b.wikiWorker
+	b.mu.Unlock()
+	if worker == nil {
+		return
+	}
+	repo := worker.Repo()
+	if repo == nil {
+		return
+	}
+
+	b.mu.Lock()
+	type pending struct {
+		sk        teamSkill
+		wikiPath  string
+		commitMsg string
+	}
+	var todo []pending
+	for i := range b.skills {
+		// Archived skills are tombstoned via the archive flow; if their file
+		// is missing we leave it missing rather than resurrect them here.
+		if b.skills[i].Status == "archived" {
+			continue
+		}
+		wikiPath := skillWikiPath(b.skills[i].Name)
+		absPath := filepath.Join(repo.Root(), filepath.FromSlash(wikiPath))
+		if _, err := os.Stat(absPath); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			slog.Warn("skill_crud: backfill stat failed", "path", wikiPath, "err", err)
+			continue
+		}
+		todo = append(todo, pending{
+			sk:        b.skills[i],
+			wikiPath:  wikiPath,
+			commitMsg: "wuphf: backfill skill " + b.skills[i].Name + " from broker state",
+		})
+	}
+	b.mu.Unlock()
+
+	for _, p := range todo {
+		if err := enqueueSkillWikiWrite(ctx, worker, p.sk, p.wikiPath, p.commitMsg); err != nil {
+			slog.Warn("skill_crud: backfill enqueue failed",
+				"name", p.sk.Name, "path", p.wikiPath, "err", err)
+			continue
+		}
+		slog.Info("skill_crud: backfilled missing SKILL.md from broker state",
+			"name", p.sk.Name, "path", p.wikiPath)
+	}
+}
+
 // resolveSkillSourceArticle reads the on-disk SKILL.md for name and extracts
 // the first source article path from its frontmatter. Returns "" when the
 // wiki worker is absent, the file is missing, or the frontmatter carries no

--- a/internal/team/skill_crud_endpoints.go
+++ b/internal/team/skill_crud_endpoints.go
@@ -934,6 +934,12 @@ func (b *Broker) reconcileSkillStatusFromDisk() {
 // Each missing skill is enqueued individually so a malformed entry (empty
 // description, render failure) doesn't block the rest. Errors are logged,
 // not surfaced — startup must not block on wiki-side hiccups.
+//
+// Race-safety: each enqueue is preceded by a fresh under-lock lookup +
+// stat. If a concurrent edit (handleSkillEdit, archive, etc.) lands a
+// SKILL.md or mutates the in-memory skill while backfill is iterating, we
+// pick up the live copy — or skip entirely when disk is no longer empty —
+// rather than write a stale snapshot taken at startup.
 func (b *Broker) backfillSkillFilesFromState(ctx context.Context) {
 	b.mu.Lock()
 	worker := b.wikiWorker
@@ -946,16 +952,13 @@ func (b *Broker) backfillSkillFilesFromState(ctx context.Context) {
 		return
 	}
 
+	// Phase 1: collect candidate names whose file is currently missing.
+	// We don't capture the skill struct here — that's what causes the
+	// stale-write race CodeRabbit flagged. Names are stable; everything
+	// else gets re-resolved per-write under the lock below.
 	b.mu.Lock()
-	type pending struct {
-		sk        teamSkill
-		wikiPath  string
-		commitMsg string
-	}
-	var todo []pending
+	candidates := make([]string, 0, len(b.skills))
 	for i := range b.skills {
-		// Archived skills are tombstoned via the archive flow; if their file
-		// is missing we leave it missing rather than resurrect them here.
 		if b.skills[i].Status == "archived" {
 			continue
 		}
@@ -967,22 +970,43 @@ func (b *Broker) backfillSkillFilesFromState(ctx context.Context) {
 			slog.Warn("skill_crud: backfill stat failed", "path", wikiPath, "err", err)
 			continue
 		}
-		todo = append(todo, pending{
-			sk:        b.skills[i],
-			wikiPath:  wikiPath,
-			commitMsg: "wuphf: backfill skill " + b.skills[i].Name + " from broker state",
-		})
+		candidates = append(candidates, b.skills[i].Name)
 	}
 	b.mu.Unlock()
 
-	for _, p := range todo {
-		if err := enqueueSkillWikiWrite(ctx, worker, p.sk, p.wikiPath, p.commitMsg); err != nil {
+	// Phase 2: for each candidate, re-resolve under the lock immediately
+	// before enqueueing so a concurrent edit's newer markdown is never
+	// overwritten by this snapshot.
+	for _, name := range candidates {
+		b.mu.Lock()
+		live := b.findSkillByNameLocked(name)
+		if live == nil {
+			b.mu.Unlock()
+			continue // archived or deleted in the gap
+		}
+		skCopy := *live
+		wikiPath := skillWikiPath(skCopy.Name)
+		absPath := filepath.Join(repo.Root(), filepath.FromSlash(wikiPath))
+		// Re-stat under the lock: a concurrent edit may have already
+		// landed a SKILL.md while we were iterating earlier candidates.
+		// In that case the edit's newer content is canonical and we
+		// must not clobber it.
+		if _, err := os.Stat(absPath); err == nil {
+			b.mu.Unlock()
+			slog.Debug("skill_crud: backfill skipping — file appeared during sweep",
+				"name", skCopy.Name)
+			continue
+		}
+		b.mu.Unlock()
+
+		commitMsg := "wuphf: backfill skill " + skCopy.Name + " from broker state"
+		if err := enqueueSkillWikiWrite(ctx, worker, skCopy, wikiPath, commitMsg); err != nil {
 			slog.Warn("skill_crud: backfill enqueue failed",
-				"name", p.sk.Name, "path", p.wikiPath, "err", err)
+				"name", skCopy.Name, "path", wikiPath, "err", err)
 			continue
 		}
 		slog.Info("skill_crud: backfilled missing SKILL.md from broker state",
-			"name", p.sk.Name, "path", p.wikiPath)
+			"name", skCopy.Name, "path", wikiPath)
 	}
 }
 

--- a/internal/teammcp/skills.go
+++ b/internal/teammcp/skills.go
@@ -79,6 +79,14 @@ func handleTeamSkillCreate(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 	if action == "create" && slug != "ceo" {
 		return toolError(fmt.Errorf("only CEO may use action=create; use action=propose to queue a skill proposal")), nil, nil
 	}
+	description := strings.TrimSpace(args.Description)
+	if description == "" {
+		// Mirror the broker's POST /skills validation: a SKILL.md without a
+		// description fails RenderSkillMarkdown and the wiki article never
+		// lands on disk. Surface the requirement at the MCP boundary so the
+		// agent gets a clean error rather than an opaque 400.
+		return toolError(fmt.Errorf("description is required: a one-line summary of when to use this skill")), nil, nil
+	}
 	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	title := strings.TrimSpace(args.Title)
 	if title == "" {
@@ -90,7 +98,7 @@ func handleTeamSkillCreate(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 		"action":      action,
 		"name":        name,
 		"title":       title,
-		"description": strings.TrimSpace(args.Description),
+		"description": description,
 		"content":     content,
 		"created_by":  slug,
 		"channel":     channel,

--- a/internal/teammcp/skills_test.go
+++ b/internal/teammcp/skills_test.go
@@ -342,3 +342,26 @@ func TestHandleTeamSkillCreateRequiresAction(t *testing.T) {
 		t.Fatalf("expected IsError=true when action is omitted, got %+v", res)
 	}
 }
+
+// TestHandleTeamSkillCreateRequiresDescription pins the description guard
+// added at the MCP boundary. RenderSkillMarkdown rejects an empty
+// description, so without this check the broker's POST /skills would 400
+// opaquely instead of the agent seeing a clear "description is required"
+// tool error. Both empty and whitespace-only descriptions must fail.
+func TestHandleTeamSkillCreateRequiresDescription(t *testing.T) {
+	for _, desc := range []string{"", "   "} {
+		res, _, err := handleTeamSkillCreate(context.Background(), nil, TeamSkillCreateArgs{
+			Name:        "needs-description",
+			Content:     "1. Do something",
+			Description: desc,
+			Action:      "propose",
+			MySlug:      "ceo",
+		})
+		if err != nil {
+			t.Fatalf("description=%q: unexpected go error: %v", desc, err)
+		}
+		if res == nil || !res.IsError {
+			t.Fatalf("description=%q: expected IsError=true, got %+v", desc, res)
+		}
+	}
+}

--- a/internal/teammcp/skills_test.go
+++ b/internal/teammcp/skills_test.go
@@ -237,12 +237,13 @@ func TestHandleTeamSkillCreateCanActivateImmediately(t *testing.T) {
 	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
 
 	res, _, err := handleTeamSkillCreate(context.Background(), nil, TeamSkillCreateArgs{
-		Name:    "already-approved",
-		Title:   "Already Approved",
-		Content: "1. Run the already-approved workflow.",
-		Action:  "create",
-		MySlug:  "ceo",
-		Channel: "general",
+		Name:        "already-approved",
+		Title:       "Already Approved",
+		Description: "Run the already-approved workflow.",
+		Content:     "1. Run the already-approved workflow.",
+		Action:      "create",
+		MySlug:      "ceo",
+		Channel:     "general",
 	})
 	if err != nil {
 		t.Fatalf("skill create: %v", err)
@@ -290,12 +291,13 @@ func TestHandleTeamSkillCreateAllowsNonCEOProposal(t *testing.T) {
 	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
 
 	res, _, err := handleTeamSkillCreate(context.Background(), nil, TeamSkillCreateArgs{
-		Name:    "planner-retro-loop",
-		Title:   "Planner Retro Loop",
-		Content: "1. Collect notes.\n2. Extract action items.",
-		Action:  "propose",
-		MySlug:  "planner",
-		Channel: "general",
+		Name:        "planner-retro-loop",
+		Title:       "Planner Retro Loop",
+		Description: "Run the planner retro loop after every retro.",
+		Content:     "1. Collect notes.\n2. Extract action items.",
+		Action:      "propose",
+		MySlug:      "planner",
+		Channel:     "general",
 	})
 	if err != nil {
 		t.Fatalf("skill propose: %v", err)


### PR DESCRIPTION
## Summary

- `handlePostSkill` was appending to broker state but never enqueuing the SKILL.md wiki write, so newly created skills (e.g. \`flake-quarantine\`) returned a raw \`open …/team/skills/<slug>.md: no such file or directory\` from \`/wiki/article\` until they were edited or archived. Every other CRUD handler in \`skill_crud_endpoints.go\` already enqueues the write — the create path was the lone leak.
- Plug the leak: render frontmatter + safety scan, enqueue through the existing \`WikiWorker\`, mirror \`handleSkillEdit\`'s lock-release pattern. Enqueue failures warn-log without failing the request since broker state is already mutated.
- New \`backfillSkillFilesFromState\` runs once at broker startup (alongside \`reconcileSkillStatusFromDisk\`) and writes a SKILL.md for any non-archived skill whose wiki file is missing. Heals existing zombies that were created before this fix.

## Repro

1. \`POST /skills\` with action=create and a fresh name.
2. Open the skill in the wiki UI → \`Error: {\"error\":\"open …/wiki/team/skills/<slug>.md: no such file or directory\"}\`.

After this PR: the SKILL.md is committed by the time the create response returns, so the UI renders cleanly. Existing zombie skills get backfilled on next broker boot.

## Test plan

- [x] \`go test ./internal/team/...\` (full package, 85s)
- [x] \`go vet ./...\`, \`gofmt -l\` clean
- [x] New regression: \`TestHandlePostSkill_WritesWikiFile\`
- [x] Proposal path covered: \`TestHandlePostSkill_ProposeWritesWikiFile\`
- [x] Backfill writes missing + skips archived: \`TestBackfillSkillFilesFromState_WritesMissingFiles\`
- [x] Backfill is idempotent on existing files: \`TestBackfillSkillFilesFromState_PreservesExistingFile\`
- [ ] Manual: in dev (\`wuphf-dev\`), create a skill via the chat tool, open it from the skills panel — confirm SKILL.md renders without the filesystem error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now validates required skill fields (name, description, content, created_by) and returns 400 when missing.
  * Team skill creation tooling now enforces a one-line description.

* **Bug Fixes**
  * Fixed a concurrency issue so skill creation no longer deadlocks or hangs.

* **Improvements**
  * Missing skill wiki pages are backfilled on startup (asynchronous) so pages become visible.
  * Wiki write failures are logged as warnings and don’t fail requests.
  * Create responses return the post-create snapshot.

* **Tests**
  * Added regression tests for wiki writes and backfill behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/747)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->