### PR TITLE
fix(installer): sign Windows binaries via electron-builder azureSignOptions (#772)

### DIFF
--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -326,6 +326,7 @@ jobs:
       - name: Build + sign Windows artifacts (azureSignOptions)
         if: needs.detect-secrets.outputs.is_release == 'true'
         working-directory: apps/installer-stub
+        shell: bash
         env:
           # Auth env vars for electron-builder's azureSignOptions. The
           # Azure SDK's EnvironmentCredential picks these up automatically
@@ -338,8 +339,8 @@ jobs:
           AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
           AZURE_EXPECTED_PUBLISHER_NAME: ${{ secrets.AZURE_EXPECTED_PUBLISHER_NAME }}
         # Issue #772 ship-blocker fix: signing happens DURING electron-builder
-        # packaging, not after. electron-builder signs each .exe + .dll
-        # produced by the win-unpacked staging tree, then NSIS bundles the
+        # packaging, not after. electron-builder signs each .exe / .dll /
+        # .node from the win-unpacked staging tree, then NSIS bundles the
         # already-signed binaries into the wrapper installer .exe (which
         # also gets signed). Result: binaries the user actually executes
         # after install carry the same Authenticode signature as the
@@ -355,12 +356,42 @@ jobs:
         # account/profile/publisher) are validated in the prior
         # `Detect Azure signing secrets` step; if any are missing the job
         # fails before reaching here.
+        #
+        # Workflow-level retry (R2 codex finding): electron-builder's
+        # built-in retry only matches DNS-resolution + file-lock errors,
+        # NOT Azure 5xx / throttling / SignerSign() failures. The previous
+        # workflow had 3 explicit attempts of Azure/trusted-signing-action
+        # with sleeps; preserve that semantic by wrapping the build step
+        # in an explicit retry loop with clean dist between attempts.
+        # 30s sleep matches the prior wait_before_azure_signing_retry pattern.
         run: |
-          bun run build:win -- \
-            --config.win.azureSignOptions.endpoint="$AZURE_ENDPOINT" \
-            --config.win.azureSignOptions.codeSigningAccountName="$AZURE_SIGNING_ACCOUNT_NAME" \
-            --config.win.azureSignOptions.certificateProfileName="$AZURE_CERT_PROFILE_NAME" \
-            --config.win.azureSignOptions.publisherName="$AZURE_EXPECTED_PUBLISHER_NAME"
+          set -euo pipefail
+          attempts=3
+          for attempt in $(seq 1 "$attempts"); do
+            echo "::group::azureSignOptions build attempt ${attempt}/${attempts}"
+            rm -rf dist
+            if bun run build:win -- \
+              --config.win.azureSignOptions.endpoint="$AZURE_ENDPOINT" \
+              --config.win.azureSignOptions.codeSigningAccountName="$AZURE_SIGNING_ACCOUNT_NAME" \
+              --config.win.azureSignOptions.certificateProfileName="$AZURE_CERT_PROFILE_NAME" \
+              --config.win.azureSignOptions.publisherName="$AZURE_EXPECTED_PUBLISHER_NAME"; then
+              echo "azureSignOptions build attempt ${attempt} succeeded"
+              echo "::endgroup::"
+              if [[ "$attempt" -gt 1 ]]; then
+                echo "::warning title=Azure signing flakiness::Azure Trusted Signing required ${attempt}/${attempts} attempts to succeed. Check service health before the next release window."
+              fi
+              exit 0
+            fi
+            status=$?
+            echo "::endgroup::"
+            echo "azureSignOptions build attempt ${attempt} failed with exit ${status}"
+            if [[ "$attempt" -lt "$attempts" ]]; then
+              echo "Sleeping 30s before retry"
+              sleep 30
+            fi
+          done
+          echo "All ${attempts} azureSignOptions build attempts failed" >&2
+          exit 1
       - name: Assert allowlisted runtime deps are bundled into the Windows app
         # Issue #771 ship-blocker gate (see macOS job for full rationale).
         #
@@ -449,9 +480,21 @@ jobs:
           # signed. SmartScreen / HVCI / Smart App Control / electron-updater
           # publisherName checks all run against the INSTALLED binaries,
           # not the wrapper.
+          #
+          # IMPORTANT (R2 codex finding): electron-builder embeds the actual
+          # app payload as `$PLUGINSDIR\app-64.7z` inside the NSIS wrapper.
+          # A single `7z x` of the wrapper unpacks the wrapper layer (NSIS
+          # plugins, uninstaller, the embedded .7z) but the binaries the
+          # user runs after install live INSIDE that nested .7z. We must
+          # recursively extract the nested archive and assert against THAT
+          # tree — otherwise the smoke validates wrapper/plugin binaries
+          # while missing the exact #772 failure mode.
           $extractDir = Join-Path -Path $env:RUNNER_TEMP -ChildPath "wuphf-installer-extract"
-          if (Test-Path $extractDir) { Remove-Item -Path $extractDir -Recurse -Force }
-          New-Item -ItemType Directory -Path $extractDir | Out-Null
+          $appDir = Join-Path -Path $env:RUNNER_TEMP -ChildPath "wuphf-installer-app"
+          foreach ($d in @($extractDir, $appDir)) {
+            if (Test-Path $d) { Remove-Item -Path $d -Recurse -Force }
+            New-Item -ItemType Directory -Path $d | Out-Null
+          }
 
           $installer = $installers[0]
           # 7z is preinstalled on windows-2022 runners and can extract NSIS.
@@ -460,9 +503,29 @@ jobs:
             throw "7z failed to extract NSIS installer $($installer.FullName) (exit $LASTEXITCODE)"
           }
 
