### PR TITLE
fix(provider): drop redundant Setpgid/Noctty from Linux SysProcAttr

### DIFF
--- a/internal/provider/claude_proc_linux.go
+++ b/internal/provider/claude_proc_linux.go
@@ -8,9 +8,11 @@ import (
 )
 
 func configureClaudeProcess(cmd *exec.Cmd) {
+	// Setsid alone gives us everything we need: a new session, the child as
+	// session leader, a fresh process group, and no controlling terminal.
+	// Adding Setpgid fails with EPERM (cannot change pgid of a session
+	// leader); adding Noctty fails with ENOTTY when stdin is a pipe.
 	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid:  true,
-		Setpgid: true,
-		Noctty:  true,
+		Setsid: true,
 	}
 }


### PR DESCRIPTION
## Summary
- Linux-only fix for `configureClaudeProcess` in `internal/provider/claude_proc_linux.go`. Drops `Setpgid: true` and `Noctty: true`, keeps `Setsid: true`.
- `Setsid` already gives the child a fresh session, makes it the session leader, places it in a brand-new process group, and detaches it from any controlling terminal — `Setpgid` and `Noctty` on top are redundant *and* unconditionally fail.

## Why both flags fail
- **`Setpgid` after `Setsid`** → `EPERM`. After `setsid()`, the child is a session leader, and `setpgid(0, 0)` on a session leader is rejected by the kernel ("cannot change pgid of a session leader").
- **`Noctty` with non-tty stdin** → `ENOTTY`. Go's child hook runs `ioctl(0, TIOCNOTTY)`; the headless one-shot path feeds the prompt through `cmd.Stdin = strings.NewReader(...)`, so fd 0 is a pipe, not a terminal.

Both failures occur in Go's pre-exec child hook before `execve` is reached, so the caller sees only the opaque `fork/exec /path/to/claude: operation not permitted` (or `inappropriate ioctl for device` once `Setpgid` is removed and `Noctty` is left in).

## Reproduction
Any code path through `configureClaudeProcess` on Linux with a non-tty stdin reproduces it. A minimal driver via `provider.RunClaudeOneShotCtx` fails immediately:

```
fork/exec /home/<user>/.local/bin/claude: operation not permitted
```

`strace -f -e trace=execve` shows no `execve` syscall for the child — the child clones, exits 253 (Go's pre-exec sentinel), and never reaches exec.

## Test plan
- [ ] `bash scripts/test-go.sh ./internal/provider`
- [ ] Verify on Linux: any caller that drives `provider.RunClaudeOneShotCtx` with a piped stdin completes without `EPERM` / `ENOTTY`.
- [ ] Verify on Darwin/Windows: no behavior change — `configureClaudeProcess` is a no-op on those platforms.

## LOC delta
+5 / −3, single file. No allowlist change.