### PR TITLE
docs(agents): orthogonal PR review process + script lenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 !/docs/surfaces_test.go
 !/docs/adr/
 !/docs/adr/**
+!/docs/agents/
+!/docs/agents/**
 !/docs/architecture/
 !/docs/architecture/**
 !/docs/dogfood/

--- a/docs/agents/INSTRUCTIONS.md
+++ b/docs/agents/INSTRUCTIONS.md
@@ -189,8 +189,9 @@ uncritically on small bug fixes or documentation-only changes.
 
 For PR-shaped reviews specifically (major dependency bumps, IPC surface
 changes, anything under `apps/desktop/AGENTS.md`'s hard rules), see
-[orthogonal-pr-review.md](./orthogonal-pr-review.md). It spells out the
-lens menu, codex-vs-Claude routing, and the round-2 adversarial rhythm.
+[docs/agents/orthogonal-pr-review.md](/docs/agents/orthogonal-pr-review.md).
+It spells out the lens menu, codex-vs-Claude routing, and the round-2
+adversarial rhythm.
 
 ### Sub-agent dispatch contract
 

--- a/docs/agents/INSTRUCTIONS.md
+++ b/docs/agents/INSTRUCTIONS.md
@@ -189,8 +189,8 @@ uncritically on small bug fixes or documentation-only changes.
 
 For PR-shaped reviews specifically (major dependency bumps, IPC surface
 changes, anything under `apps/desktop/AGENTS.md`'s hard rules), see
-`docs/agents/orthogonal-pr-review.md`. It spells out the lens menu,
-codex-vs-Claude routing, and the round-2 adversarial rhythm.
+[orthogonal-pr-review.md](./orthogonal-pr-review.md). It spells out the
+lens menu, codex-vs-Claude routing, and the round-2 adversarial rhythm.
 
 ### Sub-agent dispatch contract
 

--- a/docs/agents/INSTRUCTIONS.md
+++ b/docs/agents/INSTRUCTIONS.md
@@ -187,6 +187,11 @@ discipline.
 This rhythm is appropriate for protocol-grade work; do not impose it
 uncritically on small bug fixes or documentation-only changes.
 
+For PR-shaped reviews specifically (major dependency bumps, IPC surface
+changes, anything under `apps/desktop/AGENTS.md`'s hard rules), see
+`docs/agents/orthogonal-pr-review.md`. It spells out the lens menu,
+codex-vs-Claude routing, and the round-2 adversarial rhythm.
+
 ### Sub-agent dispatch contract
 
 When a human or AI delegates work to a sub-agent through `codex exec`, Claude's

--- a/docs/agents/orthogonal-pr-review.md
+++ b/docs/agents/orthogonal-pr-review.md
@@ -1,0 +1,176 @@
+# Orthogonal PR Review
+
+A multi-agent rhythm for reviewing a single PR through several
+narrowly-scoped lenses to catch issues that one reviewer would miss.
+
+This is a **PR-review** companion to the design-time pattern in
+`INSTRUCTIONS.md` ("Triangulation through orthogonal sub-agents") and
+the implementation rhythm ("Multi-round review rhythm"). The
+triangulation script at `scripts/dispatch-triangulation.sh` is the
+underlying mechanism; this doc adds a PR-shaped lens menu, dispatch
+guidance for mixed codex + Claude fleets, and the round-2 rhythm.
+
+## When to use
+
+- **Always**: major dependency bumps that touch the build chain (Vite,
+  electron-vite, TypeScript, vitest, electron itself, Node types).
+- **Always**: changes to the contextBridge allowlist, IPC surface, or
+  any rule under `apps/desktop/AGENTS.md`'s hard-rules list.
+- **Usually**: schema migrations, broker process changes, anything
+  affecting the release pipeline.
+- **Skip**: trivial refactors, doc-only changes, copy fixes, tests-only
+  PRs that don't change product code.
+
+## Lens menu
+
+Pick 5–7 lenses from this list. Each prompt enforces "YOUR LENS, AND
+ONLY THIS LENS" so coverage doesn't overlap. Pick a default model per
+lens to bias the fleet toward orthogonality (different models, not just
+different prompts).
+
+| # | Lens | Default model | What it checks |
+|---|---|---|---|
+| 1 | Type correctness | codex | Are type fixes the right fix, or do they mask real errors? |
+| 2 | Supply chain / lockfile | codex | New transitives, peer-dep mismatches, removed deps, integrity |
+| 3 | Build / runtime parity | codex | Does the build still produce equivalent output? Externalization preserved? |
+| 4 | Scope discipline | claude (`staff-code-reviewer`) | Is the diff narrowly the advertised change, no drive-bys? |
+| 5 | Repo conventions | codex | CLAUDE.md / AGENTS.md / INSTRUCTIONS.md compliance |
+| 6 | Security / IPC | codex | Allowlist intact? No `any` across contextBridge? Sandbox preserved? |
+| 7 | Test coverage equivalence | codex | Do tests still cover what they should? Versioning consistent? |
+| 8 | Beta / pre-release stability | codex | If pinning a beta: how risky, what's the upgrade path? |
+| 9 | Adversarial sweep | codex | "Assume earlier lenses missed something — what is it?" Always include. |
+
+Lenses 1–8 are about *finding the things*. Lens 9 is about *finding what
+the finders missed*. Round 2 is centered on lens 9.
+
+## Dispatch
+
+- **Default to codex** (`codex exec --skip-git-repo-check --cd <worktree>`).
+  Cheap, parallelizes well, runs fully non-interactive. Use it for
+  every lens unless there's a reason to prefer Claude.
+- **Use Claude Agents** (`staff-code-reviewer`, `general-purpose`) when:
+  - The lens benefits from instruction-following over raw analysis
+    (scope discipline, conventions checks).
+  - The lens needs cross-package context spanning more files than
+    codex's read window comfortably handles.
+  - You're rate-limited the other way (rare).
+- **Always run in parallel.** `Bash` with `run_in_background: true` for
+  codex; `Agent` with `run_in_background: true` for Claude. Dispatch
+  every lens in a single message of tool calls.
+- **Worktree, not main checkout.** Codex agents need the diff committed
+  on a branch they can `git diff origin/main...HEAD` against. Use
+  `git worktree add` so the user's primary workspace stays clean.
+
+### Prompt structure
+
+Each lens prompt follows the same shape so the fleet stays comparable:
+
+```text
+You are reviewing PR #<N> in <owner>/<repo>, branch `<branch>`. The PR
+<one-sentence stated scope>.
+
+YOUR LENS, AND ONLY THIS LENS: <single specific concern>
+
+Investigate:
+1. <numbered step with concrete file paths>
+2. <numbered step with verification command>
+3. ...
+
+Output (under <N> words):
+- Verdict: APPROVE / APPROVE-WITH-NITS / REQUEST-CHANGES
+- Findings (numbered, with file:line refs)
+- Recommended actions
+
+Do NOT comment on <other lenses>. Stay strictly on this lens.
+```
+
+Word cap: 250–400 words per lens. Anything longer means the lens is too
+broad — split it.
+
+## Synthesis
+
+After all lenses finish:
+
+1. **Aggregate verdicts.** Any single REQUEST-CHANGES makes the
+   aggregate REQUEST-CHANGES.
+2. **Distinguish blocking from nits.**
+   - **Blocking**: build/test/runtime regression; security regression;
+     scope creep; broken externalization; peer-dep contract violation.
+   - **Nit**: stylistic; future-proofing; non-actionable opinion; the
+     fix would create more risk than the issue.
+3. **Fix the blockers in the same PR.** Don't punt to follow-ups.
+4. **Document the nits in the PR body.** A future reader should see
+   what was caught and why it's acceptable.
+5. **Verify findings before acting.** Codex sometimes claims things
+   that look authoritative but are wrong (e.g., reading
+   `viteVersion` from `vitest/node` and concluding vitest runs on a
+   given vite version when it's actually a build-time constant). Read
+   the actual files before applying the fix.
+
+## Round 2
+
+After applying fixes, dispatch a **smaller, sharper** second round on
+the new commit:
+
+- **Drop** lenses whose findings are now invariant (scope, conventions,
+  any lens that returned APPROVE in round 1).
+- **Keep** lenses that touch the changed files (build parity, lockfile
+  delta if the fix re-installed deps).
+- **Always include adversarial sweep**: prompt it with a list of what
+  round 1 covered and tell it to find what was missed.
+
+Round 2 catches regressions introduced by the round-1 fixes.
+
+## Flow
+
+```mermaid
+flowchart TD
+  PR[PR ready for review] --> Worktree[git worktree add]
+  Worktree --> Pick[Pick 5–7 lenses]
+  Pick --> Dispatch1[Round 1: codex ✕ N + Agent ✕ M, in parallel]
+  Dispatch1 --> Verdicts1[Collect verdicts]
+  Verdicts1 --> Block1{Any blocking?}
+  Block1 -->|yes| Fix[Fix blockers in same PR]
+  Fix --> Dispatch2[Round 2: tighter lenses + adversarial]
+  Dispatch2 --> Verdicts2[Collect verdicts]
+  Verdicts2 --> Block2{Any blocking?}
+  Block2 -->|yes| Fix
+  Block2 -->|no| Doc[Document residual nits in PR body]
+  Block1 -->|no| Doc
+  Doc --> Merge[Merge]
+```
+
+## Anti-patterns
+
+- **Single-lens "give it a once-over"** defeats the purpose.
+- **Same model for every lens** defeats the orthogonality.
+- **Reviewing without a worktree** — agents need the diff committed.
+- **Trusting a verdict without verifying its evidence** — codex once
+  claimed vitest was running vite 7 based on a misread export; once
+  claimed vite 8 was working when the build had silently inlined the
+  electron installer shim. Verify.
+- **Stopping after round 1 finds blockers** — the fixes need their
+  own review.
+- **Letting nits become a review-blocking checklist** — distinguish
+  blocking from non-blocking firmly.
+
+## Worked example
+
+**PR #785** — `chore(desktop)(deps-dev): bump electron-vite, typescript,
+vite, @types/node`. Round 1 dispatched 5 codex + 1 Claude across 7
+lenses. Two independent codex agents (supply-chain, build parity) caught
+that vite 8 was out of contract with electron-vite 5: bun resolved both
+versions simultaneously, vitest used the nested vite 7, and the main +
+preload bundles inlined the npm electron installer shim instead of
+externalizing electron. Round 1 fix: bump electron-vite to 6.0.0-beta.1
+(the only published line declaring `vite: ^8`).
+
+Round 2 dispatched 5 codex on tighter lenses (beta stability, bundle
+parity vs main, lockfile delta from electron-vite 6, CSS handling under
+vite 8, adversarial sweep). Adversarial sweep found that vitest still
+resolved nested vite 7 because `packages/protocol` pins vitest 2 (whose
+peer is `vite ^5`). Round 2 fix: switched the renderer to
+`"types": ["vite/client"]` and documented the vitest-vite-7 split as
+acceptable until packages/protocol can move to vitest 4.
+
+The full review trace is in PR #785's body and comments.

--- a/docs/agents/orthogonal-pr-review.md
+++ b/docs/agents/orthogonal-pr-review.md
@@ -28,20 +28,47 @@ ONLY THIS LENS" so coverage doesn't overlap. Pick a default model per
 lens to bias the fleet toward orthogonality (different models, not just
 different prompts).
 
-| # | Lens | Default model | What it checks |
+| # | Lens (script name) | Default model | What it checks |
 |---|---|---|---|
-| 1 | Type correctness | codex | Are type fixes the right fix, or do they mask real errors? |
-| 2 | Supply chain / lockfile | codex | New transitives, peer-dep mismatches, removed deps, integrity |
-| 3 | Build / runtime parity | codex | Does the build still produce equivalent output? Externalization preserved? |
-| 4 | Scope discipline | claude (`staff-code-reviewer`) | Is the diff narrowly the advertised change, no drive-bys? |
-| 5 | Repo conventions | codex | CLAUDE.md / AGENTS.md / INSTRUCTIONS.md compliance |
-| 6 | Security / IPC | codex | Allowlist intact? No `any` across contextBridge? Sandbox preserved? |
-| 7 | Test coverage equivalence | codex | Do tests still cover what they should? Versioning consistent? |
-| 8 | Beta / pre-release stability | codex | If pinning a beta: how risky, what's the upgrade path? |
-| 9 | Adversarial sweep | codex | "Assume earlier lenses missed something — what is it?" Always include. |
+| 1 | Type correctness (`types`) | codex | Are type fixes the right fix, or do they mask real errors? |
+| 2 | Supply chain / lockfile (`supply-chain`) | codex | New transitives, peer-dep mismatches, removed deps, integrity |
+| 3 | Build / runtime parity (`build-parity`) | codex | Does the build still produce equivalent output? Externalization preserved? |
+| 4 | Scope discipline (`scope`) | claude (`staff-code-reviewer`) | Is the diff narrowly the advertised change, no drive-bys? |
+| 5 | Repo conventions (`conventions`) | codex | CLAUDE.md / AGENTS.md / INSTRUCTIONS.md compliance |
+| 6 | Security / IPC (`ipc`) | codex | Allowlist intact? No `any` across contextBridge? Sandbox preserved? |
+| 7 | Test coverage equivalence (`coverage`) | codex | Do tests still cover what they should? Versioning consistent? |
+| 8 | Beta / pre-release stability (`beta`) | codex | If pinning a beta: how risky, what's the upgrade path? |
+| 9 | Adversarial sweep (`adversarial`) | codex | "Assume earlier lenses missed something — what is it?" Always include. |
 
 Lenses 1–8 are about *finding the things*. Lens 9 is about *finding what
 the finders missed*. Round 2 is centered on lens 9.
+
+## Script invocation
+
+`scripts/dispatch-triangulation.sh` accepts every lens name above (plus the
+design-time lenses `security`, `perf`, `api`, `sre`, `architecture`,
+`distsys`, `electron`). Round-1 example for a `apps/desktop`
+dependency-bump PR:
+
+```bash
+# 1. Capture the PR scope + diff highlights in a problem file
+cat > /tmp/pr-785.md <<'EOF'
+PR #785 bumps apps/desktop dev-deps: typescript 6.0.3, vite 8.0.11,
+@types/node 25.6.2, electron-vite 6.0.0-beta.1. Diff at
+`git diff origin/main...HEAD -- apps/desktop bun.lock` in this worktree.
+EOF
+
+# 2. Dispatch in parallel; each lens writes <lens>-report.md
+bash scripts/dispatch-triangulation.sh \
+  --problem-file /tmp/pr-785.md \
+  --lenses "types,supply-chain,build-parity,scope,conventions,ipc,coverage,beta,adversarial" \
+  --output-dir /tmp/pr-785-r1
+```
+
+The script writes one `<lens>-report.md` per agent and a `SYNTHESIS.md`
+that groups findings by file:line co-occurrence (2+ reports = high-
+confidence). For Claude lenses (e.g. `scope`), spawn a Claude Agent
+separately — the script is codex-only.
 
 ## Dispatch
 

--- a/docs/agents/orthogonal-pr-review.md
+++ b/docs/agents/orthogonal-pr-review.md
@@ -58,17 +58,28 @@ PR #785 bumps apps/desktop dev-deps: typescript 6.0.3, vite 8.0.11,
 `git diff origin/main...HEAD -- apps/desktop bun.lock` in this worktree.
 EOF
 
-# 2. Dispatch in parallel; each lens writes <lens>-report.md
+# 2. Dispatch the codex-side lenses in parallel; each writes <lens>-report.md.
+#    `scope` is excluded here — it's Claude-default; see step 3.
 bash scripts/dispatch-triangulation.sh \
   --problem-file /tmp/pr-785.md \
-  --lenses "types,supply-chain,build-parity,scope,conventions,ipc,coverage,beta,adversarial" \
+  --lenses "types,supply-chain,build-parity,conventions,ipc,coverage,beta,adversarial" \
   --output-dir /tmp/pr-785-r1
+
+# 3. Dispatch the Claude-default lenses separately (the script is codex-only).
+#    Use the Agent tool with subagent_type=staff-code-reviewer for `scope`.
 ```
 
 The script writes one `<lens>-report.md` per agent and a `SYNTHESIS.md`
 that groups findings by file:line co-occurrence (2+ reports = high-
-confidence). For Claude lenses (e.g. `scope`), spawn a Claude Agent
-separately — the script is codex-only.
+confidence). The script invokes `codex exec` only; route Claude-default
+lenses (currently `scope`) through `Agent` separately so the fleet
+genuinely spans different models.
+
+**Note on the script's prompt template**: `compose_prompt()` in the
+script generates a generic prompt with a 1200-word cap, not the tighter
+shape shown under "Prompt structure" below. The tighter shape is what
+you should write when dispatching `codex exec` directly. The script's
+prompt is a fallback when callers haven't pre-written a per-lens prompt.
 
 ## Dispatch
 
@@ -90,7 +101,12 @@ separately — the script is codex-only.
 
 ### Prompt structure
 
-Each lens prompt follows the same shape so the fleet stays comparable:
+PR-review dispatches are read-only — the agent never commits — so the
+heavier "Sub-agent dispatch contract" in `INSTRUCTIONS.md` simplifies:
+the package `AGENTS.md` pointer and pasted hard rules still apply, but
+verification commands and the per-finding disposition table belong to
+the synthesizer, not the reviewer. Each lens prompt follows the same
+shape below so the fleet stays comparable:
 
 ```text
 You are reviewing PR #<N> in <owner>/<repo>, branch `<branch>`. The PR

--- a/scripts/dispatch-triangulation.sh
+++ b/scripts/dispatch-triangulation.sh
@@ -100,7 +100,7 @@ electron-builder patterns?
 ELECTRON_PREAMBLE
       ;;
     supply-chain)
-      printf '%s\n' "What new transitive deps does this lockfile diff introduce? Are peer-dep contracts intact for every direct dep that has peers? Any removed-but-still-referenced packages? Verify against npm with \`npm view <pkg>@<version> peerDependencies\`."
+      printf '%s\n' "What new transitive deps does this lockfile diff introduce? Are peer-dep contracts intact for every direct dep that has peers? Any removed-but-still-referenced packages? Verify against the registry with \`bun info <pkg>@<version> peerDependencies\` (the repo standardizes on bun tooling)."
       ;;
     build-parity)
       printf '%s\n' "Does the build still produce equivalent output to main? Are externals preserved (electron, node:* built-ins)? Read the actual built bundles. Any silent inlining, chunking change, or default drift between this diff and main?"
@@ -112,7 +112,7 @@ ELECTRON_PREAMBLE
       printf '%s\n' "Does this comply with CLAUDE.md, AGENTS.md, INSTRUCTIONS.md, and any package-level AGENTS.md? Any explicit \`any\`, ignore comments (\`@ts-ignore\`, \`biome-ignore\`), ASCII diagrams in PR body, secrets, or convention drift?"
       ;;
     ipc)
-      printf '%s\n' "Did the contextBridge allowlist change? Did any IPC surface gain new verbs? Is the sandbox preserved (\`sandbox: true\`, \`contextIsolation: true\`, \`nodeIntegration: false\`)? Did any 'app data over IPC' rule break? Read \`apps/desktop/src/preload\` and \`src/main/ipc\`."
+      printf '%s\n' "Did the contextBridge allowlist change? Did any IPC surface gain new verbs? Is the sandbox preserved (\`sandbox: true\`, \`contextIsolation: true\`, \`nodeIntegration: false\`)? Did any 'app data over IPC' rule break? Read \`apps/desktop/src/preload\`, \`apps/desktop/src/main/ipc\`, and \`apps/desktop/src/shared/api-contract.ts\`."
       ;;
     coverage)
       printf '%s\n' "Do the tests still cover what they should? Are versions consistent — does vitest resolve the same vite as the build? Any silently-weakened assertion (e.g., a cast that disables a real type check)? Run the actual test command and read its output."

--- a/scripts/dispatch-triangulation.sh
+++ b/scripts/dispatch-triangulation.sh
@@ -99,6 +99,30 @@ app-builder-bin's expectations? Where does this drift from canonical
 electron-builder patterns?
 ELECTRON_PREAMBLE
       ;;
+    supply-chain)
+      printf '%s\n' "What new transitive deps does this lockfile diff introduce? Are peer-dep contracts intact for every direct dep that has peers? Any removed-but-still-referenced packages? Verify against npm with \`npm view <pkg>@<version> peerDependencies\`."
+      ;;
+    build-parity)
+      printf '%s\n' "Does the build still produce equivalent output to main? Are externals preserved (electron, node:* built-ins)? Read the actual built bundles. Any silent inlining, chunking change, or default drift between this diff and main?"
+      ;;
+    scope)
+      printf '%s\n' "Is the diff narrowly the advertised change, or are there drive-by edits? Are unrelated files touched? Is each line minimal? Read the PR body and verify the diff matches it without overselling."
+      ;;
+    conventions)
+      printf '%s\n' "Does this comply with CLAUDE.md, AGENTS.md, INSTRUCTIONS.md, and any package-level AGENTS.md? Any explicit \`any\`, ignore comments (\`@ts-ignore\`, \`biome-ignore\`), ASCII diagrams in PR body, secrets, or convention drift?"
+      ;;
+    ipc)
+      printf '%s\n' "Did the contextBridge allowlist change? Did any IPC surface gain new verbs? Is the sandbox preserved (\`sandbox: true\`, \`contextIsolation: true\`, \`nodeIntegration: false\`)? Did any 'app data over IPC' rule break? Read \`apps/desktop/src/preload\` and \`src/main/ipc\`."
+      ;;
+    coverage)
+      printf '%s\n' "Do the tests still cover what they should? Are versions consistent — does vitest resolve the same vite as the build? Any silently-weakened assertion (e.g., a cast that disables a real type check)? Run the actual test command and read its output."
+      ;;
+    beta)
+      printf '%s\n' "If a beta/pre-release version is pinned: how risky is it? Any open issues on the project's tracker that affect this code? When did the beta publish, and is there a newer beta or rc? What's the re-pin path to GA?"
+      ;;
+    adversarial)
+      printf '%s\n' "Assume the other lenses missed something. Be skeptical, paranoid, contrarian. Find the issue that wasn't covered. Cross-package effects, CI/lockfile divergence, dev-mode-only regressions, beta version churn, anything subtle. Read what no one else read."
+      ;;
     *)
       return 1
       ;;


### PR DESCRIPTION
## Summary

Documents the multi-round, multi-lens, mixed-fleet review pattern used on #785 (`apps/desktop` dependency majors), and extends `scripts/dispatch-triangulation.sh` so the doc's lens menu is invocable from the CLI.

What this adds:

- **`docs/agents/orthogonal-pr-review.md`** — PR-shaped lens menu (9 lenses), codex-vs-Claude routing, round-2 adversarial rhythm, verification discipline, anti-patterns, the #785 worked example, and a `Script invocation` section with a round-1 command.
- **`scripts/dispatch-triangulation.sh`** — 8 new lens preambles (`supply-chain`, `build-parity`, `scope`, `conventions`, `ipc`, `coverage`, `beta`, `adversarial`) alongside the existing 8 design-time lenses.
- **One-line cross-reference** in `docs/agents/INSTRUCTIONS.md` so the new doc is discoverable from the existing rhythm doc.
- **`.gitignore` allowlist** for `docs/agents/**` (the directory was previously ignored despite `INSTRUCTIONS.md` being tracked from before the rule landed).

## Why it's separate from #785

The pattern was developed *during* the #785 review; documenting it inside #785 would have mixed dep-bump scope with process docs. This PR captures the pattern cleanly so future high-stakes PRs can run `bash scripts/dispatch-triangulation.sh --lenses types,supply-chain,build-parity,...` and follow the doc.

## Verified

- `bash -n scripts/dispatch-triangulation.sh` — clean
- All 16 case branches present (8 existing + 8 new)
- `--help` still renders
- Unknown lens still rejected (`dispatch-triangulation: unknown lens: <x>`)

## Test plan

- [ ] Mermaid renders on github.com
- [ ] Cross-reference link from `INSTRUCTIONS.md` resolves
- [ ] Reviewer sanity-check: lens menu coverage and prompt phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive orthogonal multi-agent PR review guide with lens menu, dispatch and synthesis rules, flowchart, anti-patterns, and example workflows.
  * Updated contributor instructions to reference the new PR review process for specified review cases.

* **Chores**
  * Extended review-dispatch tooling to support additional specialized lenses (supply-chain, build-parity, scope, conventions, ipc, coverage, beta, adversarial).
  * Adjusted ignore rules to exempt specific docs paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/787)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->