### PR TITLE
docs: refresh memory and team-invite copy across README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ if I say yes. If I am not logged in, just open https://wuphf.team.
 
 | Flag | What it does |
 |------|-------------|
-| `--memory-backend <name>` | Pick the organizational memory backend (`markdown`, `nex`, `gbrain`, `none`) |
+| `--memory-backend <name>` | Override the built-in markdown wiki (`nex`, `gbrain`, `none`) — legacy installs only |
 | `--no-nex` | Skip the Nex backend (no context graph, no Nex-managed integrations) |
 | `--legacy-tui` | Use the legacy tmux TUI instead of the web UI |
 | `--no-open` | Don't auto-open the browser |
@@ -101,6 +101,7 @@ if I say yes. If I am not logged in, just open https://wuphf.team.
 | `--collab` | Start in collaborative mode — all agents see all messages (this is the default) |
 | `--unsafe` | Bypass agent permission checks (local dev only) |
 | `--web-port <n>` | Change the web UI port (default 7891) |
+| `--workspace <name>` | Use a specific workspace for one command (does not change the active workspace) |
 
 `--legacy-tui` is deprecated, slated for removal, and retained only while the desktop replacement lands.
 
@@ -124,58 +125,62 @@ wuphf --provider ollama --memory-backend none --no-open
 
 ## Memory: Notebooks and the Wiki
 
-Every agent gets its own **notebook**. The team shares a **wiki**. New installs get the wiki as a local git repo of markdown articles — file-over-app, readable, `git clone`-able. Existing Nex/GBrain workspaces keep their knowledge-graph backend untouched.
+WUPHF ships with built-in memory. No backend choice, no API key, no setup step in the wizard. Every agent gets its own **notebook**, and the team shares a **wiki** — a local git repo of markdown articles at `~/.wuphf/wiki/`. `cat`, `grep`, `git log`, and `git clone` all work.
 
 **The promotion flow:**
 
-1. Agent works on a task and writes raw context, observations, and tentative conclusions to its **notebook** (per-agent, scoped, local to WUPHF).
+1. An agent works on a task and writes raw context, observations, and tentative conclusions to its **notebook** (per-agent, scoped, local to WUPHF).
 2. When something in the notebook looks durable (a recurring playbook, a verified entity fact, a confirmed preference), the agent gets a promotion hint.
-3. The agent promotes it to the **wiki** (workspace-wide, on the selected backend). Now every other agent can query it.
+3. The agent promotes it to the **wiki**. Now every other agent can query it.
 4. The wiki points other agents at whoever last recorded the context, so they know who to @mention for fresher working detail.
 
 Nothing is promoted automatically. Agents decide what graduates from notebook to wiki.
 
-**Backends for the wiki:**
+The wiki is not just a markdown folder. It is a living knowledge graph: typed facts with triplets, per-entity append-only fact logs, LLM-synthesized briefs committed under the `archivist` identity, `/lookup` cited-answer retrieval, and a `/lint` suite that flags contradictions, orphans, stale claims, and broken cross-references. The web UI gives you a Wikipedia-style reading view, a rich editor with WUPHF-specific inserts, and an AI-assisted maintenance assistant. See [DESIGN-WIKI.md](DESIGN-WIKI.md) for the reading view and [docs/specs/WIKI-SCHEMA.md](docs/specs/WIKI-SCHEMA.md) for the operational contract.
 
-- `markdown` (the "team wiki" tile in onboarding — the flag name is a historical artefact) is the default for new installs since v0.0.6. It is not just a markdown folder. It is a living knowledge graph: typed facts with triplets, per-entity append-only fact logs, LLM-synthesized briefs committed under the `archivist` identity, `/lookup` cited-answer retrieval, and a `/lint` suite that flags contradictions, orphans, stale claims, and broken cross-references. Everything lives as a local git repo at `~/.wuphf/wiki/` — `cat`, `grep`, `git log`, `git clone`, all work. No API key required.
-- `nex` was the previous default. Requires a WUPHF/Nex API key; powers Nex-backed context plus WUPHF-managed integrations. Existing users stay on `nex` via persisted config — no forced migration.
-- `gbrain` mounts `gbrain serve` as the wiki backend. It requires an API key during `/init`: `OpenAI` gives you the full path with embeddings and vector search, while `Anthropic` alone is reduced mode.
-- `none` disables the shared wiki entirely. Notebooks still work locally.
+**Onboarding seeds the wiki for you.** The wizard optionally scans your website and any files you point it at, then writes a starter set of company-context articles (about, owner, products) before the first agent turn fires. Your team starts already knowing who you are and what you ship.
 