-          $extractedPayloads = Get-ChildItem -Path $extractDir -Include *.exe,*.dll -File -Recurse
-          Assert-Signed $extractedPayloads "extracted NSIS installer payload"
-          Write-Output "OK: extracted NSIS payload — $($extractedPayloads.Count) signed payloads"
+          # Layer 2a: assert wrapper-level binaries are signed. These are
+          # NSIS plugin DLLs + uninstaller .exe — also user-visible during
+          # install/uninstall and SmartScreen checks them.
+          $wrapperPayloads = Get-ChildItem -Path $extractDir -Include *.exe,*.dll -File -Recurse
+          Assert-Signed $wrapperPayloads "extracted NSIS wrapper payload"
+          Write-Output "OK: NSIS wrapper — $($wrapperPayloads.Count) signed payloads"
+
+          # Layer 2b: locate the embedded app archive ($PLUGINSDIR\app-*.7z
+          # or app-*.zip), extract it, and assert THE INSTALLED app tree
+          # is signed. This is the gate that catches #772 end-to-end.
+          $embeddedArchives = Get-ChildItem -Path $extractDir -Include 'app-*.7z','app-*.zip' -File -Recurse
+          if ($embeddedArchives.Count -eq 0) {
+            throw "Could not find embedded app-*.7z/zip under extracted NSIS payload — electron-builder's NSIS template normally embeds it under \$PLUGINSDIR. Layer 2b cannot run without it."
+          }
+          foreach ($archive in $embeddedArchives) {
+            & 7z x -y "-o$appDir" $archive.FullName
+            if ($LASTEXITCODE -ne 0) {
+              throw "7z failed to extract embedded app archive $($archive.FullName) (exit $LASTEXITCODE)"
+            }
+          }
+          $appPayloads = Get-ChildItem -Path $appDir -Include *.exe,*.dll,*.node -File -Recurse
+          Assert-Signed $appPayloads "extracted installed app tree"
+          Write-Output "OK: installed app tree — $($appPayloads.Count) signed payloads"
       - name: Assert Windows artifacts
         shell: bash
         working-directory: apps/installer-stub

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -323,23 +323,44 @@ jobs:
         if: needs.detect-secrets.outputs.is_release != 'true'
         working-directory: apps/installer-stub
         run: bun run build:win
-      - name: Build Windows artifacts
+      - name: Build + sign Windows artifacts (azureSignOptions)
         if: needs.detect-secrets.outputs.is_release == 'true'
         working-directory: apps/installer-stub
         env:
+          # Auth env vars for electron-builder's azureSignOptions. The
+          # Azure SDK's EnvironmentCredential picks these up automatically
+          # — no need to thread them through the CLI override.
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_ENDPOINT: ${{ secrets.AZURE_ENDPOINT }}
+          AZURE_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+          AZURE_CERT_PROFILE_NAME: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
           AZURE_EXPECTED_PUBLISHER_NAME: ${{ secrets.AZURE_EXPECTED_PUBLISHER_NAME }}
