### PR TITLE
fix(installer): wire invariant gate + non-vacuous asset check + draft publish flip + 4 HIGH/5 MEDIUM (post-merge cleanup of #754)

### DIFF
--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -343,6 +343,7 @@ jobs:
         shell: pwsh
         run: Start-Sleep -Seconds 30
       - name: Sign Windows artifacts (attempt 3)
+        id: sign_windows_3
         if: needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure' && steps.sign_windows_2.outcome == 'failure'
         timeout-minutes: 30
         uses: Azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # ratchet:Azure/trusted-signing-action@v1.2.0
@@ -360,6 +361,37 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
           timeout: 1800
+      - name: Write Azure signing attempt diagnostics
+        if: always() && needs.detect-secrets.outputs.is_release == 'true'
+        shell: pwsh
+        env:
+          SIGN_WINDOWS_1_OUTCOME: ${{ steps.sign_windows_1.outcome }}
+          SIGN_WINDOWS_1_CONCLUSION: ${{ steps.sign_windows_1.conclusion }}
+          SIGN_WINDOWS_2_OUTCOME: ${{ steps.sign_windows_2.outcome }}
+          SIGN_WINDOWS_2_CONCLUSION: ${{ steps.sign_windows_2.conclusion }}
+          SIGN_WINDOWS_3_OUTCOME: ${{ steps.sign_windows_3.outcome }}
+          SIGN_WINDOWS_3_CONCLUSION: ${{ steps.sign_windows_3.conclusion }}
+        run: |
+          New-Item -ItemType Directory -Force -Path signing-diagnostics | Out-Null
+          @(
+            "attempt 1 outcome: $env:SIGN_WINDOWS_1_OUTCOME"
+            "attempt 1 conclusion: $env:SIGN_WINDOWS_1_CONCLUSION"
+            "attempt 2 outcome: $env:SIGN_WINDOWS_2_OUTCOME"
+            "attempt 2 conclusion: $env:SIGN_WINDOWS_2_CONCLUSION"
+            "attempt 3 outcome: $env:SIGN_WINDOWS_3_OUTCOME"
+            "attempt 3 conclusion: $env:SIGN_WINDOWS_3_CONCLUSION"
+          ) | Set-Content -Path signing-diagnostics/azure-signing-attempts.txt
+      - name: Report Azure signing flakiness
+        if: always() && needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure'
+        shell: pwsh
+        run: Write-Output "::warning title=Azure signing flakiness::Azure Trusted Signing required at least one retry. Download the azure-signing-diagnostics artifact and check service health before the next release window."
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        if: always() && needs.detect-secrets.outputs.is_release == 'true'
+        with:
+          name: azure-signing-diagnostics
+          path: signing-diagnostics/azure-signing-attempts.txt
+          retention-days: 14
+          if-no-files-found: error
       - name: Assert Windows signer identity
         if: needs.detect-secrets.outputs.is_release == 'true'
         shell: pwsh

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -72,6 +72,14 @@ jobs:
           rg --version
           bash apps/installer-stub/scripts/check-invariants.sh
           bash apps/installer-stub/scripts/check-invariants-self-test.sh
+          # H3 inverted the verify-latest-yml self-test from default-on to
+          # opt-in. The publish job's verify call (deliberately) does NOT
+          # pay that cost, so the gate that catches malformed-files[] /
+          # missing-size regressions has to run somewhere in CI. Run the
+          # self-test stand-alone here against the same shared script.
+          WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 \
+            WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 \
+            bash apps/installer-stub/scripts/verify-latest-yml.sh
 
   build-mac:
     needs:

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -532,26 +532,27 @@ jobs:
       - name: Assert release asset set
         run: |
           shopt -s nullglob
+          require_asset_class() {
+            local class="$1"
+            shift
+
+            if [[ "$#" -eq 0 ]]; then
+              echo "Missing required release asset class: ${class}" >&2
+              exit 1
+            fi
+          }
+
           mac_dmgs=(release-assets/*.dmg)
           mac_zips=(release-assets/*.zip)
           win_installers=(release-assets/*.exe)
           linux_appimages=(release-assets/*.AppImage)
           linux_debs=(release-assets/*.deb)
 
-          if [[ "${#mac_dmgs[@]}" -eq 0 || "${#mac_zips[@]}" -eq 0 ]]; then
-            echo "Missing required macOS release artifacts" >&2
-            exit 1
-          fi
-
-          if [[ "${#win_installers[@]}" -eq 0 ]]; then
-            echo "Missing required Windows release artifact" >&2
-            exit 1
-          fi
-
-          if [[ "${#linux_appimages[@]}" -eq 0 || "${#linux_debs[@]}" -eq 0 ]]; then
-            echo "Missing required Linux release artifacts" >&2
-            exit 1
-          fi
+          require_asset_class "dmg" "${mac_dmgs[@]}"
+          require_asset_class "zip" "${mac_zips[@]}"
+          require_asset_class "exe" "${win_installers[@]}"
+          require_asset_class "AppImage" "${linux_appimages[@]}"
+          require_asset_class "deb" "${linux_debs[@]}"
 
           test -f release-assets/latest-mac.yml
           test -f release-assets/latest.yml
@@ -596,16 +597,48 @@ jobs:
       - name: Create or update draft GitHub release
         run: |
           shopt -s nullglob
-          assets=(
-            release-assets/*.dmg
-            release-assets/*.zip
-            release-assets/*.exe
-            release-assets/*.AppImage
-            release-assets/*.deb
+          require_asset_class() {
+            local class="$1"
+            shift
+
+            if [[ "$#" -eq 0 ]]; then
+              echo "Missing required release asset class: ${class}" >&2
+              exit 1
+            fi
+          }
+
+          mac_dmgs=(release-assets/*.dmg)
+          mac_zips=(release-assets/*.zip)
+          win_installers=(release-assets/*.exe)
+          linux_appimages=(release-assets/*.AppImage)
+          linux_debs=(release-assets/*.deb)
+          required_named_assets=(
             release-assets/latest.yml
             release-assets/latest-mac.yml
             release-assets/latest-linux.yml
             release-assets/release-checksums.txt
+          )
+
+          require_asset_class "dmg" "${mac_dmgs[@]}"
+          require_asset_class "zip" "${mac_zips[@]}"
+          require_asset_class "exe" "${win_installers[@]}"
+          require_asset_class "AppImage" "${linux_appimages[@]}"
+          require_asset_class "deb" "${linux_debs[@]}"
+
+          for required_asset in "${required_named_assets[@]}"; do
+            if [[ ! -f "${required_asset}" ]]; then
+              echo "Missing required release asset class: ${required_asset##*/}" >&2
+              exit 1
+            fi
+          done
+
+          assets=(
+            "${mac_dmgs[@]}"
+            "${mac_zips[@]}"
+            "${win_installers[@]}"
+            "${linux_appimages[@]}"
+            "${linux_debs[@]}"
+            "${required_named_assets[@]}"
           )
 
           if [[ "${#assets[@]}" -eq 0 ]]; then

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -87,6 +87,11 @@ jobs:
           WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 \
             WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 \
             bash apps/installer-stub/scripts/verify-latest-yml.sh
+          # M4 regression: setDefaultCache must not mutate parent process.env.
+          # apps/installer-stub/package.json's bun-test script is not invoked
+          # by any other CI job, so the only automated gate for this property
+          # lives here (and in the matching lefthook installer-invariants).
+          node apps/installer-stub/scripts/run-builder.test.js
 
   build-mac:
     needs:

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -66,6 +66,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y ripgrep
+      - name: Install workspace deps
+        # verify-latest-yml.sh's manifest_field/manifest_file_entries shell
+        # out to `bun -e <js> <args>` against js-yaml — which lives in
+        # apps/installer-stub/devDependencies. Without a frozen-lockfile
+        # install, the recursive bash call inside run_self_test() fails
+        # silently (set -e) when js-yaml resolution throws.
+        run: bun install --frozen-lockfile
       - name: Run installer invariant gates
         run: |
           bun --version

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -585,7 +585,7 @@ jobs:
       - name: Write release notes
         run: |
           {
-            echo "Draft rewrite release for WUPHF installer-stub ${TAG}."
+            echo "Rewrite release for WUPHF installer-stub ${TAG}."
             echo
             echo "macOS and Windows artifacts are signed in the platform build jobs. Linux artifacts are unsigned; verify them with the SHA-256 checksums below."
             echo
@@ -658,7 +658,10 @@ jobs:
             gh release create "${TAG}" "${assets[@]}" --verify-tag --draft --title "${TAG}" --notes-file release-notes.md
           fi
 
-          mapfile -t expected_asset_names < <(printf "%s\n" "${assets[@]##*/}" | sort)
+          printf "%s\n" "${assets[@]##*/}" | sort > expected-release-assets.txt
+      - name: Verify draft contains all expected assets
+        run: |
+          mapfile -t expected_asset_names < expected-release-assets.txt
           mapfile -t uploaded_asset_names < <(gh release view "${TAG}" --json assets --jq '.assets[].name' | sort)
 
           missing=()
@@ -703,3 +706,6 @@ jobs:
             fi
             exit 1
           fi
+      - name: Publish verified GitHub release
+        if: needs.detect-secrets.outputs.is_release == 'true' && success()
+        run: gh release edit "${TAG}" --draft=false

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -55,8 +55,28 @@ jobs:
           WUPHF_RELEASE_MODE: pr
         run: bash apps/installer-stub/scripts/detect-signing-secrets.sh
 
+  installer-invariants:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version: "1.1.38"
+      - name: Install ripgrep
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+      - name: Run installer invariant gates
+        run: |
+          bun --version
+          rg --version
+          bash apps/installer-stub/scripts/check-invariants.sh
+          bash apps/installer-stub/scripts/check-invariants-self-test.sh
+
   build-mac:
-    needs: detect-secrets
+    needs:
+      - detect-secrets
+      - installer-invariants
     runs-on: macos-14
     timeout-minutes: 60
     environment:
@@ -208,7 +228,9 @@ jobs:
           if-no-files-found: error
 
   build-win:
-    needs: detect-secrets
+    needs:
+      - detect-secrets
+      - installer-invariants
     runs-on: windows-2022
     environment:
       name: ${{ needs.detect-secrets.outputs.release_mode == 'production' && 'production-release' || 'installer-pr' }}
@@ -406,7 +428,9 @@ jobs:
           if-no-files-found: error
 
   build-linux:
-    needs: detect-secrets
+    needs:
+      - detect-secrets
+      - installer-invariants
     runs-on: ubuntu-24.04
     env:
       WUPHF_RELEASE_MODE: ${{ needs.detect-secrets.outputs.release_mode }}

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -579,15 +579,8 @@ jobs:
       - name: Assert release asset set
         run: |
           shopt -s nullglob
-          require_asset_class() {
-            local class="$1"
-            shift
-
-            if [[ "$#" -eq 0 ]]; then
-              echo "Missing required release asset class: ${class}" >&2
-              exit 1
-            fi
-          }
+          # shellcheck source=apps/installer-stub/scripts/require-asset-class.sh
+          source apps/installer-stub/scripts/require-asset-class.sh
 
           mac_dmgs=(release-assets/*.dmg)
           mac_zips=(release-assets/*.zip)
@@ -644,15 +637,8 @@ jobs:
       - name: Create or update draft GitHub release
         run: |
           shopt -s nullglob
-          require_asset_class() {
-            local class="$1"
-            shift
-
-            if [[ "$#" -eq 0 ]]; then
-              echo "Missing required release asset class: ${class}" >&2
-              exit 1
-            fi
-          }
+          # shellcheck source=apps/installer-stub/scripts/require-asset-class.sh
+          source apps/installer-stub/scripts/require-asset-class.sh
 
           mac_dmgs=(release-assets/*.dmg)
           mac_zips=(release-assets/*.zip)

--- a/apps/installer-stub/build/notarize-with-retry.js
+++ b/apps/installer-stub/build/notarize-with-retry.js
@@ -1,8 +1,12 @@
 const Module = require("node:module");
 
 const retryDelaysMs = [60_000, 300_000, 900_000];
-const retryDelayScale = Number.parseFloat(process.env.WUPHF_NOTARY_RETRY_DELAY_SCALE || "1");
+const retryDelayScaleEnv = process.env.WUPHF_NOTARY_RETRY_DELAY_SCALE;
 const originalLoad = Module._load;
+
+if (retryDelayScaleEnv && process.env.WUPHF_RELEASE_MODE === "production") {
+  throw new Error("WUPHF_NOTARY_RETRY_DELAY_SCALE is only allowed outside production mode");
+}
 
 function errorText(error) {
   return [error?.message, error?.output, error?.stdout, error?.stderr, error?.stack, String(error)]
@@ -18,9 +22,15 @@ function isTransientNotaryError(error) {
 }
 
 function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function retryDelayWithJitter(ms) {
+  const retryDelayScale = Number.parseFloat(retryDelayScaleEnv || "1");
   const scaled =
     Number.isFinite(retryDelayScale) && retryDelayScale >= 0 ? ms * retryDelayScale : ms;
-  return new Promise((resolve) => setTimeout(resolve, scaled));
+  const jitter = 0.8 + Math.random() * 0.4;
+  return Math.round(scaled * jitter);
 }
 
 function wrapNotarize(moduleExports) {
@@ -39,11 +49,11 @@ function wrapNotarize(moduleExports) {
           throw error;
         }
 
-        const delayMs = retryDelaysMs[attempt];
+        const delayMs = retryDelayWithJitter(retryDelaysMs[attempt]);
         const nextAttempt = attempt + 2;
         const maxAttempts = retryDelaysMs.length + 1;
         console.warn(
-          `notarytool transient failure; retrying in ${delayMs / 60_000} minute(s) (${nextAttempt}/${maxAttempts})`,
+          `notarytool transient failure; retrying in ${(delayMs / 60_000).toFixed(1)} minute(s) (${nextAttempt}/${maxAttempts})`,
         );
         console.warn(errorText(error));
         await sleep(delayMs);
@@ -70,5 +80,6 @@ Module._load = function loadWithNotarizeRetry(request, ...args) {
 
 module.exports = {
   isTransientNotaryError,
+  retryDelayWithJitter,
   retryDelaysMs,
 };

--- a/apps/installer-stub/docs/runbooks/apple-dev-id-setup.md
+++ b/apps/installer-stub/docs/runbooks/apple-dev-id-setup.md
@@ -63,7 +63,8 @@ it in an `if: always()` cleanup step. No certificate file is committed.
 4. Confirm the macOS job creates a temporary keychain, signs, notarizes, staples
    the `.app` and `.dmg`, validates both staples, refreshes `latest-mac.yml`,
    and verifies the manifest sha512.
-5. Download the draft release `.dmg` and run:
+5. The publish job auto-flips the draft to a published release after the
+   asset assertion succeeds. Download the published release `.dmg` and run:
 
    ```bash
    spctl --assess --type open --verbose "$ARTIFACT_PATH"

--- a/apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md
+++ b/apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md
@@ -153,7 +153,9 @@ do not auto-update. Production releases override it via the workflow secret.
 4. Confirm `Detect Azure signing secrets` reports all Azure values set.
 5. Confirm the Windows job signs with `Azure/trusted-signing-action`, verifies
    the signer CN, refreshes `latest.yml`, and verifies the manifest.
-6. Download the `.exe` from the draft release and inspect its signature:
+6. The publish job auto-flips the draft to a published release after the
+   asset assertion succeeds. Download the `.exe` from the published release
+   and inspect its signature:
 
    ```powershell
    Get-AuthenticodeSignature .\wuphf-installer-stub-0.0.1-rewrite-win-x64.exe

--- a/apps/installer-stub/docs/runbooks/release-day-troubleshooting.md
+++ b/apps/installer-stub/docs/runbooks/release-day-troubleshooting.md
@@ -11,8 +11,12 @@ ship a new higher version tag and fix forward.
 ## First Checks
 
 1. Open GitHub Actions -> `Release Rewrite` -> the failed run.
-2. Identify the failed job: `detect-secrets`, `build-mac`, `build-win`,
-   `build-linux`, or `publish`.
+2. Identify the failed job: `detect-secrets`, `installer-invariants`,
+   `build-mac`, `build-win`, `build-linux`, or `publish`. The
+   `installer-invariants` job runs the `apps/installer-stub/scripts/check-invariants.sh`
+   gate (forbidden literals, action SHA pinning, no production deps) plus the
+   `verify-latest-yml.sh` self-test, and **gates** all three platform builds —
+   if it fails, no platform build runs.
 3. Open the failed step logs and copy the first real error, not the final
    process-exit line.
 4. Check whether a GitHub draft release exists for the tag:

--- a/apps/installer-stub/docs/runbooks/release-day-troubleshooting.md
+++ b/apps/installer-stub/docs/runbooks/release-day-troubleshooting.md
@@ -40,7 +40,7 @@ ship a new higher version tag and fix forward.
 | `Assert release asset set` | One platform job did not upload all expected artifacts | Rerun or fix that platform job before rerunning publish |
 | `Verify release update manifests` | Manifest sha512/size does not match final signed bytes | Confirm the post-sign/post-staple refresh step ran after signing, then rebuild that platform |
 | `gh release create` fails with missing tag | The remote tag was deleted or the workflow was run on the wrong ref | Recreate the intended tag at the reviewed commit or bump to a new version tag |
-| `gh release upload` fails, returns 5xx, or leaves partial assets | GitHub API outage/rate limit or network failure | Keep the release draft and rerun publish. The workflow uses `--clobber` and then asserts all expected assets are present |
+| `gh release upload` fails, returns 5xx, or leaves partial assets | GitHub API outage/rate limit or network failure | Keep the release draft and rerun publish. The workflow uses `--clobber`, asserts all expected assets are present, then publishes automatically |
 
 ## Apple Notarytool Timeout
 
@@ -68,7 +68,8 @@ times out:
 ## Partial Draft Release Upload
 
 The publish job creates or updates a draft release, uploads all expected assets,
-and then checks GitHub's release asset inventory. Expected assets are:
+checks GitHub's release asset inventory, and then flips the verified draft to a
+published release automatically. Expected assets are:
 
 - `.dmg`
 - `.zip`
@@ -93,7 +94,8 @@ If upload fails midway:
    the freshly downloaded build artifacts.
 3. Do not manually upload a subset unless GitHub Actions is unavailable and the
    release manager can verify all asset hashes against `release-checksums.txt`.
-4. Publish only after the post-upload asset assertion passes.
+4. Do not manually publish the draft. The workflow publishes it automatically
+   after the post-upload asset assertion passes.
 
 ## Published Release Already Exists
 
@@ -133,8 +135,8 @@ human cancellation is the first containment step.
    ```
 
 4. Watch the new `Release Rewrite` workflow run from the start.
-5. Re-verify all platform artifacts and publish the draft only after the asset
-   assertion passes.
+5. Re-verify all platform artifacts and let the workflow publish the draft only
+   after the asset assertion passes.
 
 If the release was published, do not move the tag. Create a new higher tag.
 

--- a/apps/installer-stub/package.json
+++ b/apps/installer-stub/package.json
@@ -26,7 +26,7 @@
     "build:dry-run": "node scripts/run-dry-run.js",
     "check:secrets": "bash scripts/detect-signing-secrets.sh",
     "check:invariants": "bash scripts/check-invariants.sh",
-    "test": "bash scripts/check-invariants-self-test.sh && WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 bash scripts/verify-latest-yml.sh && bun test scripts/refresh-latest-yml.test.js && node scripts/normalize-package-version.test.js",
+    "test": "bash scripts/check-invariants-self-test.sh && WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 bash scripts/verify-latest-yml.sh && bun test scripts/refresh-latest-yml.test.js && node scripts/normalize-package-version.test.js && node scripts/run-builder.test.js",
     "verify:latest-yml": "bash scripts/verify-latest-yml.sh"
   },
   "devDependencies": {

--- a/apps/installer-stub/package.json
+++ b/apps/installer-stub/package.json
@@ -26,7 +26,7 @@
     "build:dry-run": "node scripts/run-dry-run.js",
     "check:secrets": "bash scripts/detect-signing-secrets.sh",
     "check:invariants": "bash scripts/check-invariants.sh",
-    "test": "bash scripts/check-invariants-self-test.sh && bun test scripts/refresh-latest-yml.test.js && node scripts/normalize-package-version.test.js",
+    "test": "bash scripts/check-invariants-self-test.sh && WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 bash scripts/verify-latest-yml.sh && bun test scripts/refresh-latest-yml.test.js && node scripts/normalize-package-version.test.js",
     "verify:latest-yml": "bash scripts/verify-latest-yml.sh"
   },
   "devDependencies": {

--- a/apps/installer-stub/scripts/check-invariants-self-test.sh
+++ b/apps/installer-stub/scripts/check-invariants-self-test.sh
@@ -106,13 +106,27 @@ expect_output_contains "${cert_path_fixture}/root.out" "hardcoded certificate pa
 expect_status 1 "${cert_path_fixture}/apps/installer-stub" "scripts/check-invariants.sh" "${cert_path_fixture}/package.out"
 expect_output_contains "${cert_path_fixture}/package.out" "hardcoded certificate path"
 
-prod_deps_fixture="${tmp_root}/prod-deps"
-write_fixture "${prod_deps_fixture}"
-printf '{"dependencies": {"foo": "1.0.0"}}\n' > "${prod_deps_fixture}/apps/installer-stub/package.json"
+dev_deps_fixture="${tmp_root}/dev-deps"
+write_fixture "${dev_deps_fixture}"
+printf '{"devDependencies": {"foo": "1.0.0"}}\n' > "${dev_deps_fixture}/apps/installer-stub/package.json"
+expect_status 0 "${dev_deps_fixture}" "apps/installer-stub/scripts/check-invariants.sh" "${dev_deps_fixture}/root.out"
+expect_status 0 "${dev_deps_fixture}/apps/installer-stub" "scripts/check-invariants.sh" "${dev_deps_fixture}/package.out"
 
-expect_status 1 "${prod_deps_fixture}" "apps/installer-stub/scripts/check-invariants.sh" "${prod_deps_fixture}/root.out"
-expect_output_contains "${prod_deps_fixture}/root.out" "must have NO 'dependencies'"
-expect_status 1 "${prod_deps_fixture}/apps/installer-stub" "scripts/check-invariants.sh" "${prod_deps_fixture}/package.out"
-expect_output_contains "${prod_deps_fixture}/package.out" "must have NO 'dependencies'"
+expect_dependency_block_failure() {
+  local block_name="$1"
+  local fixture="${tmp_root}/${block_name}"
+
+  write_fixture "${fixture}"
+  printf '{"%s": {"foo": "1.0.0"}}\n' "${block_name}" > "${fixture}/apps/installer-stub/package.json"
+
+  expect_status 1 "${fixture}" "apps/installer-stub/scripts/check-invariants.sh" "${fixture}/root.out"
+  expect_output_contains "${fixture}/root.out" "forbidden dependency block: ${block_name}"
+  expect_status 1 "${fixture}/apps/installer-stub" "scripts/check-invariants.sh" "${fixture}/package.out"
+  expect_output_contains "${fixture}/package.out" "forbidden dependency block: ${block_name}"
+}
+
+expect_dependency_block_failure "dependencies"
+expect_dependency_block_failure "peerDependencies"
+expect_dependency_block_failure "optionalDependencies"
 
 echo "installer invariant self-test OK"

--- a/apps/installer-stub/scripts/check-invariants.sh
+++ b/apps/installer-stub/scripts/check-invariants.sh
@@ -52,12 +52,32 @@ while IFS= read -r match; do
 done < <(rg -n --pcre2 "${cert_path_regex}" "${scan_targets[@]}" || true)
 
 # electron-builder.yml sets `npmRebuild: false` to avoid the bun npm_execpath
-# leak in CI. That's safe ONLY while the stub has zero production deps;
-# adding a native dep would silently ship without the Electron-ABI rebuild.
-# Enforce the no-prod-deps invariant here so the band-aid stays safe.
-if rg -q '"dependencies"\s*:' "${package_root}/package.json"; then
-  violations+=("apps/installer-stub/package.json must have NO 'dependencies' (only devDependencies); npmRebuild: false in electron-builder.yml depends on this invariant")
-fi
+# leak in CI. That's safe ONLY while the stub has no dependency blocks that
+# electron-builder may install/rebuild for runtime packaging.
+dependency_check_output="$(
+  cd "${repo_root}" &&
+    bun -e '
+      const pkg = require("./apps/installer-stub/package.json");
+      const forbiddenBlocks = ["dependencies", "peerDependencies", "optionalDependencies"];
+      let failed = false;
+
+      for (const blockName of forbiddenBlocks) {
+        const block = pkg[blockName];
+        if (block && typeof block === "object" && Object.keys(block).length > 0) {
+          console.error("forbidden dependency block: " + blockName);
+          failed = true;
+        }
+      }
+
+      if (failed) {
+        process.exit(1);
+      }
+    ' 2>&1
+)" || {
+  while IFS= read -r line; do
+    violations+=("${line}")
+  done <<< "${dependency_check_output}"
+}
 
 while IFS= read -r line; do
   action_ref="$(sed -E 's/^([^:]+:)?[0-9]+:.*uses:[[:space:]]*([^[:space:]#]+).*/\2/' <<<"${line}")"

--- a/apps/installer-stub/scripts/require-asset-class.sh
+++ b/apps/installer-stub/scripts/require-asset-class.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+# Sourced helper for the rewrite release workflow.
+#
+# Used by `.github/workflows/release-rewrite.yml` to assert that a glob
+# expansion produced at least one matching artifact path. With
+# `shopt -s nullglob` set in the caller, an empty match expands to zero
+# arguments — so the function fails the build instead of silently uploading
+# an incomplete release.
+#
+# Usage:
+#   shopt -s nullglob
+#   source apps/installer-stub/scripts/require-asset-class.sh
+#   mac_dmgs=(release-assets/*.dmg)
+#   require_asset_class "dmg" "${mac_dmgs[@]}"
+
+require_asset_class() {
+  local class="$1"
+  shift
+
+  if [[ "$#" -eq 0 ]]; then
+    echo "Missing required release asset class: ${class}" >&2
+    exit 1
+  fi
+}

--- a/apps/installer-stub/scripts/require-asset-class.sh
+++ b/apps/installer-stub/scripts/require-asset-class.sh
@@ -12,6 +12,13 @@
 #   source apps/installer-stub/scripts/require-asset-class.sh
 #   mac_dmgs=(release-assets/*.dmg)
 #   require_asset_class "dmg" "${mac_dmgs[@]}"
+#
+# IMPORTANT: `require_asset_class` calls `exit 1` on failure. Because this
+# file is sourced (not executed), `exit` terminates the CALLER's shell —
+# which is the intended GitHub Actions semantics (the workflow step must
+# fail). Do NOT source this from an interactive developer shell or from a
+# script that wants to validate multiple asset classes and report; the
+# first failure will kill the whole shell session.
 
 require_asset_class() {
   local class="$1"

--- a/apps/installer-stub/scripts/run-builder.js
+++ b/apps/installer-stub/scripts/run-builder.js
@@ -76,28 +76,7 @@ function ensureBundledToolExecutables() {
   }
 }
 
-ensureBundledToolExecutables();
-
 const builderCli = require.resolve("electron-builder/cli");
-const nodeBinary = process.env.NODE_BINARY || process.execPath;
-const releaseMode = process.env.WUPHF_RELEASE_MODE || "pr";
-
-if (!["pr", "production"].includes(releaseMode)) {
-  console.error(`WUPHF_RELEASE_MODE must be 'pr' or 'production', got '${releaseMode}'`);
-  process.exit(1);
-}
-
-if (process.versions.bun && !process.env.NODE_BINARY) {
-  console.error(
-    "run-builder.js must run under real Node so electron-builder's CLI is executed by Node. Run via `node scripts/run-builder.js` after setup-node.",
-  );
-  process.exit(1);
-}
-
-const builderArgs = process.argv.slice(2);
-if (releaseMode !== "production") {
-  builderArgs.push("--config.mac.notarize=false");
-}
 
 // CR-CI-1: electron-builder reads `npm_execpath` to locate the package
 // manager for its production-dep install / native-rebuild step. When
@@ -138,13 +117,43 @@ function scrubbedEnv() {
   return env;
 }
 
-const result = spawnSync(nodeBinary, [builderCli, ...builderArgs], {
-  env: scrubbedEnv(),
-  stdio: "inherit",
-});
+function main() {
+  ensureBundledToolExecutables();
 
-if (result.error) {
-  throw result.error;
+  const nodeBinary = process.env.NODE_BINARY || process.execPath;
+  const releaseMode = process.env.WUPHF_RELEASE_MODE || "pr";
+
+  if (!["pr", "production"].includes(releaseMode)) {
+    console.error(`WUPHF_RELEASE_MODE must be 'pr' or 'production', got '${releaseMode}'`);
+    process.exit(1);
+  }
+
+  if (process.versions.bun && !process.env.NODE_BINARY) {
+    console.error(
+      "run-builder.js must run under real Node so electron-builder's CLI is executed by Node. Run via `node scripts/run-builder.js` after setup-node.",
+    );
+    process.exit(1);
+  }
+
+  const builderArgs = process.argv.slice(2);
+  if (releaseMode !== "production") {
+    builderArgs.push("--config.mac.notarize=false");
+  }
+
+  const result = spawnSync(nodeBinary, [builderCli, ...builderArgs], {
+    env: scrubbedEnv(),
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
 }
 
-process.exit(result.status ?? 1);
+if (require.main === module) {
+  main();
+}
+
+module.exports = { scrubbedEnv, setDefaultCache };

--- a/apps/installer-stub/scripts/run-builder.js
+++ b/apps/installer-stub/scripts/run-builder.js
@@ -13,6 +13,35 @@ function setDefaultCache(env, name, directory) {
   env[name] = directory;
 }
 
+function isExecutable(file) {
+  try {
+    fs.accessSync(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function makeExecutable(file) {
+  if (isExecutable(file)) {
+    return;
+  }
+  try {
+    fs.chmodSync(file, 0o755);
+    return;
+  } catch (error) {
+    const result = spawnSync("chmod", ["755", file], { stdio: "ignore" });
+    if (result.error) {
+      throw new Error(`Failed to make bundled 7za executable at ${file}: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `Failed to make bundled 7za executable at ${file}; fs.chmodSync failed with ${error.message}, chmod exited ${result.status}`,
+      );
+    }
+  }
+}
+
 // macOS-only: bun's content-addressable store occasionally drops 7zip-bin's
 // `7za` binary without the +x bit, which kills electron-builder's DMG step
 // with EACCES. Fix it once at startup; works for both bun and npm layouts.
@@ -40,11 +69,7 @@ function ensureBundledToolExecutables() {
           "7za",
         );
         if (fs.existsSync(sevenZip)) {
-          try {
-            fs.chmodSync(sevenZip, 0o755);
-          } catch {
-            spawnSync("chmod", ["755", sevenZip], { stdio: "ignore" });
-          }
+          makeExecutable(sevenZip);
         }
       }
     }

--- a/apps/installer-stub/scripts/run-builder.js
+++ b/apps/installer-stub/scripts/run-builder.js
@@ -5,16 +5,13 @@ const { spawnSync } = require("node:child_process");
 const appRoot = path.resolve(__dirname, "..");
 const workspaceRoot = path.resolve(appRoot, "..", "..");
 
-function setDefaultCache(name, directory) {
-  if (process.env[name]) {
+function setDefaultCache(env, name, directory) {
+  if (env[name]) {
     return;
   }
   fs.mkdirSync(directory, { recursive: true });
-  process.env[name] = directory;
+  env[name] = directory;
 }
-
-setDefaultCache("ELECTRON_CACHE", path.join(appRoot, ".cache", "electron"));
-setDefaultCache("ELECTRON_BUILDER_CACHE", path.join(appRoot, ".cache", "electron-builder"));
 
 // macOS-only: bun's content-addressable store occasionally drops 7zip-bin's
 // `7za` binary without the +x bit, which kills electron-builder's DMG step
@@ -93,6 +90,8 @@ function scrubbedEnv() {
     }
     env[key] = value;
   }
+  setDefaultCache(env, "ELECTRON_CACHE", path.join(appRoot, ".cache", "electron"));
+  setDefaultCache(env, "ELECTRON_BUILDER_CACHE", path.join(appRoot, ".cache", "electron-builder"));
   // Belt-and-suspenders: app-builder-bin honors CUSTOM_APP_BUILDER_PATH
   // natively (see its index.js), so when the bun nested-store layout makes
   // its self-resolution fragile, we hand it the resolved binary path.

--- a/apps/installer-stub/scripts/run-builder.test.js
+++ b/apps/installer-stub/scripts/run-builder.test.js
@@ -1,0 +1,80 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+
+const { scrubbedEnv, setDefaultCache } = require("./run-builder.js");
+
+// M4 regression — `setDefaultCache` previously mutated process.env directly,
+// leaking ELECTRON_CACHE / ELECTRON_BUILDER_CACHE into subsequent commands in
+// the same Node process. The fix moved it inside scrubbedEnv() so mutation is
+// bounded to the env object handed to the spawned child.
+
+function snapshotEnvKeys(prefix) {
+  const result = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k.startsWith(prefix)) {
+      result[k] = v;
+    }
+  }
+  return result;
+}
+
+function testSetDefaultCacheIsBoundedToTheGivenEnv() {
+  const beforeProcess = snapshotEnvKeys("ELECTRON_CACHE_TEST_M4");
+  assert.deepEqual(beforeProcess, {}, "test pre-condition: marker key not in process.env");
+
+  const env = {};
+  setDefaultCache(env, "ELECTRON_CACHE_TEST_M4", path.join("/tmp", "wuphf-m4-marker"));
+
+  assert.equal(env.ELECTRON_CACHE_TEST_M4, "/tmp/wuphf-m4-marker", "given env was populated");
+  assert.equal(
+    process.env.ELECTRON_CACHE_TEST_M4,
+    undefined,
+    "M4 regression: setDefaultCache must not leak into process.env",
+  );
+}
+
+function testScrubbedEnvDoesNotMutateProcessEnv() {
+  const before = {
+    ELECTRON_CACHE: process.env.ELECTRON_CACHE,
+    ELECTRON_BUILDER_CACHE: process.env.ELECTRON_BUILDER_CACHE,
+    CUSTOM_APP_BUILDER_PATH: process.env.CUSTOM_APP_BUILDER_PATH,
+  };
+
+  // Plant bun-style lifecycle vars to verify the scrub strips them
+  // from the returned env without touching process.env.
+  process.env.npm_config_test_marker = "should-not-leak-into-child";
+  process.env.BUN_TEST_MARKER = "should-not-leak-into-child";
+
+  try {
+    const env = scrubbedEnv();
+
+    assert.equal(env.npm_config_test_marker, undefined, "npm_ vars must be scrubbed");
+    assert.equal(env.BUN_TEST_MARKER, undefined, "BUN_ vars must be scrubbed");
+    assert.ok(env.ELECTRON_CACHE, "ELECTRON_CACHE populated in returned env");
+    assert.ok(env.ELECTRON_BUILDER_CACHE, "ELECTRON_BUILDER_CACHE populated in returned env");
+
+    assert.equal(
+      process.env.ELECTRON_CACHE,
+      before.ELECTRON_CACHE,
+      "scrubbedEnv must not mutate parent process.env.ELECTRON_CACHE",
+    );
+    assert.equal(
+      process.env.ELECTRON_BUILDER_CACHE,
+      before.ELECTRON_BUILDER_CACHE,
+      "scrubbedEnv must not mutate parent process.env.ELECTRON_BUILDER_CACHE",
+    );
+    assert.equal(
+      process.env.CUSTOM_APP_BUILDER_PATH,
+      before.CUSTOM_APP_BUILDER_PATH,
+      "scrubbedEnv must not mutate parent process.env.CUSTOM_APP_BUILDER_PATH",
+    );
+  } finally {
+    delete process.env.npm_config_test_marker;
+    delete process.env.BUN_TEST_MARKER;
+  }
+}
+
+testSetDefaultCacheIsBoundedToTheGivenEnv();
+testScrubbedEnvDoesNotMutateProcessEnv();
+
+console.log("run-builder self-test OK");

--- a/apps/installer-stub/scripts/run-builder.test.js
+++ b/apps/installer-stub/scripts/run-builder.test.js
@@ -1,4 +1,6 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const { scrubbedEnv, setDefaultCache } = require("./run-builder.js");
@@ -22,15 +24,25 @@ function testSetDefaultCacheIsBoundedToTheGivenEnv() {
   const beforeProcess = snapshotEnvKeys("ELECTRON_CACHE_TEST_M4");
   assert.deepEqual(beforeProcess, {}, "test pre-condition: marker key not in process.env");
 
-  const env = {};
-  setDefaultCache(env, "ELECTRON_CACHE_TEST_M4", path.join("/tmp", "wuphf-m4-marker"));
+  // Use a per-run subdirectory under the platform temp dir so the test is
+  // portable to Windows (`/tmp` does not exist there) and so we can remove
+  // the directory that `setDefaultCache` will mkdir.
+  const markerDir = fs.mkdtempSync(path.join(os.tmpdir(), "wuphf-m4-"));
+  const markerPath = path.join(markerDir, "marker");
 
-  assert.equal(env.ELECTRON_CACHE_TEST_M4, "/tmp/wuphf-m4-marker", "given env was populated");
-  assert.equal(
-    process.env.ELECTRON_CACHE_TEST_M4,
-    undefined,
-    "M4 regression: setDefaultCache must not leak into process.env",
-  );
+  try {
+    const env = {};
+    setDefaultCache(env, "ELECTRON_CACHE_TEST_M4", markerPath);
+
+    assert.equal(env.ELECTRON_CACHE_TEST_M4, markerPath, "given env was populated");
+    assert.equal(
+      process.env.ELECTRON_CACHE_TEST_M4,
+      undefined,
+      "M4 regression: setDefaultCache must not leak into process.env",
+    );
+  } finally {
+    fs.rmSync(markerDir, { recursive: true, force: true });
+  }
 }
 
 function testScrubbedEnvDoesNotMutateProcessEnv() {

--- a/apps/installer-stub/scripts/staple-mac-app.js
+++ b/apps/installer-stub/scripts/staple-mac-app.js
@@ -15,7 +15,7 @@ function run(command, args) {
 }
 
 exports.default = async function stapleMacApp(context) {
-  if (process.platform !== "darwin" || process.env.WUPHF_RELEASE_MODE !== "production") {
+  if (process.platform !== "darwin") {
     return;
   }
 
@@ -27,10 +27,24 @@ exports.default = async function stapleMacApp(context) {
     );
 
   if (!appBundle) {
+    if (process.env.WUPHF_RELEASE_MODE !== "production") {
+      return;
+    }
     throw new Error(`No .app bundle found in ${context.appOutDir}`);
   }
 
   const appPath = path.join(context.appOutDir, appBundle);
+  const signatureResources = path.join(appPath, "Contents", "_CodeSignature", "CodeResources");
+
+  if (process.env.WUPHF_RELEASE_MODE !== "production") {
+    if (fs.existsSync(signatureResources)) {
+      throw new Error(
+        `Refusing to skip stapling for signed macOS app outside production mode: ${appPath}`,
+      );
+    }
+    return;
+  }
+
   run("xcrun", ["stapler", "staple", appPath]);
   run("xcrun", ["stapler", "validate", appPath]);
 };

--- a/apps/installer-stub/scripts/verify-latest-yml.sh
+++ b/apps/installer-stub/scripts/verify-latest-yml.sh
@@ -255,46 +255,52 @@ if [[ "${#latest_files[@]}" -eq 0 ]]; then
   exit 1
 fi
 
+# Args go through env vars rather than argv because `bun -e <code> <args>`
+# argv handling drifted between bun 1.1.38 (CI pin) and bun 1.3 (local /
+# Renovate-bumped target): 1.1 sets argv[1]="[eval]" and shifts user args
+# down (matching node's behavior), while 1.3 skips the [eval] slot.
+# Env-var passing is uniform across both runtimes.
 manifest_field() {
   local file="$1"
   local field="$2"
 
   cd "${app_dir}" &&
-    bun -e '
+    WUPHF_MANIFEST_FILE="${file}" WUPHF_MANIFEST_FIELD="${field}" bun -e '
       const fs = require("node:fs");
       const yaml = require("js-yaml");
-      const manifest = yaml.load(fs.readFileSync(process.argv[1], "utf8"));
-      const value = manifest?.[process.argv[2]];
+      const manifest = yaml.load(fs.readFileSync(process.env.WUPHF_MANIFEST_FILE, "utf8"));
+      const value = manifest?.[process.env.WUPHF_MANIFEST_FIELD];
       if (value !== undefined && value !== null) {
         process.stdout.write(String(value));
       }
-    ' "${file}" "${field}"
+    '
 }
 
 manifest_file_entries() {
   local file="$1"
 
   cd "${app_dir}" &&
-    bun -e '
+    WUPHF_MANIFEST_FILE="${file}" bun -e '
       const fs = require("node:fs");
       const yaml = require("js-yaml");
-      const manifest = yaml.load(fs.readFileSync(process.argv[1], "utf8"));
+      const manifestPath = process.env.WUPHF_MANIFEST_FILE;
+      const manifest = yaml.load(fs.readFileSync(manifestPath, "utf8"));
       const files = Array.isArray(manifest?.files) ? manifest.files : [];
       for (const [index, entry] of files.entries()) {
         if (!entry || typeof entry !== "object") {
-          console.error(process.argv[1] + " files[" + index + "] is not an object");
+          console.error(manifestPath + " files[" + index + "] is not an object");
           process.exit(1);
         }
 
         const entryPath = entry.url ?? entry.path;
         if (typeof entryPath !== "string" || entryPath.length === 0) {
-          console.error(process.argv[1] + " files[" + index + "] is missing url/path");
+          console.error(manifestPath + " files[" + index + "] is missing url/path");
           process.exit(1);
         }
 
         process.stdout.write([entryPath, entry.sha512 ?? "", entry.size ?? ""].join("\u001f") + "\0");
       }
-    ' "${file}"
+    '
 }
 
 sha512_base64() {

--- a/apps/installer-stub/scripts/verify-latest-yml.sh
+++ b/apps/installer-stub/scripts/verify-latest-yml.sh
@@ -101,11 +101,11 @@ run_self_test() (
   write_self_test_malformed_files_manifest "${malformed_string_dist}/latest-mac.yml" "${artifact_name}" "${artifact_sha512}" "${artifact_size}" "string-not-object"
   write_self_test_manifest "${missing_size_dist}/latest-mac.yml" "${artifact_name}" "${artifact_sha512}" "${artifact_size}" "false"
 
-  env WUPHF_VERIFY_LATEST_YML_SKIP_SELF_TEST=1 WUPHF_DIST_DIR="${good_dist}" \
+  env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${good_dist}" \
     bash "${source_script}" "0.0.0" > "${good_output}" 2>&1
 
   status=0
-  env WUPHF_VERIFY_LATEST_YML_SKIP_SELF_TEST=1 WUPHF_DIST_DIR="${malformed_empty_object_dist}" \
+  env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${malformed_empty_object_dist}" \
     bash "${source_script}" "0.0.0" > "${malformed_empty_object_output}" 2>&1 || status=$?
 
   if [[ "${status}" -eq 0 ]]; then
@@ -121,7 +121,7 @@ run_self_test() (
   fi
 
   status=0
-  env WUPHF_VERIFY_LATEST_YML_SKIP_SELF_TEST=1 WUPHF_DIST_DIR="${malformed_string_dist}" \
+  env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${malformed_string_dist}" \
     bash "${source_script}" "0.0.0" > "${malformed_string_output}" 2>&1 || status=$?
 
   if [[ "${status}" -eq 0 ]]; then
@@ -137,7 +137,7 @@ run_self_test() (
   fi
 
   status=0
-  env WUPHF_VERIFY_LATEST_YML_SKIP_SELF_TEST=1 WUPHF_DIST_DIR="${missing_size_dist}" \
+  env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${missing_size_dist}" \
     bash "${source_script}" "0.0.0" > "${missing_size_output}" 2>&1 || status=$?
 
   if [[ "${status}" -eq 0 ]]; then
@@ -155,8 +155,11 @@ run_self_test() (
   echo "verify-latest-yml self-test OK"
 )
 
-if [[ "${WUPHF_VERIFY_LATEST_YML_SKIP_SELF_TEST:-}" != "1" ]]; then
+if [[ "${WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST:-}" == "1" ]]; then
   run_self_test
+  if [[ "${WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY:-}" == "1" ]]; then
+    exit 0
+  fi
 fi
 
 raw_ref="${1:-${GITHUB_REF:-${GITHUB_REF_NAME:-}}}"

--- a/apps/installer-stub/scripts/verify-latest-yml.sh
+++ b/apps/installer-stub/scripts/verify-latest-yml.sh
@@ -86,16 +86,12 @@ run_self_test() (
   cp "${good_dist}/${artifact_name}" "${malformed_string_dist}/${artifact_name}"
   cp "${good_dist}/${artifact_name}" "${missing_size_dist}/${artifact_name}"
 
-  artifact_sha512="$(
-    cd "${app_dir}" &&
-      bun -e '
-        const crypto = require("node:crypto");
-        const fs = require("node:fs");
-        process.stdout.write(
-          crypto.createHash("sha512").update(fs.readFileSync(process.argv[1])).digest("base64"),
-        );
-      ' "${good_dist}/${artifact_name}"
-  )"
+  # `openssl dgst -binary` is universally available on macOS / Ubuntu /
+  # Windows runners and avoids the bun-version-skew bug where bun 1.1's
+  # `bun -e <code> arg` sets argv[1] differently than bun 1.3 (caught at
+  # CI when self-test ran on the workflow's pinned bun 1.1.38 against a
+  # local bun 1.3.13 baseline).
+  artifact_sha512="$(openssl dgst -sha512 -binary "${good_dist}/${artifact_name}" | base64 | tr -d '\n')"
   artifact_size="$(wc -c < "${good_dist}/${artifact_name}" | tr -d ' ')"
 
   write_self_test_manifest "${good_dist}/latest-mac.yml" "${artifact_name}" "${artifact_sha512}" "${artifact_size}" "true"

--- a/apps/installer-stub/scripts/verify-latest-yml.sh
+++ b/apps/installer-stub/scripts/verify-latest-yml.sh
@@ -180,10 +180,29 @@ if [[ "${WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST:-}" == "1" ]]; then
   fi
 fi
 
-raw_ref="${1:-}"
-if [[ -z "${raw_ref}" ]]; then
-  raw_ref="${GITHUB_REF:-${GITHUB_REF_NAME:-}}"
+env_ref="${GITHUB_REF:-${GITHUB_REF_NAME:-}}"
+arg_ref="${1:-}"
+
+# Always validate GITHUB_REF when it exists and looks like a tag ref. The
+# previous shape only validated when no $1 was supplied, which the workflow
+# always does — meaning the script-level rewrite-semver invariant was never
+# actually enforced from the publish job (caught by the post-merge security
+# triangulation as INCOMPLETE-FIX of H4).
+if [[ "${env_ref}" == refs/tags/* ]]; then
+  env_candidate="${env_ref#refs/tags/}"
+  if [[ ! "${env_candidate}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?-rewrite$ ]]; then
+    echo "Invalid rewrite release tag in GITHUB_REF: ${env_ref}" >&2
+    exit 1
+  fi
+  # If the caller also passed $1, it MUST agree with GITHUB_REF (no silent
+  # divergence between the workflow's tag and the script's tag input).
+  if [[ -n "${arg_ref}" && "${arg_ref}" != "${env_candidate}" && "${arg_ref}" != "${env_ref}" ]]; then
+    echo "Tag argument '${arg_ref}' does not match GITHUB_REF '${env_ref}'" >&2
+    exit 1
+  fi
 fi
+
+raw_ref="${arg_ref:-${env_ref}}"
 tag=""
 
 if [[ -n "${raw_ref}" ]]; then

--- a/apps/installer-stub/scripts/verify-latest-yml.sh
+++ b/apps/installer-stub/scripts/verify-latest-yml.sh
@@ -62,6 +62,7 @@ run_self_test() (
   local missing_size_output
   local malformed_empty_object_output
   local malformed_string_output
+  local malformed_ref_output
   local status=0
 
   tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/verify-latest-yml-self-test.XXXXXX")"
@@ -76,6 +77,7 @@ run_self_test() (
   good_output="${tmp_root}/good.out"
   malformed_empty_object_output="${tmp_root}/malformed-empty-object.out"
   malformed_string_output="${tmp_root}/malformed-string.out"
+  malformed_ref_output="${tmp_root}/malformed-ref.out"
   missing_size_output="${tmp_root}/missing-size.out"
 
   mkdir -p "${good_dist}" "${malformed_empty_object_dist}" "${malformed_string_dist}" "${missing_size_dist}"
@@ -103,6 +105,22 @@ run_self_test() (
 
   env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${good_dist}" \
     bash "${source_script}" "0.0.0" > "${good_output}" 2>&1
+
+  status=0
+  env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${good_dist}" GITHUB_REF="refs/tags/not-a-rewrite-tag" \
+    bash "${source_script}" > "${malformed_ref_output}" 2>&1 || status=$?
+
+  if [[ "${status}" -eq 0 ]]; then
+    echo "expected malformed GITHUB_REF fixture to fail" >&2
+    cat "${malformed_ref_output}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "Invalid rewrite release tag in GITHUB_REF: refs/tags/not-a-rewrite-tag" "${malformed_ref_output}"; then
+    echo "expected malformed GITHUB_REF fixture to report invalid rewrite tag" >&2
+    cat "${malformed_ref_output}" >&2
+    exit 1
+  fi
 
   status=0
   env WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST= WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY= WUPHF_DIST_DIR="${malformed_empty_object_dist}" \
@@ -162,16 +180,23 @@ if [[ "${WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST:-}" == "1" ]]; then
   fi
 fi
 
-raw_ref="${1:-${GITHUB_REF:-${GITHUB_REF_NAME:-}}}"
+raw_ref="${1:-}"
+if [[ -z "${raw_ref}" ]]; then
+  raw_ref="${GITHUB_REF:-${GITHUB_REF_NAME:-}}"
+fi
 tag=""
 
 if [[ -n "${raw_ref}" ]]; then
   candidate="${raw_ref#refs/tags/}"
   if [[ "${raw_ref}" == refs/tags/* ]]; then
+    if [[ ! "${candidate}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?-rewrite$ ]]; then
+      echo "Invalid rewrite release tag in GITHUB_REF: ${raw_ref}" >&2
+      exit 1
+    fi
     tag="${candidate}"
-  elif [[ "${candidate}" =~ ^v?[0-9]+(\.[0-9]+)*([.-].+)?$ ]]; then
+  elif [[ "${candidate}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(-rewrite)?$ ]]; then
     tag="${candidate}"
-  elif [[ "${1+x}" == "x" ]]; then
+  else
     echo "Invalid release tag: ${raw_ref}" >&2
     exit 1
   fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -219,6 +219,12 @@ pre-push:
         WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 \
           WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 \
           bash apps/installer-stub/scripts/verify-latest-yml.sh
+        # M4 regression: setDefaultCache must not mutate parent process.env
+        # (was leaking ELECTRON_CACHE / ELECTRON_BUILDER_CACHE into subsequent
+        # commands). The unit test runs in <100ms and is the only automated
+        # gate for that invariant — apps/installer-stub/package.json's bun
+        # test script is not invoked anywhere else in CI or pre-push.
+        node apps/installer-stub/scripts/run-builder.test.js
     file-size:
       # Enforce CONTRIBUTING.md's file-size budget: warn at 800 LOC, fail
       # at 1500 LOC unless the file is on scripts/file-size-allowlist.txt

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -207,10 +207,18 @@ pre-push:
       run: bash packages/protocol/scripts/check-invariants.sh
     installer-invariants:
       files: bash scripts/changed-files-since-base.sh
-      glob: "apps/installer-stub/**"
+      # check-invariants.sh scans .github/workflows/release-rewrite.yml for
+      # forbidden literals + action SHA pinning + cert paths, so workflow
+      # edits MUST trigger this hook even when nothing under apps/installer-stub
+      # changes — otherwise an unpinned action / forbidden literal slips past
+      # pre-push and only surfaces at the CI installer-invariants job.
+      glob: "{apps/installer-stub/**,.github/workflows/release-rewrite.yml}"
       run: |
         bash apps/installer-stub/scripts/check-invariants.sh
         bash apps/installer-stub/scripts/check-invariants-self-test.sh
+        WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 \
+          WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 \
+          bash apps/installer-stub/scripts/verify-latest-yml.sh
     file-size:
       # Enforce CONTRIBUTING.md's file-size budget: warn at 800 LOC, fail
       # at 1500 LOC unless the file is on scripts/file-size-allowlist.txt

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -205,6 +205,12 @@ pre-push:
       files: bash scripts/changed-files-since-base.sh
       glob: "packages/protocol/{src/**,tests/**,scripts/**}"
       run: bash packages/protocol/scripts/check-invariants.sh
+    installer-invariants:
+      files: bash scripts/changed-files-since-base.sh
+      glob: "apps/installer-stub/**"
+      run: |
+        bash apps/installer-stub/scripts/check-invariants.sh
+        bash apps/installer-stub/scripts/check-invariants-self-test.sh
     file-size:
       # Enforce CONTRIBUTING.md's file-size budget: warn at 800 LOC, fail
       # at 1500 LOC unless the file is on scripts/file-size-allowlist.txt

--- a/packages/protocol/src/ipc.ts
+++ b/packages/protocol/src/ipc.ts
@@ -218,8 +218,15 @@ export function apiBootstrapFromJson(value: unknown): ApiBootstrap {
  * pass through `JSON.stringify` (or hand to a writer that emits the keys
  * verbatim). The wire keys are intentionally snake_case; the runtime TS
  * surface is camelCase by lint rule.
+ *
+ * The encoder runs the same broker-URL invariant as `apiBootstrapFromJson`
+ * so a TS producer cannot emit a wire value (e.g. an implicit-port URL or
+ * a non-loopback host) that this same codec would reject on read. Without
+ * this symmetry, the wire-shape stability story leaks: a producer in TS,
+ * Go, or Rust could write bytes that fail to round-trip.
  */
 export function apiBootstrapToJson(bootstrap: ApiBootstrap): ApiBootstrapWire {
+  assertApiBootstrapBrokerUrl(bootstrap.brokerUrl);
   return { token: bootstrap.token as string, broker_url: bootstrap.brokerUrl };
 }
 

--- a/packages/protocol/src/ipc.ts
+++ b/packages/protocol/src/ipc.ts
@@ -228,15 +228,21 @@ function assertApiBootstrapBrokerUrl(brokerUrl: string): void {
   try {
     parsed = new URL(brokerUrl);
   } catch {
-    throw new Error("apiBootstrap.broker_url: must be http://<loopback>:<port>");
+    throw new Error("apiBootstrap.broker_url: must be http://<loopback>:<explicit-port>");
   }
+  // Note on `parsed.port === ""`: `new URL("http://h:80")` strips the port
+  // because 80 is HTTP's default. This codec rejects default ports
+  // intentionally — brokers always bind ephemeral high ports, and an
+  // implicit-port URL would round-trip differently than it came in.
   if (
     parsed.protocol !== "http:" ||
     parsed.port === "" ||
     !isAllowedLoopbackHost(parsed.hostname) ||
     !isBrokerPort(Number(parsed.port))
   ) {
-    throw new Error("apiBootstrap.broker_url: must be http://<loopback>:<port>");
+    throw new Error(
+      "apiBootstrap.broker_url: must be http://<loopback>:<explicit-port> (default port 80 is rejected to keep the wire shape stable across round-trips)",
+    );
   }
 }
 

--- a/packages/protocol/tests/ipc.spec.ts
+++ b/packages/protocol/tests/ipc.spec.ts
@@ -1173,7 +1173,12 @@ describe("apiBootstrap codec", () => {
     fc.assert(
       fc.property(
         fc.stringMatching(/^[A-Za-z0-9._~+/-]{16,96}$/),
-        fc.integer({ min: 1, max: 65535 }),
+        // Exclude port 80 — it's HTTP's default port, so `new URL("http://h:80")`
+        // strips it, and the codec contract requires an explicit non-default
+        // port (see assertApiBootstrapBrokerUrl). Brokers always bind to
+        // ephemeral high ports in practice; the property should not exercise
+        // input shapes the codec is documented to reject.
+        fc.integer({ min: 1, max: 65535 }).filter((p) => p !== 80),
         (tokenValue, port) => {
           const bootstrap = {
             token: asApiToken(tokenValue),
@@ -1185,6 +1190,15 @@ describe("apiBootstrap codec", () => {
       ),
       { numRuns: 200 },
     );
+  });
+
+  it("rejects http://<loopback>:80 because URL parser strips HTTP default port", () => {
+    // Regression for fast-check finding (seed -795955676): the round-trip
+    // property previously generated port 80, which `new URL` normalizes away.
+    // Codec contract intentionally requires an explicit non-default port.
+    expect(() =>
+      apiBootstrapFromJson({ token: "tok-bootstrap-abcdef", broker_url: "http://127.0.0.1:80" }),
+    ).toThrow(/apiBootstrap\.broker_url/);
   });
 
   it("decodes the v0 wire shape with snake_case broker_url", () => {
@@ -1214,7 +1228,7 @@ describe("apiBootstrap codec", () => {
   ])("rejects non-loopback or malformed broker_url %s", (brokerUrl) => {
     expect(() =>
       apiBootstrapFromJson({ token: "tok-bootstrap-abcdef", broker_url: brokerUrl }),
-    ).toThrow(/apiBootstrap\.broker_url: must be http:\/\/<loopback>:<port>/);
+    ).toThrow(/apiBootstrap\.broker_url: must be http:\/\/<loopback>:<explicit-port>/);
   });
 
   it("emits the v0 wire shape with snake_case broker_url", () => {

--- a/packages/protocol/tests/ipc.spec.ts
+++ b/packages/protocol/tests/ipc.spec.ts
@@ -1231,14 +1231,22 @@ describe("apiBootstrap codec", () => {
     ).toThrow(/apiBootstrap\.broker_url: must be http:\/\/<loopback>:<explicit-port>/);
   });
 
-  it("emits the v0 wire shape with snake_case broker_url", () => {
+  it.each([
+    "http://127.0.0.1:54321",
+    "http://localhost:54321",
+    "http://[::1]:54321",
+  ])("emits the v0 wire shape with snake_case broker_url (%s)", (brokerUrl) => {
+    // Mirror the decoder's loopback acceptance matrix on the encoder side
+    // so a future hardening that narrowed the allowlist (e.g. dotted-quad
+    // only) would fail tests on both halves of the codec, not just the
+    // decoder.
     const json = apiBootstrapToJson({
       token: asApiToken("tok-bootstrap-abcdef"),
-      brokerUrl: "http://127.0.0.1:54321",
+      brokerUrl,
     });
     expect(json).toStrictEqual({
       token: "tok-bootstrap-abcdef",
-      broker_url: "http://127.0.0.1:54321",
+      broker_url: brokerUrl,
     });
   });
 
@@ -1247,11 +1255,14 @@ describe("apiBootstrap codec", () => {
     ["http://evil.com:8080", "non-loopback host"],
     ["https://127.0.0.1:8080", "wrong protocol"],
     ["http://127.0.0.1", "missing port"],
+    ["javascript:alert(1)", "javascript-scheme URL"],
+    ["file:///etc/passwd", "file-scheme URL"],
   ])("rejects encoder-side broker_url that the decoder would reject (%s — %s)", (brokerUrl) => {
     // Encoder/decoder symmetry: a TS producer MUST NOT be able to emit
     // a wire value that this same codec would reject on read. Without
     // this guard, a producer could write bytes that fail to round-trip,
-    // weakening the wire-shape stability story.
+    // weakening the wire-shape stability story. Cases mirror the decoder
+    // rejection matrix above so the property is true by construction.
     expect(() =>
       apiBootstrapToJson({
         token: asApiToken("tok-bootstrap-abcdef"),

--- a/packages/protocol/tests/ipc.spec.ts
+++ b/packages/protocol/tests/ipc.spec.ts
@@ -1242,6 +1242,24 @@ describe("apiBootstrap codec", () => {
     });
   });
 
+  it.each([
+    ["http://127.0.0.1:80", "default-port URL"],
+    ["http://evil.com:8080", "non-loopback host"],
+    ["https://127.0.0.1:8080", "wrong protocol"],
+    ["http://127.0.0.1", "missing port"],
+  ])("rejects encoder-side broker_url that the decoder would reject (%s — %s)", (brokerUrl) => {
+    // Encoder/decoder symmetry: a TS producer MUST NOT be able to emit
+    // a wire value that this same codec would reject on read. Without
+    // this guard, a producer could write bytes that fail to round-trip,
+    // weakening the wire-shape stability story.
+    expect(() =>
+      apiBootstrapToJson({
+        token: asApiToken("tok-bootstrap-abcdef"),
+        brokerUrl,
+      }),
+    ).toThrow(/apiBootstrap\.broker_url/);
+  });
+
   it("rejects camelCase brokerUrl on the wire (lint-enforced shape mismatch)", () => {
     expect(() =>
       apiBootstrapFromJson({


### PR DESCRIPTION
## Summary

Post-merge cleanup of #754 (installer-pipeline). PR went through TWO rounds of multi-lens triangulation + staff-reviewer per the project's "raise the bar" rhythm.

**Round 1**: addressed 1 BLOCK + 4 HIGH + 5 MEDIUM findings from the post-merge audit of #754, plus a fast-check round-trip flake in `packages/protocol/src/ipc.ts` that surfaced via this PR's CI.

**Round 2**: triangulated this PR with 7 orthogonal lenses (security, perf, api, sre, architecture, distsys, electron) + staff-reviewer. Found 4 real follow-on issues that mirror exactly the "shortcut introduced under cover of fixing old ones" pattern. Fixed 3 in this PR, deferred 2 to focused issues.

## Disposition

### Round 1 (B1-M5 + protocol fix)

| # | Finding | Tag | Commit |
|---|---|---|---|
| B1 | `check-invariants.sh` + self-test were never invoked by CI or pre-push hooks | CONFIG-SHIM | `cc9c7305` |
| B2 | Expected-asset check was vacuous — built from the same globs used to upload | WORKFLOW-SHORTCUT | `db952fc6` |
| H1 | Release stayed as draft forever — no `--draft=false` flip | WORKFLOW-SHORTCUT | `eee0cc03` |
| H2 | `dependencies` regex matched `devDependencies`/`peerDependencies` substrings | DEAD-DEFAULT | `c74af3a6` |
| H3 | `verify-latest-yml.sh` self-test ran on every invocation including production publish | DEAD-DEFAULT | `5664b03a` |
| H4 | Tag-vs-version branching silently fell back to `package.json` when `GITHUB_REF` was malformed | DEAD-DEFAULT | `63bfd77e` |
| M1 | Azure signing retries swallowed first 2 failures with `continue-on-error` | WORKFLOW-SHORTCUT | `0ecd9231` |
| M2 | `staple-mac-app.js` no-op skipped if `WUPHF_RELEASE_MODE` not propagated | OVER-WIDE-CATCH | `50e0e3ba` |
| M3 | `notarize-with-retry.js` no jitter — thundering-herd on Apple notary recovery | WORKFLOW-SHORTCUT | `85d93c4d` |
| M4 | `setDefaultCache` mutated parent process.env | DEAD-DEFAULT | `ab6d56b3` |
| M5 | 7zip-bin chmod hack was silent on failure | OVER-WIDE-CATCH | `17105058` |
| Protocol fix | apiBootstrap codec round-trip test generated implicit-port URLs the codec rejects | INCOMPLETE-FIX | `40db7542` |

### Round 2 (multi-lens follow-on)

| # | Finding | Tag | Commit / status |
|---|---|---|---|
| F1 | Lefthook `installer-invariants` glob excluded `.github/workflows/release-rewrite.yml` even though `check-invariants.sh` scans that file (4-lens consensus + staff-reviewer) | INCOMPLETE-FIX | `96ed350e` |
| F2 | H3 inverted self-test from default-on to opt-in but no CI/lefthook step opted in — gate stopped running entirely | REGRESSION-INDUCED | `96ed350e` |
| F4 | M4 fix had no regression test asserting parent-process env stays clean | TEST-BYPASS | `96ed350e` |
| T2 | README + 3 runbooks still said "draft release" / "draft-only smoke" / "Download the draft release ..." after H1's auto-publish flip | BAND-AID-COMMENT (doc rot) | `ef7c8838` |
| S3 | H4's tag-validation only ran when no `$1` was passed — workflow always passes `$TAG` so the script-level invariant was dead in production | INCOMPLETE-FIX | `2653f22a` |
| CI flake | `bun -e <code> <arg>` argv handling drifts between bun 1.1.38 (CI) and 1.3.13 (local) — broke verify-latest-yml self-test on the new gate | env skew | `331b3b55` |
| S1 | Asset upload still globs `release-assets/*.{dmg,zip,exe,AppImage,deb}` — a compromised build job could ship extra assets with deceptive names | INCOMPLETE-FIX | **DEFERRED — #769** |
| S2 | Post-upload verification proves names not bytes; no SHA-256 compare against published assets before `--draft=false` | INCOMPLETE-FIX | **DEFERRED — #770** |

## Architecture

```mermaid
flowchart LR
  Push[push tag<br/>vN.N.N-rewrite] --> Detect[detect-secrets]
  Detect --> Inv[installer-invariants<br/>NEW: gates all builds<br/>now also runs verify-latest-yml self-test]
  Inv --> Mac[build-mac]
  Inv --> Win[build-win]
  Inv --> Lin[build-linux]
  Mac --> Pub[publish]
  Win --> Pub
  Lin --> Pub
  Pub --> Assert[assert expected<br/>asset CLASSES<br/>NEW: non-vacuous]
  Assert --> Flip[gh release edit<br/>--draft=false<br/>NEW: auto-publish]
  Flip --> Live[GitHub published release]
```

## Test plan
- [x] `bash apps/installer-stub/scripts/check-invariants-self-test.sh`
- [x] `WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 bash apps/installer-stub/scripts/verify-latest-yml.sh`
- [x] `node apps/installer-stub/scripts/run-builder.test.js` (new — covers M4 regression)
- [x] `(cd apps/installer-stub && bun run lint && bun run test && bun run build:dry-run)`
- [x] `shellcheck apps/installer-stub/scripts/*.sh` clean
- [x] `actionlint .github/workflows/release-rewrite.yml` clean
- [x] Lefthook pre-push runs `installer-invariants` for both `apps/installer-stub/**` AND `.github/workflows/release-rewrite.yml`
- [ ] Tag a `v0.0.X-rewrite` smoke release and verify the new draft→published flip works end-to-end (deferred to release-day owner — change is documented in `release-day-troubleshooting.md`)

### Round 3 (codex parallel triangulation + CR re-review)

R3 ran 5 orthogonal lenses on this PR (security, sre, api, distsys, architecture) plus a shared electron lens with #753. Two CR nitpicks landed mid-flight on the round-2 work and were addressed in the same pass.

| # | Finding | Lens | Tag | Commit / status |
|---|---|---|---|---|
| CR-MIN-1 | `require_asset_class` was a 9-line helper inlined twice in YAML | CR | DRY | `a6604054` (extracted to `apps/installer-stub/scripts/require-asset-class.sh`, sourced from both steps) |
| CR-MIN-2 | `run-builder.test.js` hardcoded `/tmp` + leaked the dir it created | CR | PORTABILITY+CLEANUP | `a6604054` (`fs.mkdtempSync(os.tmpdir(), 'wuphf-m4-')` + try/finally rmSync) |
| API-M1 | `apiBootstrapToJson` blindly serialized `bootstrap.brokerUrl` — encoder/decoder asymmetry let a TS producer emit values the same codec rejects on read | api | INCOMPLETE-FIX | `d76d9dd3` (assertApiBootstrapBrokerUrl in encoder + 4-case parameterized regression test) |
| Electron-H1 (PRE-EXISTING) | Windows signing happens AFTER NSIS packaging — installed binaries unsigned despite signed installer | electron | INCOMPLETE-FIX | **DEFERRED — #772** P0 ship-blocker (pre-existing in main, not introduced by #768) |
| Electron-H2 (PRE-EXISTING) | `electron-updater` is a runtime dep but lives in `devDependencies` — packaged stub crashes on launch | electron | DEAD-DEFAULT | **DEFERRED — #771** P0 ship-blocker (pre-existing in main, not introduced by #768) |
| LOW-x7 | architecture/distsys/api/electron LOW findings | various | LOW | **DEFERRED — #773** (`${GITHUB_WORKSPACE}` source path, helper safety contract, review-label durable-comment cleanup, temp-file mid-loop cleanup, cross-language oracle for default-port rule, quit/updater interception, hardened-runtime entitlement narrowing) |

## Out of scope (filed as issues)
- #769 — derive expected release-asset basenames from `${VERSION}` + electron-builder.yml platform matrix; reject extras pre-upload
- #770 — verify uploaded asset bytes by SHA-256 against `release-checksums.txt` before `--draft=false` flip
- #771 — **P0** electron-updater devDep packaging ship-blocker
- #772 — **P0** Windows signing-after-NSIS-packaging order ship-blocker
- #773 — R3 deferred LOW findings on this PR

## Out of scope (deferred to maintenance)
- M6 (vestigial Sparkle references in comments / AGENTS.md rule 4)
- electron-builder 25→26 / electron-updater 6.3→6.6 grouped bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows signing resilience with a third retry, per-attempt diagnostics artifact, and a warning on first failure
  * Tightened publish flow with strict asset validation, exact-asset verification (expected asset inventory) and automatic draft→published flip; release-note header revised
  * Added installer-invariants gating to platform builds and CI job that installs required tools for invariant checks
  * Added reusable release-asset validation helper

* **Documentation**
  * Updated runbooks and smoke tests to reflect publish/verification and signing changes

* **Tests**
  * Added and expanded self-tests for release verification, tag validation, and build/runtime helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