-**Internal naming (for code spelunkers):** the notebook is `private` memory, the wiki is `shared` memory. On the team-wiki backend (`markdown`) the MCP tools are `notebook_write | notebook_read | notebook_list | notebook_search | notebook_promote | team_wiki_read | team_wiki_search | team_wiki_list | team_wiki_write | wuphf_wiki_lookup | run_lint | resolve_contradiction`. On `nex`/`gbrain` the MCP tools are the legacy `team_memory_query | team_memory_write | team_memory_promote`. The two tool sets never coexist on one server instance — backend selection flips the surface. See `DESIGN-WIKI.md` for the reading view and `docs/specs/WIKI-SCHEMA.md` for the operational contract.
-
-Examples:
+**Legacy backends.** Existing installs on Nex or GBrain keep working — backend selection is sticky in `config.json` and there is no forced migration. The CLI flag stays available for power users and for moving off legacy backends:
 
 ```bash
-wuphf --memory-backend markdown   # new default
-wuphf --memory-backend nex
-wuphf --memory-backend gbrain
-wuphf --memory-backend none
+wuphf --memory-backend nex      # hosted Nex graph + WUPHF-managed integrations
+wuphf --memory-backend gbrain   # local Postgres-backed graph
+wuphf --memory-backend none     # no shared wiki; notebooks still work
 ```
 
-When you select `gbrain`, onboarding asks for an OpenAI or Anthropic key up front and explains the tradeoff. If you want embeddings and vector search, use OpenAI.
+The web wizard no longer surfaces this as a choice. Markdown is the default and the only path for fresh installs.
+
+**Internal naming (for code spelunkers):** the notebook is `private` memory, the wiki is `shared` memory. On the built-in markdown backend the MCP tools are `notebook_write | notebook_read | notebook_list | notebook_search | notebook_promote | team_wiki_read | team_wiki_search | team_wiki_list | team_wiki_write | wuphf_wiki_lookup | run_lint | resolve_contradiction`. On `nex`/`gbrain` the MCP tools are the legacy `team_memory_query | team_memory_write | team_memory_promote`. The two tool sets never coexist on one server instance — backend selection flips the surface.
 
 ## Other Commands
 
 The examples below assume `wuphf` is on your `PATH`. If you just built the binary and haven't moved it, prefix with `./` (as in Get Started above) or run `go install ./cmd/wuphf` to drop it in `$GOPATH/bin`.
 
 ```bash
-wuphf init          # First-time setup
-wuphf share         # Invite one team member over Tailscale/WireGuard
-wuphf shred         # Delete workspace state and reopen onboarding
-wuphf --1o1         # 1:1 with the CEO
-wuphf --1o1 cro     # 1:1 with a specific agent
+wuphf init                    # First-time setup
+wuphf share                   # Invite one team member over Tailscale/WireGuard
+wuphf shred                   # Delete workspace state and reopen onboarding
+wuphf workspace list          # Run multiple isolated offices side by side
+wuphf workspace switch <name> # Flip the active workspace
+wuphf --1o1                   # 1:1 with the CEO
+wuphf --1o1 cro               # 1:1 with a specific agent
 ```
 
 ## Share With a Team Member
 
-Prerequisite: both machines are on the same Tailscale or WireGuard network.
+Two ways to invite a teammate. Pick the one that fits your network.
+
+**Private network — Tailscale or WireGuard.** Both machines on the same private mesh. The invite never leaves the network and no public interface is exposed:
 
 ```bash
 wuphf share
 ```
 
