### PR TITLE
fix(web): keep DM agent accordions readable in tight viewports

### DIFF
--- a/web/e2e/screenshots/dm-accordions.mjs
+++ b/web/e2e/screenshots/dm-accordions.mjs
@@ -218,7 +218,12 @@ async function installDMMocks(context, { withBlocking = false } = {}) {
 }
 
 async function captureState({ name, withBlocking, preFix }) {
-  const base = process.env.BASE_URL ?? "http://localhost:5273";
+  // Strip a trailing slash so `${base}${DM_URL}` always produces a single
+  // separator — CI sometimes ships BASE_URL with a trailing `/`.
+  const base = (process.env.BASE_URL ?? "http://localhost:5273").replace(
+    /\/+$/,
+    "",
+  );
   await installDMMocks(context, { withBlocking });
   // Navigate to about:blank first so the new state forces a full re-mount.
   // Without this, page.goto to the same hash route is treated as a no-op

--- a/web/e2e/screenshots/dm-accordions.mjs
+++ b/web/e2e/screenshots/dm-accordions.mjs
@@ -150,7 +150,10 @@ const PRE_FIX_CSS = `
     white-space: normal !important;
   }
   .dm-chat-drawer { max-height: 38vh !important; }
-  .dm-chat-drawer-body { overflow-y: visible !important; }
+  /* Pre-fix had no overflow-y declaration on the drawer body, so the
+     default cascade applied. 'unset' reverts to that initial value
+     (effectively 'visible' here) without hard-coding the keyword. */
+  .dm-chat-drawer-body { overflow-y: unset !important; }
   .agent-workbench-stream { min-height: 240px !important; }
   .agent-workbench-stream-log {
     height: 320px !important;
@@ -222,7 +225,7 @@ async function captureState({ name, withBlocking, preFix }) {
   // by react-router and the previous state lingers — every screenshot ends
   // up identical.
   await page.goto("about:blank");
-  await page.goto(`${base}/${DM_URL}`, { waitUntil: "load" });
+  await page.goto(`${base}${DM_URL}`, { waitUntil: "load" });
   await page.waitForSelector(".status-bar", { timeout: 15_000 });
   await page.evaluate(async () => {
     const m = await import("/src/stores/app.ts");

--- a/web/e2e/screenshots/dm-accordions.mjs
+++ b/web/e2e/screenshots/dm-accordions.mjs
@@ -250,26 +250,32 @@ async function captureState({ name, withBlocking, preFix }) {
   await shotElement(page, '[data-testid="dm-workbench"]', OUT, name);
 }
 
-await captureState({
-  name: "01-before-idle",
-  withBlocking: false,
-  preFix: true,
-});
-await captureState({
-  name: "02-after-idle",
-  withBlocking: false,
-  preFix: false,
-});
-await captureState({
-  name: "03-before-with-interview",
-  withBlocking: true,
-  preFix: true,
-});
-await captureState({
-  name: "04-after-with-interview",
-  withBlocking: true,
-  preFix: false,
-});
+try {
+  await captureState({
+    name: "01-before-idle",
+    withBlocking: false,
+    preFix: true,
+  });
+  await captureState({
+    name: "02-after-idle",
+    withBlocking: false,
+    preFix: false,
+  });
+  await captureState({
+    name: "03-before-with-interview",
+    withBlocking: true,
+    preFix: true,
+  });
+  await captureState({
+    name: "04-after-with-interview",
+    withBlocking: true,
+    preFix: false,
+  });
 
-console.log(`captured 4 screenshots to ${OUT}`);
-await browser.close();
+  console.log(`captured 4 screenshots to ${OUT}`);
+} finally {
+  // Guarantee Playwright teardown even if a captureState throws — without
+  // this an unhandled error in CI leaves the chromium process pinned and
+  // the runner stalls until the global timeout.
+  await browser.close();
+}

--- a/web/e2e/screenshots/dm-accordions.mjs
+++ b/web/e2e/screenshots/dm-accordions.mjs
@@ -1,0 +1,272 @@
+// Capture before/after of the DM agent workbench accordion fix (PR #748).
+//
+// The bug surfaced on tight viewports — short laptop screens or any time the
+// chat drawer's InterviewBar widened the bottom of the DM view. The four
+// workbench accordions (Active tasks, Live stream, Recent activity, Recent
+// tasks) shared a flex column with no `flex-shrink: 0`, so a tall sibling
+// (the live-stream log fixed at 320px) squeezed sibling headers out of view.
+// On top of that, `.dm-chat-drawer` had no internal scroll and capped at
+// 38vh — when an InterviewBar opened, the composer got clipped.
+//
+// This spec captures the same DM page in two states (idle + with a blocking
+// approval) under both the old CSS and the new CSS, so a reviewer can scan
+// the four screenshots side-by-side. The "before" panes inject the pre-fix
+// values via `addStyleTag` on top of the patched stylesheet — same DOM,
+// same data, only the rules under test differ.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh dm-accordions 748
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+// 1280×760 mirrors a typical 13" laptop after the OS chrome is subtracted —
+// the viewport size where the bug was reported. 760 leaves the workbench
+// pane with the same ~387px the user saw on a 779px window.
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 760 },
+});
+
+const AGENT_SLUG = "ceo";
+const DM_URL = "/#/dm/ceo";
+
+// Members payload mirrors the `/api/office-members` shape consumed by the
+// sidebar. We only need enough for the agent rail to render; one member is
+// fine because the DM view itself doesn't iterate the whole list.
+const MEMBERS = {
+  members: [
+    {
+      slug: AGENT_SLUG,
+      name: "CEO",
+      role: "CEO",
+      created_by: "wuphf",
+      created_at: "2026-05-01T10:00:00Z",
+      built_in: true,
+      provider: {},
+      status: "idle",
+      activity: "idle",
+      online: true,
+    },
+    {
+      slug: "planner",
+      name: "Planner",
+      role: "planner",
+      built_in: false,
+      provider: {},
+      status: "idle",
+      activity: "idle",
+      online: false,
+    },
+  ],
+};
+
+// Two open tasks for @ceo so Active tasks renders rows instead of the empty
+// state — keeps the section a meaningful height rather than a one-liner.
+const TASK_LIST = {
+  tasks: [
+    {
+      id: "task-100",
+      title: "Investigate latest broker latency spike",
+      status: "in_progress",
+      owner: AGENT_SLUG,
+      channel: "general",
+      created_at: "2026-05-08T09:00:00Z",
+      updated_at: "2026-05-09T10:00:00Z",
+    },
+    {
+      id: "task-101",
+      title: "Draft Q3 board update",
+      status: "open",
+      owner: AGENT_SLUG,
+      channel: "general",
+      created_at: "2026-05-07T15:00:00Z",
+      updated_at: "2026-05-08T11:30:00Z",
+    },
+  ],
+};
+
+const AGENT_LOGS = {
+  tasks: [
+    {
+      taskId: "task-100",
+      agentSlug: AGENT_SLUG,
+      toolCallCount: 4,
+      firstToolAt: Date.parse("2026-05-09T09:30:00Z"),
+      lastToolAt: Date.parse("2026-05-09T10:00:00Z"),
+      hasError: false,
+      sizeBytes: 12_400,
+    },
+  ],
+};
+
+const NO_REQUESTS = { requests: [] };
+
+// Single blocking request — exercises the bug path where InterviewBar
+// expands the chat drawer past its 38vh cap, clipping the composer.
+const BLOCKING_REQUEST = {
+  requests: [
+    {
+      id: "req-1",
+      from: AGENT_SLUG,
+      question:
+        "@ceo wants to conn mod def: gj5en67fz04. Approve?",
+      title: "CONN MOD DEF: gj5en67fz04 — [REDACTED] via Notion",
+      kind: "external_action",
+      blocking: true,
+      required: true,
+      channel: "general",
+      created_at: "2026-05-09T10:05:00Z",
+      options: [
+        { id: "approve", label: "Approve" },
+        { id: "deny", label: "Deny" },
+      ],
+      context: "Action: [REDACTED] via Notion. Account: [REDACTED]. Channel: #general",
+    },
+  ],
+};
+
+// CSS that reverts the patch in PR #748. Layered on top of the loaded
+// stylesheet via `page.addStyleTag` so we can capture the broken state
+// without checking out main. Each rule mirrors a removed value from the
+// diff and uses `!important` to win specificity.
+const PRE_FIX_CSS = `
+  .collapsible-section { flex-shrink: 1 !important; }
+  .collapsible-section-title {
+    overflow: visible !important;
+    text-overflow: clip !important;
+    white-space: normal !important;
+  }
+  .dm-chat-drawer { max-height: 38vh !important; }
+  .dm-chat-drawer-body { overflow-y: visible !important; }
+  .agent-workbench-stream { min-height: 240px !important; }
+  .agent-workbench-stream-log {
+    height: 320px !important;
+    max-height: none !important;
+    min-height: 220px !important;
+  }
+`;
+
+async function installDMMocks(context, { withBlocking = false } = {}) {
+  // The patterns are anchored as regexes against the path so a glob like
+  // `**/api/tasks*` doesn't accidentally intercept ESM imports vite serves
+  // for `/src/api/tasks.ts` — that misroute breaks module loading and the
+  // shell never mounts.
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      await ctx.route(/\/api\/office-members(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(MEMBERS),
+        }),
+      );
+      await ctx.route(/\/api\/members(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ members: MEMBERS.members }),
+        }),
+      );
+      await ctx.route(/\/api\/channels(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({
+            channels: [{ slug: "general", topic: "" }],
+          }),
+        }),
+      );
+      await ctx.route(/\/api\/tasks(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(TASK_LIST),
+        }),
+      );
+      await ctx.route(/\/api\/agent-logs(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(AGENT_LOGS),
+        }),
+      );
+      await ctx.route(/\/api\/messages(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ messages: [] }),
+        }),
+      );
+      await ctx.route(/\/api\/requests(\?|$)/, (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(withBlocking ? BLOCKING_REQUEST : NO_REQUESTS),
+        }),
+      );
+    },
+  });
+}
+
+async function captureState({ name, withBlocking, preFix }) {
+  const base = process.env.BASE_URL ?? "http://localhost:5273";
+  await installDMMocks(context, { withBlocking });
+  // Navigate to about:blank first so the new state forces a full re-mount.
+  // Without this, page.goto to the same hash route is treated as a no-op
+  // by react-router and the previous state lingers — every screenshot ends
+  // up identical.
+  await page.goto("about:blank");
+  await page.goto(`${base}/${DM_URL}`, { waitUntil: "load" });
+  await page.waitForSelector(".status-bar", { timeout: 15_000 });
+  await page.evaluate(async () => {
+    const m = await import("/src/stores/app.ts");
+    m.useAppStore.setState({
+      brokerConnected: true,
+      onboardingComplete: true,
+    });
+  });
+  await page.waitForSelector('[data-testid="dm-workbench"]', {
+    timeout: 10_000,
+  });
+  if (preFix) {
+    await page.addStyleTag({ content: PRE_FIX_CSS });
+  }
+  // Let layout settle (live stream connects, accordion gap reflows). 800ms
+  // is generous but cheap — each spec runs once per PR. Long enough for
+  // the InterviewBar query to land and re-render the drawer.
+  await page.waitForTimeout(800);
+  // Frame on the DMView (workbench + drawer) so the screenshot focuses on
+  // the area the fix touches and the sidebar's variable agent count
+  // doesn't muddy the diff.
+  await shotElement(page, '[data-testid="dm-workbench"]', OUT, name);
+}
+
+await captureState({
+  name: "01-before-idle",
+  withBlocking: false,
+  preFix: true,
+});
+await captureState({
+  name: "02-after-idle",
+  withBlocking: false,
+  preFix: false,
+});
+await captureState({
+  name: "03-before-with-interview",
+  withBlocking: true,
+  preFix: true,
+});
+await captureState({
+  name: "04-after-with-interview",
+  withBlocking: true,
+  preFix: false,
+});
+
+console.log(`captured 4 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -521,20 +521,21 @@
 
 /* The shared `.agent-stream-log` caps height at 300px for the right-rail
    AgentPanel. Inside the workbench the section has the whole pane to
-   stretch into, so we override and let the log fill the available space
-   (with a sensible floor so an empty stream still shows a meaningful
-   panel). */
+   stretch into, so we let the log claim a healthy chunk while staying
+   adaptive: a fixed 320px height was forcing sibling accordions to clip
+   their headers on short viewports (e.g. when the chat drawer's
+   InterviewBar is open). Letting it shrink to a sensible floor keeps
+   every accordion's title visible and lets the pane scroll naturally. */
 .agent-workbench-stream {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  min-height: 240px;
+  min-height: 200px;
 }
 .agent-workbench-stream-log {
   flex: 1;
-  max-height: none;
-  min-height: 220px;
-  height: 320px;
+  min-height: 160px;
+  max-height: 320px;
 }
 
 /* ─── Agent Profile Panel ─── */
@@ -784,6 +785,6 @@
   }
 
   .agent-workbench-stream-log {
-    height: 260px;
+    max-height: 260px;
   }
 }

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2845,6 +2845,11 @@ html[data-theme="nex"]
   border-radius: var(--radius-md);
   background: var(--bg-card);
   overflow: hidden;