-        # Override win.publisherName so it matches the Authenticode CN of
-        # the Azure cert. electron-updater compares the publisherName baked
-        # into app-update.yml against the SignerCertificate CN of the
-        # downloaded installer at update time; a mismatch breaks auto-update
-        # silently for end users. The placeholder in electron-builder.yml is
-        # ONLY usable for local PR builds (which do not auto-update).
+        # Issue #772 ship-blocker fix: signing happens DURING electron-builder
+        # packaging, not after. electron-builder signs each .exe + .dll
+        # produced by the win-unpacked staging tree, then NSIS bundles the
+        # already-signed binaries into the wrapper installer .exe (which
+        # also gets signed). Result: binaries the user actually executes
+        # after install carry the same Authenticode signature as the
+        # downloaded installer, which is what users + SmartScreen + HVCI
+        # + electron-updater publisherName-check all expect.
+        #
+        # Previously this signing happened in a SEPARATE workflow step
+        # AFTER NSIS packaging, signing only the outer wrapper. The
+        # binaries already embedded inside the NSIS payload kept their
+        # unsigned form — bug #772.
+        #
+        # All required Azure secrets (tenant/client/secret/endpoint/
+        # account/profile/publisher) are validated in the prior
+        # `Detect Azure signing secrets` step; if any are missing the job
+        # fails before reaching here.
         run: |
-          if [ -z "$AZURE_EXPECTED_PUBLISHER_NAME" ]; then
-            echo "AZURE_EXPECTED_PUBLISHER_NAME is required for release builds (binds win.publisherName to Authenticode CN)" >&2
-            exit 1
-          fi
-          bun run build:win -- --config.win.signtoolOptions.publisherName="$AZURE_EXPECTED_PUBLISHER_NAME"
+          bun run build:win -- \
+            --config.win.azureSignOptions.endpoint="$AZURE_ENDPOINT" \
+            --config.win.azureSignOptions.codeSigningAccountName="$AZURE_SIGNING_ACCOUNT_NAME" \
+            --config.win.azureSignOptions.certificateProfileName="$AZURE_CERT_PROFILE_NAME" \
+            --config.win.azureSignOptions.publisherName="$AZURE_EXPECTED_PUBLISHER_NAME"
       - name: Assert allowlisted runtime deps are bundled into the Windows app
         # Issue #771 ship-blocker gate (see macOS job for full rationale).
         #
@@ -365,105 +386,16 @@ jobs:
         continue-on-error: ${{ needs.detect-secrets.outputs.is_release != 'true' }}
         working-directory: apps/installer-stub
         run: node scripts/check-packaged-runtime-deps.js dist