-Send the printed `/join` URL to one team member. The invite is one use, expires after 24 hours, and the shared web listener only starts on a private-network address by default. Public interfaces are blocked unless you pass an explicit unsafe override.
+Or click "Create invite" on the Health Check tile inside the office to mint one without leaving the browser. Send the printed `/join` URL to your teammate. The invite is one use, expires after 24 hours, and the shared web listener only binds to a private-network address by default.
+
+**Public tunnel — no shared network needed.** Click "Start tunnel" on the Health Check tile and WUPHF spins up a Cloudflare quick tunnel. The trycloudflare URL is paired with a 6-digit passcode the joiner has to type before they can land in the office; the join handler is rate-limited per source IP so a leaked URL alone cannot be brute-forced. `cloudflared` is bundled with the npm install (verified against a pinned SHA256 per platform) so the button works on first launch with zero extra setup.
+
+The tunnel path is opt-in and shown behind a confirmation dialog with the usual disclaimers (URL exposure, channel hygiene, invite-token semantics, TLS). Public LAN binds on the network-share path remain blocked unless you pass `--unsafe-lan`.
 
 For the full walkthrough, see [Share WUPHF With a Team Member](docs/tutorials/share-with-team-member.md).
 
@@ -257,7 +262,7 @@ Connects SaaS accounts (Gmail, Slack, etc.) through Composio's hosted OAuth flow
 | Live visibility | Stdout streaming |
 | Mid-task steering | DM any agent, no restart |
 | Runtimes | Mix Claude Code, Codex, and OpenClaw in one channel |
-| Memory | Per-agent notebook + shared workspace wiki (knowledge graphs on GBrain or Nex) |
+| Memory | Per-agent notebook + shared workspace wiki, git-native markdown by default (no API key needed) |
 | Price | Free and open source (MIT, self-hosted, your API keys) |
 
 ## Benchmark
@@ -312,7 +317,13 @@ Every claim in this README, grounded to the code that makes it true.
 | Prebuilt binary via goreleaser | 🟡 config ready | `.goreleaser.yml` — tags pending |
 | Resume in-flight work on restart | ✅ shipped v0.0.2.0 | see `CHANGELOG.md` |
 | LLM Wiki — git-native team memory (Karpathy-style) with Wikipedia-style UI | ✅ shipped | `internal/team/wiki_git.go`, `internal/team/wiki_worker.go`, `web/src/components/wiki/`, `DESIGN-WIKI.md` |
-| `--memory-backend markdown` (new default for fresh installs) | ✅ shipped | `internal/config/config.go` (`MemoryBackendMarkdown`) |
+| Markdown wiki is the default for fresh installs (web wizard hides the choice) | ✅ shipped | `internal/config/config.go` (`MemoryBackendMarkdown`), `web/src/components/onboarding/Wizard.tsx` |
+| Multi-workspace — run isolated offices side by side, pause/resume per workspace | ✅ shipped | `cmd/wuphf/workspace.go`, `internal/workspaces/` |
+| Public-tunnel invite via bundled `cloudflared` (passcode + rate limit) | ✅ shipped | `cmd/wuphf/tunnel.go`, `cmd/wuphf/share_join_guard.go`, `npm/scripts/cloudflared.json` |
+| Onboarding wizard with company-context scan (website + files → wiki seed) | ✅ shipped | `web/src/components/onboarding/`, `internal/operations/company_seed.go`, `internal/team/broker_company_seed.go` |
+| Live agent event pills + Tier-2 hover peek on the office rail | ✅ shipped | `web/src/components/sidebar/AgentEventPill.tsx`, `internal/team/headless_activity_classifier.go` |
+| Wiki rich editor + AI-assisted maintenance assistant | ✅ shipped | `web/src/components/wiki/editor/`, wiki maintenance MCP tools |
+| Skills publish/install across public hubs (Anthropic, LobeHub, GitHub) | ✅ shipped | `cmd/wuphf/skills_publish.go` |
 
 Legend: ✅ shipped · 🟡 partial · 🔜 planned. If a claim and a status disagree, the code wins — file an issue.
 

--- a/website/index.html
+++ b/website/index.html
@@ -1546,7 +1546,7 @@
       <div class="compare-label">WHAT YOU GET</div>
       <ul class="compare-list compare-list-pos">
         <li>Agents continuously learn your work playbooks and build personalized skills. The office gets sharper the more you use it.</li>
-        <li>Each agent gets its own notebook. The team shares a wiki. When a conclusion in an agent's notebook holds up, it gets promoted to the wiki so the whole office benefits. Both are knowledge graphs under the hood, on Garry Tan's GBrain or Nex.</li>
+        <li>Each agent gets its own notebook. The team shares a wiki. When a conclusion in an agent's notebook holds up, it gets promoted to the wiki so the whole office benefits. Built-in markdown wiki, file-over-app, lives as a local git repo. No API key, no hosted backend.</li>
         <li>Mix Claude Code, Codex, and OpenClaw agents in one channel. They execute your work 24x7.</li>
         <li>Local. Runs on your machine. No cloud in the critical path.</li>
         <li>7x fewer tokens per session. Fresh sessions, not accumulated context.</li>
