### PR TITLE
feat(cli): wuphf task subcommand family (start/list/review/block)

### DIFF
--- a/cmd/wuphf/icp_acceptance_test.go
+++ b/cmd/wuphf/icp_acceptance_test.go
@@ -66,7 +66,7 @@ func (fakeICPIntakeProvider) CallSpecLLM(_ context.Context, _, userPrompt string
 	switch {
 	case strings.Contains(intent, "cache invalidation"):
 		return fenceFakeICPSpec(map[string]any{
-			"problem":        "The cache invalidation logic does not invalidate stale entries.",
+			"problem":       "The cache invalidation logic does not invalidate stale entries.",
 			"targetOutcome": "Cache hit-rate drops to expected after invalidation events.",
 			"acceptanceCriteria": []map[string]string{
 				{"statement": "Stale entries no longer return on subsequent reads."},
@@ -76,7 +76,7 @@ func (fakeICPIntakeProvider) CallSpecLLM(_ context.Context, _, userPrompt string
 		}), nil
 	case strings.Contains(intent, "JWT validation"):
 		return fenceFakeICPSpec(map[string]any{
-			"problem":        "JWT validation accepts expired tokens with a stale clock skew window.",
+			"problem":       "JWT validation accepts expired tokens with a stale clock skew window.",
 			"targetOutcome": "Expired tokens are rejected within 30s of expiry.",
 			"acceptanceCriteria": []map[string]string{
 				{"statement": "Expired JWTs are rejected after the configured leeway."},
@@ -86,7 +86,7 @@ func (fakeICPIntakeProvider) CallSpecLLM(_ context.Context, _, userPrompt string
 		}), nil
 	case strings.Contains(intent, "auth header"):
 		return fenceFakeICPSpec(map[string]any{
-			"problem":        "Outbound API calls do not yet attach the new auth header.",
+			"problem":       "Outbound API calls do not yet attach the new auth header.",
 			"targetOutcome": "Every external request carries the new x-wuphf-auth header.",
 			"acceptanceCriteria": []map[string]string{
 				{"statement": "All outbound HTTP calls attach the new header."},
@@ -96,7 +96,7 @@ func (fakeICPIntakeProvider) CallSpecLLM(_ context.Context, _, userPrompt string
 		}), nil
 	case strings.Contains(intent, "dependency upgrade"):
 		return fenceFakeICPSpec(map[string]any{
-			"problem":        "The dependency upgrade PR has been sitting open and needs landing.",
+			"problem":       "The dependency upgrade PR has been sitting open and needs landing.",
 			"targetOutcome": "The upgrade ships green and unblocks downstream work.",
 			"acceptanceCriteria": []map[string]string{
 				{"statement": "PR #742 merges cleanly."},
@@ -386,16 +386,10 @@ func TestICP_Tutorial2_ReviewerTimeoutPath(t *testing.T) {
 // unblock cascade. Task A is blocked on task B; when B merges, A
 // auto-transitions blocked_on_pr_merge → review.
 //
-// Known gap: BlockTask routes through transitionLifecycleLocked to
-// LifecycleStateBlockedOnPRMerge but does NOT populate task.BlockedOn
-// with the blocker's ID. unblockDependentsLocked sweeps over
-// task.BlockedOn membership, so the cascade does not fire automatically
-// for tasks blocked via the CLI / HTTP /tasks/{id}/block endpoint.
-// The test therefore drives the cascade by adding the BlockedOn link
-// directly via SetTaskBlockedOnForTest before merging B. This wires
-// the rest of the cascade correctly and surfaces the underlying
-// data-flow gap as a documented v1.1 follow-up rather than a silent
-// regression.
+// The CLI / HTTP block path now records the blocker reference into
+// task.BlockedOn directly (BlockTask signature carries the blockerID
+// since the v1 BlockedOn fix). unblockDependentsLocked sweeps that
+// list, so the cascade fires end-to-end without any test-only helper.
 func TestICP_Tutorial3_BlockAndUnblockCascade(t *testing.T) {
 	b, _ := startICPBroker(t)
 	client := newProductionLikeClient()
@@ -432,13 +426,16 @@ func TestICP_Tutorial3_BlockAndUnblockCascade(t *testing.T) {
 		t.Fatalf("could not identify tasks A and B from inbox %+v", payload.Rows)
 	}
 
-	// Block A on B.
+	// Block A on B. The HTTP /tasks/{id}/block route reads the {on}
+	// field and forwards it to BlockTask, which appends the blocker
+	// reference to task.BlockedOn under b.mu. No test-only helper
+	// needed; the cascade picks it up from the typed list.
 	if err := client.BlockTask(context.Background(), taskA, taskB, "A depends on B's merge"); err != nil {
 		t.Fatalf("block A on B: %v", err)
 	}
-	// Workaround for the v1.1 gap: also pin BlockedOn so the unblock
-	// cascade can find A by sweeping b.tasks[*].BlockedOn membership.
-	b.SetTaskBlockedOnForTest(taskA, []string{taskB})
+	if got := blockedOnForTask(b, taskA); !containsTaskID(got, taskB) {
+		t.Fatalf("expected task A.BlockedOn to contain %q after CLI block, got %v", taskB, got)
+	}
 
 	// Verify A is blocked.
 	blockedPayload, err := client.ListInbox(context.Background(), "blocked")
@@ -522,3 +519,27 @@ func (c *testClock) String() string {
 // Compile-time guard: the production CLI must satisfy brokerClient. If
 // the interface drifts, this assertion fails before any ICP test runs.
 var _ brokerClient = (*httpBrokerClient)(nil)
+
+// blockedOnForTask returns the task.BlockedOn snapshot for the given
+// task id by walking the live broker state. Used by Tutorial 3 to
+// assert the CLI / HTTP block path populated the typed BlockedOn list
+// (rather than relying on a test-only helper).
+func blockedOnForTask(b *team.Broker, taskID string) []string {
+	for _, task := range b.AllTasks() {
+		if task.ID == taskID {
+			out := make([]string, len(task.BlockedOn))
+			copy(out, task.BlockedOn)
+			return out
+		}
+	}
+	return nil
+}
+
+func containsTaskID(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/wuphf/icp_acceptance_test.go
+++ b/cmd/wuphf/icp_acceptance_test.go
@@ -1,0 +1,524 @@
+//go:build icp
+
+// Package main hosts the Lane F CLI ICP acceptance tests.
+//
+// Run with: go test -tags icp ./cmd/wuphf/... -timeout 5m
+//
+// These tests exercise the three Sam tutorials documented in
+// /tmp/wuphf-icp-tutorials.md (also tracked in the design doc) end-to-
+// end against a real broker process started in-process, exposed over
+// real HTTP, and exercised through the production httpBrokerClient.
+//
+// What this covers (and does not cover):
+//
+//   - The HTTP wire shape: every CLI subcommand goes through the same
+//     newBrokerRequest helper as `wuphf log`, against a broker started
+//     via b.StartOnPort(0). No in-process Broker pointer leaks into the
+//     CLI execution path.
+//   - The lifecycle transitions: intake → ready → running → review →
+//     decision → merged. The convergence rule fires on grade arrival;
+//     the timeout filler fires on sweep with the deadline elapsed.
+//   - The block-and-unblock cascade: task A blocked on task B's PR
+//     merge auto-transitions blocked_on_pr_merge → review when task B
+//     merges.
+//   - The intake parse path: the fake provider returns canned JSON
+//     matching the Spec schema, the validator + parser run, and the
+//     CLI's confirm prompt advances the task.
+//
+// What this does NOT cover (deferred to dogfood gate #12):
+//
+//   - Real-LLM intake against the live anthropic/ollama/openai chain.
+//   - Browser-side Decision Packet rendering (Lane G's Vitest +
+//     Playwright suite covers that path separately).
+//   - Worktree-side owner-agent execution (the design's "Lane H"
+//     headless runner is out of scope for v1).
+//
+// The build tag keeps these tests out of the default Go test suite so
+// CI does not pay the broker-spinup cost on every run; they are
+// deliberately invoked via `go test -tags icp` when validating the
+// ICP gates.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// fakeICPIntakeProvider is the canned-JSON IntakeProvider the broker
+// invokes inside b.StartIntake when the test seam is installed. It
+// returns a Spec keyed off the intent string so each tutorial gets a
+// realistic payload without standing up a real LLM.
+type fakeICPIntakeProvider struct{}
+
+func (fakeICPIntakeProvider) CallSpecLLM(_ context.Context, _, userPrompt string) (string, error) {
+	intent := extractFakeIntent(userPrompt)
+	switch {
+	case strings.Contains(intent, "cache invalidation"):
+		return fenceFakeICPSpec(map[string]any{
+			"problem":        "The cache invalidation logic does not invalidate stale entries.",
+			"targetOutcome": "Cache hit-rate drops to expected after invalidation events.",
+			"acceptanceCriteria": []map[string]string{
+				{"statement": "Stale entries no longer return on subsequent reads."},
+				{"statement": "Existing cache tests pass."},
+			},
+			"assignment": "Audit the invalidation function in cache.go and fix the bug.",
+		}), nil
+	case strings.Contains(intent, "JWT validation"):
+		return fenceFakeICPSpec(map[string]any{
+			"problem":        "JWT validation accepts expired tokens with a stale clock skew window.",
+			"targetOutcome": "Expired tokens are rejected within 30s of expiry.",
+			"acceptanceCriteria": []map[string]string{
+				{"statement": "Expired JWTs are rejected after the configured leeway."},
+				{"statement": "JWT-related security tests pass under racy clock conditions."},
+			},
+			"assignment": "Audit jwt.go and tighten the clock-skew check.",
+		}), nil
+	case strings.Contains(intent, "auth header"):
+		return fenceFakeICPSpec(map[string]any{
+			"problem":        "Outbound API calls do not yet attach the new auth header.",
+			"targetOutcome": "Every external request carries the new x-wuphf-auth header.",
+			"acceptanceCriteria": []map[string]string{
+				{"statement": "All outbound HTTP calls attach the new header."},
+				{"statement": "Existing integration tests pass."},
+			},
+			"assignment": "Wire the new header through the outbound client middleware.",
+		}), nil
+	case strings.Contains(intent, "dependency upgrade"):
+		return fenceFakeICPSpec(map[string]any{
+			"problem":        "The dependency upgrade PR has been sitting open and needs landing.",
+			"targetOutcome": "The upgrade ships green and unblocks downstream work.",
+			"acceptanceCriteria": []map[string]string{
+				{"statement": "PR #742 merges cleanly."},
+				{"statement": "Lockfile resolves to the new versions."},
+			},
+			"assignment": "Land PR #742, resolving any merge conflicts.",
+		}), nil
+	}
+	// Fallback: return a generic Spec so unrelated intents still parse.
+	return fenceFakeICPSpec(map[string]any{
+		"problem": "Unparsed test intent: " + intent,
+		"acceptanceCriteria": []map[string]string{
+			{"statement": "Address the intent."},
+		},
+		"assignment": "Address: " + intent,
+	}), nil
+}
+
+func extractFakeIntent(userPrompt string) string {
+	const marker = "---\n"
+	first := strings.Index(userPrompt, marker)
+	if first < 0 {
+		return userPrompt
+	}
+	rest := userPrompt[first+len(marker):]
+	end := strings.Index(rest, marker)
+	if end < 0 {
+		return strings.TrimSpace(rest)
+	}
+	return strings.TrimSpace(rest[:end])
+}
+
+func fenceFakeICPSpec(spec map[string]any) string {
+	body, _ := json.Marshal(spec)
+	return "```json\n" + string(body) + "\n```"
+}
+
+// startICPBroker spins up a real team.Broker on an OS-assigned port,
+// installs the fake intake provider, sets the brokerClientFactory so
+// the CLI exercises its production HTTP path against the live
+// listener, and returns a teardown closure.
+func startICPBroker(t *testing.T) (*team.Broker, string) {
+	t.Helper()
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
+	b := team.NewBrokerAt(statePath)
+	b.SetIntakeProviderFactory(func() team.IntakeProvider { return fakeICPIntakeProvider{} })
+
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("StartOnPort: %v", err)
+	}
+	t.Cleanup(b.Stop)
+
+	addr := b.Addr()
+	if addr == "" {
+		t.Fatalf("broker addr is empty")
+	}
+	baseURL := "http://" + addr
+	token := b.Token()
+
+	// Point the CLI's environment-derived base URL + token at this broker
+	// so newBrokerRequest authenticates correctly. t.Setenv restores the
+	// originals at end of test.
+	t.Setenv("WUPHF_BROKER_BASE_URL", baseURL)
+	t.Setenv("WUPHF_BROKER_TOKEN", token)
+
+	// Guard rail: probe /tasks/inbox so we know the listener is healthy
+	// before any tutorial step runs. Saves debugging time when a
+	// runtime-home permission issue would otherwise surface as a flaky
+	// transition error mid-tutorial.
+	if err := waitForBrokerReady(baseURL, token, 5*time.Second); err != nil {
+		t.Fatalf("broker not ready: %v", err)
+	}
+	return b, baseURL
+}
+
+func waitForBrokerReady(baseURL, token string, deadline time.Duration) error {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/tasks/inbox?filter=all", nil)
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return errors.New("broker did not become ready in time")
+}
+
+// brokerHTTPPost is a tight helper for the test-only paths that need to
+// punch through the broker over raw HTTP (lifecycle transitions for
+// task B in tutorial 3, etc.). The CLI uses its own client; this is
+// for the agent-side test choreography.
+func brokerHTTPPost(t *testing.T, baseURL, path, token string, body any) (*http.Response, []byte) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post %s: %v", path, err)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	return resp, respBody
+}
+
+// newProductionLikeClient returns the same httpBrokerClient the
+// production CLI uses, configured with a short test timeout to keep
+// latent failures snappy.
+func newProductionLikeClient() brokerClient {
+	return &httpBrokerClient{httpClient: &http.Client{Timeout: 10 * time.Second}}
+}
+
+// TestICP_Tutorial1_SingleTaskHappyPath drives Sam's first scenario
+// from /tmp/wuphf-icp-tutorials.md against a live broker:
+//
+//  1. wuphf task start "fix the broken cache invalidation"
+//  2. confirm with "y"
+//  3. simulate a reviewer grade (1 minor finding, 0 critical)
+//  4. assert the task converges to LifecycleStateDecision.
+func TestICP_Tutorial1_SingleTaskHappyPath(t *testing.T) {
+	b, baseURL := startICPBroker(t)
+	token := b.Token()
+	client := newProductionLikeClient()
+
+	// Step 1+2: task start over the live HTTP wire, "y" piped via stdin.
+	err := runTaskStartWithClient(context.Background(), client,
+		"fix the broken cache invalidation", "", strings.NewReader("y\n"))
+	if err != nil {
+		t.Fatalf("task start: %v", err)
+	}
+
+	// Find the task in the inbox over the live HTTP wire.
+	payload, err := client.ListInbox(context.Background(), "all")
+	if err != nil {
+		t.Fatalf("list inbox: %v", err)
+	}
+	if len(payload.Rows) != 1 {
+		t.Fatalf("expected 1 task in inbox after intake; got %d (%+v)", len(payload.Rows), payload.Rows)
+	}
+	taskID := payload.Rows[0].TaskID
+	if !strings.HasPrefix(taskID, "task-") {
+		t.Fatalf("unexpected task id: %q", taskID)
+	}
+	if got := payload.Rows[0].LifecycleState; got != team.LifecycleStateRunning {
+		t.Fatalf("post-confirm state: got %q, want %q", got, team.LifecycleStateRunning)
+	}
+
+	// Step 3: simulate the owner agent finishing → reviewer-routing
+	// fires automatically via the broker's internal layer once we
+	// transition to review. We do this via the live HTTP transition
+	// endpoint to mirror the design contract.
+	resp, body := brokerHTTPPost(t, baseURL, "/tasks/"+taskID+"/transition", token, map[string]string{
+		"to":     string(team.LifecycleStateReview),
+		"reason": "owner agent committed session report",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transition running → review: %d %s", resp.StatusCode, body)
+	}
+
+	// Append a grade directly via the broker API (Lane D's owner-side
+	// AppendReviewerGrade is callable for tests; in production this
+	// would arrive via the headless runner). Use the in-process
+	// b.AppendReviewerGrade because the on-the-wire grade-submission
+	// endpoint is reserved for Lane G's tunnel-human flow.
+	if err := b.AppendReviewerGrade(taskID, team.ReviewerGrade{
+		ReviewerSlug: "reviewer",
+		Severity:     team.SeverityMinor,
+		Reasoning:    "small style nit",
+	}); err != nil {
+		t.Fatalf("append grade: %v", err)
+	}
+
+	// Step 4: assert convergence to LifecycleStateDecision. The grade
+	// arrival path runs evaluateConvergenceLocked synchronously under
+	// b.mu, so the next inbox fetch must observe the decision state.
+	payload2, err := client.ListInbox(context.Background(), "needs_decision")
+	if err != nil {
+		t.Fatalf("list inbox post-grade: %v", err)
+	}
+	if len(payload2.Rows) != 1 || payload2.Rows[0].TaskID != taskID {
+		t.Fatalf("expected task %q in needs_decision filter; got %+v", taskID, payload2.Rows)
+	}
+	if got := payload2.Rows[0].LifecycleState; got != team.LifecycleStateDecision {
+		t.Fatalf("post-grade lifecycle state: got %q, want %q", got, team.LifecycleStateDecision)
+	}
+}
+
+// TestICP_Tutorial2_ReviewerTimeoutPath exercises the reviewer-process-
+// exit / timeout convergence path. Three reviewers are assigned; two
+// grade; the third never does. After the deadline elapses, the
+// sweeper fills the missing slot with SeveritySkipped and the task
+// transitions to decision.
+func TestICP_Tutorial2_ReviewerTimeoutPath(t *testing.T) {
+	b, baseURL := startICPBroker(t)
+	token := b.Token()
+	client := newProductionLikeClient()
+
+	// Fast-forward the broker's reviewer clock so the timeout fires
+	// without us needing to wait the full real-world duration. The
+	// reviewerNow override is the same seam Lane D's unit tests use.
+	clk := newTestClock(time.Now().UTC())
+	b.SetReviewerNowFn(clk.Now)
+
+	if err := runTaskStartWithClient(context.Background(), client,
+		"tighten the JWT validation", "", strings.NewReader("y\n")); err != nil {
+		t.Fatalf("task start: %v", err)
+	}
+
+	payload, err := client.ListInbox(context.Background(), "all")
+	if err != nil {
+		t.Fatalf("list inbox: %v", err)
+	}
+	if len(payload.Rows) != 1 {
+		t.Fatalf("expected exactly 1 task; got %d", len(payload.Rows))
+	}
+	taskID := payload.Rows[0].TaskID
+
+	resp, body := brokerHTTPPost(t, baseURL, "/tasks/"+taskID+"/transition", token, map[string]string{
+		"to":     string(team.LifecycleStateReview),
+		"reason": "owner agent committed session report",
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("transition running → review: %d %s", resp.StatusCode, body)
+	}
+
+	// Pin a known three-reviewer roster AFTER the transition so the
+	// roster stamping wins over the routing layer's derivation (which
+	// runs synchronously inside transitionLifecycleLocked when
+	// task.Reviewers is empty). The helper also re-stamps
+	// ReviewStartedAt so the deadline anchors at clk.Now() rather
+	// than wall time.
+	b.SetTaskReviewersForTest(taskID, []string{"reviewer", "security", "perf"})
+
+	// Two reviewers grade; the third (security) goes silent.
+	for _, slug := range []string{"reviewer", "perf"} {
+		if err := b.AppendReviewerGrade(taskID, team.ReviewerGrade{
+			ReviewerSlug: slug,
+			Severity:     team.SeverityNitpick,
+			Reasoning:    "lgtm",
+		}); err != nil {
+			t.Fatalf("append grade %s: %v", slug, err)
+		}
+	}
+
+	// Advance the clock past the deadline and sweep.
+	clk.Advance(15 * time.Minute)
+	b.SweepReviewConvergence()
+
+	// Decision state must be reached, and the missing slot must be
+	// filled with SeveritySkipped.
+	packet, err := b.GetDecisionPacket(taskID)
+	if err != nil {
+		t.Fatalf("get decision packet: %v", err)
+	}
+	if packet.LifecycleState != team.LifecycleStateDecision {
+		t.Fatalf("packet lifecycle state: got %q, want %q", packet.LifecycleState, team.LifecycleStateDecision)
+	}
+	var sawSkipped bool
+	for _, g := range packet.ReviewerGrades {
+		if g.ReviewerSlug == "security" && g.Severity == team.SeveritySkipped {
+			sawSkipped = true
+			break
+		}
+	}
+	if !sawSkipped {
+		t.Fatalf("expected security reviewer slot filled with skipped; got grades %+v", packet.ReviewerGrades)
+	}
+}
+
+// TestICP_Tutorial3_BlockAndUnblockCascade exercises the block-and-
+// unblock cascade. Task A is blocked on task B; when B merges, A
+// auto-transitions blocked_on_pr_merge → review.
+//
+// Known gap: BlockTask routes through transitionLifecycleLocked to
+// LifecycleStateBlockedOnPRMerge but does NOT populate task.BlockedOn
+// with the blocker's ID. unblockDependentsLocked sweeps over
+// task.BlockedOn membership, so the cascade does not fire automatically
+// for tasks blocked via the CLI / HTTP /tasks/{id}/block endpoint.
+// The test therefore drives the cascade by adding the BlockedOn link
+// directly via SetTaskBlockedOnForTest before merging B. This wires
+// the rest of the cascade correctly and surfaces the underlying
+// data-flow gap as a documented v1.1 follow-up rather than a silent
+// regression.
+func TestICP_Tutorial3_BlockAndUnblockCascade(t *testing.T) {
+	b, _ := startICPBroker(t)
+	client := newProductionLikeClient()
+
+	// Create task A.
+	if err := runTaskStartWithClient(context.Background(), client,
+		"wire the new auth header", "", strings.NewReader("y\n")); err != nil {
+		t.Fatalf("task A start: %v", err)
+	}
+	// Create task B.
+	if err := runTaskStartWithClient(context.Background(), client,
+		"ship the dependency upgrade PR", "", strings.NewReader("y\n")); err != nil {
+		t.Fatalf("task B start: %v", err)
+	}
+
+	payload, err := client.ListInbox(context.Background(), "all")
+	if err != nil {
+		t.Fatalf("list inbox: %v", err)
+	}
+	if len(payload.Rows) != 2 {
+		t.Fatalf("expected 2 tasks; got %d", len(payload.Rows))
+	}
+
+	var taskA, taskB string
+	for _, row := range payload.Rows {
+		if strings.Contains(row.Title, "auth header") {
+			taskA = row.TaskID
+		}
+		if strings.Contains(row.Title, "dependency upgrade") {
+			taskB = row.TaskID
+		}
+	}
+	if taskA == "" || taskB == "" {
+		t.Fatalf("could not identify tasks A and B from inbox %+v", payload.Rows)
+	}
+
+	// Block A on B.
+	if err := client.BlockTask(context.Background(), taskA, taskB, "A depends on B's merge"); err != nil {
+		t.Fatalf("block A on B: %v", err)
+	}
+	// Workaround for the v1.1 gap: also pin BlockedOn so the unblock
+	// cascade can find A by sweeping b.tasks[*].BlockedOn membership.
+	b.SetTaskBlockedOnForTest(taskA, []string{taskB})
+
+	// Verify A is blocked.
+	blockedPayload, err := client.ListInbox(context.Background(), "blocked")
+	if err != nil {
+		t.Fatalf("list blocked: %v", err)
+	}
+	var sawA bool
+	for _, row := range blockedPayload.Rows {
+		if row.TaskID == taskA {
+			sawA = true
+			break
+		}
+	}
+	if !sawA {
+		t.Fatalf("expected task A in blocked filter; got %+v", blockedPayload.Rows)
+	}
+
+	// Drive B through to merged via the same path the human merge
+	// action takes. RecordTaskDecision("merge") transitions decision
+	// → merged AND fires OnDecisionRecorded, which is the load-
+	// bearing hook for the unblock cascade. The two intermediate
+	// transitions (running → review, review → decision) are issued
+	// directly because no human is in the loop yet.
+	for _, target := range []team.LifecycleState{
+		team.LifecycleStateReview,
+		team.LifecycleStateDecision,
+	} {
+		if err := b.TransitionLifecycle(taskB, target, "tutorial 3: drive B to "+string(target)); err != nil {
+			t.Fatalf("transition B to %s: %v", target, err)
+		}
+	}
+	if err := b.RecordTaskDecision(taskB, "merge"); err != nil {
+		t.Fatalf("RecordTaskDecision merge B: %v", err)
+	}
+
+	// A must auto-unblock (blocked_on_pr_merge → review).
+	finalPayload, err := client.ListInbox(context.Background(), "all")
+	if err != nil {
+		t.Fatalf("list inbox post-merge: %v", err)
+	}
+	var stateA team.LifecycleState
+	for _, row := range finalPayload.Rows {
+		if row.TaskID == taskA {
+			stateA = row.LifecycleState
+		}
+	}
+	switch stateA {
+	case team.LifecycleStateReview, team.LifecycleStateDecision, team.LifecycleStateMerged:
+		// any of these is acceptable — A unblocked. Tutorial 3 specifies
+		// review as the immediate target, but if the test broker has
+		// reviewer routing wired in such a way that convergence fires
+		// instantly (no reviewers assigned, etc.) the cascade may
+		// continue further. The load-bearing assertion is that A is
+		// no longer in blocked_on_pr_merge.
+	default:
+		t.Fatalf("task A did not auto-unblock; final state = %q", stateA)
+	}
+}
+
+// testClock is a minimal monotonic-ish clock for the timeout test.
+type testClock struct {
+	now time.Time
+}
+
+func newTestClock(t time.Time) *testClock { return &testClock{now: t} }
+
+func (c *testClock) Now() time.Time {
+	return c.now
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.now = c.now.Add(d)
+}
+
+// String makes the test output a bit friendlier when a deadline assertion
+// trips and the test prints the clock value.
+func (c *testClock) String() string {
+	return fmt.Sprintf("testClock(%s)", c.now.Format(time.RFC3339Nano))
+}
+
+// Compile-time guard: the production CLI must satisfy brokerClient. If
+// the interface drifts, this assertion fails before any ICP test runs.
+var _ brokerClient = (*httpBrokerClient)(nil)

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -127,6 +127,9 @@ func printSubcommandHelp(sub string) {
 		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from <hub>           Pull a skill into your wiki")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo[@branch]")
+	case "task":
+		printTaskHelp()
+		return
 	case "upgrade":
 		fmt.Fprintln(os.Stderr, "wuphf upgrade — check npm for a newer wuphf and show the changelog")
 		fmt.Fprintln(os.Stderr, "")
@@ -446,6 +449,9 @@ func main() {
 			runWorkspace(args[1:])
 		case "skills":
 			runSkillsCmd(args[1:])
+			return
+		case "task":
+			runTaskCmd(args[1:])
 			return
 		}
 	}

--- a/cmd/wuphf/task_cmd.go
+++ b/cmd/wuphf/task_cmd.go
@@ -492,7 +492,7 @@ func runTaskReview(args []string) {
 		os.Exit(2)
 	}
 	url := brokerBaseURL() + "#/task/" + id
-	if err := openBrowser(url); err != nil {
+	if err := openBrowser(context.Background(), url); err != nil {
 		fmt.Fprintf(os.Stderr, "task review: open %s: %v\n", url, err)
 		fmt.Fprintln(os.Stderr, "  Open it manually in your browser instead.")
 		os.Exit(1)
@@ -520,15 +520,15 @@ func isSafeTaskID(id string) bool {
 	return true
 }
 
-func openBrowser(url string) error {
+func openBrowser(ctx context.Context, url string) error {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		cmd = exec.CommandContext(ctx, "open", url)
 	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url)
 	default:
-		cmd = exec.Command("xdg-open", url)
+		cmd = exec.CommandContext(ctx, "xdg-open", url)
 	}
 	return cmd.Start()
 }

--- a/cmd/wuphf/task_cmd.go
+++ b/cmd/wuphf/task_cmd.go
@@ -9,27 +9,32 @@ package main
 //   - `wuphf task review <id>`         — open the Decision Packet view in the browser
 //   - `wuphf task block <id> --on <pr-or-task-id>` — set blocked_on_pr_merge
 //
-// The implementation talks to the broker via its existing HTTP API
-// (/tasks/inbox, /tasks/{id}, /tasks/{id}/block) and uses raw stdin
-// (bufio.Scanner) for confirmation prompts, consistent with the
-// `confirmDestructive` pattern already in main.go.
+// All subcommands talk to a running `wuphf` broker over its existing HTTP
+// API. `task start` posts to /tasks/intake (broker-only auth) for the
+// intake roundtrip, then to /tasks/{id}/transition for the ready and
+// running advances. `task list` calls GET /tasks/inbox; `task block` calls
+// POST /tasks/{id}/block. `task review` opens the Decision Packet URL in
+// the user's default browser.
 //
-// `task start` is the only subcommand that requires the broker to be
-// running locally — it calls Broker.StartIntake in-process via a small
-// helper that boots a transient broker only when no live one is
-// reachable. For v1 the simpler contract is: the user must have
-// `wuphf` running (the broker), and the CLI POSTs intent to a future
-// /tasks/intake endpoint. For minimal scope, v1 ships in-process
-// intake against a Broker borrowed via the package-level handle.
+// All HTTP calls go through newBrokerRequest, which reads the broker
+// auth token from $WUPHF_BROKER_TOKEN (preferred) or the on-disk
+// brokeraddr.ResolveTokenFile() path, matching `wuphf log`'s pattern.
 //
-// Lane B exposes IntakeProvider + AutoAssignCountdown + ErrIntakeNoProvider
+// The package-level brokerClient hook lets tests inject a fake without
+// standing up a real broker process. Production code uses the
+// httpBrokerClient implementation, which targets the local broker the
+// user has running (default 127.0.0.1:7890; override via brokeraddr).
+//
+// Lane B exposes IntakeOutcome + AutoAssignCountdown + ErrIntakeNoProvider
 // for this caller; the CLI honours Spec.AutoAssign with a 3-second
 // cancellable countdown over stdin keypresses.
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -77,12 +82,167 @@ func printTaskHelp() {
 	fmt.Fprintln(os.Stderr, "  wuphf task block <id> --on <ref>         Mark task blocked on a PR or task")
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "Filters: needs_decision (default), running, blocked, merged_today, all.")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Auth: every subcommand reads the broker token from $WUPHF_BROKER_TOKEN")
+	fmt.Fprintln(os.Stderr, "      (preferred) or the on-disk token file written by `wuphf` on start.")
 }
 
-// runTaskStart implements `wuphf task start [intent]`. v1 talks to the
-// broker via an in-process call after dialing the local broker over
-// HTTP to confirm one is running; without a running broker the CLI
-// surfaces a clear error rather than starting a one-shot.
+// brokerClient is the thin interface the CLI uses to talk to a running
+// broker. Production code installs httpBrokerClient via
+// brokerClientFactory; tests inject a fake for unit coverage and a real
+// httptest-backed client for ICP/integration coverage.
+type brokerClient interface {
+	StartIntake(ctx context.Context, intent string) (*team.IntakeOutcome, error)
+	TransitionLifecycle(ctx context.Context, taskID string, to team.LifecycleState, reason string) error
+	BlockTask(ctx context.Context, taskID, on, reason string) error
+	ListInbox(ctx context.Context, filter string) (team.InboxPayload, error)
+}
+
+// brokerClientFactory builds a brokerClient on demand. Tests override this
+// to inject a fake; production callers leave it nil and fall through to
+// the default httpBrokerClient against the local broker.
+var brokerClientFactory func() brokerClient
+
+// resolveBrokerClient returns the brokerClient the CLI should use for the
+// current invocation. Tests set brokerClientFactory; production paths
+// fall through to httpBrokerClient against the local broker.
+func resolveBrokerClient() brokerClient {
+	if brokerClientFactory != nil {
+		if c := brokerClientFactory(); c != nil {
+			return c
+		}
+	}
+	return defaultHTTPBrokerClient()
+}
+
+// httpBrokerClient is the production implementation of brokerClient. It
+// posts JSON to the running broker via the same newBrokerRequest helper
+// every other command in this package uses, so the auth token and base
+// URL come from the same source of truth.
+type httpBrokerClient struct {
+	httpClient *http.Client
+}
+
+func defaultHTTPBrokerClient() brokerClient {
+	return &httpBrokerClient{httpClient: &http.Client{Timeout: 35 * time.Second}}
+}
+
+func (c *httpBrokerClient) StartIntake(ctx context.Context, intent string) (*team.IntakeOutcome, error) {
+	body, err := json.Marshal(map[string]string{"intent": intent})
+	if err != nil {
+		return nil, fmt.Errorf("intake: marshal: %w", err)
+	}
+	req, err := newBrokerRequest(ctx, http.MethodPost, brokerURL("/tasks/intake"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w (is the broker running? try `wuphf` first)", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("intake: broker returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	var wire struct {
+		TaskID     string    `json:"taskId"`
+		Spec       team.Spec `json:"spec"`
+		AutoAssign string    `json:"autoAssign,omitempty"`
+	}
+	if err := json.Unmarshal(respBody, &wire); err != nil {
+		return nil, fmt.Errorf("intake: parse response: %w", err)
+	}
+	out := &team.IntakeOutcome{
+		TaskID:     wire.TaskID,
+		Spec:       wire.Spec,
+		AutoAssign: wire.AutoAssign,
+	}
+	if wire.AutoAssign != "" {
+		out.Countdown = team.NewAutoAssignCountdown()
+	}
+	return out, nil
+}
+
+func (c *httpBrokerClient) TransitionLifecycle(ctx context.Context, taskID string, to team.LifecycleState, reason string) error {
+	if !isSafeTaskID(taskID) {
+		return fmt.Errorf("transition: task id contains invalid characters")
+	}
+	body, err := json.Marshal(map[string]string{"to": string(to), "reason": reason})
+	if err != nil {
+		return fmt.Errorf("transition: marshal: %w", err)
+	}
+	req, err := newBrokerRequest(ctx, http.MethodPost, brokerURL("/tasks/"+taskID+"/transition"), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w (is the broker running?)", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("transition: broker returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+}
+
+func (c *httpBrokerClient) BlockTask(ctx context.Context, taskID, on, reason string) error {
+	if !isSafeTaskID(taskID) {
+		return fmt.Errorf("block: task id contains invalid characters")
+	}
+	body, err := json.Marshal(map[string]string{"on": on, "reason": reason})
+	if err != nil {
+		return fmt.Errorf("block: marshal: %w", err)
+	}
+	req, err := newBrokerRequest(ctx, http.MethodPost, brokerURL("/tasks/"+taskID+"/block"), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%w (is the broker running?)", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("block: broker returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+}
+
+func (c *httpBrokerClient) ListInbox(ctx context.Context, filter string) (team.InboxPayload, error) {
+	url := brokerURL("/tasks/inbox?filter=" + filter)
+	req, err := newBrokerRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return team.InboxPayload{}, err
+	}
+	httpClient := c.httpClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return team.InboxPayload{}, fmt.Errorf("%w (is the broker running? try `wuphf` first)", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return team.InboxPayload{}, fmt.Errorf("broker returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	var payload team.InboxPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return team.InboxPayload{}, fmt.Errorf("parse: %w", err)
+	}
+	return payload, nil
+}
+
+// runTaskStart implements `wuphf task start [intent]`. It posts the
+// intent to a running broker via POST /tasks/intake, prompts the user
+// to confirm, then posts intake → ready → running transitions.
 func runTaskStart(args []string) {
 	fs := flag.NewFlagSet("task start", flag.ExitOnError)
 	autoAssign := fs.String("auto-assign", "", "Override Spec.AutoAssign (skip the countdown)")
@@ -92,6 +252,8 @@ func runTaskStart(args []string) {
 		fmt.Fprintln(os.Stderr, "Usage:")
 		fmt.Fprintln(os.Stderr, "  wuphf task start \"fix the cache invalidation bug\"")
 		fmt.Fprintln(os.Stderr, "  wuphf task start                       # reads the intent from stdin")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Auth: reads broker token from $WUPHF_BROKER_TOKEN or the on-disk token file.")
 	}
 	_ = fs.Parse(args)
 	intent := strings.TrimSpace(strings.Join(fs.Args(), " "))
@@ -107,53 +269,36 @@ func runTaskStart(args []string) {
 		os.Exit(2)
 	}
 
-	// v1 simplification: the CLI shells out via the broker by doing a
-	// short health probe then borrowing a process-local broker for the
-	// intake call. The "production" path is the HTTP intake endpoint
-	// which is a v1.1 task; v1 ships a usable CLI surface against a
-	// running broker by spinning up an in-process Broker for the
-	// intake roundtrip alone. This keeps the CLI testable end-to-end
-	// without requiring a real broker process during integration tests.
 	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
 	defer cancel()
-	if err := runTaskStartInProcess(ctx, intent, *autoAssign); err != nil {
+	if err := runTaskStartWithClient(ctx, resolveBrokerClient(), intent, *autoAssign, os.Stdin); err != nil {
 		fmt.Fprintf(os.Stderr, "task start: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-// runTaskStartInProcess is the broker-borrowed implementation. It is
-// exported for tests via the taskStartInProcessHook seam below.
-func runTaskStartInProcess(ctx context.Context, intent, autoAssignOverride string) error {
-	broker, provider, err := taskStartHook(ctx)
-	if err != nil {
-		return err
-	}
-	if broker == nil || provider == nil {
-		return fmt.Errorf("broker or intake provider unavailable")
+// runTaskStartWithClient is the testable core. The brokerClient is the
+// live HTTP wire in production and a fake/httptest-backed impl in tests.
+// stdin is parameterised so tests can pipe a confirmation answer.
+func runTaskStartWithClient(ctx context.Context, client brokerClient, intent, autoAssignOverride string, stdin io.Reader) error {
+	if client == nil {
+		return errors.New("broker client unavailable")
 	}
 
 	fmt.Fprint(os.Stderr, "Interrogating spec... ")
 	startedAt := time.Now()
 	tickStop := streamElapsed(startedAt)
-	outcome, err := broker.StartIntake(ctx, intent, provider)
+	outcome, err := client.StartIntake(ctx, intent)
 	close(tickStop)
 	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return err
 	}
+	if outcome == nil {
+		return errors.New("intake: empty outcome")
+	}
 
 	printSpec(outcome.Spec)
-
-	confirm := func() (bool, error) {
-		fmt.Fprint(os.Stderr, "Start running this task? (y/n) ")
-		scanner := bufio.NewScanner(os.Stdin)
-		if !scanner.Scan() {
-			return false, scanner.Err()
-		}
-		ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
-		return ans == "y" || ans == "yes", nil
-	}
 
 	autoAssign := strings.TrimSpace(autoAssignOverride)
 	if autoAssign == "" {
@@ -166,14 +311,14 @@ func runTaskStartInProcess(ctx context.Context, intent, autoAssignOverride strin
 		cancelCh := make(chan struct{})
 		go func() {
 			buf := make([]byte, 1)
-			_, _ = os.Stdin.Read(buf)
+			_, _ = stdin.Read(buf)
 			outcome.Countdown.Cancel()
 			close(cancelCh)
 		}()
 		if outcome.Countdown.Wait(ctx) {
 			confirmed = true
 		} else {
-			ok, err := confirm()
+			ok, err := promptYesNo(stdin, "Start running this task? (y/n) ")
 			if err != nil {
 				return err
 			}
@@ -181,7 +326,7 @@ func runTaskStartInProcess(ctx context.Context, intent, autoAssignOverride strin
 		}
 		_ = cancelCh
 	} else {
-		ok, err := confirm()
+		ok, err := promptYesNo(stdin, "Start running this task? (y/n) ")
 		if err != nil {
 			return err
 		}
@@ -193,21 +338,28 @@ func runTaskStartInProcess(ctx context.Context, intent, autoAssignOverride strin
 		return nil
 	}
 
-	if err := broker.TransitionLifecycle(outcome.TaskID, team.LifecycleStateReady, "task start: human confirmed"); err != nil {
+	if err := client.TransitionLifecycle(ctx, outcome.TaskID, team.LifecycleStateReady, "task start: human confirmed"); err != nil {
 		return fmt.Errorf("intake → ready: %w", err)
 	}
-	if err := broker.TransitionLifecycle(outcome.TaskID, team.LifecycleStateRunning, "task start: ready → running"); err != nil {
+	if err := client.TransitionLifecycle(ctx, outcome.TaskID, team.LifecycleStateRunning, "task start: ready → running"); err != nil {
 		return fmt.Errorf("ready → running: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "Task %s now running.\n", outcome.TaskID)
 	return nil
 }
 
-// taskStartHook is the test seam: production overrides this with a
-// helper that boots a transient broker + intake provider; tests inject
-// a fake.
-var taskStartHook = func(ctx context.Context) (*team.Broker, team.IntakeProvider, error) {
-	return nil, nil, fmt.Errorf("task start: not yet wired to a live broker (set WUPHF_TASK_PROVIDER for tests)")
+// promptYesNo (F-FU-4) is the single y/n prompt helper used by every
+// task subcommand that needs an interactive confirmation. Reads one
+// line from stdin, treats "y" / "yes" (case-insensitive, trimmed) as
+// affirmative, anything else as negative. Empty input returns false.
+func promptYesNo(stdin io.Reader, prompt string) (bool, error) {
+	fmt.Fprint(os.Stderr, prompt)
+	scanner := bufio.NewScanner(stdin)
+	if !scanner.Scan() {
+		return false, scanner.Err()
+	}
+	ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
+	return ans == "y" || ans == "yes", nil
 }
 
 func streamElapsed(start time.Time) chan struct{} {
@@ -252,12 +404,16 @@ func printSpec(spec team.Spec) {
 	fmt.Println("--------------------------------------")
 }
 
-// runTaskList implements `wuphf task list`. Calls GET /tasks/inbox,
-// groups by LifecycleState, prints to stdout.
+// runTaskList implements `wuphf task list`. Calls GET /tasks/inbox via
+// the brokerClient, groups by LifecycleState, prints to stdout.
+//
+// Auth: $WUPHF_BROKER_TOKEN env var (preferred) or the on-disk token
+// file at brokeraddr.ResolveTokenFile(). Same source of truth as
+// `wuphf log`. (F-FU-2)
 func runTaskList(args []string) {
 	fs := flag.NewFlagSet("task list", flag.ExitOnError)
 	filter := fs.String("filter", "all", "Inbox filter (needs_decision/running/blocked/merged_today/all)")
-	jsonOut := fs.Bool("json", false, "Print the raw inbox payload as JSON")
+	jsonOut := fs.Bool("json", false, "Print the raw inbox payload as JSON (writes to stdout; errors to stderr)")
 	fs.Usage = func() {
 		fmt.Fprintln(os.Stderr, "wuphf task list — print the inbox grouped by lifecycle state")
 		fmt.Fprintln(os.Stderr, "")
@@ -265,35 +421,22 @@ func runTaskList(args []string) {
 		fmt.Fprintln(os.Stderr, "  wuphf task list                            All tasks across all states")
 		fmt.Fprintln(os.Stderr, "  wuphf task list --filter=needs_decision    Only the inbox-headline filter")
 		fmt.Fprintln(os.Stderr, "  wuphf task list --json                     Emit the raw broker payload")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Auth: reads broker token from $WUPHF_BROKER_TOKEN (preferred) or the")
+		fmt.Fprintln(os.Stderr, "on-disk token file written by `wuphf` on broker start. Pipe-safe: data goes")
+		fmt.Fprintln(os.Stderr, "to stdout, errors to stderr.")
 	}
 	_ = fs.Parse(args)
-	url := brokerURL("/tasks/inbox?filter=" + *filter)
-	req, err := newBrokerRequest(context.Background(), http.MethodGet, url, nil)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "task list: build request: %v\n", err)
-		os.Exit(1)
-	}
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Do(req)
+	client := resolveBrokerClient()
+	payload, err := client.ListInbox(context.Background(), *filter)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "task list: %v\n", err)
-		fmt.Fprintln(os.Stderr, "  (is the broker running? try `wuphf` first)")
-		os.Exit(1)
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "task list: broker returned %d: %s\n", resp.StatusCode, strings.TrimSpace(string(body)))
 		os.Exit(1)
 	}
 	if *jsonOut {
-		fmt.Println(string(body))
+		raw, _ := json.Marshal(payload)
+		fmt.Println(string(raw))
 		return
-	}
-	var payload team.InboxPayload
-	if err := json.Unmarshal(body, &payload); err != nil {
-		fmt.Fprintf(os.Stderr, "task list: parse: %v\n", err)
-		os.Exit(1)
 	}
 	printInboxPayload(payload)
 }
@@ -391,7 +534,7 @@ func openBrowser(url string) error {
 }
 
 // runTaskBlock implements `wuphf task block <id> --on <ref>`. POSTs
-// to /tasks/{id}/block on the running broker.
+// to /tasks/{id}/block on the running broker via the brokerClient.
 func runTaskBlock(args []string) {
 	fs := flag.NewFlagSet("task block", flag.ExitOnError)
 	on := fs.String("on", "", "PR or task ID this task is blocked on (required)")
@@ -416,28 +559,8 @@ func runTaskBlock(args []string) {
 		fmt.Fprintln(os.Stderr, "task block: --on is required")
 		os.Exit(2)
 	}
-	body, err := json.Marshal(map[string]string{"on": *on, "reason": *reason})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "task block: encode body: %v\n", err)
-		os.Exit(1)
-	}
-	url := brokerURL("/tasks/" + id + "/block")
-	req, err := newBrokerRequest(context.Background(), http.MethodPost, url, strings.NewReader(string(body)))
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "task block: build request: %v\n", err)
-		os.Exit(1)
-	}
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
+	if err := resolveBrokerClient().BlockTask(context.Background(), id, *on, *reason); err != nil {
 		fmt.Fprintf(os.Stderr, "task block: %v\n", err)
-		fmt.Fprintln(os.Stderr, "  (is the broker running? try `wuphf` first)")
-		os.Exit(1)
-	}
-	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		fmt.Fprintf(os.Stderr, "task block: broker returned %d: %s\n", resp.StatusCode, strings.TrimSpace(string(respBody)))
 		os.Exit(1)
 	}
 	fmt.Printf("Task %s blocked on %s.\n", id, *on)

--- a/cmd/wuphf/task_cmd.go
+++ b/cmd/wuphf/task_cmd.go
@@ -344,12 +344,37 @@ func runTaskReview(args []string) {
 		os.Exit(2)
 	}
 	id := strings.TrimSpace(args[0])
+	if !isSafeTaskID(id) {
+		fmt.Fprintln(os.Stderr, "task review: task id contains invalid characters")
+		os.Exit(2)
+	}
 	url := brokerBaseURL() + "#/task/" + id
 	if err := openBrowser(url); err != nil {
 		fmt.Fprintf(os.Stderr, "task review: open %s: %v\n", url, err)
 		fmt.Fprintln(os.Stderr, "  Open it manually in your browser instead.")
 		os.Exit(1)
 	}
+}
+
+// isSafeTaskID guards the small set of characters teamTask IDs use today.
+// We do not pass arbitrary URL-encoded ids to `open`/`xdg-open`/`rundll32`
+// to avoid surprises with shell-meta characters that some launchers
+// re-parse internally.
+func isSafeTaskID(id string) bool {
+	if id == "" || len(id) > 128 {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func openBrowser(url string) error {
@@ -383,6 +408,10 @@ func runTaskBlock(args []string) {
 		os.Exit(2)
 	}
 	id := strings.TrimSpace(fs.Arg(0))
+	if !isSafeTaskID(id) {
+		fmt.Fprintln(os.Stderr, "task block: task id contains invalid characters")
+		os.Exit(2)
+	}
 	if strings.TrimSpace(*on) == "" {
 		fmt.Fprintln(os.Stderr, "task block: --on is required")
 		os.Exit(2)

--- a/cmd/wuphf/task_cmd.go
+++ b/cmd/wuphf/task_cmd.go
@@ -1,0 +1,415 @@
+package main
+
+// task_cmd.go is the Lane F CLI surface for the multi-agent control loop.
+//
+// Subcommands (all dispatched from main.go's `task` switch arm):
+//
+//   - `wuphf task start [intent]`      — prompt-driven intake → ready → running
+//   - `wuphf task list [--filter=<f>]` — print inbox grouped by LifecycleState
+//   - `wuphf task review <id>`         — open the Decision Packet view in the browser
+//   - `wuphf task block <id> --on <pr-or-task-id>` — set blocked_on_pr_merge
+//
+// The implementation talks to the broker via its existing HTTP API
+// (/tasks/inbox, /tasks/{id}, /tasks/{id}/block) and uses raw stdin
+// (bufio.Scanner) for confirmation prompts, consistent with the
+// `confirmDestructive` pattern already in main.go.
+//
+// `task start` is the only subcommand that requires the broker to be
+// running locally — it calls Broker.StartIntake in-process via a small
+// helper that boots a transient broker only when no live one is
+// reachable. For v1 the simpler contract is: the user must have
+// `wuphf` running (the broker), and the CLI POSTs intent to a future
+// /tasks/intake endpoint. For minimal scope, v1 ships in-process
+// intake against a Broker borrowed via the package-level handle.
+//
+// Lane B exposes IntakeProvider + AutoAssignCountdown + ErrIntakeNoProvider
+// for this caller; the CLI honours Spec.AutoAssign with a 3-second
+// cancellable countdown over stdin keypresses.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// runTaskCmd dispatches `wuphf task <verb> [args]`.
+func runTaskCmd(args []string) {
+	if len(args) == 0 || subcommandWantsHelp(args) {
+		printTaskHelp()
+		return
+	}
+	verb, rest := args[0], args[1:]
+	switch verb {
+	case "start":
+		runTaskStart(rest)
+	case "list", "ls":
+		runTaskList(rest)
+	case "review", "open":
+		runTaskReview(rest)
+	case "block":
+		runTaskBlock(rest)
+	default:
+		fmt.Fprintf(os.Stderr, "wuphf task: unknown verb %q\n", verb)
+		printTaskHelp()
+		os.Exit(2)
+	}
+}
+
+func printTaskHelp() {
+	fmt.Fprintln(os.Stderr, "wuphf task — drive the multi-agent control loop")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Usage:")
+	fmt.Fprintln(os.Stderr, "  wuphf task start [intent]                Walk an intent through intake → ready → running")
+	fmt.Fprintln(os.Stderr, "  wuphf task list [--filter=<filter>]      List tasks grouped by lifecycle state")
+	fmt.Fprintln(os.Stderr, "  wuphf task review <id>                   Open the Decision Packet view in your browser")
+	fmt.Fprintln(os.Stderr, "  wuphf task block <id> --on <ref>         Mark task blocked on a PR or task")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Filters: needs_decision (default), running, blocked, merged_today, all.")
+}
+
+// runTaskStart implements `wuphf task start [intent]`. v1 talks to the
+// broker via an in-process call after dialing the local broker over
+// HTTP to confirm one is running; without a running broker the CLI
+// surfaces a clear error rather than starting a one-shot.
+func runTaskStart(args []string) {
+	fs := flag.NewFlagSet("task start", flag.ExitOnError)
+	autoAssign := fs.String("auto-assign", "", "Override Spec.AutoAssign (skip the countdown)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "wuphf task start — drive an intent through intake")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf task start \"fix the cache invalidation bug\"")
+		fmt.Fprintln(os.Stderr, "  wuphf task start                       # reads the intent from stdin")
+	}
+	_ = fs.Parse(args)
+	intent := strings.TrimSpace(strings.Join(fs.Args(), " "))
+	if intent == "" {
+		fmt.Fprint(os.Stderr, "Intent: ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			intent = strings.TrimSpace(scanner.Text())
+		}
+	}
+	if intent == "" {
+		fmt.Fprintln(os.Stderr, "task start: empty intent")
+		os.Exit(2)
+	}
+
+	// v1 simplification: the CLI shells out via the broker by doing a
+	// short health probe then borrowing a process-local broker for the
+	// intake call. The "production" path is the HTTP intake endpoint
+	// which is a v1.1 task; v1 ships a usable CLI surface against a
+	// running broker by spinning up an in-process Broker for the
+	// intake roundtrip alone. This keeps the CLI testable end-to-end
+	// without requiring a real broker process during integration tests.
+	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
+	defer cancel()
+	if err := runTaskStartInProcess(ctx, intent, *autoAssign); err != nil {
+		fmt.Fprintf(os.Stderr, "task start: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runTaskStartInProcess is the broker-borrowed implementation. It is
+// exported for tests via the taskStartInProcessHook seam below.
+func runTaskStartInProcess(ctx context.Context, intent, autoAssignOverride string) error {
+	broker, provider, err := taskStartHook(ctx)
+	if err != nil {
+		return err
+	}
+	if broker == nil || provider == nil {
+		return fmt.Errorf("broker or intake provider unavailable")
+	}
+
+	fmt.Fprint(os.Stderr, "Interrogating spec... ")
+	startedAt := time.Now()
+	tickStop := streamElapsed(startedAt)
+	outcome, err := broker.StartIntake(ctx, intent, provider)
+	close(tickStop)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return err
+	}
+
+	printSpec(outcome.Spec)
+
+	confirm := func() (bool, error) {
+		fmt.Fprint(os.Stderr, "Start running this task? (y/n) ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if !scanner.Scan() {
+			return false, scanner.Err()
+		}
+		ans := strings.TrimSpace(strings.ToLower(scanner.Text()))
+		return ans == "y" || ans == "yes", nil
+	}
+
+	autoAssign := strings.TrimSpace(autoAssignOverride)
+	if autoAssign == "" {
+		autoAssign = strings.TrimSpace(outcome.AutoAssign)
+	}
+
+	confirmed := false
+	if autoAssign != "" && outcome.Countdown != nil {
+		fmt.Fprintf(os.Stderr, "Auto-assigning to %s in 3s — press any key to cancel...\n", autoAssign)
+		cancelCh := make(chan struct{})
+		go func() {
+			buf := make([]byte, 1)
+			_, _ = os.Stdin.Read(buf)
+			outcome.Countdown.Cancel()
+			close(cancelCh)
+		}()
+		if outcome.Countdown.Wait(ctx) {
+			confirmed = true
+		} else {
+			ok, err := confirm()
+			if err != nil {
+				return err
+			}
+			confirmed = ok
+		}
+		_ = cancelCh
+	} else {
+		ok, err := confirm()
+		if err != nil {
+			return err
+		}
+		confirmed = ok
+	}
+
+	if !confirmed {
+		fmt.Fprintln(os.Stderr, "Cancelled. Task left in intake.")
+		return nil
+	}
+
+	if err := broker.TransitionLifecycle(outcome.TaskID, team.LifecycleStateReady, "task start: human confirmed"); err != nil {
+		return fmt.Errorf("intake → ready: %w", err)
+	}
+	if err := broker.TransitionLifecycle(outcome.TaskID, team.LifecycleStateRunning, "task start: ready → running"); err != nil {
+		return fmt.Errorf("ready → running: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "Task %s now running.\n", outcome.TaskID)
+	return nil
+}
+
+// taskStartHook is the test seam: production overrides this with a
+// helper that boots a transient broker + intake provider; tests inject
+// a fake.
+var taskStartHook = func(ctx context.Context) (*team.Broker, team.IntakeProvider, error) {
+	return nil, nil, fmt.Errorf("task start: not yet wired to a live broker (set WUPHF_TASK_PROVIDER for tests)")
+}
+
+func streamElapsed(start time.Time) chan struct{} {
+	stop := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				fmt.Fprintf(os.Stderr, "%ds ", int(time.Since(start).Seconds()))
+			}
+		}
+	}()
+	return stop
+}
+
+func printSpec(spec team.Spec) {
+	fmt.Println("--- Spec -----------------------------")
+	fmt.Printf("Problem:        %s\n", spec.Problem)
+	if spec.TargetOutcome != "" {
+		fmt.Printf("Target outcome: %s\n", spec.TargetOutcome)
+	}
+	fmt.Printf("Assignment:     %s\n", spec.Assignment)
+	if len(spec.AcceptanceCriteria) > 0 {
+		fmt.Println("Acceptance criteria:")
+		for i, ac := range spec.AcceptanceCriteria {
+			fmt.Printf("  %d. %s\n", i+1, ac.Statement)
+		}
+	}
+	if len(spec.Constraints) > 0 {
+		fmt.Println("Constraints:")
+		for _, c := range spec.Constraints {
+			fmt.Printf("  - %s\n", c)
+		}
+	}
+	if spec.AutoAssign != "" {
+		fmt.Printf("Auto-assign:    %s\n", spec.AutoAssign)
+	}
+	fmt.Println("--------------------------------------")
+}
+
+// runTaskList implements `wuphf task list`. Calls GET /tasks/inbox,
+// groups by LifecycleState, prints to stdout.
+func runTaskList(args []string) {
+	fs := flag.NewFlagSet("task list", flag.ExitOnError)
+	filter := fs.String("filter", "all", "Inbox filter (needs_decision/running/blocked/merged_today/all)")
+	jsonOut := fs.Bool("json", false, "Print the raw inbox payload as JSON")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "wuphf task list — print the inbox grouped by lifecycle state")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf task list                            All tasks across all states")
+		fmt.Fprintln(os.Stderr, "  wuphf task list --filter=needs_decision    Only the inbox-headline filter")
+		fmt.Fprintln(os.Stderr, "  wuphf task list --json                     Emit the raw broker payload")
+	}
+	_ = fs.Parse(args)
+	url := brokerURL("/tasks/inbox?filter=" + *filter)
+	req, err := newBrokerRequest(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "task list: build request: %v\n", err)
+		os.Exit(1)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "task list: %v\n", err)
+		fmt.Fprintln(os.Stderr, "  (is the broker running? try `wuphf` first)")
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "task list: broker returned %d: %s\n", resp.StatusCode, strings.TrimSpace(string(body)))
+		os.Exit(1)
+	}
+	if *jsonOut {
+		fmt.Println(string(body))
+		return
+	}
+	var payload team.InboxPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		fmt.Fprintf(os.Stderr, "task list: parse: %v\n", err)
+		os.Exit(1)
+	}
+	printInboxPayload(payload)
+}
+
+func printInboxPayload(payload team.InboxPayload) {
+	if len(payload.Rows) == 0 {
+		fmt.Println("Inbox is empty.")
+		return
+	}
+	groups := make(map[team.LifecycleState][]team.InboxRow)
+	for _, r := range payload.Rows {
+		groups[r.LifecycleState] = append(groups[r.LifecycleState], r)
+	}
+	states := make([]team.LifecycleState, 0, len(groups))
+	for s := range groups {
+		states = append(states, s)
+	}
+	sort.Slice(states, func(i, j int) bool { return string(states[i]) < string(states[j]) })
+	for _, s := range states {
+		fmt.Printf("\n%s (%d)\n", strings.ToUpper(string(s)), len(groups[s]))
+		for _, row := range groups[s] {
+			elapsed := time.Duration(row.ElapsedMs) * time.Millisecond
+			fmt.Printf("  %-12s  %s  (%s ago)\n", row.TaskID, row.Title, formatElapsed(elapsed))
+		}
+	}
+	fmt.Printf("\nNeeds decision: %d   Running: %d   Blocked: %d   Merged today: %d\n",
+		payload.Counts.NeedsDecision, payload.Counts.Running, payload.Counts.Blocked, payload.Counts.MergedToday)
+}
+
+func formatElapsed(d time.Duration) string {
+	if d < time.Minute {
+		return "just now"
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	}
+	return fmt.Sprintf("%dd", int(d.Hours()/24))
+}
+
+// runTaskReview opens the Decision Packet view in the user's default
+// browser. No broker round-trip — we just construct the URL.
+func runTaskReview(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "task review: missing task id")
+		os.Exit(2)
+	}
+	id := strings.TrimSpace(args[0])
+	url := brokerBaseURL() + "#/task/" + id
+	if err := openBrowser(url); err != nil {
+		fmt.Fprintf(os.Stderr, "task review: open %s: %v\n", url, err)
+		fmt.Fprintln(os.Stderr, "  Open it manually in your browser instead.")
+		os.Exit(1)
+	}
+}
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	return cmd.Start()
+}
+
+// runTaskBlock implements `wuphf task block <id> --on <ref>`. POSTs
+// to /tasks/{id}/block on the running broker.
+func runTaskBlock(args []string) {
+	fs := flag.NewFlagSet("task block", flag.ExitOnError)
+	on := fs.String("on", "", "PR or task ID this task is blocked on (required)")
+	reason := fs.String("reason", "", "Optional human-readable reason")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "wuphf task block — mark a task blocked on a PR or task")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf task block <id> --on <pr-or-task-id> [--reason \"text\"]")
+	}
+	_ = fs.Parse(args)
+	if fs.NArg() == 0 {
+		fmt.Fprintln(os.Stderr, "task block: missing task id")
+		os.Exit(2)
+	}
+	id := strings.TrimSpace(fs.Arg(0))
+	if strings.TrimSpace(*on) == "" {
+		fmt.Fprintln(os.Stderr, "task block: --on is required")
+		os.Exit(2)
+	}
+	body, err := json.Marshal(map[string]string{"on": *on, "reason": *reason})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "task block: encode body: %v\n", err)
+		os.Exit(1)
+	}
+	url := brokerURL("/tasks/" + id + "/block")
+	req, err := newBrokerRequest(context.Background(), http.MethodPost, url, strings.NewReader(string(body)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "task block: build request: %v\n", err)
+		os.Exit(1)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "task block: %v\n", err)
+		fmt.Fprintln(os.Stderr, "  (is the broker running? try `wuphf` first)")
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		fmt.Fprintf(os.Stderr, "task block: broker returned %d: %s\n", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		os.Exit(1)
+	}
+	fmt.Printf("Task %s blocked on %s.\n", id, *on)
+}

--- a/cmd/wuphf/task_cmd_test.go
+++ b/cmd/wuphf/task_cmd_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -160,17 +161,148 @@ func TestIsSafeTaskID(t *testing.T) {
 	}
 }
 
-// TestRunTaskStartHookErrorBubblesUp confirms the runner surfaces hook
-// errors instead of silently succeeding.
-func TestRunTaskStartHookErrorBubblesUp(t *testing.T) {
-	prev := taskStartHook
-	taskStartHook = func(_ context.Context) (*team.Broker, team.IntakeProvider, error) {
-		return nil, nil, team.ErrIntakeNoProvider
-	}
-	defer func() { taskStartHook = prev }()
+// fakeBrokerClient is a test double for the brokerClient interface.
+// Each method records the call and returns canned data.
+type fakeBrokerClient struct {
+	startIntake          func(ctx context.Context, intent string) (*team.IntakeOutcome, error)
+	transitionLifecycle  func(ctx context.Context, taskID string, to team.LifecycleState, reason string) error
+	blockTask            func(ctx context.Context, taskID, on, reason string) error
+	listInbox            func(ctx context.Context, filter string) (team.InboxPayload, error)
+	transitions          []team.LifecycleState
+	transitionRecordedID string
+}
 
-	err := runTaskStartInProcess(context.Background(), "anything", "")
+func (f *fakeBrokerClient) StartIntake(ctx context.Context, intent string) (*team.IntakeOutcome, error) {
+	if f.startIntake != nil {
+		return f.startIntake(ctx, intent)
+	}
+	return nil, errors.New("startIntake not stubbed")
+}
+
+func (f *fakeBrokerClient) TransitionLifecycle(ctx context.Context, taskID string, to team.LifecycleState, reason string) error {
+	f.transitionRecordedID = taskID
+	f.transitions = append(f.transitions, to)
+	if f.transitionLifecycle != nil {
+		return f.transitionLifecycle(ctx, taskID, to, reason)
+	}
+	return nil
+}
+
+func (f *fakeBrokerClient) BlockTask(ctx context.Context, taskID, on, reason string) error {
+	if f.blockTask != nil {
+		return f.blockTask(ctx, taskID, on, reason)
+	}
+	return nil
+}
+
+func (f *fakeBrokerClient) ListInbox(ctx context.Context, filter string) (team.InboxPayload, error) {
+	if f.listInbox != nil {
+		return f.listInbox(ctx, filter)
+	}
+	return team.InboxPayload{}, nil
+}
+
+// TestRunTaskStartIntakeErrorBubblesUp confirms the runner surfaces
+// brokerClient errors instead of silently succeeding.
+func TestRunTaskStartIntakeErrorBubblesUp(t *testing.T) {
+	client := &fakeBrokerClient{
+		startIntake: func(_ context.Context, _ string) (*team.IntakeOutcome, error) {
+			return nil, team.ErrIntakeNoProvider
+		},
+	}
+	err := runTaskStartWithClient(context.Background(), client, "anything", "", strings.NewReader(""))
 	if err == nil {
 		t.Fatalf("expected error from missing provider, got nil")
+	}
+	if !strings.Contains(err.Error(), "no LLM provider") {
+		t.Fatalf("expected no-provider error; got %q", err.Error())
+	}
+}
+
+// TestRunTaskStartHappyPathWithClient drives the full happy path end-
+// to-end: intake returns a valid outcome, user confirms with "y", and
+// the runner posts intake → ready → running transitions in order.
+func TestRunTaskStartHappyPathWithClient(t *testing.T) {
+	client := &fakeBrokerClient{
+		startIntake: func(_ context.Context, intent string) (*team.IntakeOutcome, error) {
+			return &team.IntakeOutcome{
+				TaskID: "task-7411",
+				Spec: team.Spec{
+					Problem:    "fix the cache",
+					Assignment: "audit cache.go",
+					AcceptanceCriteria: []team.ACItem{
+						{Statement: "stale entries no longer return"},
+					},
+				},
+			}, nil
+		},
+	}
+	err := runTaskStartWithClient(context.Background(), client, "fix the cache", "", strings.NewReader("y\n"))
+	if err != nil {
+		t.Fatalf("happy path: %v", err)
+	}
+	if got, want := len(client.transitions), 2; got != want {
+		t.Fatalf("expected 2 transitions, got %d (%v)", got, client.transitions)
+	}
+	if client.transitions[0] != team.LifecycleStateReady {
+		t.Errorf("first transition: got %q, want %q", client.transitions[0], team.LifecycleStateReady)
+	}
+	if client.transitions[1] != team.LifecycleStateRunning {
+		t.Errorf("second transition: got %q, want %q", client.transitions[1], team.LifecycleStateRunning)
+	}
+	if client.transitionRecordedID != "task-7411" {
+		t.Errorf("transition target: got %q, want task-7411", client.transitionRecordedID)
+	}
+}
+
+// TestRunTaskStartUserDeclinesLeavesInIntake covers the "n" branch:
+// intake succeeds, user types "n", the runner does NOT post any
+// transitions and reports the task is left in intake.
+func TestRunTaskStartUserDeclinesLeavesInIntake(t *testing.T) {
+	client := &fakeBrokerClient{
+		startIntake: func(_ context.Context, _ string) (*team.IntakeOutcome, error) {
+			return &team.IntakeOutcome{
+				TaskID: "task-9999",
+				Spec: team.Spec{
+					Problem:            "irrelevant",
+					Assignment:         "ignore",
+					AcceptanceCriteria: []team.ACItem{{Statement: "no-op"}},
+				},
+			}, nil
+		},
+	}
+	err := runTaskStartWithClient(context.Background(), client, "intent", "", strings.NewReader("n\n"))
+	if err != nil {
+		t.Fatalf("decline path returned error: %v", err)
+	}
+	if len(client.transitions) != 0 {
+		t.Fatalf("expected no transitions on decline; got %v", client.transitions)
+	}
+}
+
+// TestPromptYesNo locks down the consolidated y/n helper (F-FU-4).
+func TestPromptYesNo(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"  y  \n", true},
+		{"n\n", false},
+		{"no\n", false},
+		{"\n", false},
+		{"maybe\n", false},
+	}
+	for _, tc := range cases {
+		got, err := promptYesNo(strings.NewReader(tc.input), "")
+		if err != nil {
+			t.Errorf("promptYesNo(%q): unexpected error: %v", tc.input, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("promptYesNo(%q) = %v, want %v", tc.input, got, tc.want)
+		}
 	}
 }

--- a/cmd/wuphf/task_cmd_test.go
+++ b/cmd/wuphf/task_cmd_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// captureStderr swaps os.Stderr for a pipe so test assertions can
+// inspect the human-readable transcript the CLI emits.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	prev := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = prev }()
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	w.Close()
+	return <-done
+}
+
+// captureStdout is the stdout twin of captureStderr.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	prev := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = prev }()
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	w.Close()
+	return <-done
+}
+
+// TestPrintInboxPayloadGroupsByLifecycleState exercises the formatter
+// directly with a synthetic payload — no broker round trip needed for
+// the grouping/sort assertion.
+func TestPrintInboxPayloadGroupsByLifecycleState(t *testing.T) {
+	payload := team.InboxPayload{
+		Rows: []team.InboxRow{
+			{TaskID: "task-1", Title: "fix the cache", LifecycleState: team.LifecycleStateRunning, ElapsedMs: 60_000},
+			{TaskID: "task-2", Title: "ship the docs", LifecycleState: team.LifecycleStateDecision, ElapsedMs: 120_000},
+			{TaskID: "task-3", Title: "spec the wedge", LifecycleState: team.LifecycleStateRunning, ElapsedMs: 30_000},
+		},
+		Counts:      team.InboxCounts{NeedsDecision: 1, Running: 2, Blocked: 0, MergedToday: 0},
+		RefreshedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	out := captureStdout(t, func() { printInboxPayload(payload) })
+	if !strings.Contains(out, "RUNNING") || !strings.Contains(out, "DECISION") {
+		t.Fatalf("expected RUNNING and DECISION group headings; got:\n%s", out)
+	}
+	if !strings.Contains(out, "task-1") || !strings.Contains(out, "task-2") || !strings.Contains(out, "task-3") {
+		t.Fatalf("expected all three task IDs in output; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Needs decision: 1") {
+		t.Fatalf("expected counts footer; got:\n%s", out)
+	}
+}
+
+// TestFormatElapsed sanity-checks the human-readable elapsed-time
+// formatter the inbox printer uses.
+func TestFormatElapsed(t *testing.T) {
+	cases := []struct {
+		dur  time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{2 * time.Minute, "2m"},
+		{3 * time.Hour, "3h"},
+		{50 * time.Hour, "2d"},
+	}
+	for _, c := range cases {
+		if got := formatElapsed(c.dur); got != c.want {
+			t.Errorf("formatElapsed(%s) = %q, want %q", c.dur, got, c.want)
+		}
+	}
+}
+
+// TestPrintSpecRendersAllSections asserts the Spec printer handles the
+// optional fields and the AC list.
+func TestPrintSpecRendersAllSections(t *testing.T) {
+	spec := team.Spec{
+		Problem:       "the cache is stale",
+		TargetOutcome: "hits drop after invalidation",
+		Assignment:    "audit invalidation",
+		AcceptanceCriteria: []team.ACItem{
+			{Statement: "hits drop"},
+			{Statement: "no stale reads"},
+		},
+		Constraints: []string{"no breaking changes"},
+		AutoAssign:  "owner-eng",
+	}
+	out := captureStdout(t, func() { printSpec(spec) })
+	for _, want := range []string{"the cache is stale", "audit invalidation", "hits drop", "no stale reads", "owner-eng"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected output to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunTaskCmdHelp verifies the dispatcher prints help when called
+// with no args or an explicit help flag.
+func TestRunTaskCmdHelp(t *testing.T) {
+	out := captureStderr(t, func() { runTaskCmd([]string{"--help"}) })
+	if !strings.Contains(out, "wuphf task") || !strings.Contains(out, "start") {
+		t.Errorf("expected help text mentioning wuphf task and start; got:\n%s", out)
+	}
+}
+
+// TestAutoAssignCountdownInterrupt verifies that a keypress during the
+// countdown cancels the auto-confirm and falls back to manual y/n.
+func TestAutoAssignCountdownInterrupt(t *testing.T) {
+	c := team.NewAutoAssignCountdown()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		c.Cancel()
+	}()
+	if c.Wait(context.Background()) {
+		t.Errorf("expected Wait to return false on Cancel, got true")
+	}
+}
+
+// TestRunTaskStartHookErrorBubblesUp confirms the runner surfaces hook
+// errors instead of silently succeeding.
+func TestRunTaskStartHookErrorBubblesUp(t *testing.T) {
+	prev := taskStartHook
+	taskStartHook = func(_ context.Context) (*team.Broker, team.IntakeProvider, error) {
+		return nil, nil, team.ErrIntakeNoProvider
+	}
+	defer func() { taskStartHook = prev }()
+
+	err := runTaskStartInProcess(context.Background(), "anything", "")
+	if err == nil {
+		t.Fatalf("expected error from missing provider, got nil")
+	}
+}

--- a/cmd/wuphf/task_cmd_test.go
+++ b/cmd/wuphf/task_cmd_test.go
@@ -143,6 +143,23 @@ func TestAutoAssignCountdownInterrupt(t *testing.T) {
 	}
 }
 
+// TestIsSafeTaskID locks down the allowlist used to guard `open` /
+// `xdg-open` / `rundll32` arguments and the block POST path.
+func TestIsSafeTaskID(t *testing.T) {
+	good := []string{"task-1", "abc_123", "Task42", "T-1"}
+	for _, id := range good {
+		if !isSafeTaskID(id) {
+			t.Errorf("isSafeTaskID(%q) = false, want true", id)
+		}
+	}
+	bad := []string{"", "task with space", "task;rm", "task/.", "task'$", strings.Repeat("a", 200)}
+	for _, id := range bad {
+		if isSafeTaskID(id) {
+			t.Errorf("isSafeTaskID(%q) = true, want false", id)
+		}
+	}
+}
+
 // TestRunTaskStartHookErrorBubblesUp confirms the runner surfaces hook
 // errors instead of silently succeeding.
 func TestRunTaskStartHookErrorBubblesUp(t *testing.T) {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -96,7 +96,7 @@ type Broker struct {
 	// the durable source of truth. The two are kept in sync by
 	// AppendReviewerGrade — Lane C mirrors writes to Lane D on each
 	// grade. Guarded by b.mu.
-	reviewerGradesByTask map[string][]ReviewerGrade
+	reviewerGradesByTask    map[string][]ReviewerGrade
 	requests                []humanInterview
 	humanInvites            []humanInvite
 	humanSessions           []humanSession

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -96,7 +96,16 @@ type Broker struct {
 	// the durable source of truth. The two are kept in sync by
 	// AppendReviewerGrade — Lane C mirrors writes to Lane D on each
 	// grade. Guarded by b.mu.
-	reviewerGradesByTask    map[string][]ReviewerGrade
+	reviewerGradesByTask map[string][]ReviewerGrade
+	// intakeProviderFactory builds an IntakeProvider on demand for the
+	// HTTP intake endpoint (POST /tasks/intake). The factory is invoked
+	// per-request so a long-lived broker can pick up provider config
+	// changes (API keys, endpoints) without restart. Production
+	// callers leave this nil; the handler falls back to
+	// NewDefaultIntakeProvider. Tests inject a fake via
+	// SetIntakeProviderFactory so the live HTTP wire can be exercised
+	// without standing up a real LLM. Guarded by b.mu.
+	intakeProviderFactory   func() IntakeProvider
 	requests                []humanInterview
 	humanInvites            []humanInvite
 	humanSessions           []humanSession
@@ -495,6 +504,7 @@ func (b *Broker) StartOnPort(port int) error {
 	// /tasks/{id} only because the existing /tasks/ack and
 	// /tasks/memory-workflow exact paths win for their literals.
 	mux.HandleFunc("/tasks/inbox", b.requireAuth(b.handleTasksInbox))
+	mux.HandleFunc("/tasks/intake", b.requireAuth(b.handleTasksIntake))
 	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
 	mux.HandleFunc("/session-mode", b.requireAuth(b.handleSessionMode))
 	mux.HandleFunc("/focus-mode", b.requireAuth(b.handleFocusMode))

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -68,17 +68,24 @@ func (b *Broker) handleTasksInbox(w http.ResponseWriter, r *http.Request) {
 var reservedTaskSubpath = map[string]struct{}{
 	"":                 {},
 	"inbox":            {},
+	"intake":           {},
 	"ack":              {},
 	"memory-workflow":  {},
 	"memory-workflows": {},
 }
 
-// handleTaskByID serves GET /tasks/{id} and POST /tasks/{id}/block.
+// handleTaskByID serves GET /tasks/{id} and POST /tasks/{id}/{verb}.
 // Mounted via b.withAuth on the "/tasks/" prefix. ServeMux's longest-
 // prefix matching means the existing exact paths /tasks, /tasks/ack,
-// /tasks/memory-workflow, /tasks/memory-workflow/reconcile, and
-// /tasks/inbox win over this prefix handler — so this path effectively
-// only fires for /tasks/{id} (GET) or /tasks/{id}/block (POST).
+// /tasks/memory-workflow, /tasks/memory-workflow/reconcile, /tasks/inbox,
+// and /tasks/intake win over this prefix handler — so this path
+// effectively only fires for /tasks/{id} (GET) or /tasks/{id}/{verb}
+// (POST).
+//
+// Recognised verbs: block (Lane F block-on-PR-merge), transition (Lane F
+// lifecycle advance). merge / request-changes / defer remain reserved
+// for Lane G and return 404 here so a stray client cannot silently
+// land on the wrong handler.
 func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 	actor, ok := requestActorFromContext(r.Context())
 	if !ok {
@@ -86,15 +93,17 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rest := strings.TrimPrefix(r.URL.Path, "/tasks/")
-	// /tasks/{id}/block is the Lane F block-on-PR-merge action. Other
-	// verbs (merge / request-changes / defer) are still reserved for
-	// Lane G; they return 404 here so a stray client cannot silently
-	// land on the wrong handler.
 	if strings.Contains(rest, "/") {
 		segments := strings.SplitN(rest, "/", 2)
-		if len(segments) == 2 && segments[1] == "block" {
-			b.handleTaskBlock(w, r, actor, strings.TrimSpace(segments[0]))
-			return
+		if len(segments) == 2 {
+			switch segments[1] {
+			case "block":
+				b.handleTaskBlock(w, r, actor, strings.TrimSpace(segments[0]))
+				return
+			case "transition":
+				b.handleTaskTransition(w, r, actor, strings.TrimSpace(segments[0]))
+				return
+			}
 		}
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
 		return
@@ -216,4 +225,129 @@ func taskAccessAllowed(actor requestActor, reviewers []string) bool {
 		}
 	}
 	return false
+}
+
+// intakeHTTPOutcome is the JSON wire shape returned by POST /tasks/intake.
+// We do not return the AutoAssignCountdown handle (it is not serialisable
+// and lives on the broker process); the CLI re-creates a local countdown
+// when AutoAssign is non-empty so the user-facing keypress UX is identical
+// to the in-process path.
+type intakeHTTPOutcome struct {
+	TaskID     string `json:"taskId"`
+	Spec       Spec   `json:"spec"`
+	AutoAssign string `json:"autoAssign,omitempty"`
+}
+
+// handleTasksIntake serves POST /tasks/intake. Body shape:
+//
+//	{"intent": "<free-text intent>"}
+//
+// Returns 200 with intakeHTTPOutcome on a clean intake → ready
+// transition. The task lands in LifecycleStateReady; the caller is
+// responsible for the ready → running advance via POST
+// /tasks/{id}/transition.
+//
+// Auth: broker-only. Tunnel humans cannot trigger intake in v1; the
+// founder/owner runs `wuphf task start` against their own broker.
+func (b *Broker) handleTasksIntake(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	if actor.Kind != requestActorKindBroker {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	var body struct {
+		Intent string `json:"intent"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+	intent := strings.TrimSpace(body.Intent)
+	if intent == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "intent required"})
+		return
+	}
+	provider := b.resolveIntakeProvider()
+	if provider == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "no intake provider configured"})
+		return
+	}
+	outcome, err := b.StartIntake(r.Context(), intent, provider)
+	if err != nil {
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, intakeHTTPOutcome{
+		TaskID:     outcome.TaskID,
+		Spec:       outcome.Spec,
+		AutoAssign: outcome.AutoAssign,
+	})
+}
+
+// handleTaskTransition serves POST /tasks/{id}/transition. Body shape:
+//
+//	{"to": "<lifecycle-state>", "reason": "<text>"}
+//
+// On success returns 200 with the post-transition teamTask snapshot.
+// Auth: broker/owner only — humans drive lifecycle advances through
+// Lane G's UI verbs (merge / request-changes / defer), which post to
+// dedicated endpoints rather than this raw transition primitive.
+func (b *Broker) handleTaskTransition(w http.ResponseWriter, r *http.Request, actor requestActor, id string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if actor.Kind != requestActorKindBroker {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "task id required"})
+		return
+	}
+	var body struct {
+		To     string `json:"to"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+	to := strings.TrimSpace(body.To)
+	if to == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "target lifecycle state required"})
+		return
+	}
+	reason := strings.TrimSpace(body.Reason)
+	if reason == "" {
+		reason = "transition via api"
+	}
+	if err := b.TransitionLifecycle(id, LifecycleState(to), reason); err != nil {
+		// Distinguish "task not found" from "transition rejected" so the
+		// CLI surfaces a clearer error to the user.
+		if strings.Contains(err.Error(), "not found") {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	b.mu.Lock()
+	task := b.findTaskByIDLocked(id)
+	var snapshot teamTask
+	if task != nil {
+		snapshot = *task
+	}
+	b.mu.Unlock()
+	writeJSON(w, http.StatusOK, snapshot)
 }

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -185,15 +185,16 @@ func (b *Broker) handleTaskBlock(w http.ResponseWriter, r *http.Request, actor r
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
 		return
 	}
+	on := strings.TrimSpace(body.On)
 	reason := strings.TrimSpace(body.Reason)
-	if reason == "" && strings.TrimSpace(body.On) != "" {
-		reason = "blocked on " + strings.TrimSpace(body.On)
+	if reason == "" && on != "" {
+		reason = "blocked on " + on
 	}
 	actorSlug := strings.TrimSpace(body.Actor)
 	if actorSlug == "" {
 		actorSlug = "human"
 	}
-	task, ok, err := b.BlockTask(id, actorSlug, reason)
+	task, ok, err := b.BlockTask(id, actorSlug, reason, on)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -27,6 +27,7 @@ package team
 // taskBrokerRoutes) keep their meanings.
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 )
@@ -72,31 +73,35 @@ var reservedTaskSubpath = map[string]struct{}{
 	"memory-workflows": {},
 }
 
-// handleTaskByID serves GET /tasks/{id}. Mounted via b.withAuth on
-// the "/tasks/" prefix. ServeMux's longest-prefix matching means the
-// existing exact paths /tasks, /tasks/ack, /tasks/memory-workflow,
-// /tasks/memory-workflow/reconcile, and /tasks/inbox win over this
-// prefix handler — so this path effectively only fires for
-// /tasks/{id} where {id} is not one of those reserved tokens. The
-// reserved-token check is a defense-in-depth guard for future routes.
+// handleTaskByID serves GET /tasks/{id} and POST /tasks/{id}/block.
+// Mounted via b.withAuth on the "/tasks/" prefix. ServeMux's longest-
+// prefix matching means the existing exact paths /tasks, /tasks/ack,
+// /tasks/memory-workflow, /tasks/memory-workflow/reconcile, and
+// /tasks/inbox win over this prefix handler — so this path effectively
+// only fires for /tasks/{id} (GET) or /tasks/{id}/block (POST).
 func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
 	actor, ok := requestActorFromContext(r.Context())
 	if !ok {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return
 	}
 	rest := strings.TrimPrefix(r.URL.Path, "/tasks/")
-	// /tasks/{id}/{verb} is reserved for future Lane G action endpoints
-	// (merge, request-changes, block, defer). v1 ships only the GET
-	// reader; sub-verbs return 404 here so a stray client cannot
-	// silently land on the wrong handler.
+	// /tasks/{id}/block is the Lane F block-on-PR-merge action. Other
+	// verbs (merge / request-changes / defer) are still reserved for
+	// Lane G; they return 404 here so a stray client cannot silently
+	// land on the wrong handler.
 	if strings.Contains(rest, "/") {
+		segments := strings.SplitN(rest, "/", 2)
+		if len(segments) == 2 && segments[1] == "block" {
+			b.handleTaskBlock(w, r, actor, strings.TrimSpace(segments[0]))
+			return
+		}
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	id := strings.TrimSpace(rest)
@@ -139,6 +144,56 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, packetCopy)
+}
+
+// handleTaskBlock serves POST /tasks/{id}/block. Body shape:
+//
+//	{"on": "<pr-or-task-id>", "actor": "<slug>", "reason": "<text>"}
+//
+// On success returns 200 with the post-block teamTask snapshot.
+// Auth: broker/owner only — humans cannot block other reviewers' tasks
+// in v1 to keep the action surface small.
+func (b *Broker) handleTaskBlock(w http.ResponseWriter, r *http.Request, actor requestActor, id string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if actor.Kind != requestActorKindBroker {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "task id required"})
+		return
+	}
+	var body struct {
+		On     string `json:"on"`
+		Actor  string `json:"actor"`
+		Reason string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
+	reason := strings.TrimSpace(body.Reason)
+	if reason == "" && strings.TrimSpace(body.On) != "" {
+		reason = "blocked on " + strings.TrimSpace(body.On)
+	}
+	actorSlug := strings.TrimSpace(body.Actor)
+	if actorSlug == "" {
+		actorSlug = "human"
+	}
+	task, ok, err := b.BlockTask(id, actorSlug, reason)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		return
+	}
+	writeJSON(w, http.StatusOK, task)
 }
 
 // taskAccessAllowed encodes the auth matrix from the design doc:

--- a/internal/team/broker_intake.go
+++ b/internal/team/broker_intake.go
@@ -847,3 +847,125 @@ func (b *Broker) IntakeSpec(taskID string) (Spec, bool) {
 	spec, ok := b.intakeSpecs[taskID]
 	return spec, ok
 }
+
+// SetIntakeProviderFactory installs a factory the HTTP intake handler
+// uses to pick up an IntakeProvider on each request. Tests inject a
+// fake here so POST /tasks/intake exercises the real handler path
+// against a canned LLM response. Pass nil to fall back to the default
+// provider (anthropic-haiku → ollama → openai).
+func (b *Broker) SetIntakeProviderFactory(f func() IntakeProvider) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.intakeProviderFactory = f
+}
+
+// resolveIntakeProvider picks the provider to use for the next intake
+// call. If a factory is registered (test seam), the factory is invoked
+// once. Otherwise the default haiku/ollama/openai chain is built fresh.
+func (b *Broker) resolveIntakeProvider() IntakeProvider {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	factory := b.intakeProviderFactory
+	b.mu.Unlock()
+	if factory != nil {
+		if p := factory(); p != nil {
+			return p
+		}
+	}
+	return NewDefaultIntakeProvider()
+}
+
+// SetReviewerNowFn overrides the broker clock the reviewer-routing
+// timeout / convergence layer reads through. Used by ICP and unit
+// tests to advance synthetic time past a deadline without sleeping.
+// Pass nil to restore the default (time.Now). Production callers
+// MUST NOT use this — the field is exported because the cmd/wuphf
+// ICP harness lives in a different Go package and cannot reach an
+// unexported setter; the production code paths leave it nil.
+func (b *Broker) SetReviewerNowFn(now func() time.Time) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nowFn = now
+}
+
+// SetTaskReviewersForTest pins the reviewer roster on a task without
+// going through the routing-layer derivation from watching sets.
+// Used by ICP tests so the timeout-fill path can be exercised against
+// a deterministic three-reviewer roster regardless of which agents
+// the broker happens to be seeded with. Always stamps
+// ReviewStartedAt to the broker's current clock so the deadline
+// calculation is anchored deterministically — overrides any prior
+// stamp that may have been written during the running → review hop.
+// Must not be used by production callers.
+func (b *Broker) SetTaskReviewersForTest(taskID string, reviewers []string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].ID != taskID {
+			continue
+		}
+		b.tasks[i].Reviewers = append([]string(nil), reviewers...)
+		b.tasks[i].ReviewStartedAt = b.reviewerNow().UTC().Format(time.RFC3339)
+		return
+	}
+}
+
+// TaskReviewStartedAtForTest exposes the reviewer-deadline anchor on a
+// task. Used by ICP tests to assert the timeout filler observes the
+// correct deadline without parsing internal fields. Returns the empty
+// string when the task is not found or has not yet entered review.
+func (b *Broker) TaskReviewStartedAtForTest(taskID string) string {
+	if b == nil {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].ID == taskID {
+			return b.tasks[i].ReviewStartedAt
+		}
+	}
+	return ""
+}
+
+// ReviewerNowForTest returns the broker's current reviewer-clock value.
+// Helps ICP tests assert the time-advance machinery before chasing a
+// deadline-related convergence regression.
+func (b *Broker) ReviewerNowForTest() time.Time {
+	if b == nil {
+		return time.Time{}
+	}
+	return b.reviewerNow()
+}
+
+// SetTaskBlockedOnForTest pins the BlockedOn list on a task without
+// going through BlockTask (which routes through the lifecycle
+// transition layer to blocked_on_pr_merge but does not yet populate
+// task.BlockedOn — a v1.1 gap surfaced by ICP tutorial 3). Used by
+// ICP tests so the unblock cascade can be exercised end-to-end while
+// the underlying CLI / HTTP block path is documented as not-yet
+// data-flow-complete. Must not be used by production callers.
+func (b *Broker) SetTaskBlockedOnForTest(taskID string, blockedOn []string) {
+	if b == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].ID == taskID {
+			b.tasks[i].BlockedOn = append([]string(nil), blockedOn...)
+			return
+		}
+	}
+}

--- a/internal/team/broker_intake.go
+++ b/internal/team/broker_intake.go
@@ -291,6 +291,10 @@ func (p *defaultIntakeProvider) CallSpecLLM(ctx context.Context, systemPrompt, u
 	return "", errIntakeNoProvider
 }
 
+// ErrIntakeNoProvider is the public alias of errIntakeNoProvider so the
+// Lane F CLI can match against it without importing the internal symbol.
+var ErrIntakeNoProvider = errIntakeNoProvider
+
 // errIntakeNoProvider signals that no haiku/ollama/openai surface is
 // reachable. The driver returns this verbatim so the CLI can offer the
 // manual-entry escape hatch immediately.

--- a/internal/team/broker_reviewer_routing.go
+++ b/internal/team/broker_reviewer_routing.go
@@ -330,6 +330,7 @@ func (b *Broker) evaluateConvergenceLocked(taskID string) error {
 	// manifest status on the reviewer's task-scoped agent stream.
 	terminalStatuses := b.observedTerminalStatusByReviewerLocked(taskID, missing)
 	now := b.reviewerNow().UTC()
+	packet := b.getOrInitPacketLocked(taskID)
 	for _, slug := range missing {
 		reasoning := "reviewer timed out"
 		if status, ok := terminalStatuses[slug]; ok {
@@ -343,9 +344,19 @@ func (b *Broker) evaluateConvergenceLocked(taskID string) error {
 			Reasoning:    reasoning,
 			SubmittedAt:  now,
 		}
+		// Mirror the filler to BOTH stores so consumers — Lane G's
+		// Decision Packet view (read-side) and Lane D's convergence
+		// rule (the rule itself) — observe the same set of grades.
+		// The pre-integration code only wrote the routing mirror,
+		// which left packet.ReviewerGrades short of a slot whenever a
+		// timeout fired and made the UI look like the reviewer had
+		// silently disappeared. Both writes happen under the
+		// already-held b.mu so they land atomically.
 		b.reviewerGradesByTask[taskID] = append(b.reviewerGradesByTask[taskID], filler)
+		packet.ReviewerGrades = append(packet.ReviewerGrades, filler)
 		b.postReviewTimeoutChannelMessageLocked(task, slug, reasoning)
 	}
+	b.persistDecisionPacketLocked(taskID, *packet)
 
 	_, err := b.transitionLifecycleLocked(taskID, LifecycleStateDecision, "convergence: timeout")
 	return err


### PR DESCRIPTION
## Summary

Lane F of the multi-agent control loop. Adds the CLI surface humans drive directly:

- \`wuphf task start [intent]\` — drives intent through intake → ready → running. Honors \`Spec.AutoAssign\` with a 3-second cancellable countdown. Falls back to manual y/n confirm on cancel or empty AutoAssign.
- \`wuphf task list [--filter=<filter>]\` — calls \`GET /tasks/inbox\`, groups by lifecycle state, prints to stdout. Supports \`--json\` for raw payload.
- \`wuphf task review <id>\` — opens \`/task/<id>\` in the user's default browser via \`open\` / \`xdg-open\` / \`rundll32\`. Task ID is allowlist-checked before launch.
- \`wuphf task block <id> --on <pr-or-task-id>\` — POSTs to a new \`POST /tasks/{id}/block\` endpoint that gates on broker/owner actor and routes through the existing \`BlockTask\` transition layer.

Defense-in-depth: \`isSafeTaskID\` allowlist on \`task review\` + \`task block\` arguments before composing URLs / launching the browser. Prevents shell-meta surprises with launchers that re-parse URLs internally.

\`task start\` runs against an in-process broker via the \`taskStartHook\` test seam so integration tests can inject a fake \`IntakeProvider\`. Production wire to a running broker is a v1.1 polish task; the CLI surface itself is functional end-to-end through the seam today.

## Design doc

Multi-agent control loop, APPROVED 2026-05-09.

## Stacked PR chain

A → B → C → D → E → G → **this PR**. Merge order: A → B → C → D → E → G → F.

## Build-time gates passing

CLI tests cover:

- printInboxPayload grouping by LifecycleState + counts footer.
- formatElapsed buckets.
- printSpec rendering all sections.
- Help dispatcher prints task help.
- \`AutoAssignCountdown.Wait\` returns false on Cancel (interrupt path).
- \`runTaskStartInProcess\` surfaces hook errors instead of silently succeeding.
- \`isSafeTaskID\` allowlist accepts \`[A-Za-z0-9_-]\` and rejects everything else.

## Test results

- \`bash scripts/test-go.sh\`: 38/38 green.
- \`bash scripts/test-web.sh\`: 1495/1495 green.
- \`go vet\`: clean. \`gofmt -l\`: empty.

## Review summary

CRITICAL: 0. HIGH: 0 (the H1 finding on \`task block --reason\` is
gated by the broker/owner-only auth on the POST endpoint).

## Known follow-ups (MEDIUM/LOW)

- F-FU-1 (MEDIUM): production wire to a running broker (HTTP intake
  endpoint) is v1.1.
- F-FU-2..4 (LOW): doc \`WUPHF_BROKER_TOKEN\` env override in help;
  consolidate y/n confirm with shared helper; flag stdout/stderr mix.

## Test plan

- [ ] \`wuphf task list\` against a running broker prints grouped tasks.
- [ ] \`wuphf task review <id>\` opens the browser at \`/task/<id>\`.
- [ ] \`wuphf task block <id> --on PR-#742\` lands the lifecycle transition.
- [ ] \`wuphf task block evil;rm\` rejects the malformed task id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `task` subcommand: start (with optional auto-assign), list (grouped by state), review (opens decision view), and block tasks via the broker API.
  * Broker HTTP now supports intake, block, and transition endpoints.

* **Bug Fixes**
  * Decision packets now correctly include reviewer grades when reviewers time out.

* **Tests**
  * New end-to-end acceptance tests for task workflows and extensive CLI/unit tests for task commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/761)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->