### PR TITLE
fix(review): refreshTick dep — SSE state_change now triggers re-fetch

### DIFF
--- a/web/src/components/review/ReviewQueueKanban.tsx
+++ b/web/src/components/review/ReviewQueueKanban.tsx
@@ -43,7 +43,7 @@ export default function ReviewQueueKanban() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [_refreshTick, setRefreshTick] = useState(0);
+  const [refreshTick, setRefreshTick] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -63,7 +63,7 @@ export default function ReviewQueueKanban() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [refreshTick]);
 
   useEffect(() => {
     const unsub = subscribeNotebookEvents((ev) => {


### PR DESCRIPTION
## Summary

- Renames `_refreshTick` → `refreshTick` (removes false "unused" signal)
- Adds `refreshTick` to the fetch effect's dependency array so `review:state_change` SSE events actually trigger re-fetches
- Also fixes the rollback path in `handleStateChange` — it increments the tick to re-fetch, but the empty dep array meant that increment was silently swallowed

## Changes

- `web/src/components/review/ReviewQueueKanban.tsx` — two-line fix

## Test plan

- [ ] Trigger a `review:state_change` SSE event; confirm ReviewQueue re-fetches
- [ ] Cause an `updateReviewState` API failure; confirm optimistic update rolls back via re-fetch
- [ ] No regression in Kanban column rendering or DnD behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)