@@ -1598,7 +1598,7 @@
     <details class="faq-item">
       <summary class="faq-q">Where is the context stored, and how long does it last?</summary>
       <div class="faq-a">
-        Local SQLite for channel history in <code>~/.wuphf/state</code>. Per-project, so client work stays isolated. Each agent also has its own knowledge graph: private memory for focused work, plus shared workspace memory for the whole team. Threads, channel history, and knowledge persist until you delete the file. Day 2, the agents still remember PR numbers, blockers, and decisions from yesterday.
+        Local SQLite for channel history in <code>~/.wuphf/state</code>. Per-project, so client work stays isolated. Each agent also gets its own notebook for focused work; durable conclusions get promoted into a shared team wiki at <code>~/.wuphf/wiki</code>, a real git repo of markdown articles you can <code>cat</code>, <code>grep</code>, and <code>git clone</code>. Threads, channel history, and the wiki persist until you delete the files. Day 2, the agents still remember PR numbers, blockers, and decisions from yesterday.
       </div>
     </details>
     <details class="faq-item">
@@ -1611,6 +1611,12 @@
       <summary class="faq-q">Does my data leave the machine?</summary>
       <div class="faq-a">
         The runtime is local. Context is local. The only network calls are to the LLM provider you configure, for inference. If you point WUPHF at a local model, nothing leaves the machine at all. No telemetry, no analytics ping, no phone-home.
+      </div>
+    </details>
+    <details class="faq-item">
+      <summary class="faq-q">Can I invite a teammate into the office?</summary>
+      <div class="faq-a">
+        Yes. Two ways. If you and your teammate are on the same Tailscale or WireGuard network, run <code>wuphf share</code> (or click "Create invite" inside the office) and send the printed <code>/join</code> URL. If you are not on a shared private network, click "Start tunnel" inside the office and WUPHF spins up a Cloudflare quick tunnel paired with a 6-digit passcode the joiner has to type before they can land in the office. <code>cloudflared</code> ships bundled with the npm install. Invites are one-use, expire in 24 hours, and the join handler is rate-limited per source IP so a leaked URL alone cannot be brute-forced.
       </div>
     </details>
     <details class="faq-item">


### PR DESCRIPTION
## Summary

The web wizard no longer offers a memory-backend picker — markdown is the built-in default and only path for fresh installs. The Health Check tile now offers public-tunnel invites alongside the private-network share. README and the landing site were still framing both as choice-driven.

## What changed

**README**
- Memory section reframed: built-in markdown wiki, file-over-app, no API key. Legacy nex/gbrain stay behind the CLI flag. Onboarding company-context scan called out.
- Share With a Team Member rewritten as private-network vs public-tunnel paths (cloudflared bundled, 6-digit passcode, per-IP rate limit). Both mention the in-browser invite tile.
- Options table: `--memory-backend` reframed as legacy override; new `--workspace` row.
- Other Commands: surface `wuphf workspace list/switch`.
- Why WUPHF memory row updated to git-native markdown.
- Claim Status: six new rows for shipped landmarks (multi-workspace, public-tunnel invite, company-context scan, live agent event pills, wiki rich editor + maintenance, skills publish/install). All file references spot-checked against the tree.

**website/index.html**
- WHY WUPHF compare-list memory line updated to markdown wiki framing.
- FAQ "Where is context stored" updated to mention notebooks and the team wiki at `~/.wuphf/wiki` as a real git repo.
- New FAQ entry "Can I invite a teammate into the office?" covering private-network and public-tunnel paths.

## Test plan

- [ ] `cat README.md | head -250` reads cleanly and reflects the shipped product
- [ ] `open website/index.html` in a browser, confirm WHY WUPHF list and FAQ render and the new "Can I invite a teammate?" entry expands
- [ ] Spot-check Claim Status file references resolve (`internal/operations/company_seed.go`, `cmd/wuphf/tunnel.go`, `cmd/wuphf/skills_publish.go`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation about the built-in markdown wiki and agent notebooks workflow.
  * Expanded team collaboration section with details on two methods to invite teammates.
  * Updated FAQ covering context storage and team onboarding processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/750)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->