### PR TITLE
feat(reviewer-routing): Watching field + intersection routing + convergence rule

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -88,6 +88,13 @@ type Broker struct {
 	// tests that never touch the harness path pay no cost. Guarded by
 	// b.mu via the public mutators in broker_decision_packet.go.
 	decisionPackets *decisionPacketState
+	// reviewerGradesByTask is the Lane D routing-side transient store of
+	// ReviewerGrade entries keyed by task ID. Lane D writes here for
+	// convergence/timeout rule evaluation; Lane C's Decision Packet is
+	// the durable source of truth. The two are kept in sync by
+	// SubmitReviewerGrade — Lane D mirrors writes to Lane C on each grade.
+	// Guarded by b.mu.
+	reviewerGradesByTask map[string][]ReviewerGrade
 	requests                []humanInterview
 	humanInvites            []humanInvite
 	humanSessions           []humanSession

--- a/internal/team/broker_decision_packet.go
+++ b/internal/team/broker_decision_packet.go
@@ -387,6 +387,15 @@ func (b *Broker) AppendReviewerGrade(taskID string, grade ReviewerGrade) error {
 		ReviewerSlug:   grade.ReviewerSlug,
 		Severity:       grade.Severity,
 	})
+	// Mirror into Lane D's routing-side store so the convergence rule
+	// runs on every grade. The routing helper is mutex-free under the
+	// already-held b.mu and skips re-canonicalising fields the packet
+	// path already validated.
+	if task := b.taskByIDLocked(taskID); task != nil {
+		if err := b.appendReviewerGradeRoutingLocked(taskID, grade); err != nil {
+			log.Printf("broker: routing-side mirror of grade for task %q failed: %v", taskID, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/team/broker_decision_packet_test.go
+++ b/internal/team/broker_decision_packet_test.go
@@ -103,6 +103,15 @@ func (s *fakeDecisionPacketStore) writesCopy() []DecisionPacket {
 	return out
 }
 
+// resetWrites clears the recorded write log so a test setup phase that
+// performs incidental persistence (e.g. AssignReviewers) does not skew a
+// later write-count assertion.
+func (s *fakeDecisionPacketStore) resetWrites() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.writes = nil
+}
+
 // seedTaskInState installs a task into b.tasks at the given lifecycle
 // state. Mirrors the small fixture used by Lane A's tests so we don't
 // drag in the full intake driver.
@@ -312,6 +321,14 @@ func TestDecisionPacketRetrySucceedsBeforeBudget(t *testing.T) {
 	b.SetDecisionPacketStore(store)
 	taskID := "task-transient"
 	seedTaskInState(t, b, taskID, LifecycleStateReview)
+	// Pre-assign two reviewers so convergence has something to wait on
+	// after the first grade lands; otherwise the Lane D mirror would
+	// immediately transition to decision and add a second persisted
+	// write that this retry-budget assertion is not measuring.
+	if err := b.AssignReviewers(taskID, []string{"reviewer-flap", "reviewer-still-pending"}); err != nil {
+		t.Fatalf("AssignReviewers: %v", err)
+	}
+	store.resetWrites()
 
 	if err := b.AppendReviewerGrade(taskID, ReviewerGrade{
 		ReviewerSlug: "reviewer-flap",

--- a/internal/team/broker_lifecycle_transition.go
+++ b/internal/team/broker_lifecycle_transition.go
@@ -355,6 +355,24 @@ func (b *Broker) transitionLifecycleLocked(taskID string, newState LifecycleStat
 		// running-state durability. The hook is a no-op when no
 		// packet has been seeded for the task.
 		b.onLifecycleTransitionLocked(taskID, prev, newState)
+		// Lane D wire (#9): when a task enters review, auto-resolve
+		// the reviewer set from the watching configuration and stamp
+		// it onto the task. Skip when the task already carries a
+		// manually-assigned reviewer list (caller may have invoked
+		// AssignReviewers explicitly before transitioning) so we do
+		// not stomp explicit human/owner overrides.
+		if newState == LifecycleStateReview && prev != LifecycleStateReview {
+			if len(task.Reviewers) == 0 {
+				slugs, resolveErr := b.resolveReviewersLocked(taskID)
+				if resolveErr != nil {
+					log.Printf("broker: lifecycle transition %q -> review: resolve reviewers failed: %v", taskID, resolveErr)
+				} else if len(slugs) > 0 {
+					if assignErr := b.assignReviewersLocked(taskID, slugs); assignErr != nil {
+						log.Printf("broker: lifecycle transition %q -> review: assign reviewers failed: %v", taskID, assignErr)
+					}
+				}
+			}
+		}
 		return task, nil
 	}
 	return nil, fmt.Errorf("transition lifecycle: task %q not found", taskID)

--- a/internal/team/broker_lifecycle_transition.go
+++ b/internal/team/broker_lifecycle_transition.go
@@ -373,6 +373,16 @@ func (b *Broker) transitionLifecycleLocked(taskID string, newState LifecycleStat
 				}
 			}
 		}
+		// Lane D follow-up D-FU-1: drop the routing-side reviewer-grade
+		// mirror entry on the merged transition. The Decision Packet
+		// retains the canonical grade list (Lane C owns persistence);
+		// b.reviewerGradesByTask is a routing-side index used solely
+		// for evaluateConvergenceLocked. Without this cleanup a long-
+		// running broker accumulates one entry per merged task with no
+		// downstream consumer.
+		if newState == LifecycleStateMerged {
+			b.gcReviewerGradesByTaskLocked(taskID)
+		}
 		return task, nil
 	}
 	return nil, fmt.Errorf("transition lifecycle: task %q not found", taskID)

--- a/internal/team/broker_reviewer_routing.go
+++ b/internal/team/broker_reviewer_routing.go
@@ -1,0 +1,716 @@
+package team
+
+// broker_reviewer_routing.go is Lane D's reviewer-routing layer. It owns
+// four responsibilities:
+//
+//  1. Snapshotting a task's "what changed" signals (file diff, wiki
+//     paths touched, manifest tool calls observed, spec tags) into
+//     ReviewerRoutingSignals so routing decisions are deterministic and
+//     unit-testable without spinning up a worktree.
+//
+//  2. Computing the intersection between a task's signals and every
+//     officeMember's Watching set, returning the auto-assigned agent
+//     slug list (ResolveReviewers / AssignReviewers).
+//
+//  3. Driving the review → decision convergence rule: a task transitions
+//     when every assigned reviewer has emitted a graded review.submitted,
+//     OR the per-task timeout elapses, OR a reviewer's headless session
+//     terminates without a grade. evaluateConvergenceLocked is called on
+//     every grade append and on a 30-second background sweep.
+//
+//  4. Filling missing reviewer slots with a SeveritySkipped grade on
+//     timeout/exit so the Decision Packet always carries N grades for N
+//     assigned reviewers, never a half-open hole that blocks merge.
+//
+// Reviewer Concern #1 resolution (process-watch hook for crash detection):
+// The design doc lists scheduleTaskLifecycleLocked and the launcher_loops
+// goroutines as candidates. Neither fires reliably as a typed "agent X
+// exited without grading task Y" callback in the current broker — they
+// are pane-status / scheduler-driven loops that operate on tasks, not on
+// per-agent session lifetimes.
+//
+// What DOES fire reliably is the headless manifest event (emitHeadlessManifest
+// in headless_event.go). It is emitted unconditionally at the end of every
+// headless turn — both on cmd.Wait() success (Status=idle) and on cmd.Wait()
+// error (Status=error). For Lane D's purposes, "reviewer process exited
+// without submitting" is functionally identical to "timeout elapsed without
+// submitting" because the design treats them with the same fill behaviour
+// and the same 10-minute deadline.
+//
+// Implementation choice: the convergence sweeper observes manifest-terminal
+// events (ToolNames extraction code already walks the same lines) and
+// records the most recent terminal status per (reviewerSlug, taskID). When
+// the sweeper sees a reviewer whose terminal status is "idle" or "error"
+// AND no grade has landed AND the per-reviewer minimum-wait window has
+// elapsed (default: full timeout), it fills the slot with the
+// "reviewer process exited" reasoning instead of "reviewer timed out". This
+// preserves the design's user-visible distinction without coupling Lane D
+// to per-agent-session lifetimes the broker does not currently expose.
+//
+// All locked helpers require b.mu held by the caller; the public wrappers
+// acquire b.mu themselves.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// reviewerConvergenceManifestTerminalStatuses is the set of HeadlessEvent
+// manifest Status values that mean "this reviewer's most recent turn has
+// ended cleanly." Used by the sweeper to differentiate timed-out from
+// process-exited reviewers when filling skipped slots.
+var reviewerConvergenceManifestTerminalStatuses = map[string]struct{}{
+	"idle":  {},
+	"error": {},
+}
+
+// ResolveReviewers returns the set of agent slugs whose Watching set
+// intersects with the task's current signals. Order is stable
+// (lexicographic) so callers can assert on the slice in tests.
+//
+// Tunnel-invited humans are not auto-assigned by this function — they
+// are appended manually via the CLI (`wuphf task review --invite <slug>`)
+// and stored on teamTask.Reviewers alongside the agent slugs.
+func (b *Broker) ResolveReviewers(taskID string) ([]string, error) {
+	if b == nil {
+		return nil, fmt.Errorf("resolve reviewers: nil broker")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.resolveReviewersLocked(taskID)
+}
+
+func (b *Broker) resolveReviewersLocked(taskID string) ([]string, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil, fmt.Errorf("resolve reviewers: task id required")
+	}
+	task := b.taskByIDLocked(taskID)
+	if task == nil {
+		return nil, fmt.Errorf("resolve reviewers: task %q not found", taskID)
+	}
+	signals := b.extractRoutingSignalsLocked(task)
+	matched := make([]string, 0, len(b.members))
+	seen := make(map[string]struct{}, len(b.members))
+	for i := range b.members {
+		member := &b.members[i]
+		slug := strings.TrimSpace(member.Slug)
+		if slug == "" {
+			continue
+		}
+		if member.Watching.IsEmpty() {
+			continue
+		}
+		if !watchingMatchesSignals(member.Watching, signals) {
+			continue
+		}
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		matched = append(matched, slug)
+	}
+	sort.Strings(matched)
+	return matched, nil
+}
+
+// AssignReviewers stamps the resolved (or manually overridden) reviewer
+// slug list onto the task and stamps ReviewStartedAt with the broker's
+// clock. Idempotent: re-calling with the same slugs is a no-op for the
+// reviewer list but always re-stamps the start time so a re-entered
+// review window has a fresh deadline.
+//
+// The caller is expected to be the lifecycle transition layer's
+// running → review hook. Lane D's broker_reviewer_routing.go does not
+// register that hook itself; Lane A's transition layer is the canonical
+// invocation point. For tests, AssignReviewers can be called directly.
+func (b *Broker) AssignReviewers(taskID string, slugs []string) error {
+	if b == nil {
+		return fmt.Errorf("assign reviewers: nil broker")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.assignReviewersLocked(taskID, slugs)
+}
+
+func (b *Broker) assignReviewersLocked(taskID string, slugs []string) error {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return fmt.Errorf("assign reviewers: task id required")
+	}
+	task := b.taskByIDLocked(taskID)
+	if task == nil {
+		return fmt.Errorf("assign reviewers: task %q not found", taskID)
+	}
+	deduped := make([]string, 0, len(slugs))
+	seen := make(map[string]struct{}, len(slugs))
+	for _, raw := range slugs {
+		slug := strings.TrimSpace(raw)
+		if slug == "" {
+			continue
+		}
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		deduped = append(deduped, slug)
+	}
+	sort.Strings(deduped)
+	task.Reviewers = deduped
+	task.ReviewStartedAt = b.reviewerNow().UTC().Format(time.RFC3339)
+	return nil
+}
+
+// AppendReviewerGrade is the Lane D-side stub for Lane C's Decision
+// Packet mutator. Lane C will replace this implementation when it
+// merges; the contract preserved here is the signature
+// (taskID string, grade ReviewerGrade) error and the post-condition
+// "the grade has been recorded against the task and convergence has
+// been re-evaluated."
+//
+// While Lane C is parallel-in-flight, this stub stores grades in a
+// transient in-memory slice on the broker keyed by task ID. The slice
+// is intentionally NOT persisted to disk (Lane C owns persistence) so
+// a broker restart drops the grades — acceptable for v1 build because
+// the test suite seeds grades directly within the same process.
+//
+// Convergence is re-evaluated under b.mu after the grade lands; this
+// matches the design doc's "trigger every grade-append" contract.
+// appendReviewerGradeRoutingLocked records grade in the routing-side
+// convergence index (b.reviewerGradesByTask) and re-runs the convergence
+// rule. Lane C's AppendReviewerGrade is the public entrypoint and must
+// call this helper after the packet write so the routing path observes
+// the same grade. This avoids a second public method colliding on the
+// canonical name.
+func (b *Broker) appendReviewerGradeRoutingLocked(taskID string, grade ReviewerGrade) error {
+	return b.appendReviewerGradeLocked(taskID, grade)
+}
+
+func (b *Broker) appendReviewerGradeLocked(taskID string, grade ReviewerGrade) error {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return fmt.Errorf("append reviewer grade: task id required")
+	}
+	if strings.TrimSpace(grade.ReviewerSlug) == "" {
+		return fmt.Errorf("append reviewer grade: reviewer slug required")
+	}
+	task := b.taskByIDLocked(taskID)
+	if task == nil {
+		return fmt.Errorf("append reviewer grade: task %q not found", taskID)
+	}
+	if grade.SubmittedAt.IsZero() {
+		grade.SubmittedAt = b.reviewerNow().UTC()
+	}
+	if b.reviewerGradesByTask == nil {
+		b.reviewerGradesByTask = make(map[string][]ReviewerGrade)
+	}
+	existing := b.reviewerGradesByTask[taskID]
+	// Idempotency on (taskID, ReviewerSlug): a second grade from the
+	// same reviewer overwrites the first slot rather than appending,
+	// so the convergence rule sees the latest grade. This matches the
+	// design's "review.submitted with grade present" semantics.
+	replaced := false
+	for i := range existing {
+		if existing[i].ReviewerSlug == grade.ReviewerSlug {
+			existing[i] = grade
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		existing = append(existing, grade)
+	}
+	b.reviewerGradesByTask[taskID] = existing
+	if err := b.evaluateConvergenceLocked(taskID); err != nil {
+		log.Printf("broker: reviewer convergence eval after grade append for task %q failed: %v", taskID, err)
+	}
+	return nil
+}
+
+// ReviewerGrades returns a copy of the grades recorded against a task.
+// Used by tests; production consumers go through Lane C's Decision
+// Packet read path.
+func (b *Broker) ReviewerGrades(taskID string) []ReviewerGrade {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	src := b.reviewerGradesByTask[strings.TrimSpace(taskID)]
+	out := make([]ReviewerGrade, len(src))
+	copy(out, src)
+	return out
+}
+
+// evaluateConvergenceLocked runs the convergence rule for a single task.
+// Three exit paths:
+//
+//   - All assigned reviewers have a grade → transition to decision.
+//   - Timeout elapsed AND at least one reviewer is missing → fill missing
+//     slots with SeveritySkipped, transition to decision.
+//   - Otherwise → no-op.
+//
+// Caller must hold b.mu. Idempotent: a task already in decision (or
+// post-decision) is skipped without error.
+func (b *Broker) evaluateConvergenceLocked(taskID string) error {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil
+	}
+	task := b.taskByIDLocked(taskID)
+	if task == nil {
+		return fmt.Errorf("convergence: task %q not found", taskID)
+	}
+	if task.LifecycleState != LifecycleStateReview {
+		return nil
+	}
+	reviewers := task.Reviewers
+	if len(reviewers) == 0 {
+		// No assigned reviewers means nothing to wait for; transition
+		// immediately. The Decision Packet will surface as "no review
+		// required" — the human still gates the merge.
+		_, err := b.transitionLifecycleLocked(taskID, LifecycleStateDecision, "convergence: no reviewers assigned")
+		return err
+	}
+
+	grades := b.reviewerGradesByTask[taskID]
+	graded := make(map[string]bool, len(grades))
+	for _, g := range grades {
+		graded[g.ReviewerSlug] = true
+	}
+
+	missing := make([]string, 0, len(reviewers))
+	for _, slug := range reviewers {
+		if !graded[slug] {
+			missing = append(missing, slug)
+		}
+	}
+
+	if len(missing) == 0 {
+		// All graded. Fire the transition exactly once; the lifecycle
+		// transition layer rejects duplicate transitions because the
+		// state will already be decision after this call.
+		_, err := b.transitionLifecycleLocked(taskID, LifecycleStateDecision, "convergence: all reviewers graded")
+		return err
+	}
+
+	// Some reviewers are still pending. Check timeout.
+	deadline := b.reviewerDeadlineLocked(task)
+	if deadline.IsZero() {
+		// No start-time recorded — defensive. Treat as not-yet-elapsed.
+		return nil
+	}
+	if !b.reviewerNow().After(deadline) {
+		return nil
+	}
+
+	// Timeout elapsed. Fill each missing slot. Differentiate "process
+	// exited" from "timed out" by checking the most-recent terminal
+	// manifest status on the reviewer's task-scoped agent stream.
+	terminalStatuses := b.observedTerminalStatusByReviewerLocked(taskID, missing)
+	now := b.reviewerNow().UTC()
+	for _, slug := range missing {
+		reasoning := "reviewer timed out"
+		if status, ok := terminalStatuses[slug]; ok {
+			if _, terminal := reviewerConvergenceManifestTerminalStatuses[status]; terminal {
+				reasoning = "reviewer process exited"
+			}
+		}
+		filler := ReviewerGrade{
+			ReviewerSlug: slug,
+			Severity:     SeveritySkipped,
+			Reasoning:    reasoning,
+			SubmittedAt:  now,
+		}
+		b.reviewerGradesByTask[taskID] = append(b.reviewerGradesByTask[taskID], filler)
+		b.postReviewTimeoutChannelMessageLocked(task, slug, reasoning)
+	}
+
+	_, err := b.transitionLifecycleLocked(taskID, LifecycleStateDecision, "convergence: timeout")
+	return err
+}
+
+// EvaluateConvergence is the public wrapper around
+// evaluateConvergenceLocked. Acquires b.mu. Used by tests and by the
+// background sweeper goroutine.
+func (b *Broker) EvaluateConvergence(taskID string) error {
+	if b == nil {
+		return fmt.Errorf("evaluate convergence: nil broker")
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.evaluateConvergenceLocked(taskID)
+}
+
+// SweepReviewConvergence iterates every task currently in the review
+// bucket of the lifecycle index and re-evaluates convergence. Cheap
+// because the lifecycle index is O(1) and only review-state tasks are
+// scanned (not the full task list). Called by the 30-second background
+// goroutine and exposed for direct test invocation.
+func (b *Broker) SweepReviewConvergence() {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.sweepReviewConvergenceLocked()
+}
+
+func (b *Broker) sweepReviewConvergenceLocked() {
+	bucket := b.lifecycleIndex[LifecycleStateReview]
+	for _, taskID := range bucket {
+		if err := b.evaluateConvergenceLocked(taskID); err != nil {
+			log.Printf("broker: review-convergence sweep for task %q failed: %v", taskID, err)
+		}
+	}
+}
+
+// StartReviewConvergenceSweeper launches the 30-second background
+// goroutine that re-evaluates convergence for every review-state task.
+// Returns a stop function the caller invokes on broker shutdown. Tests
+// avoid this entry point and drive convergence by calling
+// EvaluateConvergence / SweepReviewConvergence directly with their own
+// fake clock.
+func (b *Broker) StartReviewConvergenceSweeper(ctx context.Context) func() {
+	if b == nil {
+		return func() {}
+	}
+	ticker := time.NewTicker(time.Duration(reviewConvergenceTickInterval) * time.Second)
+	done := make(chan struct{})
+	var once sync.Once
+	stop := func() {
+		once.Do(func() {
+			ticker.Stop()
+			close(done)
+		})
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			case <-ticker.C:
+				b.SweepReviewConvergence()
+			}
+		}
+	}()
+	return stop
+}
+
+// reviewerDeadlineLocked computes the convergence deadline for a task
+// from ReviewStartedAt + max(ReviewTimeoutSeconds, default). Returns
+// the zero Time when ReviewStartedAt cannot be parsed, which the
+// caller treats as "do not time out yet."
+func (b *Broker) reviewerDeadlineLocked(task *teamTask) time.Time {
+	if task == nil {
+		return time.Time{}
+	}
+	startedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(task.ReviewStartedAt))
+	if err != nil {
+		return time.Time{}
+	}
+	timeoutSeconds := task.ReviewTimeoutSeconds
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = reviewConvergenceDefaultTimeoutSeconds
+	}
+	return startedAt.Add(time.Duration(timeoutSeconds) * time.Second)
+}
+
+// reviewerNow returns the broker's clock. Tests inject b.nowFn to
+// advance synthetic time without sleeping; production callers go
+// through time.Now.
+func (b *Broker) reviewerNow() time.Time {
+	if b == nil {
+		return time.Now()
+	}
+	if b.nowFn != nil {
+		return b.nowFn()
+	}
+	return time.Now()
+}
+
+// observedTerminalStatusByReviewerLocked walks the most-recent manifest
+// HeadlessEvent recorded for each reviewer on the task's agent stream
+// and returns the latest Status (idle/error) per reviewer. Reviewers
+// without any manifest events on this task are absent from the map.
+//
+// Cheap because each reviewer's stream is bounded by
+// agentStreamTaskHistoryLimit. We do not parse non-manifest events
+// (status/text/tool_use/tool_result) — only manifest, which carries
+// the terminal Status.
+func (b *Broker) observedTerminalStatusByReviewerLocked(taskID string, slugs []string) map[string]string {
+	out := make(map[string]string, len(slugs))
+	if b.agentStreams == nil {
+		return out
+	}
+	for _, slug := range slugs {
+		stream, ok := b.agentStreams[slug]
+		if !ok {
+			continue
+		}
+		// Walk in reverse so the FIRST manifest we hit is the most
+		// recent. recentTaskLocked returns chronological order, so
+		// iterate from the end.
+		stream.mu.Lock()
+		lines := stream.taskLines[taskID]
+		stream.mu.Unlock()
+		for i := len(lines) - 1; i >= 0; i-- {
+			var ev HeadlessEvent
+			if err := json.Unmarshal([]byte(strings.TrimSpace(lines[i])), &ev); err != nil {
+				continue
+			}
+			if ev.Type != HeadlessEventTypeManifest {
+				continue
+			}
+			out[slug] = ev.Status
+			break
+		}
+	}
+	return out
+}
+
+// extractRoutingSignalsLocked builds a ReviewerRoutingSignals snapshot
+// for the task. Three sources:
+//
+//   - Files / WikiPaths: `git diff --name-only` between the worktree
+//     and the parent branch. WikiPaths is the subset of Files that
+//     glob-match the wiki article path convention. Empty when the
+//     worktree path is unset (legacy task) or the diff exec fails;
+//     errors are logged, not propagated, because routing on best-effort
+//     signals is preferable to gating the entire convergence path.
+//
+//   - ToolNames: union of HeadlessEvent.ToolCalls from manifest events
+//     across every agent stream that has lines for this task.
+//
+//   - TaskTags: verbatim teamTask.Tags.
+func (b *Broker) extractRoutingSignalsLocked(task *teamTask) ReviewerRoutingSignals {
+	if task == nil {
+		return ReviewerRoutingSignals{}
+	}
+	signals := ReviewerRoutingSignals{
+		TaskTags: append([]string(nil), task.Tags...),
+	}
+
+	files := b.taskWorktreeDiffLocked(task)
+	signals.Files = files
+	signals.WikiPaths = filterWikiPaths(files)
+
+	signals.ToolNames = b.taskManifestToolNamesLocked(task.ID)
+
+	return signals
+}
+
+// taskWorktreeDiffLocked runs `git diff --name-only` against the task's
+// worktree and parent branch. Returns nil on any error; logging is
+// best-effort only.
+func (b *Broker) taskWorktreeDiffLocked(task *teamTask) []string {
+	worktreePath := strings.TrimSpace(task.WorktreePath)
+	if worktreePath == "" {
+		return nil
+	}
+	parent := strings.TrimSpace(task.WorktreeBranch)
+	if parent == "" {
+		parent = "HEAD"
+	}
+	out, err := runGitOutput(worktreePath, "diff", "--name-only", parent)
+	if err != nil {
+		log.Printf("broker: reviewer routing: diff failed for task %q (worktree=%q parent=%q): %v",
+			task.ID, worktreePath, parent, err)
+		return nil
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	files := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files
+}
+
+// taskManifestToolNamesLocked returns the union of distinct
+// HeadlessEvent.ToolCalls.ToolName values observed across every agent
+// stream's task-scoped buffer for taskID. Order is lexicographic.
+func (b *Broker) taskManifestToolNamesLocked(taskID string) []string {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return nil
+	}
+	if b.agentStreams == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	for _, stream := range b.agentStreams {
+		stream.mu.Lock()
+		lines := stream.taskLines[taskID]
+		// Copy to drop the lock fast.
+		buf := make([]string, len(lines))
+		copy(buf, lines)
+		stream.mu.Unlock()
+		for _, line := range buf {
+			var ev HeadlessEvent
+			if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &ev); err != nil {
+				continue
+			}
+			if ev.Type != HeadlessEventTypeManifest {
+				continue
+			}
+			for _, call := range ev.ToolCalls {
+				name := strings.TrimSpace(call.ToolName)
+				if name == "" {
+					continue
+				}
+				seen[name] = struct{}{}
+			}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for name := range seen {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// filterWikiPaths returns the subset of paths that look like wiki
+// article paths. The convention is "wiki/" or "team/" prefixes (the
+// repo's wiki worker stores articles under either); this matches the
+// PR #729 manifest extractor's wiki-recognition heuristic.
+func filterWikiPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		clean := strings.TrimPrefix(strings.TrimSpace(p), "./")
+		if clean == "" {
+			continue
+		}
+		if strings.HasPrefix(clean, "wiki/") || strings.HasPrefix(clean, "team/") {
+			out = append(out, clean)
+		}
+	}
+	return out
+}
+
+// watchingMatchesSignals returns true when ANY non-empty Watching
+// category has at least one entry that matches the task's signals.
+// Empty categories are skipped (an empty Files list does not auto-match
+// every diff). At least one Watching category must be non-empty for
+// any match to be reported — caller filters out IsEmpty agents earlier.
+func watchingMatchesSignals(w Watching, s ReviewerRoutingSignals) bool {
+	if len(w.Files) > 0 && anyGlobMatches(w.Files, s.Files) {
+		return true
+	}
+	if len(w.WikiPaths) > 0 && anyGlobMatches(w.WikiPaths, s.WikiPaths) {
+		return true
+	}
+	if len(w.ToolNames) > 0 && anyExactMatches(w.ToolNames, s.ToolNames) {
+		return true
+	}
+	if len(w.TaskTags) > 0 && anyExactMatches(w.TaskTags, s.TaskTags) {
+		return true
+	}
+	return false
+}
+
+// anyGlobMatches reports whether any pattern in patterns matches any
+// candidate in candidates under filepath.Match semantics. Invalid
+// glob patterns are logged and skipped — the routing layer must not
+// fail an entire convergence because one agent's Watching set carries a
+// malformed entry.
+func anyGlobMatches(patterns, candidates []string) bool {
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		for _, candidate := range candidates {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "" {
+				continue
+			}
+			ok, err := filepath.Match(pattern, candidate)
+			if err != nil {
+				log.Printf("broker: reviewer routing: invalid glob %q: %v", pattern, err)
+				break
+			}
+			if ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// anyExactMatches reports whether any value in want is present in have
+// (string-equal, trimmed). Used for ToolNames and TaskTags where glob
+// semantics would over-match short canonical identifiers.
+func anyExactMatches(want, have []string) bool {
+	if len(want) == 0 || len(have) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(have))
+	for _, v := range have {
+		v = strings.TrimSpace(v)
+		if v != "" {
+			set[v] = struct{}{}
+		}
+	}
+	for _, v := range want {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		if _, ok := set[v]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// taskByIDLocked returns the *teamTask pointer for the given ID, or nil
+// if not found. Caller must hold b.mu. Lookups are O(N) over b.tasks
+// because the broker does not currently maintain a primary-key index;
+// the lifecycle index is per-state, not per-id. This matches existing
+// patterns in broker_tasks_*.go.
+func (b *Broker) taskByIDLocked(taskID string) *teamTask {
+	for i := range b.tasks {
+		if b.tasks[i].ID == taskID {
+			return &b.tasks[i]
+		}
+	}
+	return nil
+}
+
+// postReviewTimeoutChannelMessageLocked posts the agent.review.timeout
+// banner to the team channel. Caller must hold b.mu. The message is
+// kind=agent.review.timeout so the frontend can render a distinct
+// banner without sniffing message text.
+func (b *Broker) postReviewTimeoutChannelMessageLocked(task *teamTask, reviewerSlug, reasoning string) {
+	if task == nil {
+		return
+	}
+	channel := strings.TrimSpace(task.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	now := b.reviewerNow().UTC().Format(time.RFC3339)
+	msg := channelMessage{
+		ID:        fmt.Sprintf("review-timeout-%s-%s-%d", task.ID, reviewerSlug, b.reviewerNow().UnixNano()),
+		From:      "system",
+		Channel:   channel,
+		Kind:      "agent.review.timeout",
+		Title:     fmt.Sprintf("Reviewer %s did not grade task %s", reviewerSlug, task.ID),
+		Content:   fmt.Sprintf("Reviewer %q on task %q: %s — slot filled with skipped placeholder.", reviewerSlug, task.ID, reasoning),
+		Timestamp: now,
+	}
+	b.appendMessageLocked(msg)
+}

--- a/internal/team/broker_reviewer_routing.go
+++ b/internal/team/broker_reviewer_routing.go
@@ -249,6 +249,20 @@ func (b *Broker) ReviewerGrades(taskID string) []ReviewerGrade {
 	return out
 }
 
+// gcReviewerGradesByTaskLocked drops the routing-side mirror entry for
+// a merged task. The Decision Packet retains the canonical grade list
+// — this index is used only by evaluateConvergenceLocked, which never
+// runs after a task transitions out of LifecycleStateReview.
+//
+// Caller must hold b.mu. Idempotent: a missing entry is a no-op.
+func (b *Broker) gcReviewerGradesByTaskLocked(taskID string) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" || b.reviewerGradesByTask == nil {
+		return
+	}
+	delete(b.reviewerGradesByTask, taskID)
+}
+
 // evaluateConvergenceLocked runs the convergence rule for a single task.
 // Three exit paths:
 //

--- a/internal/team/broker_reviewer_routing_test.go
+++ b/internal/team/broker_reviewer_routing_test.go
@@ -1,0 +1,539 @@
+package team
+
+// broker_reviewer_routing_test.go covers Lane D's reviewer-routing
+// scope: the intersection-routing function and the three convergence
+// paths (all-graded / timeout / process-exit) called out in
+// success-criteria gate #4 of the multi-agent control loop design.
+//
+// Tests deliberately avoid spinning a worktree, an HTTP server, or a
+// real headless launcher — every signal is constructed in-memory so
+// the tests run in <50ms each and stay deterministic on CI. The fake
+// clock pattern matches broker_middleware_test.go's b.nowFn override.
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+)
+
+// routingFakeClock advances on demand. Use Advance(d) to push the broker's
+// observable wall-clock forward by d without sleeping.
+type routingFakeClock struct {
+	t time.Time
+}
+
+func newRoutingFakeClockAt(t time.Time) *routingFakeClock { return &routingFakeClock{t: t} }
+func (c *routingFakeClock) Now() time.Time                { return c.t }
+func (c *routingFakeClock) Advance(d time.Duration) {
+	c.t = c.t.Add(d)
+}
+
+// seedTaskInReview installs a task in lifecycle review with the given
+// reviewer slug list. The convergence sweeper expects ReviewStartedAt
+// to be set; the helper uses the broker's clock so tests can advance
+// it deterministically.
+func seedTaskInReview(t *testing.T, b *Broker, taskID string, reviewers []string, timeoutSeconds int) {
+	t.Helper()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.tasks = append(b.tasks, teamTask{
+		ID:                   taskID,
+		Title:                "test-" + taskID,
+		Channel:              "general",
+		LifecycleState:       LifecycleStateRunning,
+		Reviewers:            reviewers,
+		ReviewTimeoutSeconds: timeoutSeconds,
+	})
+	b.indexLifecycleLocked(taskID, "", LifecycleStateRunning)
+	if _, err := b.transitionLifecycleLocked(taskID, LifecycleStateReview, "test seed"); err != nil {
+		t.Fatalf("seed transition: %v", err)
+	}
+	// AssignReviewers stamps ReviewStartedAt — call directly so the
+	// fake clock value is captured.
+	if err := b.assignReviewersLocked(taskID, reviewers); err != nil {
+		t.Fatalf("assign reviewers: %v", err)
+	}
+}
+
+// pushManifestLine simulates a HeadlessEvent manifest line landing on
+// the agent stream's task-scoped buffer. Used by the process-exit and
+// tool-name routing tests.
+func pushManifestLine(t *testing.T, b *Broker, slug, taskID, status string, toolNames []string) {
+	t.Helper()
+	stream := b.AgentStream(slug)
+	calls := make([]HeadlessManifestEntry, 0, len(toolNames))
+	for _, name := range toolNames {
+		calls = append(calls, HeadlessManifestEntry{ToolName: name, Count: 1})
+	}
+	ev := HeadlessEvent{
+		Kind:      HeadlessEventKind,
+		Type:      HeadlessEventTypeManifest,
+		Provider:  HeadlessProviderClaude,
+		Agent:     slug,
+		TaskID:    taskID,
+		Status:    status,
+		ToolCalls: calls,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	stream.PushTask(taskID, string(data)+"\n")
+}
+
+// TestReviewerConvergenceAllGraded exercises path 1 of build-time gate
+// #4: every assigned reviewer emits a graded review.submitted, the
+// broker fires exactly one decision transition, and the lifecycle
+// index ends with the task in the decision bucket.
+func TestReviewerConvergenceAllGraded(t *testing.T) {
+	clk := newRoutingFakeClockAt(time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
+	b := newTestBroker(t)
+	b.nowFn = clk.Now
+
+	reviewers := []string{"agent-a", "agent-b", "agent-c"}
+	seedTaskInReview(t, b, "task-1", reviewers, 600)
+
+	for _, slug := range reviewers {
+		if err := b.AppendReviewerGrade("task-1", ReviewerGrade{
+			ReviewerSlug: slug,
+			Severity:     SeverityMinor,
+			Suggestion:   "ok",
+			Reasoning:    "looks fine",
+		}); err != nil {
+			t.Fatalf("append grade for %s: %v", slug, err)
+		}
+	}
+
+	b.mu.Lock()
+	task := b.taskByIDLocked("task-1")
+	state := task.LifecycleState
+	bucket := append([]string(nil), b.lifecycleIndex[LifecycleStateDecision]...)
+	b.mu.Unlock()
+	if state != LifecycleStateDecision {
+		t.Fatalf("expected task in decision after all grades; got %q", state)
+	}
+	if len(bucket) != 1 || bucket[0] != "task-1" {
+		t.Fatalf("expected decision bucket to contain task-1; got %v", bucket)
+	}
+
+	// All three grades should be present, none filled with skipped.
+	grades := b.ReviewerGrades("task-1")
+	if len(grades) != 3 {
+		t.Fatalf("expected 3 grades, got %d", len(grades))
+	}
+	for _, g := range grades {
+		if g.Severity == SeveritySkipped {
+			t.Errorf("reviewer %s should not have been skipped: %+v", g.ReviewerSlug, g)
+		}
+	}
+}
+
+// TestReviewerConvergenceTimeoutFillsSkipped exercises path 2: 3
+// reviewers, 1 misses the deadline. The missing slot is filled with
+// SeveritySkipped + "reviewer timed out". Exactly one transition fires.
+func TestReviewerConvergenceTimeoutFillsSkipped(t *testing.T) {
+	clk := newRoutingFakeClockAt(time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
+	b := newTestBroker(t)
+	b.nowFn = clk.Now
+
+	reviewers := []string{"agent-a", "agent-b", "agent-c"}
+	seedTaskInReview(t, b, "task-2", reviewers, 600) // 10-min timeout
+
+	// Only two reviewers grade.
+	for _, slug := range []string{"agent-a", "agent-b"} {
+		if err := b.AppendReviewerGrade("task-2", ReviewerGrade{
+			ReviewerSlug: slug,
+			Severity:     SeverityMajor,
+			Reasoning:    "needs work",
+		}); err != nil {
+			t.Fatalf("append grade for %s: %v", slug, err)
+		}
+	}
+
+	// Sweeper before timeout: should not transition.
+	b.SweepReviewConvergence()
+	b.mu.Lock()
+	task := b.taskByIDLocked("task-2")
+	preTimeoutState := task.LifecycleState
+	b.mu.Unlock()
+	if preTimeoutState != LifecycleStateReview {
+		t.Fatalf("task should still be in review pre-timeout; got %q", preTimeoutState)
+	}
+
+	// Advance past the deadline.
+	clk.Advance(11 * time.Minute)
+	b.SweepReviewConvergence()
+
+	b.mu.Lock()
+	task = b.taskByIDLocked("task-2")
+	state := task.LifecycleState
+	b.mu.Unlock()
+	if state != LifecycleStateDecision {
+		t.Fatalf("expected task in decision after timeout; got %q", state)
+	}
+
+	grades := b.ReviewerGrades("task-2")
+	if len(grades) != 3 {
+		t.Fatalf("expected 3 grades after timeout fill; got %d", len(grades))
+	}
+
+	// The agent-c slot must be the skipped filler.
+	var filler *ReviewerGrade
+	for i := range grades {
+		if grades[i].ReviewerSlug == "agent-c" {
+			filler = &grades[i]
+		}
+	}
+	if filler == nil {
+		t.Fatal("expected agent-c filler grade; not found")
+	}
+	if filler.Severity != SeveritySkipped {
+		t.Errorf("filler severity: got %q, want %q", filler.Severity, SeveritySkipped)
+	}
+	if filler.Reasoning != "reviewer timed out" {
+		t.Errorf("filler reasoning: got %q, want %q", filler.Reasoning, "reviewer timed out")
+	}
+
+	// Exactly one transition fired: re-sweep must be idempotent.
+	bucketBefore := taskBucketCounts(b)
+	b.SweepReviewConvergence()
+	bucketAfter := taskBucketCounts(b)
+	if !bucketsEqual(bucketBefore, bucketAfter) {
+		t.Fatalf("sweep was not idempotent: before=%v after=%v", bucketBefore, bucketAfter)
+	}
+
+	// agent.review.timeout banner posted.
+	b.mu.Lock()
+	var banner *channelMessage
+	for i := range b.messages {
+		if b.messages[i].Kind == "agent.review.timeout" {
+			banner = &b.messages[i]
+			break
+		}
+	}
+	b.mu.Unlock()
+	if banner == nil {
+		t.Fatal("expected agent.review.timeout banner; none posted")
+	}
+}
+
+// TestReviewerConvergenceProcessExitFillsSkipped exercises path 3: a
+// reviewer's session emits a manifest-terminal event (idle/error)
+// without ever calling AppendReviewerGrade. After the deadline, the
+// missing slot is filled with reasoning "reviewer process exited",
+// distinguishing it from the plain timeout case.
+func TestReviewerConvergenceProcessExitFillsSkipped(t *testing.T) {
+	clk := newRoutingFakeClockAt(time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
+	b := newTestBroker(t)
+	b.nowFn = clk.Now
+
+	reviewers := []string{"agent-a", "agent-b", "agent-c"}
+	seedTaskInReview(t, b, "task-3", reviewers, 600)
+
+	// Two reviewers grade normally.
+	for _, slug := range []string{"agent-a", "agent-b"} {
+		if err := b.AppendReviewerGrade("task-3", ReviewerGrade{
+			ReviewerSlug: slug,
+			Severity:     SeverityMinor,
+			Reasoning:    "fine",
+		}); err != nil {
+			t.Fatalf("append grade for %s: %v", slug, err)
+		}
+	}
+
+	// agent-c emits a terminal manifest event without grading.
+	pushManifestLine(t, b, "agent-c", "task-3", "error", []string{"Read", "Edit"})
+
+	clk.Advance(11 * time.Minute)
+	b.SweepReviewConvergence()
+
+	grades := b.ReviewerGrades("task-3")
+	if len(grades) != 3 {
+		t.Fatalf("expected 3 grades; got %d", len(grades))
+	}
+	var filler *ReviewerGrade
+	for i := range grades {
+		if grades[i].ReviewerSlug == "agent-c" {
+			filler = &grades[i]
+		}
+	}
+	if filler == nil {
+		t.Fatal("expected agent-c filler grade; not found")
+	}
+	if filler.Severity != SeveritySkipped {
+		t.Errorf("filler severity: got %q, want %q", filler.Severity, SeveritySkipped)
+	}
+	if filler.Reasoning != "reviewer process exited" {
+		t.Errorf("filler reasoning: got %q, want %q (process-exit must be distinct from plain timeout)", filler.Reasoning, "reviewer process exited")
+	}
+
+	b.mu.Lock()
+	state := b.taskByIDLocked("task-3").LifecycleState
+	b.mu.Unlock()
+	if state != LifecycleStateDecision {
+		t.Fatalf("expected task in decision; got %q", state)
+	}
+
+	// No half-open slot left: re-sweep must not append a second
+	// filler or fire a second transition.
+	beforeGrades := len(b.ReviewerGrades("task-3"))
+	b.SweepReviewConvergence()
+	afterGrades := len(b.ReviewerGrades("task-3"))
+	if beforeGrades != afterGrades {
+		t.Fatalf("re-sweep added duplicate grades: before=%d after=%d", beforeGrades, afterGrades)
+	}
+}
+
+// TestResolveReviewersIntersection is the routing test required by the
+// Lane D scope: 3 agents with overlapping Watching sets, simulate a
+// task touching specific files / tools / wiki paths, assert exactly
+// the right intersection of agents is returned and tunnel humans are
+// not auto-assigned.
+func TestResolveReviewersIntersection(t *testing.T) {
+	b := newTestBroker(t)
+
+	b.mu.Lock()
+	b.members = []officeMember{
+		{
+			Slug: "agent-frontend",
+			Watching: Watching{
+				Files: []string{"web/*.tsx", "web/src/**.ts"},
+			},
+		},
+		{
+			Slug: "agent-backend",
+			Watching: Watching{
+				Files:     []string{"internal/*.go"},
+				ToolNames: []string{"go-test"},
+			},
+		},
+		{
+			Slug: "agent-wiki",
+			Watching: Watching{
+				WikiPaths: []string{"wiki/*.md"},
+				TaskTags:  []string{"docs"},
+			},
+		},
+		{
+			// No Watching set — must never be auto-assigned.
+			Slug: "agent-untagged",
+		},
+	}
+	// Pre-populate agent stream with manifest events so ToolNames
+	// extraction picks up "go-test" for the backend agent.
+	b.tasks = append(b.tasks, teamTask{
+		ID:             "task-route",
+		Title:          "routing test",
+		LifecycleState: LifecycleStateRunning,
+		Tags:           []string{"docs"},
+	})
+	b.indexLifecycleLocked("task-route", "", LifecycleStateRunning)
+	b.mu.Unlock()
+
+	pushManifestLine(t, b, "owner-agent", "task-route", "idle", []string{"go-test", "Read"})
+
+	// We can't run a real `git diff` in this unit test, so synthesize
+	// signals directly through a thin wrapper that bypasses
+	// taskWorktreeDiffLocked. The simplest path: stamp a worktree
+	// path that does not exist, then assert that file-glob agents
+	// are NOT matched (because the diff returns nothing). Wiki and
+	// tool routing still fire from the in-memory signals.
+	slugs, err := b.ResolveReviewers("task-route")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	want := []string{"agent-backend", "agent-wiki"}
+	sort.Strings(slugs)
+	sort.Strings(want)
+	if !routingStringSlicesEqual(slugs, want) {
+		t.Fatalf("intersection: got %v, want %v", slugs, want)
+	}
+
+	// Now stamp a synthetic Files signal via a focused integration
+	// path: write a Watching-Files match by simulating a populated
+	// Files signal. We do this by inserting a fake filepath glob the
+	// extractor will see when called via a tagged path. Simplest:
+	// re-run with a task tag that intersects agent-frontend's Files
+	// glob via a separate test path. Since we cannot inject Files
+	// without a real worktree, the assertion above already proves the
+	// negative case (no Files match → no agent-frontend). The full
+	// Files-glob match is exercised by TestWatchingMatchesSignals
+	// below, which calls watchingMatchesSignals directly.
+}
+
+// TestWatchingMatchesSignals exercises the four-category match logic
+// in isolation, including the empty-category guard and the
+// invalid-glob fallback. Faster and more thorough than driving the
+// full ResolveReviewers stack for every shape.
+func TestWatchingMatchesSignals(t *testing.T) {
+	cases := []struct {
+		name     string
+		watching Watching
+		signals  ReviewerRoutingSignals
+		want     bool
+	}{
+		{
+			name:     "empty watching does not match anything",
+			watching: Watching{},
+			signals:  ReviewerRoutingSignals{Files: []string{"web/index.tsx"}},
+			want:     false,
+		},
+		{
+			name:     "files glob match",
+			watching: Watching{Files: []string{"web/*.tsx"}},
+			signals:  ReviewerRoutingSignals{Files: []string{"web/index.tsx"}},
+			want:     true,
+		},
+		{
+			name:     "files glob no match",
+			watching: Watching{Files: []string{"server/*.go"}},
+			signals:  ReviewerRoutingSignals{Files: []string{"web/index.tsx"}},
+			want:     false,
+		},
+		{
+			name:     "wiki path glob match",
+			watching: Watching{WikiPaths: []string{"wiki/*.md"}},
+			signals:  ReviewerRoutingSignals{WikiPaths: []string{"wiki/billing.md"}},
+			want:     true,
+		},
+		{
+			name:     "tool name exact match",
+			watching: Watching{ToolNames: []string{"go-test"}},
+			signals:  ReviewerRoutingSignals{ToolNames: []string{"Read", "go-test"}},
+			want:     true,
+		},
+		{
+			name:     "task tag exact match",
+			watching: Watching{TaskTags: []string{"docs"}},
+			signals:  ReviewerRoutingSignals{TaskTags: []string{"docs", "frontend"}},
+			want:     true,
+		},
+		{
+			name:     "non-empty watching with all-empty signals does not match",
+			watching: Watching{Files: []string{"*.go"}},
+			signals:  ReviewerRoutingSignals{},
+			want:     false,
+		},
+		{
+			name:     "any-of OR semantics: tool match wins even when files don't",
+			watching: Watching{Files: []string{"docs/*.md"}, ToolNames: []string{"go-test"}},
+			signals:  ReviewerRoutingSignals{Files: []string{"web/x.tsx"}, ToolNames: []string{"go-test"}},
+			want:     true,
+		},
+		{
+			name:     "invalid glob does not crash, returns no match for that pattern",
+			watching: Watching{Files: []string{"[abc"}}, // unbalanced bracket — invalid
+			signals:  ReviewerRoutingSignals{Files: []string{"abc"}},
+			want:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := watchingMatchesSignals(tc.watching, tc.signals)
+			if got != tc.want {
+				t.Fatalf("watchingMatchesSignals: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractRoutingSignalsToolNames exercises the manifest-event
+// walker that builds the ToolNames signal from agent streams. Asserts
+// dedupe, sorted output, and that non-manifest events are ignored.
+func TestExtractRoutingSignalsToolNames(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.tasks = []teamTask{{ID: "task-tools", LifecycleState: LifecycleStateRunning}}
+	b.indexLifecycleLocked("task-tools", "", LifecycleStateRunning)
+	b.mu.Unlock()
+
+	pushManifestLine(t, b, "agent-1", "task-tools", "idle", []string{"Read", "Edit"})
+	pushManifestLine(t, b, "agent-2", "task-tools", "idle", []string{"Edit", "go-test"})
+	// Non-manifest line that must be ignored.
+	stream := b.AgentStream("agent-3")
+	stream.PushTask("task-tools", `{"kind":"headless_event","type":"text","tool_name":"NotAManifestTool"}`+"\n")
+
+	b.mu.Lock()
+	task := b.taskByIDLocked("task-tools")
+	signals := b.extractRoutingSignalsLocked(task)
+	b.mu.Unlock()
+
+	want := []string{"Edit", "Read", "go-test"}
+	if !routingStringSlicesEqual(signals.ToolNames, want) {
+		t.Fatalf("ToolNames: got %v, want %v", signals.ToolNames, want)
+	}
+}
+
+// TestAssignReviewersDedupesAndStampsStart asserts that
+// AssignReviewers normalises the slug list (dedupe, trim, sort) and
+// stamps ReviewStartedAt with the broker's clock. ReviewStartedAt is
+// the load-bearing input to the deadline calculation, so a missed
+// stamp would silently make the timeout never fire.
+func TestAssignReviewersDedupesAndStampsStart(t *testing.T) {
+	clk := newRoutingFakeClockAt(time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
+	b := newTestBroker(t)
+	b.nowFn = clk.Now
+
+	b.mu.Lock()
+	b.tasks = []teamTask{{ID: "task-asgn", LifecycleState: LifecycleStateReview}}
+	b.indexLifecycleLocked("task-asgn", "", LifecycleStateReview)
+	b.mu.Unlock()
+
+	if err := b.AssignReviewers("task-asgn", []string{"  agent-b  ", "agent-a", "", "agent-b"}); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+
+	b.mu.Lock()
+	task := b.taskByIDLocked("task-asgn")
+	got := append([]string(nil), task.Reviewers...)
+	startedAt := task.ReviewStartedAt
+	b.mu.Unlock()
+
+	want := []string{"agent-a", "agent-b"}
+	if !routingStringSlicesEqual(got, want) {
+		t.Fatalf("Reviewers: got %v, want %v", got, want)
+	}
+	if startedAt != clk.Now().UTC().Format(time.RFC3339) {
+		t.Fatalf("ReviewStartedAt: got %q, want %q", startedAt, clk.Now().UTC().Format(time.RFC3339))
+	}
+}
+
+// taskBucketCounts and bucketsEqual are tiny test helpers used by the
+// idempotency assertions above.
+func taskBucketCounts(b *Broker) map[LifecycleState]int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make(map[LifecycleState]int, len(b.lifecycleIndex))
+	for state, ids := range b.lifecycleIndex {
+		out[state] = len(ids)
+	}
+	return out
+}
+
+func bucketsEqual(a, b map[LifecycleState]int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func routingStringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/team/broker_reviewer_routing_test.go
+++ b/internal/team/broker_reviewer_routing_test.go
@@ -608,6 +608,74 @@ func TestAssignReviewersDedupesAndStampsStart(t *testing.T) {
 	}
 }
 
+// TestReviewerGradesByTaskGCOnMerged covers Lane D follow-up D-FU-1:
+// the routing-side mirror b.reviewerGradesByTask must drop the
+// merged task's entry on the LifecycleStateMerged transition.
+// Without this cleanup a long-running broker accumulates one entry
+// per merged task (the Decision Packet keeps the canonical grade
+// list; the routing-side index is only consumed by
+// evaluateConvergenceLocked, which never runs after a task leaves
+// LifecycleStateReview).
+//
+// Acceptance: seed 2 tasks in review, fully grade both so they
+// transition to decision, then merge one. The merged task drops out
+// of the mirror; the still-pending task keeps its entry. Length goes
+// from N to N-1.
+func TestReviewerGradesByTaskGCOnMerged(t *testing.T) {
+	clk := newRoutingFakeClockAt(time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
+	b := newTestBroker(t)
+	b.nowFn = clk.Now
+
+	reviewers := []string{"agent-a", "agent-b"}
+	seedTaskInReview(t, b, "task-merge", reviewers, 600)
+	seedTaskInReview(t, b, "task-other", reviewers, 600)
+
+	for _, taskID := range []string{"task-merge", "task-other"} {
+		for _, slug := range reviewers {
+			if err := b.AppendReviewerGrade(taskID, ReviewerGrade{
+				ReviewerSlug: slug,
+				Severity:     SeverityMinor,
+				Reasoning:    "ok",
+			}); err != nil {
+				t.Fatalf("append grade %s/%s: %v", taskID, slug, err)
+			}
+		}
+	}
+
+	b.mu.Lock()
+	beforeLen := len(b.reviewerGradesByTask)
+	mergeBefore := len(b.reviewerGradesByTask["task-merge"])
+	otherBefore := len(b.reviewerGradesByTask["task-other"])
+	b.mu.Unlock()
+	if beforeLen != 2 || mergeBefore != 2 || otherBefore != 2 {
+		t.Fatalf("pre-merge: expected map len=2 with both tasks holding 2 grades; got len=%d merge=%d other=%d",
+			beforeLen, mergeBefore, otherBefore)
+	}
+
+	// Merge task-merge via the public lifecycle transition entry. This
+	// is the same path RecordTaskDecision uses on a packet merge.
+	if err := b.TransitionLifecycle("task-merge", LifecycleStateMerged, "test merge"); err != nil {
+		t.Fatalf("transition merge: %v", err)
+	}
+
+	b.mu.Lock()
+	afterLen := len(b.reviewerGradesByTask)
+	_, mergeStill := b.reviewerGradesByTask["task-merge"]
+	otherAfter := len(b.reviewerGradesByTask["task-other"])
+	b.mu.Unlock()
+
+	if afterLen != beforeLen-1 {
+		t.Fatalf("expected reviewerGradesByTask len to drop from %d to %d; got %d",
+			beforeLen, beforeLen-1, afterLen)
+	}
+	if mergeStill {
+		t.Fatal("expected task-merge entry to be GC'd from reviewerGradesByTask")
+	}
+	if otherAfter != 2 {
+		t.Fatalf("expected task-other grades intact (len=2); got %d", otherAfter)
+	}
+}
+
 // taskBucketCounts and bucketsEqual are tiny test helpers used by the
 // idempotency assertions above.
 func taskBucketCounts(b *Broker) map[LifecycleState]int {

--- a/internal/team/broker_reviewer_routing_test.go
+++ b/internal/team/broker_reviewer_routing_test.go
@@ -286,6 +286,112 @@ func TestReviewerConvergenceProcessExitFillsSkipped(t *testing.T) {
 	}
 }
 
+// TestReviewerConvergenceRaceGradeOnTimeoutBoundary (D-FU-2) covers
+// the corner case where a grade arrives in the same second the timeout
+// would otherwise fire. The convergence rule is idempotent — both
+// branches converge to LifecycleStateDecision, the grade-arrival path
+// transitions on "all reviewers graded" and the sweeper-timeout path
+// is then a no-op because the task is already past review. This test
+// asserts both orderings (grade-then-sweep, sweep-then-grade) land on
+// the same final state and produce the same number of grades, so a
+// future contributor refactoring evaluateConvergenceLocked cannot
+// silently introduce a race that double-fires the transition or
+// double-fills the missing slot.
+func TestReviewerConvergenceRaceGradeOnTimeoutBoundary(t *testing.T) {
+	cases := []struct {
+		name       string
+		gradeFirst bool
+	}{
+		{name: "grade lands then sweep fires", gradeFirst: true},
+		{name: "sweep fires then grade lands", gradeFirst: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			clk := newRoutingFakeClockAt(time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC))
+			b := newTestBroker(t)
+			b.nowFn = clk.Now
+
+			reviewers := []string{"agent-a", "agent-b"}
+			seedTaskInReview(t, b, "task-race", reviewers, 600)
+
+			// Stage one reviewer's grade so the boundary case has exactly
+			// one slot still missing when the deadline elapses.
+			if err := b.AppendReviewerGrade("task-race", ReviewerGrade{
+				ReviewerSlug: "agent-a",
+				Severity:     SeverityNitpick,
+				Reasoning:    "lgtm",
+			}); err != nil {
+				t.Fatalf("seed first grade: %v", err)
+			}
+
+			// Advance the clock to the exact deadline; both code paths
+			// (sweeper timeout fill, late-arrival grade) become eligible
+			// to fire on the same broker tick.
+			clk.Advance(10 * time.Minute)
+
+			finalGrade := ReviewerGrade{
+				ReviewerSlug: "agent-b",
+				Severity:     SeverityMinor,
+				Reasoning:    "small nit",
+			}
+
+			if tc.gradeFirst {
+				if err := b.AppendReviewerGrade("task-race", finalGrade); err != nil {
+					t.Fatalf("late grade arrival: %v", err)
+				}
+				b.SweepReviewConvergence()
+			} else {
+				b.SweepReviewConvergence()
+				if err := b.AppendReviewerGrade("task-race", finalGrade); err != nil {
+					t.Fatalf("late grade arrival after sweep: %v", err)
+				}
+			}
+
+			b.mu.Lock()
+			task := b.taskByIDLocked("task-race")
+			finalState := task.LifecycleState
+			b.mu.Unlock()
+			if finalState != LifecycleStateDecision {
+				t.Fatalf("expected task in decision after race; got %q", finalState)
+			}
+
+			// The convergence rule must be idempotent: a re-sweep is a
+			// no-op (state already decision) and a duplicate grade
+			// append on agent-b overwrites the existing slot, so the
+			// total grade count stays at 2.
+			b.SweepReviewConvergence()
+			grades := b.ReviewerGrades("task-race")
+			if len(grades) != 2 {
+				t.Fatalf("expected 2 grades after race + idempotent re-sweep; got %d (%+v)", len(grades), grades)
+			}
+
+			// Whichever path fired first decides the agent-b slot:
+			//   - grade-first: real grade with SeverityMinor.
+			//   - sweep-first: timeout-filler with SeveritySkipped, then
+			//     overwritten by the late-arrival real grade.
+			// Either way, the late grade wins because AppendReviewerGrade
+			// overwrites by (taskID, ReviewerSlug). Assert agent-b's
+			// final grade matches what the reviewer actually submitted.
+			var slotB *ReviewerGrade
+			for i := range grades {
+				if grades[i].ReviewerSlug == "agent-b" {
+					slotB = &grades[i]
+				}
+			}
+			if slotB == nil {
+				t.Fatal("agent-b slot missing from grades")
+			}
+			if slotB.Severity != SeverityMinor {
+				t.Fatalf("agent-b severity: got %q, want %q (the real submitted grade should win)", slotB.Severity, SeverityMinor)
+			}
+			if slotB.Reasoning != "small nit" {
+				t.Fatalf("agent-b reasoning: got %q, want %q", slotB.Reasoning, "small nit")
+			}
+		})
+	}
+}
+
 // TestResolveReviewersIntersection is the routing test required by the
 // Lane D scope: 3 agents with overlapping Watching sets, simulate a
 // task touching specific files / tools / wiki paths, assert exactly

--- a/internal/team/broker_reviewer_routing_types.go
+++ b/internal/team/broker_reviewer_routing_types.go
@@ -1,0 +1,100 @@
+package team
+
+// broker_reviewer_routing_types.go declares the type surface for Lane D's
+// reviewer-routing layer: the per-officeMember Watching set, the typed
+// signals the broker extracts from a task before intersecting with that
+// set, and the ReviewerGrade / Severity wire types Lane D needs to call
+// into Lane C's Decision Packet mutator.
+//
+// Coordination with Lane C (parallel build): Lane C owns the Decision
+// Packet model and persistence. Lane D needs only two contract points
+// from Lane C — the Severity constant set (so the timeout filler can
+// stamp SeveritySkipped) and the AppendReviewerGrade mutator signature
+// (so the timeout filler can populate a missing slot). Both live here
+// as the Lane-D-side contract until Lane C lands; Lane C must match
+// these types exactly when it merges, or the convergence path breaks.
+//
+// Why these live in their own file: keeping them out of broker_types.go
+// preserves the "broker_types.go is the persisted-wire-shape file" rule.
+// Watching and ReviewerRoutingSignals are not persisted as standalone
+// records (Watching is a sub-field of officeMember; signals are
+// transient). The grade types are persisted by Lane C, but Lane C will
+// move them into broker_decision_packet.go when it ships, leaving this
+// file as the watching-set + signals carrier.
+
+// Watching captures the four glob/tag categories an officeMember can
+// declare interest in. Used by the broker's reviewer-routing logic to
+// auto-assign agents to a task entering review.
+//
+// Each list is matched independently — an empty list means "do not
+// match on this category", not "match everything". An agent is
+// auto-assigned when ANY of its non-empty categories intersects with
+// the task's signals; this matches CODEOWNERS-style "any line touching
+// my path" semantics rather than requiring all categories to overlap
+// (which would make multi-category Watching sets effectively unusable).
+type Watching struct {
+	// Files is the list of glob patterns matched against the output of
+	// `git diff --name-only` between the task's worktree and the task's
+	// parent branch. Patterns use Go's path/filepath.Match semantics
+	// (no globstar; ** is not expanded). Each entry must be a valid
+	// glob — invalid entries are dropped at match time and logged.
+	Files []string `json:"files,omitempty"`
+
+	// WikiPaths is the list of glob patterns matched against the
+	// wiki-relative paths that appear in the diff (i.e. the same
+	// `git diff --name-only` output, filtered to entries under the
+	// repo's wiki root). Same matching semantics as Files.
+	WikiPaths []string `json:"wiki_paths,omitempty"`
+
+	// ToolNames is matched against the union of HeadlessEvent.ToolCalls
+	// observed for the task across all manifest events on its agent
+	// stream. Comparison is exact-match on the tool name (no globs);
+	// tool names are short canonical identifiers.
+	//
+	// ToolNames was substituted for an earlier SkillDomains proposal
+	// because skill-domain tags are not currently recorded in the
+	// HeadlessEvent pipeline. Adding skill-domain recording is v1.1.
+	ToolNames []string `json:"tool_names,omitempty"`
+
+	// TaskTags is matched against teamTask.Tags. Comparison is
+	// exact-match (no globs); tags are short canonical identifiers
+	// that the spec author or owner agent attaches to a task.
+	TaskTags []string `json:"task_tags,omitempty"`
+}
+
+// IsEmpty reports whether the watching set has no patterns at all. Used
+// to skip agents that haven't declared any interest.
+func (w Watching) IsEmpty() bool {
+	return len(w.Files) == 0 && len(w.WikiPaths) == 0 && len(w.ToolNames) == 0 && len(w.TaskTags) == 0
+}
+
+// ReviewerRoutingSignals is the deterministic snapshot of a task's
+// state that the routing logic intersects against each agent's
+// Watching set. Built by extractRoutingSignalsLocked from on-disk diff
+// output, agent-stream manifest events, and the task's own Tags field.
+//
+// Kept as an explicit struct (rather than passing four slices) so the
+// test surface can construct a synthetic signal set without spinning up
+// a worktree or stream buffer.
+type ReviewerRoutingSignals struct {
+	Files     []string // diff paths from `git diff --name-only`
+	WikiPaths []string // subset of Files under the wiki root
+	ToolNames []string // unique tool names observed across the task's manifest events
+	TaskTags  []string // verbatim copy of teamTask.Tags
+}
+
+// Severity and ReviewerGrade live in broker_decision_packet_types.go
+// (Lane C). Lane D consumes them as-is for the timeout filler and
+// convergence rule. SubmittedAt is time.Time per the design doc.
+
+// reviewConvergenceTickInterval is the cadence at which the broker's
+// background sweeper re-evaluates every review-state task. 30s matches
+// the design doc; the sweeper is intentionally cheap (only iterates
+// the review bucket of the lifecycle index, never the full task list).
+const reviewConvergenceTickInterval = 30 // seconds
+
+// reviewConvergenceDefaultTimeoutSeconds is the default cap on how
+// long the broker waits for all assigned reviewers before filling
+// missing slots with SeveritySkipped and transitioning to decision.
+// teamTask.ReviewTimeoutSeconds overrides this on a per-task basis.
+const reviewConvergenceDefaultTimeoutSeconds = 600 // 10 minutes

--- a/internal/team/broker_types.go
+++ b/internal/team/broker_types.go
@@ -204,16 +204,39 @@ type teamTask struct {
 	// transition layer (b.transitionLifecycleLocked / b.TransitionLifecycle)
 	// so derived fields, the indexed lookup, and self-heal gating all stay
 	// in sync.
-	LifecycleState LifecycleState  `json:"lifecycle_state,omitempty"`
-	AckedAt        string          `json:"acked_at,omitempty"`
-	DueAt          string          `json:"due_at,omitempty"`
-	FollowUpAt     string          `json:"follow_up_at,omitempty"`
-	ReminderAt     string          `json:"reminder_at,omitempty"`
-	RecheckAt      string          `json:"recheck_at,omitempty"`
-	MemoryWorkflow *MemoryWorkflow `json:"memory_workflow,omitempty"`
-	CreatedAt      string          `json:"created_at"`
-	UpdatedAt      string          `json:"updated_at"`
-	CompletedAt    string          `json:"completed_at,omitempty"`
+	LifecycleState LifecycleState `json:"lifecycle_state,omitempty"`
+	// Reviewers is the auto-assigned agent slug list resolved by Lane D's
+	// reviewer-routing logic at the running → review transition. The CLI
+	// (`wuphf task review --invite <slug>`) appends tunnel-human slugs to
+	// this same list as additional reviewers. Convergence rule fires
+	// when every slug here has emitted a graded review.submitted event.
+	Reviewers []string `json:"reviewers,omitempty"`
+	// Tags carries spec-level domain tags (e.g. "frontend", "billing")
+	// matched against officeMember.Watching.TaskTags during reviewer
+	// routing. Lane B's Spec is the authoritative source once it lands;
+	// for v1 the task carries its own copy so the routing logic does not
+	// need a Lane-B dependency.
+	Tags []string `json:"tags,omitempty"`
+	// ReviewStartedAt is the RFC3339 timestamp at which the task entered
+	// the review state. The convergence sweeper compares this against
+	// ReviewTimeoutSeconds (or the package-level default) to decide
+	// whether the timeout has elapsed. Empty for tasks not currently in
+	// review.
+	ReviewStartedAt string `json:"review_started_at,omitempty"`
+	// ReviewTimeoutSeconds optionally overrides
+	// reviewConvergenceDefaultTimeoutSeconds for this task. Zero or
+	// negative means "use the package default". This is the
+	// task.review_timeout_seconds knob from the design doc.
+	ReviewTimeoutSeconds int             `json:"review_timeout_seconds,omitempty"`
+	AckedAt              string          `json:"acked_at,omitempty"`
+	DueAt                string          `json:"due_at,omitempty"`
+	FollowUpAt           string          `json:"follow_up_at,omitempty"`
+	ReminderAt           string          `json:"reminder_at,omitempty"`
+	RecheckAt            string          `json:"recheck_at,omitempty"`
+	MemoryWorkflow       *MemoryWorkflow `json:"memory_workflow,omitempty"`
+	CreatedAt            string          `json:"created_at"`
+	UpdatedAt            string          `json:"updated_at"`
+	CompletedAt          string          `json:"completed_at,omitempty"`
 }
 
 // Status returns the persisted status string. Read accessor for callers
@@ -255,36 +278,40 @@ func (t *teamTask) Blocked() bool {
 // the on-disk and HTTP wire formats. teamTask.MarshalJSON / UnmarshalJSON
 // route through this shadow type.
 type teamTaskWire struct {
-	ID               string          `json:"id"`
-	Channel          string          `json:"channel,omitempty"`
-	Title            string          `json:"title"`
-	Details          string          `json:"details,omitempty"`
-	Owner            string          `json:"owner,omitempty"`
-	Status           string          `json:"status"`
-	CreatedBy        string          `json:"created_by"`
-	ThreadID         string          `json:"thread_id,omitempty"`
-	TaskType         string          `json:"task_type,omitempty"`
-	PipelineID       string          `json:"pipeline_id,omitempty"`
-	PipelineStage    string          `json:"pipeline_stage,omitempty"`
-	ExecutionMode    string          `json:"execution_mode,omitempty"`
-	ReviewState      string          `json:"review_state,omitempty"`
-	SourceSignalID   string          `json:"source_signal_id,omitempty"`
-	SourceDecisionID string          `json:"source_decision_id,omitempty"`
-	WorktreePath     string          `json:"worktree_path,omitempty"`
-	WorktreeBranch   string          `json:"worktree_branch,omitempty"`
-	DependsOn        []string        `json:"depends_on,omitempty"`
-	BlockedOn        []string        `json:"blocked_on,omitempty"`
-	Blocked          bool            `json:"blocked,omitempty"`
-	LifecycleState   LifecycleState  `json:"lifecycle_state,omitempty"`
-	AckedAt          string          `json:"acked_at,omitempty"`
-	DueAt            string          `json:"due_at,omitempty"`
-	FollowUpAt       string          `json:"follow_up_at,omitempty"`
-	ReminderAt       string          `json:"reminder_at,omitempty"`
-	RecheckAt        string          `json:"recheck_at,omitempty"`
-	MemoryWorkflow   *MemoryWorkflow `json:"memory_workflow,omitempty"`
-	CreatedAt        string          `json:"created_at"`
-	UpdatedAt        string          `json:"updated_at"`
-	CompletedAt      string          `json:"completed_at,omitempty"`
+	ID                   string          `json:"id"`
+	Channel              string          `json:"channel,omitempty"`
+	Title                string          `json:"title"`
+	Details              string          `json:"details,omitempty"`
+	Owner                string          `json:"owner,omitempty"`
+	Status               string          `json:"status"`
+	CreatedBy            string          `json:"created_by"`
+	ThreadID             string          `json:"thread_id,omitempty"`
+	TaskType             string          `json:"task_type,omitempty"`
+	PipelineID           string          `json:"pipeline_id,omitempty"`
+	PipelineStage        string          `json:"pipeline_stage,omitempty"`
+	ExecutionMode        string          `json:"execution_mode,omitempty"`
+	ReviewState          string          `json:"review_state,omitempty"`
+	SourceSignalID       string          `json:"source_signal_id,omitempty"`
+	SourceDecisionID     string          `json:"source_decision_id,omitempty"`
+	WorktreePath         string          `json:"worktree_path,omitempty"`
+	WorktreeBranch       string          `json:"worktree_branch,omitempty"`
+	DependsOn            []string        `json:"depends_on,omitempty"`
+	BlockedOn            []string        `json:"blocked_on,omitempty"`
+	Blocked              bool            `json:"blocked,omitempty"`
+	LifecycleState       LifecycleState  `json:"lifecycle_state,omitempty"`
+	Reviewers            []string        `json:"reviewers,omitempty"`
+	Tags                 []string        `json:"tags,omitempty"`
+	ReviewStartedAt      string          `json:"review_started_at,omitempty"`
+	ReviewTimeoutSeconds int             `json:"review_timeout_seconds,omitempty"`
+	AckedAt              string          `json:"acked_at,omitempty"`
+	DueAt                string          `json:"due_at,omitempty"`
+	FollowUpAt           string          `json:"follow_up_at,omitempty"`
+	ReminderAt           string          `json:"reminder_at,omitempty"`
+	RecheckAt            string          `json:"recheck_at,omitempty"`
+	MemoryWorkflow       *MemoryWorkflow `json:"memory_workflow,omitempty"`
+	CreatedAt            string          `json:"created_at"`
+	UpdatedAt            string          `json:"updated_at"`
+	CompletedAt          string          `json:"completed_at,omitempty"`
 }
 
 // MarshalJSON preserves the pre-Lane-A wire format (status/review_state/
@@ -292,36 +319,40 @@ type teamTaskWire struct {
 // fields unexported on the Go struct.
 func (t teamTask) MarshalJSON() ([]byte, error) {
 	return json.Marshal(teamTaskWire{
-		ID:               t.ID,
-		Channel:          t.Channel,
-		Title:            t.Title,
-		Details:          t.Details,
-		Owner:            t.Owner,
-		Status:           t.status,
-		CreatedBy:        t.CreatedBy,
-		ThreadID:         t.ThreadID,
-		TaskType:         t.TaskType,
-		PipelineID:       t.PipelineID,
-		PipelineStage:    t.pipelineStage,
-		ExecutionMode:    t.ExecutionMode,
-		ReviewState:      t.reviewState,
-		SourceSignalID:   t.SourceSignalID,
-		SourceDecisionID: t.SourceDecisionID,
-		WorktreePath:     t.WorktreePath,
-		WorktreeBranch:   t.WorktreeBranch,
-		DependsOn:        t.DependsOn,
-		BlockedOn:        t.BlockedOn,
-		Blocked:          t.blocked,
-		LifecycleState:   t.LifecycleState,
-		AckedAt:          t.AckedAt,
-		DueAt:            t.DueAt,
-		FollowUpAt:       t.FollowUpAt,
-		ReminderAt:       t.ReminderAt,
-		RecheckAt:        t.RecheckAt,
-		MemoryWorkflow:   t.MemoryWorkflow,
-		CreatedAt:        t.CreatedAt,
-		UpdatedAt:        t.UpdatedAt,
-		CompletedAt:      t.CompletedAt,
+		ID:                   t.ID,
+		Channel:              t.Channel,
+		Title:                t.Title,
+		Details:              t.Details,
+		Owner:                t.Owner,
+		Status:               t.status,
+		CreatedBy:            t.CreatedBy,
+		ThreadID:             t.ThreadID,
+		TaskType:             t.TaskType,
+		PipelineID:           t.PipelineID,
+		PipelineStage:        t.pipelineStage,
+		ExecutionMode:        t.ExecutionMode,
+		ReviewState:          t.reviewState,
+		SourceSignalID:       t.SourceSignalID,
+		SourceDecisionID:     t.SourceDecisionID,
+		WorktreePath:         t.WorktreePath,
+		WorktreeBranch:       t.WorktreeBranch,
+		DependsOn:            t.DependsOn,
+		BlockedOn:            t.BlockedOn,
+		Blocked:              t.blocked,
+		LifecycleState:       t.LifecycleState,
+		Reviewers:            t.Reviewers,
+		Tags:                 t.Tags,
+		ReviewStartedAt:      t.ReviewStartedAt,
+		ReviewTimeoutSeconds: t.ReviewTimeoutSeconds,
+		AckedAt:              t.AckedAt,
+		DueAt:                t.DueAt,
+		FollowUpAt:           t.FollowUpAt,
+		ReminderAt:           t.ReminderAt,
+		RecheckAt:            t.RecheckAt,
+		MemoryWorkflow:       t.MemoryWorkflow,
+		CreatedAt:            t.CreatedAt,
+		UpdatedAt:            t.UpdatedAt,
+		CompletedAt:          t.CompletedAt,
 	})
 }
 
@@ -352,6 +383,10 @@ func (t *teamTask) UnmarshalJSON(data []byte) error {
 	t.BlockedOn = w.BlockedOn
 	t.blocked = w.Blocked
 	t.LifecycleState = w.LifecycleState
+	t.Reviewers = w.Reviewers
+	t.Tags = w.Tags
+	t.ReviewStartedAt = w.ReviewStartedAt
+	t.ReviewTimeoutSeconds = w.ReviewTimeoutSeconds
 	t.AckedAt = w.AckedAt
 	t.DueAt = w.DueAt
 	t.FollowUpAt = w.FollowUpAt
@@ -398,6 +433,13 @@ type officeMember struct {
 	CreatedAt      string                   `json:"created_at,omitempty"`
 	BuiltIn        bool                     `json:"built_in,omitempty"`
 	Provider       provider.ProviderBinding `json:"provider,omitempty"`
+	// Watching declares the file-glob, wiki-glob, tool-name, and task-tag
+	// categories this agent should be auto-assigned as a reviewer for when
+	// a task enters review. See broker_reviewer_routing.go (Lane D) for
+	// the intersection logic. omitempty keeps existing brokers' wire
+	// format unchanged on disk for agents that have not been configured
+	// with a watching set.
+	Watching Watching `json:"watching,omitempty"`
 }
 
 type officeActionLog struct {


### PR DESCRIPTION
## Summary

Lane D of the multi-agent control loop. Adds the CODEOWNERS-equivalent reviewer-routing layer on top of Lane A's lifecycle foundation and Lane C's Decision Packet:

- New \`Watching\` struct on \`officeMember\` with four glob/tag categories (Files / WikiPaths / ToolNames / TaskTags).
- \`teamTask\` extended with \`Reviewers\` / \`Tags\` / \`ReviewStartedAt\` / \`ReviewTimeoutSeconds\`.
- \`ResolveReviewers\` / \`AssignReviewers\` / \`EvaluateConvergence\` / \`SweepReviewConvergence\` public API.
- Convergence rule: a task transitions \`review → decision\` when (a) all assigned reviewers grade, OR (b) the per-task timeout elapses, OR (c) a reviewer's headless session exits without grading. (b) and (c) fill missing slots with \`SeveritySkipped\` + a typed reasoning string.
- Lane A wire (#9): when a task transitions to \`LifecycleStateReview\`, the routing layer auto-resolves and assigns reviewers (skipped when caller pre-set the list).
- Mirror writes between Lane C's Decision Packet and the routing-side \`reviewerGradesByTask\` index — \`AppendReviewerGrade\` writes both under \`b.mu\` so convergence + the durable packet stay in sync.
- 7 unit tests covering: routing-signals match, glob matching, all-graded convergence, timeout fill, process-exit fill, slug normalisation, no-reviewer immediate transition.

\`ReviewerGrade.SubmittedAt\` is \`time.Time\` (not RFC3339 string) — matches Lane C's design-doc-faithful definition. \`Severity\` and \`ReviewerGrade\` types live in Lane C; Lane D's pre-integration stubs were dropped at integration.

## Design doc

Multi-agent control loop, APPROVED 2026-05-09.

## Stacked PR chain

- Lane A → Lane B → Lane C → **this PR** → Lane E → Lane G → Lane F.

Merge order: A → B → C → D → E → G → F.

## Build-time gates passing

- Gate #4: reviewer convergence semantics (3 paths).

## Test results

- \`bash scripts/test-go.sh\`: 38/38 green.
- \`bash scripts/test-web.sh\`: 1495/1495 green.
- \`go vet\`: clean. \`gofmt -l\`: empty.

## Review summary

CRITICAL: 0. HIGH: 0 inline; D-FU-1 deferred to v1.1.

## Known follow-ups (MEDIUM/LOW)

- D-FU-1 (HIGH→deferred): \`reviewerGradesByTask\` never garbage-collected.
  Acceptable for v1; v1.1 should clean up on \`merged\`.
- D-FU-2 (LOW): sweeper tick + grade arrival race is idempotent
  but not asserted by a test.
- D-FU-3 (LOW): skill-domain tagging on \`HeadlessEvent\` is the
  v1.1 replacement for \`ToolNames\`.

## Test plan

- [ ] Three reviewer agents with overlapping Watching sets get
      auto-assigned correctly.
- [ ] Timeout sweeper fills missing slots with skipped grades.
- [ ] Process-exit detection fills with the \"reviewer process exited\" reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reviewer assignment based on team member watching preferences (file patterns, wiki paths, tool names, task tags).
  * Implemented review convergence logic that transitions tasks to decision state once all assigned reviewers submit grades.
  * Added review timeout handling that automatically fills missing reviewer grades after deadline expiration or process termination.
  * Extended task model with review lifecycle tracking (reviewers, start time, timeout settings).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/758)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->