+  /* Keep each accordion at its natural height so a tall sibling (e.g. the
+     live stream log) can't squeeze headers and bodies in a flex column.
+     The pane itself scrolls when total content exceeds the viewport. */
+  flex-shrink: 0;
+  min-width: 0;
 }
 
 .collapsible-section-header {
@@ -2881,6 +2886,9 @@ html[data-theme="nex"]
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .collapsible-section-meta {
@@ -2951,7 +2959,10 @@ html[data-theme="nex"]
   flex-direction: column;
   border-top: 1px solid var(--border);
   background: var(--bg-card);
-  max-height: 38vh;
+  /* Cap collapsed-drawer height so the workbench above keeps usable space.
+     When an InterviewBar is open the body content can exceed this — it then
+     scrolls internally instead of clipping the composer. */
+  max-height: 50vh;
   transition: max-height 0.18s ease-out;
 }
 
@@ -3003,6 +3014,10 @@ html[data-theme="nex"]
   flex-direction: column;
   min-height: 0;
   flex: 1;
+  /* When the body's combined content (preview + typing + interview + composer)
+     is taller than the drawer cap, scroll within the drawer instead of clipping
+     the composer at the bottom. */
+  overflow-y: auto;
 }
 
 .dm-chat-messages {
@@ -3027,7 +3042,7 @@ html[data-theme="nex"]
 
 @media (max-width: 768px) {
   .dm-chat-drawer {
-    max-height: 50vh;
+    max-height: 60vh;
   }
   .dm-chat-drawer.is-expanded {
     max-height: 92vh;


### PR DESCRIPTION
## Summary
- DMView's four workbench accordions (Active tasks, Live stream, Recent activity, Recent tasks) clipped on short viewports because the live-stream log was a fixed 320px and sections shared a flex column with no `flex-shrink: 0`.
- The chat drawer's `38vh` cap had no internal scroll, so an open InterviewBar pushed the composer off-screen.

## Changes
- `.collapsible-section { flex-shrink: 0; }` — each accordion keeps its natural height; the pane scrolls when content exceeds the viewport.
- `.collapsible-section-title` gets ellipsis truncation as a safety net.
- `.dm-chat-drawer` collapsed cap: `38vh → 50vh` (mobile `50vh → 60vh`).
- `.dm-chat-drawer-body { overflow-y: auto; }` — composer no longer clips when an approval card overflows.
- `.agent-workbench-stream-log` switched from fixed `height: 320px` to `min-height: 160px; max-height: 320px; flex: 1` so it adapts on short viewports.

## Before / After
Verified live on a fresh local office at 779px viewport:
- Before (with InterviewBar): pane 387px, Active tasks header clipped, composer clipped behind drawer cap.
- After: pane 613px, all 4 sections visible (89/259/40/40px), drawer 130px, composer fully reachable.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bunx biome check src/styles/layout.css src/styles/agents.css`
- [x] `bash scripts/test-web.sh web/src/components/messages` (67 pass)
- [x] `bash scripts/test-web.sh web/src/components/ui web/src/components/agents` (46 pass)
- [x] Manual: launched fresh office, opened `#/dm/ceo`, all 4 accordion headers visible, composer reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined workbench stream and accordion sizing to prevent content clipping and preserve header visibility; stream logs now use max-heights and lower minimums for natural scrolling and responsive shrinking.
  * Increased DM chat drawer height caps and enabled internal vertical scrolling for more reliable behavior across desktop and mobile viewports.

* **Tests**
  * Added an end-to-end screenshot test capturing DM workbench accordion states before and after the layout fixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/748)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->