-      - name: Sign Windows artifacts (attempt 1)
-        id: sign_windows_1
-        if: needs.detect-secrets.outputs.is_release == 'true'
-        continue-on-error: true
-        timeout-minutes: 30
-        uses: Azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # ratchet:Azure/trusted-signing-action@v1.2.0
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: ${{ secrets.AZURE_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          files-folder: ${{ github.workspace }}\apps\installer-stub\dist
-          files-folder-filter: "*.exe,*.dll"
-          files-folder-recurse: true
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-          timeout: 1800
-      - name: Wait before Azure signing retry 2
-        if: needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure'
-        shell: pwsh
-        run: Start-Sleep -Seconds 30
-      - name: Sign Windows artifacts (attempt 2)
-        id: sign_windows_2
-        if: needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure'
-        continue-on-error: true
-        timeout-minutes: 30
-        uses: Azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # ratchet:Azure/trusted-signing-action@v1.2.0
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: ${{ secrets.AZURE_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          files-folder: ${{ github.workspace }}\apps\installer-stub\dist
-          files-folder-filter: "*.exe,*.dll"
-          files-folder-recurse: true
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-          timeout: 1800
-      - name: Wait before Azure signing retry 3
-        if: needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure' && steps.sign_windows_2.outcome == 'failure'
-        shell: pwsh
-        run: Start-Sleep -Seconds 30
-      - name: Sign Windows artifacts (attempt 3)
-        id: sign_windows_3
-        if: needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure' && steps.sign_windows_2.outcome == 'failure'
-        timeout-minutes: 30
-        uses: Azure/trusted-signing-action@b443cf8ea4124818d2ea9f043cba29fc3ec47b16 # ratchet:Azure/trusted-signing-action@v1.2.0
-        with:
-          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          azure-client-secret: ${{ secrets.AZURE_CLIENT_SECRET }}
-          endpoint: ${{ secrets.AZURE_ENDPOINT }}
-          signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
-          certificate-profile-name: ${{ secrets.AZURE_CERT_PROFILE_NAME }}
-          files-folder: ${{ github.workspace }}\apps\installer-stub\dist
-          files-folder-filter: "*.exe,*.dll"
-          files-folder-recurse: true
-          file-digest: SHA256
-          timestamp-rfc3161: http://timestamp.acs.microsoft.com
-          timestamp-digest: SHA256
-          timeout: 1800
-      - name: Write Azure signing attempt diagnostics
-        if: always() && needs.detect-secrets.outputs.is_release == 'true'
-        shell: pwsh
-        env:
-          SIGN_WINDOWS_1_OUTCOME: ${{ steps.sign_windows_1.outcome }}
-          SIGN_WINDOWS_1_CONCLUSION: ${{ steps.sign_windows_1.conclusion }}
-          SIGN_WINDOWS_2_OUTCOME: ${{ steps.sign_windows_2.outcome }}
-          SIGN_WINDOWS_2_CONCLUSION: ${{ steps.sign_windows_2.conclusion }}
-          SIGN_WINDOWS_3_OUTCOME: ${{ steps.sign_windows_3.outcome }}
-          SIGN_WINDOWS_3_CONCLUSION: ${{ steps.sign_windows_3.conclusion }}
-        run: |
-          New-Item -ItemType Directory -Force -Path signing-diagnostics | Out-Null
-          @(
-            "attempt 1 outcome: $env:SIGN_WINDOWS_1_OUTCOME"
-            "attempt 1 conclusion: $env:SIGN_WINDOWS_1_CONCLUSION"
-            "attempt 2 outcome: $env:SIGN_WINDOWS_2_OUTCOME"
-            "attempt 2 conclusion: $env:SIGN_WINDOWS_2_CONCLUSION"
-            "attempt 3 outcome: $env:SIGN_WINDOWS_3_OUTCOME"
-            "attempt 3 conclusion: $env:SIGN_WINDOWS_3_CONCLUSION"
-          ) | Set-Content -Path signing-diagnostics/azure-signing-attempts.txt
-      - name: Report Azure signing flakiness
-        if: always() && needs.detect-secrets.outputs.is_release == 'true' && steps.sign_windows_1.outcome == 'failure'
-        shell: pwsh
-        run: Write-Output "::warning title=Azure signing flakiness::Azure Trusted Signing required at least one retry. Download the azure-signing-diagnostics artifact and check service health before the next release window."
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
-        if: always() && needs.detect-secrets.outputs.is_release == 'true'
-        with:
-          name: azure-signing-diagnostics
-          path: signing-diagnostics/azure-signing-attempts.txt
-          retention-days: 14
-          if-no-files-found: error
-      - name: Assert Windows signer identity
+      # Post-build "Sign Windows artifacts (attempt 1/2/3)" + retry sleeps
+      # + diagnostics upload were removed in #772: signing now happens
+      # DURING the electron-builder packaging step above via
+      # azureSignOptions, which signs each .exe and .dll from the
+      # win-unpacked staging tree before NSIS bundles them into the
+      # wrapper installer. electron-builder's azureSignOptions has its
+      # own retry behavior + Azure SDK timestamp + cert handling, so the
+      # external Azure/trusted-signing-action 3-attempt orchestration is
+      # no longer needed.
+      - name: Assert Windows signer identity (installer + extracted payload)
         if: needs.detect-secrets.outputs.is_release == 'true'
         shell: pwsh
         working-directory: apps/installer-stub
@@ -476,39 +408,61 @@ jobs:
             throw "AZURE_EXPECTED_PUBLISHER_NAME is required for Windows signer verification."
           }
 
-          # Azure Trusted Signing was configured (above) to recursively sign
-          # *.exe AND *.dll. Verify both classes — a partial DLL signing
-          # failure must not be allowed to slip through and ship in latest.yml.
+          function Assert-Signed($payloads, $context) {
+            if ($payloads.Count -eq 0) {
+              throw "No Windows signed payloads (.exe/.dll) found in $context."
+            }
+            foreach ($payload in $payloads) {
+              $signature = Get-AuthenticodeSignature -FilePath $payload.FullName
+              if ($signature.Status -ne "Valid") {
+                throw "Authenticode signature for $($payload.FullName) is $($signature.Status), expected Valid."
+              }
+              if ($null -eq $signature.SignerCertificate) {
+                throw "No signer certificate found for $($payload.FullName)."
+              }
+              $commonName = $signature.SignerCertificate.GetNameInfo(
+                [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
+                $false
+              )
+              if ($commonName -ne $expectedPublisher) {
+                throw "Signer CN '$commonName' does not match AZURE_EXPECTED_PUBLISHER_NAME '$expectedPublisher' for $($payload.FullName). Subject: $($signature.SignerCertificate.Subject)"
+              }
+            }
+          }
+
+          # Layer 1: verify the wrapper installer + the win-unpacked staging
+          # tree (everything electron-builder signed in-process). This is
+          # what the OLD post-build signing pipeline could check.
           $installers = Get-ChildItem -Path dist -Filter *.exe -File
           if ($installers.Count -eq 0) {
             throw "No Windows installer .exe found in dist."
           }
-          $payloads = Get-ChildItem -Path dist -Include *.exe,*.dll -File -Recurse
-          if ($payloads.Count -eq 0) {
-            throw "No Windows signed payloads (.exe/.dll) found under dist."
+          $stagingPayloads = Get-ChildItem -Path dist -Include *.exe,*.dll -File -Recurse
+          Assert-Signed $stagingPayloads "dist/ staging tree"
+          Write-Output "OK: dist/ staging tree — $($stagingPayloads.Count) signed payloads"
+
+          # Layer 2 (NEW for #772): EXTRACT the NSIS installer and assert
+          # the BINARIES THE USER ACTUALLY EXECUTES are signed. The original
+          # bug was that signing happened AFTER NSIS bundled win-unpacked,
+          # so the embedded binaries kept their unsigned form even though
+          # the wrapper installer + the unpacked staging tree both showed
+          # signed. SmartScreen / HVCI / Smart App Control / electron-updater
+          # publisherName checks all run against the INSTALLED binaries,
+          # not the wrapper.
+          $extractDir = Join-Path -Path $env:RUNNER_TEMP -ChildPath "wuphf-installer-extract"
+          if (Test-Path $extractDir) { Remove-Item -Path $extractDir -Recurse -Force }
+          New-Item -ItemType Directory -Path $extractDir | Out-Null
+
+          $installer = $installers[0]
+          # 7z is preinstalled on windows-2022 runners and can extract NSIS.
+          & 7z x -y "-o$extractDir" $installer.FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "7z failed to extract NSIS installer $($installer.FullName) (exit $LASTEXITCODE)"
           }
 
-          foreach ($payload in $payloads) {
-            $signature = Get-AuthenticodeSignature -FilePath $payload.FullName
-            if ($signature.Status -ne "Valid") {
-              throw "Authenticode signature for $($payload.FullName) is $($signature.Status), expected Valid."
-            }
-            if ($null -eq $signature.SignerCertificate) {
-              throw "No signer certificate found for $($payload.FullName)."
-            }
-
-            $commonName = $signature.SignerCertificate.GetNameInfo(
-              [System.Security.Cryptography.X509Certificates.X509NameType]::SimpleName,
-              $false
-            )
-            if ($commonName -ne $expectedPublisher) {
-              throw "Signer CN '$commonName' does not match AZURE_EXPECTED_PUBLISHER_NAME '$expectedPublisher' for $($payload.FullName). Subject: $($signature.SignerCertificate.Subject)"
-            }
-          }
-      - name: Refresh Windows update manifest after signing
-        if: needs.detect-secrets.outputs.is_release == 'true'
-        working-directory: apps/installer-stub
-        run: bun scripts/refresh-latest-yml.js dist/latest.yml
+          $extractedPayloads = Get-ChildItem -Path $extractDir -Include *.exe,*.dll -File -Recurse
+          Assert-Signed $extractedPayloads "extracted NSIS installer payload"
+          Write-Output "OK: extracted NSIS payload — $($extractedPayloads.Count) signed payloads"
       - name: Assert Windows artifacts
         shell: bash
         working-directory: apps/installer-stub

--- a/apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md
+++ b/apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md
@@ -124,28 +124,52 @@ certificate identity within that account.
 
 ## Workflow Behavior
 
-The Windows job:
+PR #772 migrated Windows signing INTO electron-builder's packaging phase
+(via `win.azureSignOptions`) so binaries embedded in the NSIS payload get
+signed BEFORE NSIS bundles them. Previously signing happened in a separate
+post-build workflow step that signed only the wrapper installer; the
+binaries the user actually executes after install were unsigned.
 
-1. Builds the NSIS installer unsigned, **passing
-   `--config.win.signtoolOptions.publisherName="$AZURE_EXPECTED_PUBLISHER_NAME"`**
-   so the value baked into `app-update.yml` matches the certificate identity
-   that will sign it. (electron-updater compares this baked-in publisher name
-   against the downloaded installer's Authenticode CN at update time; a
-   mismatch breaks auto-update silently for end users.) Note: pre-electron-builder-26
-   the option lived at top-level `win.publisherName`; the v26 schema moved
-   it under `win.signtoolOptions.publisherName`.
-2. Signs the final `.exe` AND every packaged `.dll` recursively with
-   `Azure/trusted-signing-action`, retrying up to three attempts with
-   30-second waits.
-3. Asserts the Authenticode signature is `Valid` for every signed payload
-   (`*.exe` AND `*.dll`) and that the signer CN equals
-   `AZURE_EXPECTED_PUBLISHER_NAME` for each.
-4. Refreshes `latest.yml` from the signed artifact bytes and uploads the
-   artifact.
+The Windows job now:
 
-The `win.signtoolOptions.publisherName` placeholder in `electron-builder.yml`
-(`WUPHF (installer stub)`) is intentionally kept for local PR builds, which
-do not auto-update. Production releases override it via the workflow secret.
+1. Sets the Azure auth env vars (`AZURE_TENANT_ID`, `AZURE_CLIENT_ID`,
+   `AZURE_CLIENT_SECRET`, `AZURE_ENDPOINT`, `AZURE_SIGNING_ACCOUNT_NAME`,
+   `AZURE_CERT_PROFILE_NAME`, `AZURE_EXPECTED_PUBLISHER_NAME`) at the
+   step level. The Azure SDK's `EnvironmentCredential` picks these up
+   automatically.
+2. Runs `bun run build:win` with CLI overrides:
+   `--config.win.azureSignOptions.endpoint=$AZURE_ENDPOINT`,
+   `--config.win.azureSignOptions.codeSigningAccountName=$AZURE_SIGNING_ACCOUNT_NAME`,
+   `--config.win.azureSignOptions.certificateProfileName=$AZURE_CERT_PROFILE_NAME`,
+   `--config.win.azureSignOptions.publisherName=$AZURE_EXPECTED_PUBLISHER_NAME`.
+   electron-builder signs each `.exe` and `.dll` produced by the
+   win-unpacked staging tree, then NSIS bundles the already-signed
+   binaries into the wrapper installer (which also gets signed).
+   electron-builder's azureSignOptions has its own retry behavior, so
+   no external Azure/trusted-signing-action 3-attempt orchestration is
+   needed.
+3. Asserts the Authenticode signature is `Valid` and signer CN equals
+   `AZURE_EXPECTED_PUBLISHER_NAME` for both:
+   - **Layer 1**: every `*.exe` and `*.dll` in the `dist/` staging tree
+     (the wrapper installer + everything electron-builder signed in
+     process).
+   - **Layer 2 (NEW for #772)**: every `*.exe` and `*.dll` extracted
+     FROM the NSIS installer payload via `7z x`. This is what the user
+     actually runs after install — SmartScreen, HVCI, Smart App Control,
+     and electron-updater's publisherName check all evaluate the
+     installed binaries, not the wrapper.
+
+`win.signtoolOptions.publisherName` in `electron-builder.yml`
+(`WUPHF (installer stub)`) stays as the placeholder for PR builds, which
+don't sign at all (electron-builder skips signing when no
+azureSignOptions/cscLink is present). The release workflow's CLI
+override adds `azureSignOptions` on top; per the schema, when both
+`signtoolOptions` and `azureSignOptions` are set, azureSignOptions
+wins.
+
+`refresh-latest-yml.js` is no longer invoked after signing because
+electron-builder generates `latest.yml` from the signed bytes within
+its own pipeline.
 
 ## Smoke Test
 
@@ -153,8 +177,11 @@ do not auto-update. Production releases override it via the workflow secret.
 2. Approve the `production-release` environment if GitHub asks for it.
 3. Open the `Release Rewrite` workflow run.
 4. Confirm `Detect Azure signing secrets` reports all Azure values set.
-5. Confirm the Windows job signs with `Azure/trusted-signing-action`, verifies
-   the signer CN, refreshes `latest.yml`, and verifies the manifest.
+5. Confirm the Windows job signs via electron-builder's `azureSignOptions`
+   (visible in build output as inline signing of each `.exe`/`.dll`),
+   verifies the signer CN on both the dist/ staging tree AND the
+   extracted NSIS payload, and produces `latest.yml` from the signed
+   bytes inline.
 6. The publish job auto-flips the draft to a published release after the
    asset assertion succeeds. Download the `.exe` from the published release
    and inspect its signature:

--- a/apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md
+++ b/apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md
@@ -142,22 +142,29 @@ The Windows job now:
    `--config.win.azureSignOptions.codeSigningAccountName=$AZURE_SIGNING_ACCOUNT_NAME`,
    `--config.win.azureSignOptions.certificateProfileName=$AZURE_CERT_PROFILE_NAME`,
    `--config.win.azureSignOptions.publisherName=$AZURE_EXPECTED_PUBLISHER_NAME`.
-   electron-builder signs each `.exe` and `.dll` produced by the
+   electron-builder signs each `.exe`, `.dll`, AND `.node` (per
+   `win.signExts` in `electron-builder.yml`) produced by the
    win-unpacked staging tree, then NSIS bundles the already-signed
    binaries into the wrapper installer (which also gets signed).
-   electron-builder's azureSignOptions has its own retry behavior, so
-   no external Azure/trusted-signing-action 3-attempt orchestration is
-   needed.
+   The build step is wrapped in a 3-attempt workflow retry loop
+   with 30-second sleeps between attempts and a `dist/` reset before
+   each retry — electron-builder's built-in retry only matches
+   DNS-resolution + file-lock errors, so Azure 5xx / throttling /
+   `SignerSign()` failures need workflow-level retry coverage.
 3. Asserts the Authenticode signature is `Valid` and signer CN equals
-   `AZURE_EXPECTED_PUBLISHER_NAME` for both:
-   - **Layer 1**: every `*.exe` and `*.dll` in the `dist/` staging tree
+   `AZURE_EXPECTED_PUBLISHER_NAME` across THREE layers:
+   - **Layer 1**: every `*.exe`/`*.dll` in the `dist/` staging tree
      (the wrapper installer + everything electron-builder signed in
      process).
-   - **Layer 2 (NEW for #772)**: every `*.exe` and `*.dll` extracted
-     FROM the NSIS installer payload via `7z x`. This is what the user
-     actually runs after install — SmartScreen, HVCI, Smart App Control,
-     and electron-updater's publisherName check all evaluate the
-     installed binaries, not the wrapper.
+   - **Layer 2a**: every `*.exe`/`*.dll` extracted from the outer NSIS
+     wrapper via `7z x` (NSIS plugin DLLs, uninstaller .exe, etc.).
+   - **Layer 2b (NEW for #772)**: every `*.exe`/`*.dll`/`*.node`
+     extracted from the embedded `app-*.7z` archive that NSIS unpacks
+     into `$INSTDIR` at install time. THIS is the binary tree the user
+     actually runs after install — SmartScreen, HVCI, Smart App
+     Control, and electron-updater's publisherName check all evaluate
+     these binaries, not the wrapper. Without Layer 2b a regression
+     to post-NSIS signing would re-introduce #772 invisibly.
 
 `win.signtoolOptions.publisherName` in `electron-builder.yml`
 (`WUPHF (installer stub)`) stays as the placeholder for PR builds, which

--- a/apps/installer-stub/electron-builder.yml
+++ b/apps/installer-stub/electron-builder.yml
@@ -65,6 +65,16 @@ win:
   # the release workflow only adds azureSignOptions on top via CLI.
   signtoolOptions:
     publisherName: WUPHF (installer stub)
+  # electron-builder 26 only signs `.exe` by default. Sign DLLs + native
+  # addons too — Electron apps include framework DLLs (Electron Framework,
+  # ffmpeg, etc.) and any future N-API native addons, all of which get
+  # checked by SmartScreen / HVCI / Smart App Control / electron-updater
+  # publisherName-bind. R2 codex (3 lenses converged) flagged this as
+  # BLOCK because the assert step was claiming "every .exe and .dll"
+  # signed while the config silently dropped DLLs.
+  signExts:
+    - .dll
+    - .node
   target:
     - target: nsis
       arch:

--- a/apps/installer-stub/electron-builder.yml
+++ b/apps/installer-stub/electron-builder.yml
@@ -47,11 +47,22 @@ mac:
 dmg:
   sign: false
 win:
-  # electron-builder 26.x removed top-level `win.publisherName` (deprecated
-  # in v25 with a warning). The new home is `win.signtoolOptions.publisherName`
-  # as a single string. The CI workflow overrides this at release-build
-  # time via `--config.win.signtoolOptions.publisherName="$AZURE_EXPECTED_PUBLISHER_NAME"`
-  # to bind the baked-in publisherName to the Azure cert's Authenticode CN.
+  # publisherName lives under `signtoolOptions` for PR builds (which don't
+  # actually sign — electron-builder skips signing when no cscLink or
+  # azureSignOptions is configured, but the publisherName is still baked
+  # into app-update.yml for electron-updater's later check).
+  #
+  # For RELEASE builds, the CI workflow injects
+  # `--config.win.azureSignOptions.*` via CLI, which (a) moves signing into
+  # electron-builder's packaging phase so binaries embedded in the NSIS
+  # payload get signed BEFORE NSIS bundles them — the #772 ship-blocker
+  # fix; and (b) binds publisherName to the Azure cert's Authenticode CN
+  # for app-update.yml consistency.
+  #
+  # azureSignOptions and signtoolOptions are mutually exclusive per the
+  # electron-builder schema; when both are set, azureSignOptions wins.
+  # That is why the static config keeps signtoolOptions for PR builds and
+  # the release workflow only adds azureSignOptions on top via CLI.
   signtoolOptions:
     publisherName: WUPHF (installer stub)
   target:


### PR DESCRIPTION
## Summary

P0 ship-blocker fix for issue #772: the previous workflow signed Windows artifacts in a separate post-NSIS step against `dist/**/*.exe,*.dll` with `Azure/trusted-signing-action`. That signed the wrapper installer + the unpacked staging tree, but the binaries embedded inside the NSIS payload kept their unsigned form. End users got a notarized-by-trust installer that, on launch, presented unsigned executables to SmartScreen, HVCI, Smart App Control, and electron-updater's `publisherName` check.

## Architecture

```mermaid
flowchart LR
  subgraph BEFORE [Before #772 — broken]
    A1[bun run build:win] --> A2[NSIS bundles<br/>UNSIGNED binaries]
    A2 --> A3[Azure/trusted-signing-action<br/>signs wrapper.exe + unpacked]
    A3 --> A4[Verify dist/*.exe,*.dll signed]
    A4 --> A5["latest.yml refresh<br/>(signed bytes)"]
  end
  subgraph AFTER [After #772 — correct]
    B1["bun run build:win<br/>--config.win.azureSignOptions.*"] --> B2[electron-builder signs<br/>each .exe / .dll inline]
    B2 --> B3[NSIS bundles<br/>SIGNED binaries]
    B3 --> B4["electron-builder signs<br/>wrapper installer<br/>(latest.yml inline)"]
    B4 --> B5[Verify dist/*.exe,*.dll signed]
    B5 --> B6[NEW: 7z extract NSIS,<br/>verify embedded binaries signed]
  end
```

## Changes

| File | Change |
|---|---|
| `apps/installer-stub/electron-builder.yml` | Documented why `win.signtoolOptions.publisherName` stays for PR builds while release builds layer azureSignOptions on top via CLI. |
| `.github/workflows/release-rewrite.yml` Build step | Pass `--config.win.azureSignOptions.{endpoint,codeSigningAccountName,certificateProfileName,publisherName}` to electron-builder. Auth env vars flow via Azure SDK's EnvironmentCredential. |
| `.github/workflows/release-rewrite.yml` (delete) | Removed 3 attempts of `Azure/trusted-signing-action` + retry sleeps + per-attempt diagnostics + flakiness warning + diagnostics artifact upload + `Refresh Windows update manifest after signing` step (electron-builder generates latest.yml from signed bytes inline). |
| `.github/workflows/release-rewrite.yml` Assert step | Verify TWO layers: (Layer 1, existing) every `.exe`/`.dll` in `dist/`; (Layer 2, NEW for #772) every `.exe`/`.dll` EXTRACTED from NSIS via `7z x`. |
| `apps/installer-stub/docs/runbooks/azure-trusted-signing-setup.md` | Rewrote Workflow Behavior + Smoke Test sections to reflect the in-electron-builder signing flow. |

## Test plan

- [x] Local: `bash apps/installer-stub/scripts/check-invariants.sh` + self-test
- [x] Local: `bunx js-yaml .github/workflows/release-rewrite.yml >/dev/null` (YAML syntax)
- [ ] **Manual**: push a `v0.0.X-rewrite` smoke tag and verify the release workflow:
  - electron-builder signs each `.exe`/`.dll` inline (visible in build log)
  - The Layer 2 NSIS extraction smoke passes (was the missing test that allowed #772 to slip)
  - `latest.yml` is generated from the signed bytes (no separate refresh step)
- [ ] **Manual**: download the published `.exe` and run `Get-AuthenticodeSignature` on Windows; confirm both the installer wrapper AND the extracted application binaries (in `%LOCALAPPDATA%\Programs\WUPHF (installer stub)\`) carry the same signer CN
- [x] Lefthook pre-push runs `installer-invariants` for both `apps/installer-stub/**` AND `.github/workflows/release-rewrite.yml`

## Out of scope (not addressed in this PR)

- The Windows packaged-runtime-deps gate is still `continue-on-error` for PR builds (per #780); fixing that is tracked at #781. This PR doesn't touch it.

Closes #772.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows signing workflow and verification process with enhanced validation across multiple release components
  * Refined Windows release configuration and supporting documentation for signing setup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/783)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->