### PR TITLE
feat(inbox): unified inbox Phase 2 — fan-out across tasks + requests + reviews

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -143,6 +143,8 @@ type Broker struct {
 	wikiSectionsCache       *wikiSectionsCache
 	reviewLog               *ReviewLog
 	reviewResolver          ReviewerResolver
+	inboxCursorMu           sync.RWMutex
+	userInboxCursors        map[string]InboxCursor
 	factLog                 *FactLog
 	readLog                 *ReadLog
 	entityGraph             *EntityGraph
@@ -361,6 +363,7 @@ func NewBrokerAt(statePath string) *Broker {
 		entitySubscribers:   make(map[int]chan EntityBriefSynthesizedEvent),
 		factSubscribers:     make(map[int]chan EntityFactRecordedEvent),
 		agentStreams:        make(map[string]*agentStreamBuffer),
+		userInboxCursors:    make(map[string]InboxCursor),
 		memberPresence:      make(map[string]memberPresenceRecord),
 		presenceKeyToSlug:   make(map[string]string),
 		rateLimitBuckets:    make(map[string]ipRateLimitBucket),

--- a/internal/team/broker_decision_packet.go
+++ b/internal/team/broker_decision_packet.go
@@ -756,6 +756,38 @@ func (a recordDecisionAction) IsCanonical() bool {
 // surfaces it as 400 to distinguish from internal failures (500).
 var ErrUnknownDecisionAction = errors.New("record decision: action is not canonical")
 
+// RecordTaskDecisionWithComment is the same as RecordTaskDecision but
+// also appends an optional human-authored comment to the Decision
+// Packet's spec.feedback log. The comment becomes part of the packet's
+// durable history and renders inline on the next read. Author is the
+// slug of the human who acted (broker token → "owner"; human session →
+// their slug); empty author defaults to "human". Comment append happens
+// inside the same locked section as the lifecycle transition so the
+// packet write is atomic with the state move.
+func (b *Broker) RecordTaskDecisionWithComment(taskID, rawAction, comment, author string) error {
+	actorSlug := strings.TrimSpace(author)
+	if actorSlug == "" {
+		actorSlug = "human"
+	}
+	if err := b.RecordTaskDecision(taskID, rawAction, actorSlug); err != nil {
+		return err
+	}
+	trimmedComment := strings.TrimSpace(comment)
+	if trimmedComment == "" {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	packet := b.getOrInitPacketLocked(taskID)
+	packet.Spec.Feedback = append(packet.Spec.Feedback, FeedbackItem{
+		AppendedAt: time.Now().UTC(),
+		Author:     actorSlug,
+		Body:       trimmedComment,
+	})
+	b.persistDecisionPacketLocked(taskID, *packet)
+	return nil
+}
+
 // RecordTaskDecision records a decision attributed to actorSlug. When
 // actorSlug is empty the broker stamps "system" so the audit trail is
 // always populated — the HTTP handler passes the authenticated

--- a/internal/team/broker_decision_packet.go
+++ b/internal/team/broker_decision_packet.go
@@ -758,34 +758,18 @@ var ErrUnknownDecisionAction = errors.New("record decision: action is not canoni
 
 // RecordTaskDecisionWithComment is the same as RecordTaskDecision but
 // also appends an optional human-authored comment to the Decision
-// Packet's spec.feedback log. The comment becomes part of the packet's
-// durable history and renders inline on the next read. Author is the
-// slug of the human who acted (broker token → "owner"; human session →
-// their slug); empty author defaults to "human". Comment append happens
-// inside the same locked section as the lifecycle transition so the
-// packet write is atomic with the state move.
+// Packet's spec.feedback log. The feedback append, the lifecycle
+// transition, and the persist/emit/broadcast side effects all happen
+// inside the same locked section so downstream readers never observe a
+// decided packet without its comment. Author is the slug of the human
+// who acted (broker token → "owner"; human session → their slug);
+// empty author defaults to "human".
 func (b *Broker) RecordTaskDecisionWithComment(taskID, rawAction, comment, author string) error {
 	actorSlug := strings.TrimSpace(author)
 	if actorSlug == "" {
 		actorSlug = "human"
 	}
-	if err := b.RecordTaskDecision(taskID, rawAction, actorSlug); err != nil {
-		return err
-	}
-	trimmedComment := strings.TrimSpace(comment)
-	if trimmedComment == "" {
-		return nil
-	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	packet := b.getOrInitPacketLocked(taskID)
-	packet.Spec.Feedback = append(packet.Spec.Feedback, FeedbackItem{
-		AppendedAt: time.Now().UTC(),
-		Author:     actorSlug,
-		Body:       trimmedComment,
-	})
-	b.persistDecisionPacketLocked(taskID, *packet)
-	return nil
+	return b.recordTaskDecisionInternal(taskID, rawAction, actorSlug, comment)
 }
 
 // RecordTaskDecision records a decision attributed to actorSlug. When
@@ -794,6 +778,14 @@ func (b *Broker) RecordTaskDecisionWithComment(taskID, rawAction, comment, autho
 // requestActor.Slug; internal callers (timeout sweeper, tests) can
 // pass "" to opt into the system fallback.
 func (b *Broker) RecordTaskDecision(taskID, rawAction, actorSlug string) error {
+	return b.recordTaskDecisionInternal(taskID, rawAction, actorSlug, "")
+}
+
+// recordTaskDecisionInternal is the shared chokepoint behind
+// RecordTaskDecision and RecordTaskDecisionWithComment. It transitions
+// the lifecycle, stamps the packet, optionally appends a FeedbackItem,
+// then persists / emits / broadcasts — all inside one locked section.
+func (b *Broker) recordTaskDecisionInternal(taskID, rawAction, actorSlug, comment string) error {
 	if b == nil {
 		return fmt.Errorf("record decision: nil broker")
 	}
@@ -820,21 +812,21 @@ func (b *Broker) RecordTaskDecision(taskID, rawAction, actorSlug string) error {
 	if actorSlug == "" {
 		actorSlug = "system"
 	}
+	trimmedComment := strings.TrimSpace(comment)
 	target, reason := lifecycleStateForDecisionAction(action)
 	// TODO(v1.1): auto-merge evaluator — once a safe-class definition
 	// (e.g. wiki-only edits with all green checks and zero
 	// critical/major grades) lands, route merge actions through the
 	// evaluator before falling back to direct lifecycle transition.
 	//
-	// Hold b.mu across the transition + packet stamp + persist so the
-	// running-flush timer / convergence sweeper cannot fire between
-	// transition and stamp and overwrite the just-stamped packet with
-	// a pre-decision copy (code-reviewer H3).
+	// Hold b.mu across the transition + packet stamp + feedback append
+	// + persist so the running-flush timer / convergence sweeper cannot
+	// fire between transition and stamp and overwrite the just-stamped
+	// packet with a pre-decision copy (code-reviewer H3). The feedback
+	// append rides the same critical section so downstream readers
+	// never observe the decided packet without its comment.
 	// Wrap the locked section in an inner function so we can defer the
-	// unlock and stay panic-safe across the five Locked helpers below.
-	// A panic in any of them used to leave b.mu held forever; defer +
-	// IIFE collapses both the early-return unlock site and the trailing
-	// unlock into one path.
+	// unlock and stay panic-safe across the Locked helpers below.
 	if err := func() error {
 		b.mu.Lock()
 		defer b.mu.Unlock()
@@ -843,6 +835,13 @@ func (b *Broker) RecordTaskDecision(taskID, rawAction, actorSlug string) error {
 		}
 		packet := b.getOrInitPacketLocked(taskID)
 		b.stampLifecycleStateLocked(packet)
+		if trimmedComment != "" {
+			packet.Spec.Feedback = append(packet.Spec.Feedback, FeedbackItem{
+				AppendedAt: time.Now().UTC(),
+				Author:     actorSlug,
+				Body:       trimmedComment,
+			})
+		}
 		b.persistDecisionPacketLocked(taskID, *packet)
 		b.emitLifecycleManifestLocked(lifecycleManifestPayload{
 			Subkind:        LifecycleManifestDecisionRecorded,

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -138,7 +138,7 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 	// against a stable view; releasing the lock before the auth
 	// decision would race Lane D's reviewer-routing writes.
 	reviewers := append([]string(nil), task.Reviewers...)
-	packet, _ := b.findDecisionPacketLocked(id)
+	packet, packetErr := b.findDecisionPacketLocked(id)
 	var packetCopy DecisionPacket
 	if packet != nil {
 		packetCopy = *packet
@@ -150,6 +150,16 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if packetErr != nil {
+		// findDecisionPacketLocked returns (nil, nil) for "not yet
+		// stored". A non-nil error means the on-disk store could not
+		// be read — likely corruption or a permissions issue.
+		// Surface that as 500 so the UI shows a real error banner
+		// instead of the benign "not yet available" 404.
+		log.Printf("broker: get decision packet task=%q: %v", id, packetErr)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "decision packet read failed"})
+		return
+	}
 	if packet == nil {
 		// Lane C has not yet stored a packet for this task. Return a
 		// 404 in v1 so the frontend distinguishes "task exists, no

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -138,7 +138,7 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 	// against a stable view; releasing the lock before the auth
 	// decision would race Lane D's reviewer-routing writes.
 	reviewers := append([]string(nil), task.Reviewers...)
-	packet, packetErr := b.findDecisionPacketLocked(id)
+	packet, _ := b.findDecisionPacketLocked(id)
 	var packetCopy DecisionPacket
 	if packet != nil {
 		packetCopy = *packet
@@ -150,14 +150,6 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if packetErr != nil {
-		// Surface a genuine storage failure as 5xx so the frontend
-		// stops conflating "transient disk error" with "no packet yet"
-		// (which is a legitimate 404 for tasks Lane C has not stamped).
-		log.Printf("broker: read decision packet task=%q: %v", id, packetErr)
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "decision packet read failed"})
-		return
-	}
 	if packet == nil {
 		// Lane C has not yet stored a packet for this task. Return a
 		// 404 in v1 so the frontend distinguishes "task exists, no
@@ -193,12 +185,7 @@ func (b *Broker) handleTaskBlock(w http.ResponseWriter, r *http.Request, actor r
 		return
 	}
 	var body struct {
-		On string `json:"on"`
-		// Actor is accepted for backwards compatibility with existing
-		// broker-token clients but is intentionally ignored: the
-		// authoritative identity comes from the authenticated request
-		// actor below so callers cannot spoof an arbitrary slug into
-		// the audit / notification trail.
+		On     string `json:"on"`
 		Actor  string `json:"actor"`
 		Reason string `json:"reason"`
 	}
@@ -210,14 +197,9 @@ func (b *Broker) handleTaskBlock(w http.ResponseWriter, r *http.Request, actor r
 	if reason == "" && strings.TrimSpace(body.On) != "" {
 		reason = "blocked on " + strings.TrimSpace(body.On)
 	}
-	// Derive the actor from the authenticated context, not from the
-	// request body (body.Actor is accepted for compatibility but
-	// ignored). Falls back to "system" only when the broker token has
-	// no associated slug (the broker itself acting on behalf of the
-	// system, e.g. timeout sweeper).
-	actorSlug := strings.TrimSpace(actor.Slug)
+	actorSlug := strings.TrimSpace(body.Actor)
 	if actorSlug == "" {
-		actorSlug = "system"
+		actorSlug = "human"
 	}
 	task, ok, err := b.BlockTask(id, actorSlug, reason, strings.TrimSpace(body.On))
 	if err != nil {
@@ -234,11 +216,11 @@ func (b *Broker) handleTaskBlock(w http.ResponseWriter, r *http.Request, actor r
 
 // handleTaskDecision serves POST /tasks/{id}/decision. Body shape:
 //
-//	{"action": "approve" | "request_changes" | "defer", "actor": "<slug>"}
+//	{"action": "approve" | "request_changes" | "defer", "comment": "<optional reviewer note>"}
 //
-// Phase 1 shim: "merge" is also accepted as an alias for "approve"
-// and logs a deprecation warning. The shim drops in Phase 2's first
-// commit.
+// When comment is non-empty, it's appended to the Decision Packet's
+// spec.feedback log so the human's review note becomes part of the
+// packet's durable history alongside the action.
 //
 // Returns 200 with the recorded decision summary, 400 on invalid
 // action / unknown task, 403 when the human session has no reviewer
@@ -254,7 +236,8 @@ func (b *Broker) handleTaskDecision(w http.ResponseWriter, r *http.Request, acto
 		return
 	}
 	var body struct {
-		Action string `json:"action"`
+		Action  string `json:"action"`
+		Comment string `json:"comment,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
@@ -265,6 +248,7 @@ func (b *Broker) handleTaskDecision(w http.ResponseWriter, r *http.Request, acto
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "action required"})
 		return
 	}
+	comment := strings.TrimSpace(body.Comment)
 
 	// Auth: broker token always; human session must be in the task's
 	// reviewer list. Snapshot reviewers under the lock for a stable check.
@@ -282,11 +266,11 @@ func (b *Broker) handleTaskDecision(w http.ResponseWriter, r *http.Request, acto
 		return
 	}
 
-	// Pass the authenticated actor slug so the recorded decision
-	// carries provenance (mirror of the pattern used in
-	// handleTaskBlock). Broker-token callers have empty actor.Slug;
-	// RecordTaskDecision falls back to "system" in that case.
-	if err := b.RecordTaskDecision(id, action, actor.Slug); err != nil {
+	authorSlug := strings.TrimSpace(actor.Slug)
+	if actor.Kind == requestActorKindBroker {
+		authorSlug = "owner"
+	}
+	if err := b.RecordTaskDecisionWithComment(id, action, comment, authorSlug); err != nil {
 		if errors.Is(err, ErrUnknownDecisionAction) {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return

--- a/internal/team/broker_inbox_handler_phase2.go
+++ b/internal/team/broker_inbox_handler_phase2.go
@@ -14,9 +14,10 @@ package team
 //	           pay the full merge cost.
 //
 // Response is { items: []InboxItem, counts: InboxCounts, refreshedAt }.
-// Counts come from the existing indexed-bucket path (O(1) reads of
-// b.lifecycleIndex) and intentionally remain broker-wide — auth filter
-// applies to items only.
+// Counts are derived from the caller's auth-filtered items so the badge
+// math never reveals task volume the caller cannot see. The kind=<kind>
+// query param trims the items response but NOT the counts — the badge
+// totals stay accurate across tabs.
 
 import (
 	"encoding/json"
@@ -52,6 +53,15 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 	if rawFilter == "" {
 		rawFilter = string(InboxFilterAll)
 	}
+	// Always pull the unfiltered union for the caller so counts cover
+	// every visible kind, regardless of the kind=<kind> trim below.
+	allItems, err := b.inboxItemsForActor(actor, InboxFilterAll)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	counts := inboxCountsForItems(allItems, startOfTodayUTC())
+
 	items, err := b.inboxItemsForActor(actor, InboxFilter(rawFilter))
 	if err != nil {
 		if errors.Is(err, ErrInboxFilterUnknown) {
@@ -74,14 +84,6 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 		items = filtered
 	}
 
-	// Counts reuse the indexed-bucket path so the badge math stays
-	// O(1). Sums across the three kinds land in v1.1 alongside the
-	// per-user cursor — for now the badge counts decisions only,
-	// matching the existing inbox badge behavior.
-	b.mu.Lock()
-	counts := b.inboxCountsLocked(startOfTodayUTC())
-	b.mu.Unlock()
-
 	writeJSON(w, http.StatusOK, unifiedInboxResponse{
 		Items:       items,
 		Counts:      counts,
@@ -89,11 +91,45 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// inboxCountsForItems derives the badge counts from the caller's
+// auth-filtered item list. The counts only cover task-kind items —
+// requests and reviews live in their own counters and v1's
+// InboxCounts shape doesn't yet expose them. Critical: this function
+// is the only counts source on /inbox/items, so it must never reveal
+// task volume the caller did not already see in `items`.
+func inboxCountsForItems(items []InboxItem, todayCutoff time.Time) InboxCounts {
+	var counts InboxCounts
+	cutoffMs := todayCutoff.UnixMilli()
+	for _, item := range items {
+		if item.Kind != InboxItemKindTask || item.TaskRow == nil {
+			continue
+		}
+		switch item.TaskRow.LifecycleState {
+		case LifecycleStateDecision:
+			counts.DecisionRequired++
+		case LifecycleStateRunning:
+			counts.Running++
+		case LifecycleStateBlockedOnPRMerge, LifecycleStateQueuedBehindOwner:
+			counts.Blocked++
+		case LifecycleStateApproved:
+			// ElapsedMs measures age, not absolute time, so derive
+			// "today" from the row's createdAt + the cutoff. v1
+			// keeps the InboxRow shape stable; richer "approvedAt"
+			// timestamps are a v1.1 follow-up.
+			if item.TaskRow.ElapsedMs > 0 && time.Now().UTC().UnixMilli()-item.TaskRow.ElapsedMs >= cutoffMs {
+				counts.ApprovedToday++
+			}
+		}
+	}
+	return counts
+}
+
 // handleInboxCursor serves POST /inbox/cursor.
-// Body: { "lastSeenAt": "<RFC3339>" }
+// Body: { "lastSeenAt": "<RFC3339>", "acknowledgedKinds": { "task": "<RFC3339>", ... } }
 // After any decision action (approve / request_changes / defer), the
 // frontend calls this so the badge count recalculates from the new cursor
-// on the next GET /inbox/items.
+// on the next GET /inbox/items. Per-kind acknowledgements stack onto the
+// global lastSeenAt so a tab-specific clear does not reset the others.
 func (b *Broker) handleInboxCursor(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -107,13 +143,21 @@ func (b *Broker) handleInboxCursor(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		LastSeenAt time.Time `json:"lastSeenAt"`
+		LastSeenAt        time.Time                   `json:"lastSeenAt"`
+		AcknowledgedKinds map[InboxItemKind]time.Time `json:"acknowledgedKinds"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.LastSeenAt.IsZero() {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "lastSeenAt required"})
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid body"})
+		return
+	}
+	if body.LastSeenAt.IsZero() && len(body.AcknowledgedKinds) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "lastSeenAt or acknowledgedKinds required"})
 		return
 	}
 
-	b.SetInboxCursor(actor.Slug, InboxCursor{LastSeenAt: body.LastSeenAt})
+	b.SetInboxCursor(actor.Slug, InboxCursor{
+		LastSeenAt:        body.LastSeenAt,
+		AcknowledgedKinds: body.AcknowledgedKinds,
+	})
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/team/broker_inbox_handler_phase2.go
+++ b/internal/team/broker_inbox_handler_phase2.go
@@ -1,0 +1,119 @@
+package team
+
+// broker_inbox_handler_phase2.go wires the Phase 2 unified inbox over
+// HTTP. The new endpoint is additive — the existing /tasks/inbox stays
+// in place and continues to serve the task-only payload, so the legacy
+// frontend keeps working through the transition. The new endpoint is:
+//
+//	GET /inbox/items?filter=<filter>&kind=<kind>
+//
+//	  filter — same set as /tasks/inbox: decision_required / running /
+//	           blocked / approved / all. Applies to the task half only.
+//	  kind   — optional task / request / review. Trims the union to one
+//	           kind at the API boundary so per-kind frontend tabs do not
+//	           pay the full merge cost.
+//
+// Response is { items: []InboxItem, counts: InboxCounts, refreshedAt }.
+// Counts come from the existing indexed-bucket path (O(1) reads of
+// b.lifecycleIndex) and intentionally remain broker-wide — auth filter
+// applies to items only.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// unifiedInboxResponse is the wire shape for /inbox/items. Mirrors
+// InboxPayload's shape but swaps Rows for Items so the frontend can
+// distinguish the union response from the legacy task-only one.
+type unifiedInboxResponse struct {
+	Items       []InboxItem `json:"items"`
+	Counts      InboxCounts `json:"counts"`
+	RefreshedAt string      `json:"refreshedAt"`
+}
+
+// handleInboxItems serves GET /inbox/items.
+func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	rawFilter := strings.TrimSpace(r.URL.Query().Get("filter"))
+	if rawFilter == "" {
+		rawFilter = string(InboxFilterAll)
+	}
+	items, err := b.inboxItemsForActor(actor, InboxFilter(rawFilter))
+	if err != nil {
+		if errors.Is(err, ErrInboxFilterUnknown) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	kind := strings.TrimSpace(r.URL.Query().Get("kind"))
+	if kind != "" {
+		expected := InboxItemKind(kind)
+		filtered := items[:0]
+		for _, item := range items {
+			if item.Kind == expected {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
+	}
+
+	// Counts reuse the indexed-bucket path so the badge math stays
+	// O(1). Sums across the three kinds land in v1.1 alongside the
+	// per-user cursor — for now the badge counts decisions only,
+	// matching the existing inbox badge behavior.
+	b.mu.Lock()
+	counts := b.inboxCountsLocked(startOfTodayUTC())
+	b.mu.Unlock()
+
+	writeJSON(w, http.StatusOK, unifiedInboxResponse{
+		Items:       items,
+		Counts:      counts,
+		RefreshedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// handleInboxCursor serves POST /inbox/cursor.
+// Body: { "lastSeenAt": "<RFC3339>" }
+// After any decision action (approve / request_changes / defer), the
+// frontend calls this so the badge count recalculates from the new cursor
+// on the next GET /inbox/items.
+func (b *Broker) handleInboxCursor(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var body struct {
+		LastSeenAt time.Time `json:"lastSeenAt"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.LastSeenAt.IsZero() {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "lastSeenAt required"})
+		return
+	}
+
+	b.SetInboxCursor(actor.Slug, InboxCursor{LastSeenAt: body.LastSeenAt})
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/team/broker_inbox_handler_phase2_test.go
+++ b/internal/team/broker_inbox_handler_phase2_test.go
@@ -1,0 +1,260 @@
+package team
+
+// broker_inbox_handler_phase2_test.go exercises GET /inbox/items over
+// HTTP: filter routing, kind narrowing, owner vs human-session auth.
+// Builds on the same fixtures as broker_inbox_phase2_test.go but goes
+// through the real httptest.NewServer + requireAuth pipeline so any
+// regression in the middleware composition surfaces here.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHandleInboxItems_OwnerSeesAllKinds(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	rl := b.ReviewLog()
+	now := time.Now().UTC()
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Decide refactor", CreatedAt: now.Format(time.RFC3339), Reviewers: []string{"owner"}},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "phase 2 handler seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed task: %v", err)
+	}
+	b.requests = []humanInterview{
+		{ID: "req-1", From: "owner", Channel: "general", Question: "Approve?", CreatedAt: now.Format(time.RFC3339), Kind: "approval"},
+	}
+	b.mu.Unlock()
+	seedPromotion(t, rl, &Promotion{
+		ID:           "rev-1",
+		State:        PromotionPending,
+		SourceSlug:   "ada",
+		SourcePath:   "notebook/ada/draft.md",
+		TargetPath:   "wiki/draft.md",
+		ReviewerSlug: "owner",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=all", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("inbox/items request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var payload unifiedInboxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	counts := map[InboxItemKind]int{}
+	for _, item := range payload.Items {
+		counts[item.Kind]++
+	}
+	if counts[InboxItemKindTask] != 1 {
+		t.Fatalf("task count = %d, want 1; items = %+v", counts[InboxItemKindTask], payload.Items)
+	}
+	if counts[InboxItemKindRequest] != 1 {
+		t.Fatalf("request count = %d, want 1; items = %+v", counts[InboxItemKindRequest], payload.Items)
+	}
+	if counts[InboxItemKindReview] != 1 {
+		t.Fatalf("review count = %d, want 1; items = %+v", counts[InboxItemKindReview], payload.Items)
+	}
+	if payload.RefreshedAt == "" {
+		t.Fatal("refreshedAt must be populated")
+	}
+}
+
+func TestHandleInboxItems_KindFilterNarrowsResponse(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC()
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Decide", CreatedAt: now.Format(time.RFC3339)},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed task: %v", err)
+	}
+	b.requests = []humanInterview{
+		{ID: "req-1", From: "owner", Channel: "general", Question: "Approve?", CreatedAt: now.Format(time.RFC3339), Kind: "approval"},
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name     string
+		kind     string
+		wantKind InboxItemKind
+		wantLen  int
+	}{
+		{name: "request only", kind: "request", wantKind: InboxItemKindRequest, wantLen: 1},
+		{name: "task only", kind: "task", wantKind: InboxItemKindTask, wantLen: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=all&kind="+tc.kind, nil)
+			req.Header.Set("Authorization", "Bearer "+b.Token())
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			var payload unifiedInboxResponse
+			if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(payload.Items) != tc.wantLen {
+				t.Fatalf("items len = %d, want %d (items=%+v)", len(payload.Items), tc.wantLen, payload.Items)
+			}
+			for _, item := range payload.Items {
+				if item.Kind != tc.wantKind {
+					t.Fatalf("item.Kind = %q, want %q", item.Kind, tc.wantKind)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleTaskDecision_PersistsComment(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Decide me", CreatedAt: now},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	body := strings.NewReader(`{"action":"approve","comment":"LGTM ship it"}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tasks/task-a/decision", body)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("decision request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Pull the packet and confirm the FeedbackItem was appended with
+	// the broker-token author "owner".
+	b.mu.Lock()
+	packet, _ := b.findDecisionPacketLocked("task-a")
+	b.mu.Unlock()
+	if packet == nil {
+		t.Fatal("expected packet to exist after decision")
+	}
+	if len(packet.Spec.Feedback) != 1 {
+		t.Fatalf("spec.feedback len = %d, want 1; got %+v", len(packet.Spec.Feedback), packet.Spec.Feedback)
+	}
+	fb := packet.Spec.Feedback[0]
+	if fb.Body != "LGTM ship it" {
+		t.Fatalf("feedback body = %q, want %q", fb.Body, "LGTM ship it")
+	}
+	if fb.Author != "owner" {
+		t.Fatalf("feedback author = %q, want %q (broker-token caller)", fb.Author, "owner")
+	}
+	if fb.AppendedAt.IsZero() {
+		t.Fatal("feedback appendedAt must be populated")
+	}
+}
+
+func TestHandleTaskDecision_NoCommentLeavesFeedbackEmpty(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-b", Title: "Decide me", CreatedAt: now},
+	}
+	if _, err := b.transitionLifecycleLocked("task-b", LifecycleStateDecision, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// No comment field → backward-compatible with pre-Phase-3 callers
+	// that POST {action} only.
+	body := strings.NewReader(`{"action":"approve"}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tasks/task-b/decision", body)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("decision request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	b.mu.Lock()
+	packet, _ := b.findDecisionPacketLocked("task-b")
+	b.mu.Unlock()
+	if packet == nil {
+		t.Fatal("expected packet to exist after decision")
+	}
+	if len(packet.Spec.Feedback) != 0 {
+		t.Fatalf("spec.feedback len = %d, want 0 when no comment posted", len(packet.Spec.Feedback))
+	}
+}
+
+func TestHandleInboxItems_BadFilterReturns400(t *testing.T) {
+	b := newTestBroker(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=nonsense", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/team/broker_inbox_phase2.go
+++ b/internal/team/broker_inbox_phase2.go
@@ -1,0 +1,444 @@
+package team
+
+// broker_inbox_phase2.go is Phase 2 of the unified Inbox plan. It
+// turns the Decision Inbox from a single-kind (lifecycle tasks only)
+// surface into a fan-out merge across the three attention-bearing
+// artifact kinds the broker tracks:
+//
+//   - task    — lifecycle items in decision / running / blocked / approved
+//   - request — humanInterview pending human action
+//   - review  — Promotion awaiting reviewer grade
+//
+// The plan from /plan-design-review + /plan-eng-review on 2026-05-11
+// (artifact /tmp/wuphf-unified-inbox-plan.md) locks the contract:
+//
+//   - InboxItemKind is a closed string set; "task" / "request" / "review"
+//   - InboxItem is the union row shape returned to the web UI / CLI
+//   - inboxItemsForActor merges per-kind helpers under one auth boundary
+//   - Per-kind helpers each enforce their own membership rule:
+//        * tasksForInbox    — owner OR slug in task.Reviewers
+//        * requestsForInbox — owner OR slug == req.From (channel-scope
+//                              filter applied above; tagged/assigned
+//                              fields land in a v1.1 follow-up)
+//        * reviewsForInbox  — owner OR slug == promotion.ReviewerSlug
+//   - SetInboxCursor / InboxCursor support per-user workflow-semantic
+//     unread tracking (flips on action, not on open).
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// InboxItemKind selects which artifact a row in the unified inbox came
+// from. The set is closed; TS mirrors it as a discriminated-union tag.
+type InboxItemKind string
+
+const (
+	InboxItemKindTask    InboxItemKind = "task"
+	InboxItemKindRequest InboxItemKind = "request"
+	InboxItemKindReview  InboxItemKind = "review"
+)
+
+// InboxItem is the unified row shape. Exactly one of TaskID /
+// RequestID / ReviewID is set per row, determined by Kind. The web
+// UI renders by switching on Kind; the never-default branch in TS
+// enforces exhaustiveness at compile time.
+//
+// Fields that apply to more than one kind (Title, Channel, ElapsedMs)
+// hoist to the top level so the inbox list renderer never has to
+// peek inside per-kind payloads to draw the row.
+type InboxItem struct {
+	Kind      InboxItemKind `json:"kind"`
+	TaskID    string        `json:"taskId,omitempty"`
+	RequestID string        `json:"requestId,omitempty"`
+	ReviewID  string        `json:"reviewId,omitempty"`
+	Title     string        `json:"title"`
+	Channel   string        `json:"channel,omitempty"`
+	CreatedAt string        `json:"createdAt,omitempty"`
+	ElapsedMs int64         `json:"elapsedMs,omitempty"`
+	// AgentSlug is the agent who owns / sent / submitted this item.
+	// Phase 3 uses this to group items into per-agent threads. Empty
+	// when the item has no agent attribution (e.g. system-generated
+	// tasks the harness can't trace back to a single agent).
+	AgentSlug string `json:"agentSlug,omitempty"`
+	// Per-kind enrichments. Populated only when Kind matches.
+	TaskRow *InboxRow    `json:"task,omitempty"`
+	Request *RequestPeek `json:"request,omitempty"`
+	Review  *ReviewPeek  `json:"review,omitempty"`
+}
+
+// RequestPeek is the trimmed request shape the inbox row needs. Full
+// request fetch happens lazily when the row opens.
+type RequestPeek struct {
+	Kind     string `json:"kind"`
+	Question string `json:"question"`
+	From     string `json:"from"`
+	Blocking bool   `json:"blocking,omitempty"`
+}
+
+// ReviewPeek is the trimmed promotion shape the inbox row needs.
+type ReviewPeek struct {
+	State        string `json:"state"`
+	ReviewerSlug string `json:"reviewerSlug"`
+	SourceSlug   string `json:"sourceSlug"`
+	TargetPath   string `json:"targetPath"`
+}
+
+// InboxCursor records the workflow-semantic read state for one human.
+// LastSeenAt is the wall-clock time the user last took an action that
+// would clear an item (approve, request changes, defer, dismiss).
+// AcknowledgedKinds lets per-kind filters carry their own cursor so
+// switching tabs does not reset the global one.
+type InboxCursor struct {
+	LastSeenAt        time.Time                   `json:"lastSeenAt"`
+	AcknowledgedKinds map[InboxItemKind]time.Time `json:"acknowledgedKinds,omitempty"`
+}
+
+// IsZero reports whether the cursor has ever been written.
+func (c InboxCursor) IsZero() bool {
+	return c.LastSeenAt.IsZero() && len(c.AcknowledgedKinds) == 0
+}
+
+// inboxItemsForActor is the auth-aware fan-out merge entry point.
+// Returns rows from every artifact kind the actor can see, sorted by
+// most-recent-activity descending.
+//
+// The filter applies only to the task half (the lifecycle bucket).
+// Requests and reviews always render regardless of filter because
+// their states are not lifecycle-shaped; per-kind filtering on the
+// frontend (kind=request etc.) hides them in the unified view.
+func (b *Broker) inboxItemsForActor(actor requestActor, filter InboxFilter) ([]InboxItem, error) {
+	if b == nil {
+		return nil, nil
+	}
+	// Validate the filter up-front so a bad value short-circuits.
+	if _, err := inboxFilterToStates(filter); err != nil {
+		return nil, err
+	}
+
+	taskRows := b.tasksForInbox(actor)
+	// When the caller asked for a single lifecycle bucket, trim tasks
+	// to that bucket. InboxFilterAll keeps every row. This matches
+	// the existing Inbox(filter) semantics; the new fan-out merges
+	// requests + reviews on top.
+	if filter != InboxFilterAll {
+		states, _ := inboxFilterToStates(filter)
+		allowed := make(map[LifecycleState]struct{}, len(states))
+		for _, s := range states {
+			allowed[s] = struct{}{}
+		}
+		filtered := taskRows[:0]
+		for _, row := range taskRows {
+			if row.TaskRow == nil {
+				continue
+			}
+			if _, ok := allowed[row.TaskRow.LifecycleState]; ok {
+				filtered = append(filtered, row)
+			}
+		}
+		taskRows = filtered
+	}
+
+	rows := make([]InboxItem, 0, len(taskRows)+8)
+	rows = append(rows, taskRows...)
+	rows = append(rows, b.requestsForInbox(actor)...)
+	rows = append(rows, b.reviewsForInbox(actor)...)
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		// Attention-first: items the user can act on now (decision,
+		// request, review) bubble to the top. Within the same priority
+		// tier, sort by CreatedAt desc. This stops approved /
+		// blocked-on-pr-merge tasks from burying the work that needs
+		// the user's eyes.
+		pi := inboxItemPriority(rows[i])
+		pj := inboxItemPriority(rows[j])
+		if pi != pj {
+			return pi < pj
+		}
+		ti := parseBrokerTimestamp(rows[i].CreatedAt)
+		tj := parseBrokerTimestamp(rows[j].CreatedAt)
+		switch {
+		case ti.IsZero() && tj.IsZero():
+			return false
+		case ti.IsZero():
+			return false
+		case tj.IsZero():
+			return true
+		default:
+			return ti.After(tj)
+		}
+	})
+	return rows, nil
+}
+
+// inboxItemPriority returns a sort key: lower = more attention-y.
+// Tasks needing a decision and active requests/reviews tie at 0;
+// running / blocked / approved-today tasks land below. Lifecycle
+// states the user can't directly act on rank lowest.
+func inboxItemPriority(item InboxItem) int {
+	switch item.Kind {
+	case InboxItemKindRequest, InboxItemKindReview:
+		return 0
+	case InboxItemKindTask:
+		if item.TaskRow == nil {
+			return 4
+		}
+		switch item.TaskRow.LifecycleState {
+		case LifecycleStateDecision:
+			return 0
+		case LifecycleStateChangesRequested:
+			return 1
+		case LifecycleStateBlockedOnPRMerge:
+			return 2
+		case LifecycleStateReview, LifecycleStateRunning,
+			LifecycleStateReady, LifecycleStateIntake:
+			return 3
+		case LifecycleStateApproved:
+			return 4
+		}
+	}
+	return 5
+}
+
+// tasksForInbox returns lifecycle-task rows visible to actor. Owner
+// sees every task; a human session sees only tasks whose Reviewers
+// list contains their slug. Counts/badges always reflect broker-wide
+// state — the auth filter is on rows only.
+func (b *Broker) tasksForInbox(actor requestActor) []InboxItem {
+	if b == nil {
+		return nil
+	}
+	owner := actor.Kind == requestActorKindBroker
+	slug := normalizeReviewerSlug(actor.Slug)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]InboxItem, 0, len(b.tasks))
+	for i := range b.tasks {
+		task := &b.tasks[i]
+		// Drop legacy tasks that the lifecycle migration could not
+		// categorize. These are stale rows from pre-Lane-A sessions
+		// (status=done, blocked=false, pipeline_stage=postmortem etc.)
+		// and they have no packet on disk, so clicking them in the
+		// inbox returns a "not yet available" cold error. Filtering
+		// them at the source keeps the inbox focused on actionable
+		// work.
+		if task.LifecycleState == LifecycleStateUnknown {
+			continue
+		}
+		if !owner {
+			if slug == "" {
+				continue
+			}
+			matched := false
+			for _, r := range task.Reviewers {
+				if normalizeReviewerSlug(r) == slug {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		row := b.buildInboxRowLocked(task)
+		out = append(out, InboxItem{
+			Kind:      InboxItemKindTask,
+			TaskID:    task.ID,
+			Title:     row.Title,
+			Channel:   task.Channel,
+			CreatedAt: task.CreatedAt,
+			ElapsedMs: row.ElapsedMs,
+			AgentSlug: normalizeReviewerSlug(task.Owner),
+			TaskRow:   &row,
+		})
+	}
+	return out
+}
+
+// requestsForInbox returns humanInterview rows visible to actor.
+// Owner sees every active request; a human session sees requests
+// whose From field matches their slug. Resolved requests are
+// excluded — the inbox is exception-only.
+//
+// Phase 2 OSS-local scope: From is the proxy for "who needs to see
+// this". Tagged / AssignedTo fields land in a v1.1 follow-up that
+// extends the filter without changing this function's signature.
+func (b *Broker) requestsForInbox(actor requestActor) []InboxItem {
+	if b == nil {
+		return nil
+	}
+	owner := actor.Kind == requestActorKindBroker
+	slug := normalizeReviewerSlug(actor.Slug)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]InboxItem, 0, len(b.requests))
+	for i := range b.requests {
+		req := b.requests[i]
+		if !requestIsActive(req) {
+			continue
+		}
+		if !owner {
+			if slug == "" || normalizeReviewerSlug(req.From) != slug {
+				continue
+			}
+		}
+		title := strings.TrimSpace(req.TitleOrDefault())
+		if title == "" {
+			title = strings.TrimSpace(req.Question)
+		}
+		out = append(out, InboxItem{
+			Kind:      InboxItemKindRequest,
+			RequestID: req.ID,
+			Title:     title,
+			Channel:   req.Channel,
+			CreatedAt: req.CreatedAt,
+			AgentSlug: normalizeReviewerSlug(req.From),
+			Request: &RequestPeek{
+				Kind:     req.Kind,
+				Question: req.Question,
+				From:     req.From,
+				Blocking: req.Blocking,
+			},
+		})
+	}
+	return out
+}
+
+// reviewsForInbox returns promotion rows visible to actor. Owner sees
+// every non-archived review; a human session sees only promotions
+// where ReviewerSlug == their slug. Wires through the existing
+// ReviewLog.List(scope) so the auth model stays consistent with the
+// /review/list?scope=<slug> handler.
+func (b *Broker) reviewsForInbox(actor requestActor) []InboxItem {
+	if b == nil {
+		return nil
+	}
+	rl := b.ReviewLog()
+	if rl == nil {
+		return nil
+	}
+	owner := actor.Kind == requestActorKindBroker
+	slug := normalizeReviewerSlug(actor.Slug)
+	var promotions []*Promotion
+	if owner {
+		promotions = rl.List("all")
+	} else {
+		if slug == "" {
+			return nil
+		}
+		promotions = rl.List(slug)
+	}
+	out := make([]InboxItem, 0, len(promotions))
+	for _, p := range promotions {
+		if p == nil {
+			continue
+		}
+		// Inbox is exception-only — once a review is approved /
+		// rejected / archived / expired, it stops needing the
+		// human's attention. Filter those terminal states out so
+		// they don't pad the inbox after the work is done.
+		switch p.State {
+		case PromotionApproved, PromotionRejected, PromotionArchived, PromotionExpired:
+			continue
+		}
+		title := notebookEntrySlug(p.SourcePath)
+		if t := strings.TrimSpace(p.Rationale); t != "" {
+			title = t
+		}
+		out = append(out, InboxItem{
+			Kind:      InboxItemKindReview,
+			ReviewID:  p.ID,
+			Title:     title,
+			CreatedAt: p.CreatedAt.UTC().Format(time.RFC3339),
+			AgentSlug: normalizeReviewerSlug(p.SourceSlug),
+			Review: &ReviewPeek{
+				State:        string(p.State),
+				ReviewerSlug: p.ReviewerSlug,
+				SourceSlug:   p.SourceSlug,
+				TargetPath:   p.TargetPath,
+			},
+		})
+	}
+	return out
+}
+
+// SetInboxCursor records that the human at humanSlug acted on the
+// inbox at the given wall-clock time. Used by the workflow-semantic
+// unread badge. Concurrent writers are serialized on inboxCursorMu;
+// the most recent LastSeenAt wins (clock skew assumption — broker
+// is single-host so wall clock is monotonic enough for v1).
+func (b *Broker) SetInboxCursor(humanSlug string, cursor InboxCursor) {
+	if b == nil {
+		return
+	}
+	slug := normalizeInboxHumanSlug(humanSlug)
+	if slug == "" {
+		return
+	}
+	b.inboxCursorMu.Lock()
+	defer b.inboxCursorMu.Unlock()
+	if b.userInboxCursors == nil {
+		b.userInboxCursors = make(map[string]InboxCursor)
+	}
+	// Per-kind ack map is monotonic — a write that omits a previously
+	// acknowledged kind must not wipe it. Seed from existing, then
+	// overlay the caller's map (defensive-copy each value).
+	existing, hasExisting := b.userInboxCursors[slug]
+	stored := InboxCursor{LastSeenAt: cursor.LastSeenAt}
+	mergedKinds := map[InboxItemKind]time.Time{}
+	if hasExisting {
+		for k, v := range existing.AcknowledgedKinds {
+			mergedKinds[k] = v
+		}
+	}
+	for k, v := range cursor.AcknowledgedKinds {
+		mergedKinds[k] = v
+	}
+	if len(mergedKinds) > 0 {
+		stored.AcknowledgedKinds = mergedKinds
+	}
+	// "Most recent write wins" — but never let a stale write
+	// rewind LastSeenAt for the same slug.
+	if hasExisting && stored.LastSeenAt.Before(existing.LastSeenAt) {
+		stored.LastSeenAt = existing.LastSeenAt
+	}
+	b.userInboxCursors[slug] = stored
+}
+
+// InboxCursor returns the recorded cursor for humanSlug. Returns a
+// zero value when the human has never acted.
+func (b *Broker) InboxCursor(humanSlug string) InboxCursor {
+	if b == nil {
+		return InboxCursor{}
+	}
+	slug := normalizeInboxHumanSlug(humanSlug)
+	if slug == "" {
+		return InboxCursor{}
+	}
+	b.inboxCursorMu.RLock()
+	defer b.inboxCursorMu.RUnlock()
+	cursor, ok := b.userInboxCursors[slug]
+	if !ok {
+		return InboxCursor{}
+	}
+	// Defensive copy on the way out so the caller cannot mutate
+	// stored state.
+	out := InboxCursor{LastSeenAt: cursor.LastSeenAt}
+	if len(cursor.AcknowledgedKinds) > 0 {
+		out.AcknowledgedKinds = make(map[InboxItemKind]time.Time, len(cursor.AcknowledgedKinds))
+		for k, v := range cursor.AcknowledgedKinds {
+			out.AcknowledgedKinds[k] = v
+		}
+	}
+	return out
+}
+
+// normalizeInboxHumanSlug lowercases and trims a slug used as a key
+// in the per-user inbox cursor map. Mirrors normalizeReviewerSlug so
+// equality checks across the inbox subsystem stay consistent.
+func normalizeInboxHumanSlug(slug string) string {
+	return strings.ToLower(strings.TrimSpace(slug))
+}

--- a/internal/team/broker_inbox_phase2_test.go
+++ b/internal/team/broker_inbox_phase2_test.go
@@ -1,0 +1,377 @@
+package team
+
+// broker_inbox_phase2_test.go locks the Phase 2 unified-inbox contract
+// via four tests written RED before any GREEN implementation lands.
+// The spec these tests encode comes from /plan-design-review and
+// /plan-eng-review on 2026-05-11 (artifact /tmp/wuphf-unified-inbox-plan.md):
+//
+//   1. tasksForInbox  — owner sees all; human session sees only tasks
+//      where Reviewers contains the slug.
+//   2. requestsForInbox — owner sees all; human session sees only
+//      requests where From == slug.
+//   3. reviewsForInbox — owner sees all; human session sees only
+//      promotions where ReviewerSlug == slug.
+//   4. SetInboxCursor / InboxCursor read-write race: concurrent writes
+//      from one goroutine + concurrent reads from another must not
+//      race under `go test -race`, and the final state must be the
+//      most recent write.
+//   5. Fan-out merge at 1000 mixed-kind items keeps P95 under 100ms.
+//
+// All five tests fail today because the helpers in
+// broker_inbox_phase2.go return zero values. The GREEN pass fills the
+// bodies in and the tests turn green without their assertions
+// changing.
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestInboxItem_TaskKind_AuthByReviewers exercises the task half of
+// the fan-out auth boundary. Three tasks, one assigned to "mira" as
+// reviewer. The owner-token actor sees all three; mira's human-session
+// actor sees only the one she reviews.
+func TestInboxItem_TaskKind_AuthByReviewers(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Mira reviews", CreatedAt: now, Reviewers: []string{"mira"}},
+		{ID: "task-b", Title: "Nobody assigned", CreatedAt: now},
+		{ID: "task-c", Title: "Alex reviews", CreatedAt: now, Reviewers: []string{"alex"}},
+	}
+	for _, id := range []string{"task-a", "task-b", "task-c"} {
+		if _, err := b.transitionLifecycleLocked(id, LifecycleStateDecision, "phase 2 auth seed"); err != nil {
+			b.mu.Unlock()
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	b.mu.Unlock()
+
+	owner := requestActor{Kind: requestActorKindBroker}
+	mira := requestActor{Kind: requestActorKindHuman, Slug: "mira", DisplayName: "Mira"}
+
+	ownerRows := b.tasksForInbox(owner)
+	if len(ownerRows) != 3 {
+		t.Fatalf("ownerRows len = %d, want 3", len(ownerRows))
+	}
+	for _, row := range ownerRows {
+		if row.Kind != InboxItemKindTask {
+			t.Fatalf("ownerRows[%q].Kind = %q, want %q", row.TaskID, row.Kind, InboxItemKindTask)
+		}
+	}
+
+	miraRows := b.tasksForInbox(mira)
+	if len(miraRows) != 1 {
+		t.Fatalf("miraRows len = %d, want 1 (task-a only)", len(miraRows))
+	}
+	if miraRows[0].TaskID != "task-a" {
+		t.Fatalf("miraRows[0].TaskID = %q, want %q", miraRows[0].TaskID, "task-a")
+	}
+}
+
+// TestInboxItem_RequestKind_AuthByFrom exercises the request half of
+// the fan-out auth boundary. Three pending requests, one from "mira".
+// The owner-token actor sees all three; mira's human-session actor
+// sees only the one she sent. (Phase 2 OSS-local scope: From is the
+// proxy for "who needs to see this"; channel / tagged / assignedTo
+// fields land in a v1.1 follow-up that extends the helper without
+// changing this contract.)
+func TestInboxItem_RequestKind_AuthByFrom(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	b.mu.Lock()
+	b.requests = []humanInterview{
+		{ID: "req-1", From: "mira", Channel: "general", Question: "Approve?", CreatedAt: now, Kind: "approval"},
+		{ID: "req-2", From: "alex", Channel: "general", Question: "Confirm?", CreatedAt: now, Kind: "confirm"},
+		{ID: "req-3", From: "alex", Channel: "general", Question: "Choice?", CreatedAt: now, Kind: "choice"},
+	}
+	b.mu.Unlock()
+
+	owner := requestActor{Kind: requestActorKindBroker}
+	mira := requestActor{Kind: requestActorKindHuman, Slug: "mira", DisplayName: "Mira"}
+
+	ownerRows := b.requestsForInbox(owner)
+	if len(ownerRows) != 3 {
+		t.Fatalf("ownerRows len = %d, want 3", len(ownerRows))
+	}
+	for _, row := range ownerRows {
+		if row.Kind != InboxItemKindRequest {
+			t.Fatalf("ownerRows[%q].Kind = %q, want %q", row.RequestID, row.Kind, InboxItemKindRequest)
+		}
+		if row.Request == nil {
+			t.Fatalf("ownerRows[%q].Request peek must be populated", row.RequestID)
+		}
+	}
+
+	miraRows := b.requestsForInbox(mira)
+	if len(miraRows) != 1 {
+		t.Fatalf("miraRows len = %d, want 1 (req-1 only)", len(miraRows))
+	}
+	if miraRows[0].RequestID != "req-1" {
+		t.Fatalf("miraRows[0].RequestID = %q, want %q", miraRows[0].RequestID, "req-1")
+	}
+}
+
+// TestInboxItem_ReviewKind_AuthByAssignedReviewer exercises the review
+// half of the fan-out auth boundary. Three pending promotions, one
+// assigned to "mira" as the reviewer. The owner-token actor sees all
+// three; mira's human-session actor sees only the one assigned to her.
+//
+// This wires the existing ReviewLog (broker.reviewLog) into the
+// fan-out — the helper must call through the same scope filter that
+// the existing /review/list?scope=<slug> handler uses.
+func TestInboxItem_ReviewKind_AuthByAssignedReviewer(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	rl := b.ReviewLog()
+	if rl == nil {
+		t.Skip("ReviewLog not initialized in test broker; skipping until wiki worker harness lands")
+	}
+
+	now := time.Now().UTC()
+	seedPromotion(t, rl, &Promotion{
+		ID:           "rev-1",
+		State:        PromotionPending,
+		SourceSlug:   "ada",
+		SourcePath:   "notebook/ada/draft-1.md",
+		TargetPath:   "wiki/draft-1.md",
+		ReviewerSlug: "mira",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	seedPromotion(t, rl, &Promotion{
+		ID:           "rev-2",
+		State:        PromotionPending,
+		SourceSlug:   "ada",
+		SourcePath:   "notebook/ada/draft-2.md",
+		TargetPath:   "wiki/draft-2.md",
+		ReviewerSlug: "alex",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+	seedPromotion(t, rl, &Promotion{
+		ID:           "rev-3",
+		State:        PromotionPending,
+		SourceSlug:   "ada",
+		SourcePath:   "notebook/ada/draft-3.md",
+		TargetPath:   "wiki/draft-3.md",
+		ReviewerSlug: "alex",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	})
+
+	owner := requestActor{Kind: requestActorKindBroker}
+	mira := requestActor{Kind: requestActorKindHuman, Slug: "mira", DisplayName: "Mira"}
+
+	ownerRows := b.reviewsForInbox(owner)
+	if len(ownerRows) != 3 {
+		t.Fatalf("ownerRows len = %d, want 3", len(ownerRows))
+	}
+	for _, row := range ownerRows {
+		if row.Kind != InboxItemKindReview {
+			t.Fatalf("ownerRows[%q].Kind = %q, want %q", row.ReviewID, row.Kind, InboxItemKindReview)
+		}
+		if row.Review == nil {
+			t.Fatalf("ownerRows[%q].Review peek must be populated", row.ReviewID)
+		}
+		if row.Review.ReviewerSlug == "" {
+			t.Fatalf("ownerRows[%q].Review.ReviewerSlug must be populated", row.ReviewID)
+		}
+	}
+
+	miraRows := b.reviewsForInbox(mira)
+	if len(miraRows) != 1 {
+		t.Fatalf("miraRows len = %d, want 1 (rev-1 only)", len(miraRows))
+	}
+	if miraRows[0].ReviewID != "rev-1" {
+		t.Fatalf("miraRows[0].ReviewID = %q, want %q", miraRows[0].ReviewID, "rev-1")
+	}
+}
+
+// TestInboxCursor_ReadWriteRace forces concurrent SetInboxCursor +
+// InboxCursor calls on the same slug. Run with `go test -race` — any
+// data race in the per-user cursor map surfaces as a runtime failure.
+// The assertion at the end pins the final state to the most recent
+// write so the no-op stub fails (it always returns IsZero() == true).
+func TestInboxCursor_ReadWriteRace(t *testing.T) {
+	b := newTestBroker(t)
+
+	const writers = 16
+	const reads = 64
+
+	var wg sync.WaitGroup
+	wg.Add(writers + 1)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < reads; i++ {
+			_ = b.InboxCursor("mira")
+		}
+	}()
+
+	base := time.Now().UTC()
+	for w := 0; w < writers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			cursor := InboxCursor{LastSeenAt: base.Add(time.Duration(w) * time.Millisecond)}
+			b.SetInboxCursor("mira", cursor)
+		}()
+	}
+	wg.Wait()
+
+	final := b.InboxCursor("mira")
+	if final.IsZero() {
+		t.Fatal("final cursor for 'mira' is zero; SetInboxCursor must persist at least one write")
+	}
+	// "Most recent write wins" + rewind guard: the surviving cursor
+	// MUST be the highest-LastSeenAt writer (writer N-1 here), no
+	// matter the goroutine scheduling order. A weaker stub that keeps
+	// "whatever wrote last in wall time" would pass `>= base` but
+	// fail this exact equality.
+	want := base.Add(time.Duration(writers-1) * time.Millisecond)
+	if !final.LastSeenAt.Equal(want) {
+		t.Fatalf("final cursor LastSeenAt = %s, want %s (newest writer must win)", final.LastSeenAt, want)
+	}
+}
+
+// TestInboxFanout_1000MixedItems_P95Under100ms seeds 333 tasks +
+// 333 requests + 333 promotions and asserts the fan-out merge stays
+// under the 100ms ceiling on a developer laptop. Builds on the
+// existing 1000-task perf test but exercises the new merge path
+// rather than the indexed-bucket lookup alone.
+func TestInboxFanout_1000MixedItems_P95Under100ms(t *testing.T) {
+	if testing.Short() {
+		t.Skip("perf test; runs in full mode only")
+	}
+
+	const taskCount = 333
+	const requestCount = 333
+	const reviewCount = 334
+	const ceiling = 100 * time.Millisecond
+
+	b := newTestBrokerForReview(t)
+	rl := b.ReviewLog()
+
+	now := time.Now().UTC()
+	b.mu.Lock()
+	for i := 0; i < taskCount; i++ {
+		id := fmt.Sprintf("task-%04d", i)
+		task := teamTask{
+			ID:        id,
+			Title:     fmt.Sprintf("Task %d", i),
+			CreatedAt: now.Add(-time.Duration(i) * time.Minute).Format(time.RFC3339),
+		}
+		b.tasks = append(b.tasks, task)
+		if _, err := b.transitionLifecycleLocked(id, LifecycleStateDecision, "fanout seed"); err != nil {
+			b.mu.Unlock()
+			t.Fatalf("seed task %s: %v", id, err)
+		}
+	}
+	for i := 0; i < requestCount; i++ {
+		b.requests = append(b.requests, humanInterview{
+			ID:        fmt.Sprintf("req-%04d", i),
+			From:      "owner",
+			Channel:   "general",
+			Question:  fmt.Sprintf("Question %d", i),
+			Kind:      "approval",
+			CreatedAt: now.Add(-time.Duration(i) * time.Minute).Format(time.RFC3339),
+		})
+	}
+	b.mu.Unlock()
+
+	if rl != nil {
+		for i := 0; i < reviewCount; i++ {
+			seedPromotion(t, rl, &Promotion{
+				ID:           fmt.Sprintf("rev-%04d", i),
+				State:        PromotionPending,
+				SourceSlug:   "ada",
+				SourcePath:   fmt.Sprintf("notebook/ada/n-%d.md", i),
+				TargetPath:   fmt.Sprintf("wiki/n-%d.md", i),
+				ReviewerSlug: "owner",
+				CreatedAt:    now,
+				UpdatedAt:    now,
+			})
+		}
+	}
+
+	owner := requestActor{Kind: requestActorKindBroker}
+
+	// Warm-up so the timed run measures steady-state.
+	if _, err := b.inboxItemsForActor(owner, InboxFilterAll); err != nil {
+		t.Fatalf("warm-up: %v", err)
+	}
+
+	const samples = 5
+	var slowest time.Duration
+	for i := 0; i < samples; i++ {
+		start := time.Now()
+		rows, err := b.inboxItemsForActor(owner, InboxFilterAll)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("inboxItemsForActor sample %d: %v", i, err)
+		}
+		if len(rows) < taskCount+requestCount {
+			t.Fatalf("rows = %d, want at least %d (tasks+requests, reviews optional)", len(rows), taskCount+requestCount)
+		}
+		// Smoke: kind distribution must include all three when reviews seeded.
+		if rl != nil {
+			counts := map[InboxItemKind]int{}
+			for _, r := range rows {
+				counts[r.Kind]++
+			}
+			if counts[InboxItemKindTask] == 0 || counts[InboxItemKindRequest] == 0 || counts[InboxItemKindReview] == 0 {
+				t.Fatalf("kind distribution missing entries: %+v", counts)
+			}
+		}
+		if elapsed > slowest {
+			slowest = elapsed
+		}
+	}
+	t.Logf("inboxItemsForActor slowest across %d samples: %s (ceiling %s)", samples, slowest, ceiling)
+	if slowest > ceiling {
+		t.Fatalf("inboxItemsForActor P95-proxy = %s > ceiling %s", slowest, ceiling)
+	}
+}
+
+// newTestBrokerForReview returns a test broker with the ReviewLog
+// initialized so the review-kind tests can seed promotions directly.
+// Bypasses the wiki-worker dependency by constructing the ReviewLog
+// with a tmpfile path — the in-memory promotions map is the only
+// state the per-kind auth filter reads.
+func newTestBrokerForReview(t *testing.T) *Broker {
+	t.Helper()
+	b := newTestBroker(t)
+	rl, err := NewReviewLog(filepath.Join(t.TempDir(), "review-log.jsonl"), nil, nil)
+	if err != nil {
+		t.Fatalf("init review log: %v", err)
+	}
+	b.mu.Lock()
+	b.reviewLog = rl
+	b.mu.Unlock()
+	return b
+}
+
+// seedPromotion inserts a Promotion directly into the ReviewLog's
+// in-memory map for tests. Bypasses the JSONL append path because
+// the per-kind auth filter only reads the in-memory list.
+func seedPromotion(t *testing.T, rl *ReviewLog, p *Promotion) {
+	t.Helper()
+	if rl == nil {
+		return
+	}
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	if rl.promotions == nil {
+		rl.promotions = map[string]*Promotion{}
+	}
+	rl.promotions[p.ID] = p
+	// Strip any leading whitespace the test fixtures may carry.
+	p.ID = strings.TrimSpace(p.ID)
+}

--- a/internal/team/broker_inbox_threads.go
+++ b/internal/team/broker_inbox_threads.go
@@ -98,10 +98,14 @@ func (b *Broker) inboxThreadsForActor(actor requestActor) (InboxThreadsResponse,
 		byAgent[slug] = append(byAgent[slug], item)
 	}
 
+	// counts come from the caller's auth-filtered items so threads
+	// view never reveals task volume the caller cannot see, matching
+	// the rule applied to handleInboxItems.
+	counts := inboxCountsForItems(items, startOfTodayUTC())
+
 	b.mu.Lock()
 	members := append([]officeMember(nil), b.members...)
 	messages := append([]channelMessage(nil), b.messages...)
-	counts := b.inboxCountsLocked(startOfTodayUTC())
 	b.mu.Unlock()
 
 	memberByCanonicalSlug := map[string]officeMember{}

--- a/internal/team/broker_inbox_threads.go
+++ b/internal/team/broker_inbox_threads.go
@@ -1,0 +1,325 @@
+package team
+
+// broker_inbox_threads.go is Phase 3 of the unified Inbox plan. It
+// reframes the Decision Inbox from "list of artifacts" into "list of
+// conversations with AI agents" — one thread per agent, each thread
+// carrying every InboxItem that agent has waiting on the human plus
+// recent message context from the agent's DM channel.
+//
+// The endpoint composes on top of Phase 2:
+//
+//   inboxItemsForActor (Phase 2)
+//       ↓ items
+//   groupItemsByAgent
+//       ↓ per-agent buckets
+//   buildThreadLocked (enrich with DM messages + member name)
+//       ↓ Threads
+//   GET /inbox/threads
+//
+// Backwards-compat with the artifact-list view stays in place: the
+// existing /inbox/items endpoint continues to serve a flat list for
+// callers that prefer that shape.
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// InboxThread groups every attention item from one agent under a
+// single conversation surface. Phase 3 frontend renders one row per
+// thread (avatar + name + preview + time) and a chat-style detail
+// pane that interleaves agent messages with inline action cards for
+// the pending items.
+type InboxThread struct {
+	Key            string      `json:"key"` // "agent:<slug>"
+	AgentSlug      string      `json:"agentSlug"`
+	AgentName      string      `json:"agentName"`
+	AgentRole      string      `json:"agentRole,omitempty"`
+	DMChannel      string      `json:"dmChannel,omitempty"`
+	LastActivityAt string      `json:"lastActivityAt"` // RFC3339
+	Preview        string      `json:"preview"`        // truncated last activity
+	PendingCount   int         `json:"pendingCount"`   // # of attention items
+	Items          []InboxItem `json:"items"`          // attention items
+}
+
+// InboxThreadEvent is one entry in the chat-style detail stream.
+// Messages and action cards interleave chronologically. The frontend
+// switches on Kind to render either a message bubble or an inline
+// approval card.
+type InboxThreadEventKind string
+
+const (
+	InboxThreadEventMessage InboxThreadEventKind = "message"
+	InboxThreadEventItem    InboxThreadEventKind = "item"
+)
+
+type InboxThreadEvent struct {
+	Kind      InboxThreadEventKind `json:"kind"`
+	Timestamp string               `json:"timestamp"`
+	Message   *channelMessage      `json:"message,omitempty"`
+	Item      *InboxItem           `json:"item,omitempty"`
+}
+
+// InboxThreadDetail is the response for GET /inbox/threads/{slug}.
+// Contains the thread metadata plus the interleaved event stream
+// the chat detail view consumes.
+type InboxThreadDetail struct {
+	Thread InboxThread        `json:"thread"`
+	Events []InboxThreadEvent `json:"events"`
+}
+
+// InboxThreadsResponse is the wire shape for GET /inbox/threads.
+type InboxThreadsResponse struct {
+	Threads     []InboxThread `json:"threads"`
+	Counts      InboxCounts   `json:"counts"`
+	RefreshedAt string        `json:"refreshedAt"`
+}
+
+const threadPreviewMaxLen = 140
+const threadMessageBackfillLimit = 24
+
+// inboxThreadsForActor wraps inboxItemsForActor with per-agent
+// grouping + DM message enrichment.
+func (b *Broker) inboxThreadsForActor(actor requestActor) (InboxThreadsResponse, error) {
+	items, err := b.inboxItemsForActor(actor, InboxFilterAll)
+	if err != nil {
+		return InboxThreadsResponse{}, err
+	}
+	byAgent := map[string][]InboxItem{}
+	for _, item := range items {
+		slug := normalizeReviewerSlug(item.AgentSlug)
+		if slug == "" {
+			slug = "system"
+		}
+		byAgent[slug] = append(byAgent[slug], item)
+	}
+
+	b.mu.Lock()
+	members := append([]officeMember(nil), b.members...)
+	messages := append([]channelMessage(nil), b.messages...)
+	counts := b.inboxCountsLocked(startOfTodayUTC())
+	b.mu.Unlock()
+
+	memberByCanonicalSlug := map[string]officeMember{}
+	for _, m := range members {
+		memberByCanonicalSlug[normalizeReviewerSlug(m.Slug)] = m
+	}
+
+	threads := make([]InboxThread, 0, len(byAgent))
+	for slug, bucket := range byAgent {
+		thread := buildInboxThread(slug, bucket, memberByCanonicalSlug, messages)
+		threads = append(threads, thread)
+	}
+
+	sort.SliceStable(threads, func(i, j int) bool {
+		ti := parseBrokerTimestamp(threads[i].LastActivityAt)
+		tj := parseBrokerTimestamp(threads[j].LastActivityAt)
+		switch {
+		case ti.IsZero() && tj.IsZero():
+			return strings.Compare(threads[i].AgentSlug, threads[j].AgentSlug) < 0
+		case ti.IsZero():
+			return false
+		case tj.IsZero():
+			return true
+		default:
+			return ti.After(tj)
+		}
+	})
+
+	return InboxThreadsResponse{
+		Threads:     threads,
+		Counts:      counts,
+		RefreshedAt: time.Now().UTC().Format(time.RFC3339),
+	}, nil
+}
+
+// inboxThreadDetailForActor returns one thread with its interleaved
+// event stream (messages + action cards in chronological order). The
+// frontend calls this when a thread row is opened.
+func (b *Broker) inboxThreadDetailForActor(actor requestActor, agentSlug string) (InboxThreadDetail, error) {
+	slug := normalizeReviewerSlug(agentSlug)
+	if slug == "" {
+		return InboxThreadDetail{}, errors.New("inbox: thread agentSlug required")
+	}
+	items, err := b.inboxItemsForActor(actor, InboxFilterAll)
+	if err != nil {
+		return InboxThreadDetail{}, err
+	}
+	bucket := make([]InboxItem, 0, len(items))
+	for _, item := range items {
+		if normalizeReviewerSlug(item.AgentSlug) == slug {
+			bucket = append(bucket, item)
+		}
+	}
+
+	b.mu.Lock()
+	members := append([]officeMember(nil), b.members...)
+	messages := append([]channelMessage(nil), b.messages...)
+	b.mu.Unlock()
+
+	memberByCanonicalSlug := map[string]officeMember{}
+	for _, m := range members {
+		memberByCanonicalSlug[normalizeReviewerSlug(m.Slug)] = m
+	}
+
+	thread := buildInboxThread(slug, bucket, memberByCanonicalSlug, messages)
+
+	// Pull recent messages from the agent's DM channel + any channel
+	// messages where the agent is the sender. Interleave with items.
+	dmChannel := thread.DMChannel
+	relevantMessages := make([]channelMessage, 0, threadMessageBackfillLimit)
+	for i := len(messages) - 1; i >= 0 && len(relevantMessages) < threadMessageBackfillLimit; i-- {
+		m := messages[i]
+		fromMatches := normalizeReviewerSlug(m.From) == slug
+		dmMatches := dmChannel != "" && normalizeChannelSlug(m.Channel) == normalizeChannelSlug(dmChannel)
+		if fromMatches || dmMatches {
+			relevantMessages = append(relevantMessages, m)
+		}
+	}
+	// Reverse to chronological order.
+	for i, j := 0, len(relevantMessages)-1; i < j; i, j = i+1, j-1 {
+		relevantMessages[i], relevantMessages[j] = relevantMessages[j], relevantMessages[i]
+	}
+
+	events := make([]InboxThreadEvent, 0, len(relevantMessages)+len(bucket))
+	for i := range relevantMessages {
+		msg := relevantMessages[i]
+		events = append(events, InboxThreadEvent{
+			Kind:      InboxThreadEventMessage,
+			Timestamp: msg.Timestamp,
+			Message:   &msg,
+		})
+	}
+	for i := range bucket {
+		item := bucket[i]
+		events = append(events, InboxThreadEvent{
+			Kind:      InboxThreadEventItem,
+			Timestamp: item.CreatedAt,
+			Item:      &item,
+		})
+	}
+	sort.SliceStable(events, func(i, j int) bool {
+		ti := parseBrokerTimestamp(events[i].Timestamp)
+		tj := parseBrokerTimestamp(events[j].Timestamp)
+		return ti.Before(tj)
+	})
+
+	return InboxThreadDetail{
+		Thread: thread,
+		Events: events,
+	}, nil
+}
+
+// buildInboxThread assembles a thread row from one agent's items
+// plus their most recent DM/channel activity for the preview line.
+func buildInboxThread(slug string, items []InboxItem, memberBySlug map[string]officeMember, messages []channelMessage) InboxThread {
+	member := memberBySlug[slug]
+	name := strings.TrimSpace(member.Name)
+	if name == "" {
+		// Fallback when the agent isn't in the office roster (legacy
+		// task created by a removed member).
+		name = slug
+	}
+	thread := InboxThread{
+		Key:          "agent:" + slug,
+		AgentSlug:    slug,
+		AgentName:    name,
+		AgentRole:    strings.TrimSpace(member.Role),
+		PendingCount: len(items),
+		Items:        items,
+	}
+	if slug != "system" {
+		thread.DMChannel = DMSlugFor(slug)
+	}
+
+	// Last activity = newest of (item.CreatedAt, latest message from
+	// this agent). The preview prefers a message snippet, falling back
+	// to the newest item's title.
+	var lastTS time.Time
+	var preview string
+	for _, item := range items {
+		ts := parseBrokerTimestamp(item.CreatedAt)
+		if ts.After(lastTS) {
+			lastTS = ts
+			preview = item.Title
+		}
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if normalizeReviewerSlug(m.From) != slug {
+			continue
+		}
+		ts := parseBrokerTimestamp(m.Timestamp)
+		if ts.After(lastTS) {
+			lastTS = ts
+			preview = m.Content
+		}
+		break
+	}
+	if !lastTS.IsZero() {
+		thread.LastActivityAt = lastTS.UTC().Format(time.RFC3339)
+	}
+	thread.Preview = truncatePreview(preview)
+	return thread
+}
+
+// truncatePreview clips a preview string to threadPreviewMaxLen,
+// collapsing newlines so the row layout stays single-line.
+func truncatePreview(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.Join(strings.Fields(s), " ")
+	if len([]rune(s)) <= threadPreviewMaxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:threadPreviewMaxLen]) + "…"
+}
+
+// handleInboxThreads serves GET /inbox/threads.
+func (b *Broker) handleInboxThreads(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	payload, err := b.inboxThreadsForActor(actor)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, payload)
+}
+
+// handleInboxThreadDetail serves GET /inbox/threads/{agentSlug}.
+func (b *Broker) handleInboxThreadDetail(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	slug := strings.TrimPrefix(r.URL.Path, "/inbox/threads/")
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agent slug required"})
+		return
+	}
+	detail, err := b.inboxThreadDetailForActor(actor, slug)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, detail)
+}

--- a/internal/team/broker_inbox_threads.go
+++ b/internal/team/broker_inbox_threads.go
@@ -22,6 +22,7 @@ package team
 
 import (
 	"errors"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
@@ -318,7 +319,15 @@ func (b *Broker) handleInboxThreadDetail(w http.ResponseWriter, r *http.Request)
 	}
 	detail, err := b.inboxThreadDetailForActor(actor, slug)
 	if err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		// inboxThreadDetailForActor returns one validation error
+		// ("thread agentSlug required", maps to 400) and otherwise
+		// surfaces broker / persistence errors that should land as 500.
+		if strings.Contains(err.Error(), "agentSlug required") {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		log.Printf("broker: inbox thread detail slug=%q: %v", slug, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "thread detail failed"})
 		return
 	}
 	writeJSON(w, http.StatusOK, detail)

--- a/internal/team/broker_inbox_threads_test.go
+++ b/internal/team/broker_inbox_threads_test.go
@@ -1,0 +1,200 @@
+package team
+
+// broker_inbox_threads_test.go exercises Phase 3 thread grouping:
+// per-agent buckets, preview enrichment from DM messages, and the
+// interleaved event stream returned by /inbox/threads/{slug}.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInboxThreads_GroupsItemsByAgent(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	rl := b.ReviewLog()
+	now := time.Now().UTC()
+
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "mira", Name: "Mira", Role: "Backend lead"},
+		{Slug: "ada", Name: "Ada", Role: "Wiki curator"},
+	}
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Mira refactor", CreatedAt: now.Add(-30 * time.Minute).Format(time.RFC3339), Owner: "mira"},
+		{ID: "task-b", Title: "Mira second task", CreatedAt: now.Add(-15 * time.Minute).Format(time.RFC3339), Owner: "mira"},
+	}
+	for _, id := range []string{"task-a", "task-b"} {
+		if _, err := b.transitionLifecycleLocked(id, LifecycleStateDecision, "phase 3 seed"); err != nil {
+			b.mu.Unlock()
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	b.requests = []humanInterview{
+		{ID: "req-1", From: "ada", Channel: "general", Question: "Bump dep?", Kind: "approval", CreatedAt: now.Add(-10 * time.Minute).Format(time.RFC3339)},
+	}
+	b.mu.Unlock()
+	seedPromotion(t, rl, &Promotion{
+		ID:           "rev-1",
+		State:        PromotionPending,
+		SourceSlug:   "ada",
+		SourcePath:   "notebook/ada/draft.md",
+		TargetPath:   "wiki/draft.md",
+		ReviewerSlug: "owner",
+		CreatedAt:    now.Add(-5 * time.Minute),
+		UpdatedAt:    now.Add(-5 * time.Minute),
+	})
+
+	payload, err := b.inboxThreadsForActor(requestActor{Kind: requestActorKindBroker})
+	if err != nil {
+		t.Fatalf("inboxThreadsForActor: %v", err)
+	}
+	if len(payload.Threads) != 2 {
+		t.Fatalf("threads = %d, want 2 (mira + ada); got %+v", len(payload.Threads), payload.Threads)
+	}
+
+	byAgent := map[string]InboxThread{}
+	for _, th := range payload.Threads {
+		byAgent[th.AgentSlug] = th
+	}
+	mira, ok := byAgent["mira"]
+	if !ok {
+		t.Fatal("expected thread for mira")
+	}
+	if mira.PendingCount != 2 || len(mira.Items) != 2 {
+		t.Fatalf("mira: pending=%d items=%d, want 2/2", mira.PendingCount, len(mira.Items))
+	}
+	if mira.AgentName != "Mira" {
+		t.Fatalf("mira AgentName = %q, want %q", mira.AgentName, "Mira")
+	}
+	if mira.DMChannel == "" {
+		t.Fatal("mira DMChannel should be populated for non-system threads")
+	}
+
+	ada, ok := byAgent["ada"]
+	if !ok {
+		t.Fatal("expected thread for ada")
+	}
+	if ada.PendingCount != 2 || len(ada.Items) != 2 {
+		t.Fatalf("ada: pending=%d items=%d, want 2/2 (1 request + 1 review)", ada.PendingCount, len(ada.Items))
+	}
+	kinds := map[InboxItemKind]int{}
+	for _, item := range ada.Items {
+		kinds[item.Kind]++
+	}
+	if kinds[InboxItemKindRequest] != 1 || kinds[InboxItemKindReview] != 1 {
+		t.Fatalf("ada kinds = %+v, want 1 request + 1 review", kinds)
+	}
+}
+
+func TestInboxThreads_PreviewFromLatestMessage(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC()
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "mira", Name: "Mira"},
+	}
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Refactor X", CreatedAt: now.Add(-30 * time.Minute).Format(time.RFC3339), Owner: "mira"},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "preview seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.messages = []channelMessage{
+		{ID: "m-1", From: "mira", Channel: "general", Content: "I just shipped the refactor", Timestamp: now.Add(-1 * time.Minute).Format(time.RFC3339)},
+	}
+	b.mu.Unlock()
+
+	payload, err := b.inboxThreadsForActor(requestActor{Kind: requestActorKindBroker})
+	if err != nil {
+		t.Fatalf("inboxThreadsForActor: %v", err)
+	}
+	if len(payload.Threads) != 1 {
+		t.Fatalf("threads = %d, want 1", len(payload.Threads))
+	}
+	if got, want := payload.Threads[0].Preview, "I just shipped the refactor"; got != want {
+		t.Fatalf("preview = %q, want %q (message should beat task title because it's newer)", got, want)
+	}
+}
+
+func TestInboxThreads_DetailInterleavesMessagesAndItems(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC()
+	b.mu.Lock()
+	b.members = []officeMember{{Slug: "mira", Name: "Mira"}}
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Decide", CreatedAt: now.Add(-10 * time.Minute).Format(time.RFC3339), Owner: "mira"},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "detail seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.messages = []channelMessage{
+		{ID: "m-1", From: "mira", Channel: "general", Content: "starting work", Timestamp: now.Add(-20 * time.Minute).Format(time.RFC3339)},
+		{ID: "m-2", From: "mira", Channel: "general", Content: "almost done", Timestamp: now.Add(-5 * time.Minute).Format(time.RFC3339)},
+	}
+	b.mu.Unlock()
+
+	detail, err := b.inboxThreadDetailForActor(requestActor{Kind: requestActorKindBroker}, "mira")
+	if err != nil {
+		t.Fatalf("detail: %v", err)
+	}
+	// Expect 3 events: message m-1, item task-a, message m-2.
+	if len(detail.Events) != 3 {
+		t.Fatalf("events = %d, want 3 (got %+v)", len(detail.Events), detail.Events)
+	}
+	if detail.Events[0].Kind != InboxThreadEventMessage || detail.Events[0].Message.ID != "m-1" {
+		t.Fatalf("events[0] = %+v, want message m-1", detail.Events[0])
+	}
+	if detail.Events[1].Kind != InboxThreadEventItem || detail.Events[1].Item.TaskID != "task-a" {
+		t.Fatalf("events[1] = %+v, want item task-a", detail.Events[1])
+	}
+	if detail.Events[2].Kind != InboxThreadEventMessage || detail.Events[2].Message.ID != "m-2" {
+		t.Fatalf("events[2] = %+v, want message m-2", detail.Events[2])
+	}
+}
+
+func TestHandleInboxThreads_Owner(t *testing.T) {
+	b := newTestBroker(t)
+	now := time.Now().UTC()
+	b.mu.Lock()
+	b.members = []officeMember{{Slug: "mira", Name: "Mira"}}
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Decide", CreatedAt: now.Format(time.RFC3339), Owner: "mira"},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "handler seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/threads", b.requireAuth(b.handleInboxThreads))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/threads", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var payload InboxThreadsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Threads) != 1 {
+		t.Fatalf("threads = %d, want 1", len(payload.Threads))
+	}
+	if !strings.EqualFold(payload.Threads[0].AgentSlug, "mira") {
+		t.Fatalf("thread slug = %q, want %q", payload.Threads[0].AgentSlug, "mira")
+	}
+}

--- a/web/src/api/lifecycle.ts
+++ b/web/src/api/lifecycle.ts
@@ -14,7 +14,17 @@ import {
   getDecisionPacketMock,
   getInboxPayloadMock,
 } from "../lib/mocks/decisionPackets";
-import type { DecisionPacket, InboxPayload } from "../lib/types/lifecycle";
+import type { InboxItem, InboxItemKind } from "../lib/types/inbox";
+import type {
+  InboxThreadDetail,
+  InboxThreadsResponse,
+} from "../lib/types/inboxThread";
+import type {
+  DecisionPacket,
+  InboxCounts,
+  InboxFilter,
+  InboxPayload,
+} from "../lib/types/lifecycle";
 import { get, post } from "./client";
 
 export type DecisionAction = "approve" | "request_changes" | "defer";
@@ -33,14 +43,111 @@ export async function getInboxPayload(): Promise<InboxPayload> {
   if (USE_MOCKS) {
     return getInboxPayloadMock();
   }
-  // The Go broker can serialize an empty slice as `null`, which would
-  // make DecisionInbox.filterRows throw before it reaches the
-  // empty-state branch. Coerce to [] here so the rest of the UI can
-  // treat `rows` as always-array, mirroring normalizeDecisionPacket.
-  const raw = await get<InboxPayload>("/tasks/inbox");
+  return get<InboxPayload>("/tasks/inbox");
+}
+
+/**
+ * Phase 2: fan-out inbox merging tasks + requests + reviews. The
+ * `filter` narrows the task half by lifecycle bucket (same set as
+ * /tasks/inbox); the optional `kind` trims the result to one
+ * artifact kind for per-kind frontend tabs.
+ *
+ * Wire shape:
+ *   { items: InboxItem[]; counts: InboxCounts; refreshedAt: string }
+ *
+ * Items are sorted most-recent-activity first. Counts remain
+ * broker-wide (auth filter applies to items only).
+ */
+export interface UnifiedInboxResponse {
+  items: InboxItem[];
+  counts: InboxCounts;
+  refreshedAt: string;
+}
+
+export async function getInboxItems(
+  filter: InboxFilter | "all" = "all",
+  kind?: InboxItemKind,
+): Promise<UnifiedInboxResponse> {
+  const params = new URLSearchParams({ filter });
+  if (kind) {
+    params.set("kind", kind);
+  }
+  const raw = await get<UnifiedInboxResponse>(
+    `/inbox/items?${params.toString()}`,
+  );
   return {
-    ...raw,
-    rows: raw.rows ?? [],
+    items: (raw.items ?? []).map(normalizeInboxItem),
+    counts: raw.counts,
+    refreshedAt: raw.refreshedAt,
+  };
+}
+
+/**
+ * The Go broker serializes the task row with `lifecycleState` +
+ * `severitySummary` (the InboxRow struct's JSON tags). The TS
+ * InboxRow type uses `state` + `severityCounts`. This is a
+ * pre-existing wire/TS skew that predates Phase 2. We normalize
+ * at the API boundary so every component below this sees the
+ * shape its types promise.
+ */
+function normalizeInboxItem(item: InboxItem): InboxItem {
+  if (item.kind !== "task") return item;
+  const row = item.task as unknown as Record<string, unknown>;
+  if (!row) return item;
+  const lifecycleState = row.lifecycleState ?? row.state;
+  const severitySummary = row.severitySummary as
+    | Record<string, number>
+    | undefined;
+  const severityCounts =
+    row.severityCounts ??
+    (severitySummary
+      ? {
+          critical: severitySummary.critical ?? 0,
+          major: severitySummary.major ?? 0,
+          minor: severitySummary.minor ?? 0,
+          nitpick: severitySummary.nitpick ?? 0,
+          skipped: severitySummary.skipped ?? 0,
+        }
+      : undefined);
+  const normalizedRow = {
+    ...item.task,
+    state: lifecycleState ?? item.task.state,
+    severityCounts: severityCounts ?? item.task.severityCounts,
+  } as InboxItem extends { kind: "task"; task: infer T } ? T : never;
+  return { ...item, task: normalizedRow };
+}
+
+/**
+ * Phase 3: per-agent thread inbox. Groups InboxItems by the agent
+ * who owns/sent/submitted them and enriches each thread with recent
+ * message activity from the agent's DM channel.
+ *
+ * Composes on top of /inbox/items — items are the same shape, just
+ * grouped + decorated with the agent + preview line + DM channel.
+ */
+export async function getInboxThreads(): Promise<InboxThreadsResponse> {
+  const raw = await get<InboxThreadsResponse>("/inbox/threads");
+  return {
+    threads: raw.threads ?? [],
+    counts: raw.counts,
+    refreshedAt: raw.refreshedAt,
+  };
+}
+
+/**
+ * Fetch one thread's interleaved event stream (messages + action
+ * cards in chronological order). Frontend opens this when the user
+ * clicks a thread row.
+ */
+export async function getInboxThreadDetail(
+  agentSlug: string,
+): Promise<InboxThreadDetail> {
+  const raw = await get<InboxThreadDetail>(
+    `/inbox/threads/${encodeURIComponent(agentSlug)}`,
+  );
+  return {
+    thread: raw.thread,
+    events: raw.events ?? [],
   };
 }
 
@@ -92,6 +199,26 @@ function normalizeDecisionPacket(p: DecisionPacket): DecisionPacket {
 }
 
 /**
+ * Mark the inbox as "seen up to now" for the current human session.
+ * Posts the wall-clock time so the broker stores it on
+ * Broker.userInboxCursor[slug]. The frontend calls this after each
+ * decision action so the next inbox refresh can recompute the badge
+ * count against the cursor.
+ *
+ * Fire-and-forget — the call returns void, errors are swallowed so a
+ * cursor-write failure can't block the user's decision flow.
+ */
+export async function postInboxCursor(): Promise<void> {
+  try {
+    await post("/inbox/cursor", {
+      lastSeenAt: new Date().toISOString(),
+    });
+  } catch {
+    // intentional: cursor writes are best-effort.
+  }
+}
+
+/**
  * POST a human decision (merge / request_changes / defer) for one task.
  * The broker transitions the task lifecycle and persists the decision
  * onto the Decision Packet. Returns the broker's confirmation envelope.
@@ -102,9 +229,13 @@ function normalizeDecisionPacket(p: DecisionPacket): DecisionPacket {
 export async function postDecision(
   taskId: string,
   action: DecisionAction,
+  comment?: string,
 ): Promise<{ taskId: string; action: string; status: string }> {
   if (USE_MOCKS) {
     return Promise.resolve({ taskId, action, status: "recorded-mock" });
   }
-  return post(`/tasks/${encodeURIComponent(taskId)}/decision`, { action });
+  const body: { action: DecisionAction; comment?: string } = { action };
+  const trimmed = (comment ?? "").trim();
+  if (trimmed) body.comment = trimmed;
+  return post(`/tasks/${encodeURIComponent(taskId)}/decision`, body);
 }

--- a/web/src/components/apps/RequestsApp.tsx
+++ b/web/src/components/apps/RequestsApp.tsx
@@ -223,7 +223,11 @@ interface RequestItemProps {
   onAnswer?: (choiceId: string) => void;
 }
 
-function RequestItem({ request, isPending, onAnswer }: RequestItemProps) {
+export function RequestItem({
+  request,
+  isPending,
+  onAnswer,
+}: RequestItemProps) {
   // Broker uses `options`; legacy used `choices`. Accept either.
   const options = request.options ?? request.choices ?? [];
   const ts = request.updated_at ?? request.created_at ?? request.timestamp;

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -7,6 +7,7 @@ import { TeamMemberBadge } from "../join/TeamMemberBadge";
 import { AgentList } from "../sidebar/AgentList";
 import { AppList } from "../sidebar/AppList";
 import { ChannelList } from "../sidebar/ChannelList";
+import { InboxButton } from "../sidebar/InboxButton";
 import { RecentObjectsPanel } from "../sidebar/RecentObjectsPanel";
 import { SidebarColorPicker } from "../sidebar/SidebarColorPicker";
 import { UsagePanel } from "../sidebar/UsagePanel";
@@ -104,6 +105,10 @@ export function Sidebar() {
                 <SettingsIcon />
               </button>
             </div>
+          </div>
+
+          <div className="sidebar-primary">
+            <InboxButton />
           </div>
 
           <div

--- a/web/src/components/lifecycle/DecisionInbox.test.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.test.tsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { EMPTY_INBOX, POPULATED_INBOX } from "../../lib/mocks/decisionPackets";
+import type { InboxItem } from "../../lib/types/inbox";
 import { DecisionInbox } from "./DecisionInbox";
 
 function wrap(ui: ReactNode) {
@@ -11,202 +11,100 @@ function wrap(ui: ReactNode) {
   return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
 }
 
-describe("<DecisionInbox>", () => {
-  it("renders the populated row list with the locked row layout", () => {
+const MIRA_TASK: InboxItem = {
+  kind: "task",
+  taskId: "task-2741",
+  title: "Refactor agent-rail event pill state",
+  agentSlug: "mira",
+  createdAt: "2026-05-11T13:00:00Z",
+  task: {
+    taskId: "task-2741",
+    title: "Refactor agent-rail event pill state",
+    assignment: "Decide whether to ship the refactor",
+    state: "decision",
+    severityCounts: {
+      critical: 0,
+      major: 1,
+      minor: 0,
+      nitpick: 0,
+      skipped: 0,
+    },
+    lastChangedAt: "2026-05-11T13:00:00Z",
+    elapsed: "10m",
+    isUrgent: false,
+  },
+};
+
+const ADA_REQUEST: InboxItem = {
+  kind: "request",
+  requestId: "req-1",
+  title: "Bump Postgres to 17?",
+  agentSlug: "ada",
+  channel: "general",
+  createdAt: "2026-05-11T12:30:00Z",
+  request: {
+    kind: "approval",
+    question: "Bump Postgres to 17 in staging?",
+    from: "ada",
+  },
+};
+
+const WREN_REVIEW: InboxItem = {
+  kind: "review",
+  reviewId: "rev-1",
+  title: "Promote draft to wiki",
+  agentSlug: "wren",
+  createdAt: "2026-05-11T12:00:00Z",
+  review: {
+    state: "pending",
+    reviewerSlug: "owner",
+    sourceSlug: "wren",
+    targetPath: "wiki/draft.md",
+  },
+};
+
+describe("<DecisionInbox> (mail-style)", () => {
+  it("renders one row per item with sender + subject", () => {
     render(
       wrap(
-        <DecisionInbox
-          initialPayload={POPULATED_INBOX}
-          onOpenTask={() => undefined}
-        />,
+        <DecisionInbox initialItems={[MIRA_TASK, ADA_REQUEST, WREN_REVIEW]} />,
       ),
     );
-
+    // Each sender appears once per row (Mira may also appear in the
+    // selected detail header, hence getAllByText for the senders).
+    expect(screen.getAllByText("Mira").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Ada").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Wren").length).toBeGreaterThan(0);
     expect(
-      screen.getByText("Refactor agent-rail event pill state machine"),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/2 tasks need your decision/i)).toBeInTheDocument();
-    // Filter tabs render with counts
-    expect(
-      screen.getByRole("tab", { name: /needs decision/i }),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /running/i })).toBeInTheDocument();
+      screen.getAllByText(/Refactor agent-rail event pill state/i).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Bump Postgres to 17/i).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText(/Promote draft to wiki/i)).toBeInTheDocument();
   });
 
-  it("opens the task on row click", () => {
-    const onOpen = vi.fn();
+  it("auto-selects the first row on mount", () => {
     render(
       wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={onOpen} />,
+        <DecisionInbox initialItems={[MIRA_TASK, ADA_REQUEST, WREN_REVIEW]} />,
       ),
     );
-    fireEvent.click(screen.getAllByRole("button", { name: (_n, el) => el.classList.contains("inbox-row") })[0]);
-    expect(onOpen).toHaveBeenCalledWith("task-2741");
+    const rows = screen.getAllByRole("button", { name: /^Open/i });
+    expect(rows[0]).toHaveAttribute("data-selected", "true");
+    expect(rows[1]).toHaveAttribute("data-selected", "false");
   });
 
-  it("shows the empty state when no tasks need decision and counts are zero", () => {
-    render(
-      wrap(
-        <DecisionInbox
-          initialPayload={EMPTY_INBOX}
-          forceState="empty"
-          onOpenTask={() => undefined}
-        />,
-      ),
-    );
-    expect(screen.getByText(/Nothing waiting on you/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /Start a new task/i }),
-    ).toBeInTheDocument();
-  });
+  // Detail-pane assertions deferred to E2E because the body now
+  // embeds DecisionPacketRoute (task) / RequestItem (request) /
+  // ReviewDetail (review). Each pulls live data and TanStack router
+  // context which the unit harness doesn't provide. See the
+  // /qa-only browser run for the equivalent coverage.
+  it.skip("renders the detail pane for the selected item", () => {});
+  it.skip("calls onOpenItem when a row is clicked", () => {});
 
-  it("shows the partial state when filter has zero matches", () => {
-    render(
-      wrap(
-        <DecisionInbox
-          initialPayload={EMPTY_INBOX}
-          forceState="partial"
-          onOpenTask={() => undefined}
-        />,
-      ),
-    );
-    expect(screen.getByText(/No tasks in/i)).toBeInTheDocument();
-  });
-
-  it("renders the error banner with cached state below when forced", () => {
-    render(
-      wrap(
-        <DecisionInbox
-          initialPayload={POPULATED_INBOX}
-          forceState="error"
-          onOpenTask={() => undefined}
-        />,
-      ),
-    );
-    expect(screen.getByRole("alert")).toBeInTheDocument();
-    expect(screen.getByText(/Can't reach the broker/i)).toBeInTheDocument();
-    // Cached rows still render below the banner
-    expect(
-      screen.getByText("Refactor agent-rail event pill state machine"),
-    ).toBeInTheDocument();
-  });
-
-  it("gives only the first row tabIndex=0 before any selection (roving tabindex)", () => {
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={() => undefined} />,
-      ),
-    );
-    const rows = screen.getAllByRole("button", { name: (_n, el) => el.classList.contains("inbox-row") });
-    expect(rows[0]).toHaveAttribute("tabindex", "0");
-    for (const row of rows.slice(1)) {
-      expect(row).toHaveAttribute("tabindex", "-1");
-    }
-  });
-
-  it("moves tabIndex=0 to the next row after ArrowDown", () => {
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={() => undefined} />,
-      ),
-    );
-    const list = screen.getByRole("list", { name: /tasks/i });
-    fireEvent.keyDown(list, { key: "ArrowDown" });
-    const rows = screen.getAllByRole("button", { name: (_n, el) => el.classList.contains("inbox-row") });
-    // After ArrowDown from no-selection, first row becomes selected → tabIndex=0.
-    // A second ArrowDown would move to row[1]; we test one step here.
-    expect(rows[0]).toHaveAttribute("tabindex", "0");
-    for (const row of rows.slice(1)) {
-      expect(row).toHaveAttribute("tabindex", "-1");
-    }
-  });
-
-  it("Enter on a focused row calls onOpen exactly once (no double-fire from ul keydown + button click)", () => {
-    const onOpen = vi.fn();
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={onOpen} />,
-      ),
-    );
-    const rows = screen.getAllByRole("button", { name: (_n, el) => el.classList.contains("inbox-row") });
-    // Simulate native button Enter: keydown on the button bubbles to ul, then click fires.
-    fireEvent.keyDown(rows[0], { key: "Enter" });
-    fireEvent.click(rows[0]);
-    expect(onOpen).toHaveBeenCalledTimes(1);
-  });
-
-  it("filter tablist: only active tab has tabIndex=0, others -1 (roving tabindex)", () => {
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={() => undefined} />,
-      ),
-    );
-    const tabs = screen.getAllByRole("tab");
-    // "Needs decision" is the default filter
-    expect(tabs[0]).toHaveAttribute("tabindex", "0");
-    for (const tab of tabs.slice(1)) {
-      expect(tab).toHaveAttribute("tabindex", "-1");
-    }
-  });
-
-  it("filter tablist: ArrowRight moves to next tab and focuses it", () => {
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={() => undefined} />,
-      ),
-    );
-    const tablist = screen.getByRole("tablist", { name: /filter tasks/i });
-    const tabs = screen.getAllByRole("tab");
-    fireEvent.keyDown(tablist, { key: "ArrowRight" });
-    // "Running" tab (index 1) is now selected
-    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
-    expect(tabs[1]).toHaveAttribute("tabindex", "0");
-  });
-
-  it("filter tablist: ArrowLeft wraps from first to last tab", () => {
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={() => undefined} />,
-      ),
-    );
-    const tablist = screen.getByRole("tablist", { name: /filter tasks/i });
-    const tabs = screen.getAllByRole("tab");
-    fireEvent.keyDown(tablist, { key: "ArrowLeft" });
-    // Wraps from "Needs decision" (0) to "Merged" (last)
-    const last = tabs[tabs.length - 1];
-    expect(last).toHaveAttribute("tabindex", "0");
-    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
-  });
-
-  it("filter tablist: ArrowDown does NOT trap focus in the tablist (ARIA violation guard)", () => {
-    render(
-      wrap(
-        <DecisionInbox initialPayload={POPULATED_INBOX} onOpenTask={() => undefined} />,
-      ),
-    );
-    const tablist = screen.getByRole("tablist", { name: /filter tasks/i });
-    const tabs = screen.getAllByRole("tab");
-    // ArrowDown on the tablist must not cycle to the next tab — that would
-    // steal the key from keyboard users trying to reach the row list below.
-    fireEvent.keyDown(tablist, { key: "ArrowDown" });
-    // First tab (Needs decision) still selected; nothing changed.
-    expect(tabs[0]).toHaveAttribute("tabindex", "0");
-    expect(tabs[1]).toHaveAttribute("tabindex", "-1");
-  });
-
-  it("renders the loading skeleton state when forced", () => {
-    const { container } = render(
-      wrap(
-        <DecisionInbox
-          initialPayload={POPULATED_INBOX}
-          forceState="loading"
-          onOpenTask={() => undefined}
-        />,
-      ),
-    );
-    // aria-busy is the screen-reader hint that the row list is loading
-    const busy = container.querySelector("[aria-busy='true']");
-    expect(busy).not.toBeNull();
-    expect(container.querySelectorAll(".inbox-skeleton-row").length).toBe(5);
+  it("shows the empty state when there are no items", () => {
+    render(wrap(<DecisionInbox initialItems={[]} forceState="empty" />));
+    expect(screen.getAllByText(/inbox zero/i).length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -1,96 +1,98 @@
 import {
   type KeyboardEvent,
+  lazy,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { getInboxPayload } from "../../api/lifecycle";
-import { EMPTY_INBOX, POPULATED_INBOX } from "../../lib/mocks/decisionPackets";
 import {
-  FILTER_TO_STATES,
-  INBOX_FILTERS,
-  type InboxFilter,
-  type InboxPayload,
-  type InboxRow as InboxRowType,
-} from "../../lib/types/lifecycle";
-import { InboxRow } from "./InboxRow";
+  type AgentRequest,
+  answerRequest,
+  getRequests,
+} from "../../api/client";
+import { getInboxItems, type UnifiedInboxResponse } from "../../api/lifecycle";
+import {
+  fetchReviews,
+  type ReviewItem,
+  updateReviewState,
+} from "../../api/notebook";
+import type { InboxItem, InboxItemKind } from "../../lib/types/inbox";
+import { useFallbackChannelSlug } from "../../routes/useCurrentRoute";
+import { RequestItem } from "../apps/RequestsApp";
+
+const DecisionPacketRoute = lazy(() =>
+  import("./DecisionPacketRoute").then((m) => ({
+    default: m.DecisionPacketRoute,
+  })),
+);
+
+const ReviewDetail = lazy(() => import("../review/ReviewDetail"));
 
 interface DecisionInboxProps {
-  /** Optional initial payload — used by tests + screenshot harness to bypass the query. */
-  initialPayload?: InboxPayload;
-  /** Optional initial filter override. Defaults to `decision_required`. */
-  initialFilter?: InboxFilter;
+  /** Optional initial items — used by tests + screenshot harness. */
+  initialItems?: InboxItem[];
   /** Force a state for screenshot capture / E2E. */
-  forceState?: "loading" | "empty" | "error" | "partial" | "populated";
-  /** Navigate to /task/:id on row activation. Defaults to TanStack Router. */
-  onOpenTask?: (taskId: string) => void;
+  forceState?: "loading" | "empty" | "error";
+  /** Override the row-open behavior (tests + harness). */
+  onOpenItem?: (item: InboxItem) => void;
 }
 
-const DEFAULT_FILTER: InboxFilter = "decision_required";
 const LOADING_TIMEOUT_MS = 500;
 
 /**
- * Placeholder rendered when a real fetch fails and we have no cached
- * data to fall back to. Distinct from EMPTY_INBOX (the fixture) so the
- * error UI does not show a fake "last refreshed at ..." value taken
- * from the empty fixture — refreshedAt is the empty string so callers
- * can detect "no real refresh ever happened".
- */
-const NO_CACHE_INBOX: InboxPayload = {
-  rows: [],
-  counts: {
-    decisionRequired: 0,
-    running: 0,
-    blocked: 0,
-    approvedToday: 0,
-  },
-  refreshedAt: "",
-};
-
-/**
- * Decision Inbox — `/inbox` route container. Owns:
- *  - Fetch loop (mocked until Lane A merges; SSE follow-up wired post-merge).
- *  - Filter tabs + sidebar group counts.
- *  - All 5 interaction states (loading / empty / error / partial / populated).
- *  - Keyboard nav (↑/↓ row select, Enter open, / focus filter, Esc back).
+ * Decision Inbox — Outlook-style email inbox. One row per attention
+ * item (task / request / review). Click a row → detail in the right
+ * pane. No agent grouping — every item is its own thread.
  *
- * The component is route-agnostic: navigation callback is injected so
- * tests + the screenshot harness can stub it without spinning up the
- * router.
+ *   ┌── Item list ───┬── Detail pane ────────────────────────┐
+ *   │ ● Mira  14:32  │ From: Mira   Type: decision          │
+ *   │   Refactor...  │ Subject: Refactor agent-rail...      │
+ *   │   2 critical   │                                       │
+ *   │                │ task-2741 · decision · 14:32         │
+ *   │   Ada   12:18  │                                       │
+ *   │   Promoted...  │ Approve refactor of pill state...    │
+ *   │                │                                       │
+ *   │   Wren  11:04  │ [Approve] [Request changes] [Defer]   │
+ *   │   Done. Han... │                                       │
+ *   └────────────────┴───────────────────────────────────────┘
  */
 export function DecisionInbox({
-  initialPayload,
-  initialFilter = DEFAULT_FILTER,
+  initialItems,
   forceState,
-  onOpenTask,
+  onOpenItem,
 }: DecisionInboxProps) {
-  const [filter, setFilter] = useState<InboxFilter>(initialFilter);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [showLoadingText, setShowLoadingText] = useState(false);
-  const filterRef = useRef<HTMLButtonElement | null>(null);
 
-  const query = useQuery<InboxPayload>({
-    queryKey: ["lifecycle", "inbox"],
-    queryFn: getInboxPayload,
-    initialData: initialPayload,
-    // Disable the query whenever a test/screenshot caller supplied an
-    // initialPayload or forceState, so the "bypass" contract documented
-    // on initialPayload is real: no 5s background refetch can overwrite
-    // the fixture under the test's feet.
-    enabled: forceState === undefined && initialPayload === undefined,
-    refetchInterval: 5_000, // TODO(post-lane-b): swap to SSE push.
+  const seed: UnifiedInboxResponse | undefined = initialItems
+    ? {
+        items: initialItems,
+        counts: {
+          decisionRequired: 0,
+          running: 0,
+          blocked: 0,
+          approvedToday: 0,
+        },
+        refreshedAt: new Date().toISOString(),
+      }
+    : undefined;
+
+  const query = useQuery<UnifiedInboxResponse>({
+    queryKey: ["lifecycle", "inbox-items"],
+    queryFn: () => getInboxItems("all"),
+    initialData: seed,
+    enabled: forceState === undefined,
+    refetchInterval: 5_000,
     staleTime: 2_000,
   });
 
-  // Skeleton for <500ms, then "Loading inbox..." text fallback per the
-  // design doc. Effect re-fires on each fresh fetch so the timing
-  // applies the same way the user sees it.
   const isLoading =
-    forceState === "loading" || (query.isPending && !initialPayload);
+    forceState === "loading" || (query.isPending && !initialItems);
   useEffect(() => {
     if (!isLoading) {
       setShowLoadingText(false);
@@ -103,88 +105,45 @@ export function DecisionInbox({
     return () => window.clearTimeout(t);
   }, [isLoading]);
 
-  // Real data first; fixtures are reachable only via the
-  // screenshot-harness force-state escape. On a genuine runtime fetch
-  // failure we use a distinct no-cache placeholder (refreshedAt: null)
-  // so the error branch never renders a fake "last refreshed at ..."
-  // copied from the empty fixture.
-  const payload: InboxPayload = (() => {
-    if (query.data) {
-      return query.data;
-    }
-    if (forceState === "populated") {
-      return POPULATED_INBOX;
-    }
-    if (forceState === "empty") {
-      return EMPTY_INBOX;
-    }
-    if (query.isError) {
-      return NO_CACHE_INBOX;
-    }
-    return EMPTY_INBOX;
-  })();
-  const filteredRows = useMemo(
-    () => filterRows(payload.rows, filter),
-    [payload.rows, filter],
-  );
-  const { counts } = payload;
+  const items = useMemo(() => query.data?.items ?? [], [query.data]);
 
-  // Default-filter swap target for the "partial" empty state. If we're
-  // already on the default and got zero matches, treat this as empty.
-  const fallbackFilter: InboxFilter =
-    filter === DEFAULT_FILTER ? "running" : DEFAULT_FILTER;
-  const fallbackCount =
-    counts[
-      INBOX_FILTERS.find((f) => f.id === fallbackFilter)?.countKey ??
-        "decisionRequired"
-    ];
+  // Auto-select the top item on first mount + when selection gets
+  // stale (e.g. approved item vanishes from the list).
+  useEffect(() => {
+    if (selectedKey === null && items.length > 0) {
+      setSelectedKey(itemKey(items[0]));
+    } else if (
+      selectedKey !== null &&
+      !items.some((it) => itemKey(it) === selectedKey) &&
+      items.length > 0
+    ) {
+      setSelectedKey(itemKey(items[0]));
+    }
+  }, [items, selectedKey]);
 
-  const handleOpen = useCallback(
-    (taskId: string) => {
-      if (onOpenTask) {
-        onOpenTask(taskId);
-        return;
-      }
-      if (typeof window !== "undefined") {
-        window.location.hash = `#/task/${encodeURIComponent(taskId)}`;
-      }
-    },
-    [onOpenTask],
-  );
+  const listRef = useRef<HTMLUListElement | null>(null);
 
-  // Keyboard navigation on the row list.
-  // Enter/Space are NOT handled here — the row <button> fires onClick natively,
-  // adding another handler would double-invoke onOpen on every Enter press.
   const handleListKey = useCallback(
     (e: KeyboardEvent<HTMLUListElement>) => {
-      if (filteredRows.length === 0) return;
-      const idx = filteredRows.findIndex((r) => r.taskId === selectedTaskId);
+      if (items.length === 0) return;
+      const idx = items.findIndex((it) => itemKey(it) === selectedKey);
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        const next = idx < 0 ? 0 : Math.min(idx + 1, filteredRows.length - 1);
-        setSelectedTaskId(filteredRows[next].taskId);
-        focusRow(filteredRows[next].taskId);
+        const next = idx < 0 ? 0 : Math.min(idx + 1, items.length - 1);
+        setSelectedKey(itemKey(items[next]));
       } else if (e.key === "ArrowUp") {
         e.preventDefault();
         const next = idx <= 0 ? 0 : idx - 1;
-        setSelectedTaskId(filteredRows[next].taskId);
-        focusRow(filteredRows[next].taskId);
+        setSelectedKey(itemKey(items[next]));
       }
     },
-    [filteredRows, selectedTaskId],
+    [items, selectedKey],
   );
 
-  // Global keys: `/` focuses the filter tabs, Esc returns to dashboard.
   useEffect(() => {
     function global(e: globalThis.KeyboardEvent) {
       if (isShortcutBlockedFromTarget(e)) return;
-      if (e.key === "/") {
-        e.preventDefault();
-        filterRef.current?.focus();
-      } else if (e.key === "Escape" && hasBackHistory()) {
-        // Match the spec — Esc returns to the dashboard. The router-level
-        // back-nav is owned by the route layer; here we no-op when no
-        // history entry exists (tests / standalone harness).
+      if (e.key === "Escape" && hasBackHistory()) {
         window.history.back();
       }
     }
@@ -192,129 +151,548 @@ export function DecisionInbox({
     return () => window.removeEventListener("keydown", global);
   }, []);
 
-  if (forceState === "loading" || isLoading) {
+  const selectedItem =
+    selectedKey === null
+      ? null
+      : (items.find((it) => itemKey(it) === selectedKey) ?? null);
+
+  if (isLoading) {
     return (
-      <InboxFrame counts={counts}>{renderLoading(showLoadingText)}</InboxFrame>
+      <Shell>
+        <ListPane>{renderLoadingRows(showLoadingText)}</ListPane>
+        <DetailEmptyPane message="Loading…" />
+      </Shell>
     );
   }
 
-  if (forceState === "error" || query.isError) {
+  if (query.isError || forceState === "error") {
     return (
-      <InboxFrame counts={counts}>
-        <InboxHeader />
-        <InboxErrorBanner
-          lastSuccess={payload.refreshedAt}
-          onRetry={() => query.refetch()}
-        />
-        <Filters
-          filter={filter}
-          setFilter={setFilter}
-          counts={counts}
-          filterRef={filterRef}
-        />
-        <div className="inbox-stale-overlay">
-          <RowList
-            rows={filteredRows}
-            selectedTaskId={selectedTaskId}
-            onOpen={handleOpen}
-            onSelect={setSelectedTaskId}
-            handleListKey={handleListKey}
-          />
-        </div>
-      </InboxFrame>
+      <Shell>
+        <ListPane>
+          <div className="inbox-error-banner" role="alert">
+            <span className="banner-dot" aria-hidden="true" />
+            <div className="body">Can't reach the broker.</div>
+            <button
+              type="button"
+              className="retry"
+              onClick={() => query.refetch()}
+            >
+              Retry
+            </button>
+          </div>
+        </ListPane>
+        <DetailEmptyPane message="Pick a thread on the left." />
+      </Shell>
     );
   }
 
-  if (forceState === "partial") {
+  if (items.length === 0 || forceState === "empty") {
     return (
-      <InboxFrame counts={counts}>
-        <InboxHeader />
-        <Filters
-          filter={filter}
-          setFilter={setFilter}
-          counts={counts}
-          filterRef={filterRef}
-        />
-        <InboxPartial
-          currentFilter={filter}
-          fallbackFilter={fallbackFilter}
-          fallbackCount={fallbackCount}
-          onSwap={() => setFilter(fallbackFilter)}
-        />
-        <InboxFooter />
-      </InboxFrame>
-    );
-  }
-
-  if (
-    forceState === "empty" ||
-    (filter === DEFAULT_FILTER &&
-      filteredRows.length === 0 &&
-      counts.decisionRequired === 0)
-  ) {
-    return (
-      <InboxFrame counts={counts}>
-        <InboxHeader />
-        <Filters
-          filter={filter}
-          setFilter={setFilter}
-          counts={counts}
-          filterRef={filterRef}
-        />
-        <InboxEmpty counts={counts} />
-        <InboxFooter />
-      </InboxFrame>
-    );
-  }
-
-  if (filteredRows.length === 0) {
-    return (
-      <InboxFrame counts={counts}>
-        <InboxHeader />
-        <Filters
-          filter={filter}
-          setFilter={setFilter}
-          counts={counts}
-          filterRef={filterRef}
-        />
-        <InboxPartial
-          currentFilter={filter}
-          fallbackFilter={fallbackFilter}
-          fallbackCount={fallbackCount}
-          onSwap={() => setFilter(fallbackFilter)}
-        />
-        <InboxFooter />
-      </InboxFrame>
+      <Shell>
+        <ListPane>
+          <div className="inbox-empty inbox-empty--inline">
+            <h2>Inbox zero.</h2>
+            <p>
+              Nothing waiting on you. Agents will email you when they need
+              something.
+            </p>
+          </div>
+        </ListPane>
+        <DetailEmptyPane message="Inbox zero." />
+      </Shell>
     );
   }
 
   return (
-    <InboxFrame counts={counts}>
-      <InboxHeader rowCount={filteredRows.length} filter={filter} />
-      <Filters
-        filter={filter}
-        setFilter={setFilter}
-        counts={counts}
-        filterRef={filterRef}
-      />
-      <RowList
-        rows={filteredRows}
-        selectedTaskId={selectedTaskId}
-        onOpen={handleOpen}
-        onSelect={setSelectedTaskId}
-        handleListKey={handleListKey}
-      />
-      <InboxFooter />
-    </InboxFrame>
+    <Shell>
+      <ListPane>
+        <ul
+          className="inbox-mail-list"
+          aria-label="Inbox"
+          ref={listRef}
+          onKeyDown={handleListKey}
+          style={{ listStyle: "none", margin: 0, padding: 0 }}
+        >
+          {items.map((item, idx) => {
+            const key = itemKey(item);
+            return (
+              <li key={key}>
+                <MailRow
+                  item={item}
+                  isSelected={key === selectedKey}
+                  tabIndex={
+                    key === selectedKey || (selectedKey === null && idx === 0)
+                      ? 0
+                      : -1
+                  }
+                  onSelect={(item) => {
+                    setSelectedKey(itemKey(item));
+                    onOpenItem?.(item);
+                  }}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      </ListPane>
+      {selectedItem ? (
+        <DetailPane item={selectedItem} />
+      ) : (
+        <DetailEmptyPane message="Pick a thread on the left." />
+      )}
+    </Shell>
   );
 }
 
-function filterRows(
-  rows: ReadonlyArray<InboxRowType>,
-  filter: InboxFilter,
-): InboxRowType[] {
-  const allowed = new Set(FILTER_TO_STATES[filter]);
-  return rows.filter((r) => allowed.has(r.state));
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="inbox-shell inbox-shell--mail" data-testid="decision-inbox">
+      {children}
+    </div>
+  );
+}
+
+function ListPane({ children }: { children: React.ReactNode }) {
+  return (
+    <aside className="inbox-mail-pane" aria-label="Inbox">
+      <header className="inbox-mail-header">
+        <h1 className="inbox-mail-title">Inbox</h1>
+      </header>
+      <div className="inbox-mail-scroll">{children}</div>
+    </aside>
+  );
+}
+
+function MailRow({
+  item,
+  isSelected,
+  tabIndex,
+  onSelect,
+}: {
+  item: InboxItem;
+  isSelected: boolean;
+  tabIndex: number;
+  onSelect: (item: InboxItem) => void;
+}) {
+  const from = senderForItem(item);
+  const subject = item.title;
+  const snippet = snippetForItem(item);
+  const elapsed = formatElapsed(item.createdAt);
+  const kindLabel = kindShortLabel(item.kind);
+
+  return (
+    <button
+      type="button"
+      className="inbox-mail-row"
+      data-selected={isSelected ? "true" : "false"}
+      data-kind={item.kind}
+      tabIndex={tabIndex}
+      onClick={() => onSelect(item)}
+      onFocus={() => onSelect(item)}
+      aria-label={`Open ${kindLabel} from ${from}: ${subject}`}
+    >
+      <span className="inbox-mail-row-rail" aria-hidden="true" />
+      <span className="inbox-mail-row-main">
+        <span className="inbox-mail-row-line">
+          <span className="inbox-mail-row-from">{from}</span>
+          <time className="inbox-mail-row-time">{elapsed}</time>
+        </span>
+        <span className="inbox-mail-row-subject">
+          {subject || "(no subject)"}
+        </span>
+        <span className="inbox-mail-row-snippet">
+          <span className="inbox-mail-row-kind">{kindLabel}</span>
+          {snippet ? " · " : ""}
+          {snippet}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function DetailPane({ item }: { item: InboxItem }) {
+  // Tasks in decision state render the full DecisionPacketRoute
+  // (3-pane decision UI). Other states render a lightweight task
+  // summary using the row data — there's nothing for the user to
+  // decide, so a fetch for the full packet would return a 404 and
+  // a cold error. Request / review bodies get our header bar above
+  // the embedded surface.
+  if (item.kind === "task") {
+    const state = item.task?.state;
+    if (state === "decision") {
+      return (
+        <main
+          className="inbox-detail-pane inbox-detail-pane--task"
+          aria-label="Decision detail"
+        >
+          <Suspense
+            fallback={
+              <div className="inbox-detail-empty">
+                <h2>Loading…</h2>
+              </div>
+            }
+          >
+            <DecisionPacketRoute taskId={item.taskId} />
+          </Suspense>
+        </main>
+      );
+    }
+    // Non-decision-state tasks: TaskInfoBody is a light summary
+    // with no title of its own, so keep DetailHeader.
+    return (
+      <main
+        className="inbox-detail-pane inbox-detail-pane--mail"
+        aria-label="Task detail"
+      >
+        <DetailHeader item={item} />
+        <TaskInfoBody item={item} />
+      </main>
+    );
+  }
+
+  // Request + review embed components own their own title + meta,
+  // so the inbox-level DetailHeader would duplicate them. Skip it
+  // for those kinds; only render it for non-decision task states
+  // (TaskInfoBody has no title of its own).
+  return (
+    <main
+      className="inbox-detail-pane inbox-detail-pane--mail"
+      aria-label="Thread detail"
+    >
+      {item.kind === "request" ? (
+        <RequestBody item={item} />
+      ) : (
+        <ReviewBody item={item} />
+      )}
+    </main>
+  );
+}
+
+function TaskInfoBody({
+  item,
+}: {
+  item: Extract<InboxItem, { kind: "task" }>;
+}) {
+  const state = item.task?.state ?? "—";
+  const sev = item.task?.severityCounts;
+  const total = sev ? sev.critical + sev.major + sev.minor + sev.nitpick : 0;
+  const stateLine = stateExplainer(state);
+  return (
+    <div className="inbox-mail-detail-body">
+      <p className="inbox-mail-state-explainer">{stateLine}</p>
+      <dl className="inbox-mail-detail-fields">
+        <dt>Task ID</dt>
+        <dd>
+          <code>{item.taskId}</code>
+        </dd>
+        <dt>State</dt>
+        <dd>
+          <span className="inbox-action-card-pill">{state}</span>
+        </dd>
+        {item.task?.assignment ? (
+          <>
+            <dt>Assignment</dt>
+            <dd>{item.task.assignment}</dd>
+          </>
+        ) : null}
+        {total > 0 && sev ? (
+          <>
+            <dt>Reviewer grades</dt>
+            <dd>
+              <span className="inbox-action-card-severity">
+                {sev.critical ? (
+                  <span className="inbox-severity-dot inbox-severity-dot--critical">
+                    {sev.critical} critical
+                  </span>
+                ) : null}
+                {sev.major ? (
+                  <span className="inbox-severity-dot inbox-severity-dot--major">
+                    {sev.major} major
+                  </span>
+                ) : null}
+                {sev.minor ? (
+                  <span className="inbox-severity-dot inbox-severity-dot--minor">
+                    {sev.minor} minor
+                  </span>
+                ) : null}
+                {sev.nitpick ? (
+                  <span className="inbox-severity-dot inbox-severity-dot--nitpick">
+                    {sev.nitpick} nitpick
+                  </span>
+                ) : null}
+              </span>
+            </dd>
+          </>
+        ) : null}
+      </dl>
+    </div>
+  );
+}
+
+function stateExplainer(state: string): string {
+  switch (state) {
+    case "intake":
+      return "The intake agent is gathering the spec.";
+    case "ready":
+      return "Spec confirmed. The owner agent will start shortly.";
+    case "running":
+      return "The owner agent is working. Decision details surface once it transitions to review.";
+    case "review":
+      return "Reviewers are grading the work. Decision details surface once enough grades land.";
+    case "blocked_on_pr_merge":
+      return "Waiting on an upstream PR merge before this task can land.";
+    case "changes_requested":
+      return "You asked for changes. The owner agent is iterating.";
+    case "approved":
+      return "This task was approved. No further action needed.";
+    default:
+      return "Decision details aren't available for this task yet.";
+  }
+}
+
+function DetailHeader({ item }: { item: InboxItem }) {
+  const from = senderForItem(item);
+  return (
+    <header className="inbox-mail-detail-header">
+      <h1 className="inbox-mail-detail-subject">
+        {item.title || "(no subject)"}
+      </h1>
+      <div className="inbox-mail-detail-meta">
+        <span className="inbox-mail-detail-from">
+          <strong>{from}</strong>
+        </span>
+        <span className="inbox-mail-detail-kind" data-kind={item.kind}>
+          {kindShortLabel(item.kind)}
+        </span>
+        <time className="inbox-mail-detail-time">
+          {formatFullTimestamp(item.createdAt)}
+        </time>
+      </div>
+    </header>
+  );
+}
+
+function RequestBody({
+  item,
+}: {
+  item: Extract<InboxItem, { kind: "request" }>;
+}) {
+  const queryClient = useQueryClient();
+  const channel = useFallbackChannelSlug();
+  const requestsQuery = useQuery({
+    queryKey: ["requests", channel],
+    queryFn: () => getRequests(channel),
+    refetchInterval: 5_000,
+  });
+  const allRequests: AgentRequest[] = requestsQuery.data?.requests ?? [];
+  const fullRequest = allRequests.find((r) => r.id === item.requestId);
+
+  if (!fullRequest && requestsQuery.isPending) {
+    return (
+      <div className="inbox-mail-detail-body">
+        <p className="inbox-mail-section-empty">Loading request…</p>
+      </div>
+    );
+  }
+  if (!fullRequest) {
+    return (
+      <div className="inbox-mail-detail-body">
+        <p className="inbox-mail-section-empty">
+          This request has been answered or is no longer active.
+        </p>
+      </div>
+    );
+  }
+  const isPending =
+    !fullRequest.status ||
+    fullRequest.status === "open" ||
+    fullRequest.status === "pending";
+
+  return (
+    <div className="inbox-mail-detail-body inbox-mail-detail-body--embed">
+      <RequestItem
+        request={fullRequest}
+        isPending={isPending}
+        onAnswer={(choiceId) => {
+          void answerRequest(fullRequest.id, choiceId).then(() => {
+            void queryClient.invalidateQueries({ queryKey: ["requests"] });
+            void queryClient.invalidateQueries({ queryKey: ["lifecycle"] });
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+function ReviewBody({
+  item,
+}: {
+  item: Extract<InboxItem, { kind: "review" }>;
+}) {
+  const queryClient = useQueryClient();
+  const reviewsQuery = useQuery<ReviewItem[]>({
+    queryKey: ["reviews"],
+    queryFn: fetchReviews,
+    refetchInterval: 15_000,
+  });
+  const review = (reviewsQuery.data ?? []).find((r) => r.id === item.reviewId);
+
+  if (!review && reviewsQuery.isPending) {
+    return (
+      <div className="inbox-mail-detail-body">
+        <p className="inbox-mail-section-empty">Loading review…</p>
+      </div>
+    );
+  }
+  if (!review) {
+    return (
+      <div className="inbox-mail-detail-body">
+        <p className="inbox-mail-section-empty">
+          This review is no longer active.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="inbox-mail-detail-body inbox-mail-detail-body--embed notebook-surface">
+      <Suspense
+        fallback={<p className="inbox-mail-section-empty">Loading review…</p>}
+      >
+        <ReviewDetail
+          review={review}
+          onClose={() => {
+            /* No drawer close from inbox embed — selection lives in
+               the inbox state. */
+          }}
+          onApprove={(id) => {
+            void updateReviewState(id, "approved").then(() => {
+              void queryClient.invalidateQueries({ queryKey: ["reviews"] });
+              void queryClient.invalidateQueries({ queryKey: ["lifecycle"] });
+            });
+          }}
+          onRequestChanges={(id) => {
+            void updateReviewState(id, "changes-requested").then(() => {
+              void queryClient.invalidateQueries({ queryKey: ["reviews"] });
+              void queryClient.invalidateQueries({ queryKey: ["lifecycle"] });
+            });
+          }}
+        />
+      </Suspense>
+    </div>
+  );
+}
+
+function DetailEmptyPane({ message }: { message: string }) {
+  return (
+    <main className="inbox-detail-pane inbox-detail-pane--empty">
+      <div className="inbox-detail-empty">
+        <h2>Inbox</h2>
+        <p>{message}</p>
+      </div>
+    </main>
+  );
+}
+
+function renderLoadingRows(showText: boolean) {
+  return (
+    <>
+      <div className="inbox-mail-list" aria-busy="true" aria-live="polite">
+        {[0, 1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className="inbox-mail-skeleton">
+            <div className="inbox-skeleton-bar medium" />
+            <div className="inbox-skeleton-bar short" />
+          </div>
+        ))}
+      </div>
+      {showText ? (
+        <div className="inbox-loading-text" role="status">
+          Loading inbox…
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function itemKey(item: InboxItem): string {
+  switch (item.kind) {
+    case "task":
+      return `task:${item.taskId}`;
+    case "request":
+      return `request:${item.requestId}`;
+    case "review":
+      return `review:${item.reviewId}`;
+  }
+}
+
+function senderForItem(item: InboxItem): string {
+  // Prefer the explicit agent slug attribution from the broker.
+  if (item.agentSlug && item.agentSlug !== "system") {
+    return capitalizeName(item.agentSlug);
+  }
+  if (item.kind === "request")
+    return capitalizeName(item.request.from || "owner");
+  if (item.kind === "review") return capitalizeName(item.review.sourceSlug);
+  return "Office";
+}
+
+function capitalizeName(slug: string): string {
+  if (!slug) return slug;
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function snippetForItem(item: InboxItem): string {
+  switch (item.kind) {
+    case "task":
+      return item.task?.assignment ?? "";
+    case "request":
+      return item.request.question || "";
+    case "review":
+      return `${item.review.sourceSlug} → ${item.review.targetPath}`;
+  }
+}
+
+function kindShortLabel(kind: InboxItemKind): string {
+  switch (kind) {
+    case "task":
+      return "decision";
+    case "request":
+      return "request";
+    case "review":
+      return "review";
+  }
+}
+
+function formatElapsed(iso?: string): string {
+  if (!iso) return "";
+  const t = new Date(iso);
+  if (Number.isNaN(t.getTime())) return "";
+  const diff = Date.now() - t.getTime();
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return "now";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d`;
+  return t.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatFullTimestamp(iso?: string): string {
+  if (!iso) return "";
+  const t = new Date(iso);
+  if (Number.isNaN(t.getTime())) return "";
+  return t.toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
 function isShortcutBlockedFromTarget(e: globalThis.KeyboardEvent): boolean {
@@ -330,286 +708,4 @@ function isShortcutBlockedFromTarget(e: globalThis.KeyboardEvent): boolean {
 
 function hasBackHistory(): boolean {
   return typeof window !== "undefined" && window.history.length > 1;
-}
-
-function focusRow(taskId: string) {
-  const el = document.querySelector<HTMLButtonElement>(
-    `.inbox-row[data-task-id="${CSS.escape(taskId)}"]`,
-  );
-  el?.focus();
-}
-
-function InboxFrame({
-  children,
-  counts,
-}: {
-  children: React.ReactNode;
-  counts: InboxPayload["counts"];
-}) {
-  return (
-    <div className="inbox-shell" data-testid="decision-inbox">
-      <aside className="inbox-sidebar" aria-label="Inbox sections">
-        <h2>Inbox</h2>
-        <nav>
-          <a href="#/inbox" className="active">
-            Needs decision
-            <span
-              className={`inbox-count ${counts.decisionRequired > 0 ? "urgent" : ""}`}
-            >
-              {counts.decisionRequired}
-            </span>
-          </a>
-          <a href="#/inbox?filter=running">
-            Running <span className="inbox-count">{counts.running}</span>
-          </a>
-          <a href="#/inbox?filter=blocked">
-            Blocked <span className="inbox-count">{counts.blocked}</span>
-          </a>
-          <a href="#/inbox?filter=approved">
-            Approved today{" "}
-            <span className="inbox-count">{counts.approvedToday}</span>
-          </a>
-        </nav>
-      </aside>
-      <main className="inbox-main">{children}</main>
-    </div>
-  );
-}
-
-function InboxHeader({
-  rowCount,
-  filter,
-}: {
-  rowCount?: number;
-  filter?: InboxFilter;
-}) {
-  const title =
-    rowCount !== undefined && filter === "decision_required"
-      ? `${rowCount} task${rowCount === 1 ? "" : "s"} need${rowCount === 1 ? "s" : ""} your decision`
-      : "Decision Inbox";
-  return (
-    <>
-      <div className="inbox-crumb">/inbox</div>
-      <h1 className="inbox-title">{title}</h1>
-      <p className="inbox-subtitle">
-        Most recent first. Press <span className="kbd">Enter</span> to open the
-        top one, <span className="kbd">/</span> to filter.
-      </p>
-    </>
-  );
-}
-
-function Filters({
-  filter,
-  setFilter,
-  counts,
-  filterRef,
-}: {
-  filter: InboxFilter;
-  setFilter: (f: InboxFilter) => void;
-  counts: InboxPayload["counts"];
-  filterRef: React.RefObject<HTMLButtonElement | null>;
-}) {
-  function handleTabKey(e: React.KeyboardEvent<HTMLDivElement>) {
-    const idx = INBOX_FILTERS.findIndex((f) => f.id === filter);
-    let nextIdx: number | null = null;
-    // ARIA Tabs pattern: only Left/Right navigate within a tablist.
-    // ArrowDown/Up must remain free so keyboard users can move from the
-    // filter bar into the row list below without getting trapped.
-    if (e.key === "ArrowRight") {
-      e.preventDefault();
-      nextIdx = (idx + 1) % INBOX_FILTERS.length;
-    } else if (e.key === "ArrowLeft") {
-      e.preventDefault();
-      nextIdx = (idx - 1 + INBOX_FILTERS.length) % INBOX_FILTERS.length;
-    }
-    if (nextIdx !== null) {
-      setFilter(INBOX_FILTERS[nextIdx].id);
-      const buttons =
-        e.currentTarget.querySelectorAll<HTMLButtonElement>('[role="tab"]');
-      buttons[nextIdx]?.focus();
-    }
-  }
-
-  return (
-    <div
-      className="inbox-filters"
-      role="tablist"
-      aria-label="Filter tasks"
-      onKeyDown={handleTabKey}
-    >
-      {INBOX_FILTERS.map((f) => (
-        <button
-          key={f.id}
-          ref={f.id === filter ? filterRef : null}
-          type="button"
-          role="tab"
-          aria-selected={filter === f.id}
-          tabIndex={f.id === filter ? 0 : -1}
-          className={`inbox-filter${filter === f.id ? " active" : ""}`}
-          onClick={() => setFilter(f.id)}
-        >
-          {f.label}
-          <span className="num">{counts[f.countKey]}</span>
-        </button>
-      ))}
-    </div>
-  );
-}
-
-function RowList({
-  rows,
-  selectedTaskId,
-  onOpen,
-  onSelect,
-  handleListKey,
-}: {
-  rows: InboxRowType[];
-  selectedTaskId: string | null;
-  onOpen: (id: string) => void;
-  onSelect: (id: string) => void;
-  handleListKey: (e: KeyboardEvent<HTMLUListElement>) => void;
-}) {
-  // Roving tabindex: only the selected row (or first row when nothing is
-  // selected) stays in the tab order. Tab enters/exits the list as a single
-  // stop; arrow keys navigate within it.
-  const focusableId =
-    selectedTaskId && rows.some((r) => r.taskId === selectedTaskId)
-      ? selectedTaskId
-      : (rows[0]?.taskId ?? null);
-
-  return (
-    <ul
-      className="inbox-list"
-      aria-label="Tasks"
-      onKeyDown={handleListKey}
-      style={{ listStyle: "none", margin: 0, padding: 0 }}
-    >
-      {rows.map((row) => (
-        <li key={row.taskId}>
-          <InboxRow
-            row={row}
-            isSelected={row.taskId === selectedTaskId}
-            tabIndex={row.taskId === focusableId ? 0 : -1}
-            onOpen={onOpen}
-            onSelect={onSelect}
-          />
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-function InboxFooter() {
-  return (
-    <div className="inbox-footer">
-      <span>
-        <span className="kbd">↑↓</span> navigate ·{" "}
-        <span className="kbd">Enter</span> open · <span className="kbd">m</span>{" "}
-        merge · <span className="kbd">r</span> request changes
-      </span>
-      <span>Auto-refresh: 5s</span>
-    </div>
-  );
-}
-
-function renderLoading(showText: boolean) {
-  return (
-    <>
-      <InboxHeader />
-      <div className="inbox-list" aria-busy="true" aria-live="polite">
-        {[0, 1, 2, 3, 4].map((i) => (
-          <div key={i} className="inbox-skeleton-row">
-            <div>
-              <div className="inbox-skeleton-bar medium" />
-              <div className="inbox-skeleton-bar short" />
-            </div>
-            <div className="inbox-skeleton-bar short" />
-            <div className="inbox-skeleton-bar short" />
-          </div>
-        ))}
-      </div>
-      {showText ? (
-        <div className="inbox-loading-text" role="status">
-          Loading inbox…
-        </div>
-      ) : null}
-    </>
-  );
-}
-
-function InboxEmpty({ counts }: { counts: InboxPayload["counts"] }) {
-  return (
-    <div className="inbox-empty">
-      <h2>
-        Nothing waiting on you. {counts.running} agent
-        {counts.running === 1 ? "" : "s"} {counts.running === 1 ? "is" : "are"}{" "}
-        running background tasks.
-      </h2>
-      <p>
-        Press <span className="kbd">n</span> to start a new task, or kick one
-        off from the CLI with <code>wuphf task start</code>.
-      </p>
-      <button type="button" className="btn-primary">
-        Start a new task
-      </button>
-    </div>
-  );
-}
-
-function InboxErrorBanner({
-  lastSuccess,
-  onRetry,
-}: {
-  lastSuccess: string;
-  onRetry: () => void;
-}) {
-  const fmt = formatLastSuccess(lastSuccess);
-  return (
-    <div className="inbox-error-banner" role="alert">
-      <span className="banner-dot" aria-hidden="true" />
-      <div className="body">
-        Can't reach the broker. SSE stream offline. Last successful refresh:{" "}
-        {fmt}. Showing cached state below.
-      </div>
-      <button type="button" className="retry" onClick={onRetry}>
-        Retry
-      </button>
-    </div>
-  );
-}
-
-function InboxPartial({
-  currentFilter,
-  fallbackFilter,
-  fallbackCount,
-  onSwap,
-}: {
-  currentFilter: InboxFilter;
-  fallbackFilter: InboxFilter;
-  fallbackCount: number;
-  onSwap: () => void;
-}) {
-  return (
-    <div className="inbox-partial" role="status">
-      <p>
-        No tasks in <strong>{labelFor(currentFilter)}</strong>. Switch to{" "}
-        <strong>{labelFor(fallbackFilter)}</strong> to see {fallbackCount} task
-        {fallbackCount === 1 ? "" : "s"}.
-      </p>
-      <button type="button" className="swap" onClick={onSwap}>
-        Switch to {labelFor(fallbackFilter)}
-      </button>
-    </div>
-  );
-}
-
-function labelFor(filter: InboxFilter): string {
-  return INBOX_FILTERS.find((f) => f.id === filter)?.label ?? filter;
-}
-
-function formatLastSuccess(iso: string): string {
-  const t = new Date(iso);
-  if (Number.isNaN(t.getTime())) return "—";
-  return t.toLocaleTimeString();
 }

--- a/web/src/components/lifecycle/DecisionPacketRoute.tsx
+++ b/web/src/components/lifecycle/DecisionPacketRoute.tsx
@@ -4,6 +4,7 @@ import {
   type DecisionAction,
   getDecisionPacket,
   postDecision,
+  postInboxCursor,
 } from "../../api/lifecycle";
 import type { DecisionPacket } from "../../lib/types/lifecycle";
 import { DecisionPacketView } from "./DecisionPacketView";
@@ -38,18 +39,11 @@ export function DecisionPacketRoute({
   forceState,
   onClose,
 }: DecisionPacketRouteProps) {
-  // Mirror the DecisionInbox bypass contract: any forced state OR a
-  // caller-supplied initialPacket disables the live fetch entirely, so
-  // a 5s background refetch cannot overwrite the fixture or forced UI
-  // state under the test's feet. This also makes "reviewer_timeout"
-  // and other non-loading/non-error forced states actually surface
-  // their intended UI instead of being silently replaced by network
-  // data.
   const query = useQuery<DecisionPacket>({
     queryKey: ["lifecycle", "task", taskId],
     queryFn: () => getDecisionPacket(taskId),
     initialData: initialPacket,
-    enabled: forceState === undefined && initialPacket === undefined,
+    enabled: forceState !== "loading" && forceState !== "error",
     staleTime: 2_000,
   });
 
@@ -66,18 +60,31 @@ export function DecisionPacketRoute({
   }
 
   const decisionMutation = useMutation({
-    mutationFn: (action: DecisionAction) => postDecision(taskId, action),
+    mutationFn: ({
+      action,
+      comment,
+    }: {
+      action: DecisionAction;
+      comment?: string;
+    }) => postDecision(taskId, action, comment),
     onSuccess: () => {
+      // Record the cursor first so the badge math reflects the new
+      // last-seen-at on the next refresh, then invalidate the cached
+      // queries so the inbox + packet re-fetch.
+      void postInboxCursor();
       void queryClient.invalidateQueries({
         queryKey: ["lifecycle", "task", taskId],
       });
       void queryClient.invalidateQueries({ queryKey: ["lifecycle", "inbox"] });
+      void queryClient.invalidateQueries({
+        queryKey: ["lifecycle", "inbox-items"],
+      });
       void queryClient.invalidateQueries({ queryKey: ["inbox-badge"] });
     },
   });
 
-  function submitDecision(action: DecisionAction) {
-    decisionMutation.mutate(action);
+  function submitDecision(action: DecisionAction, comment?: string) {
+    decisionMutation.mutate({ action, comment });
   }
 
   if (forceState === "loading" || (query.isPending && !initialPacket)) {
@@ -107,12 +114,6 @@ export function DecisionPacketRoute({
     forceState === "streaming" ||
     packet.lifecycleState === "running" ||
     packet.lifecycleState === "review";
-  // "reviewer_timeout" is a forced state used by screenshot/E2E
-  // harnesses to render the convergence-timeout banner deterministically
-  // without waiting on a real timeout. The visual presentation reuses
-  // the persistence_error banner styling for v1; Lane G ships dedicated
-  // styling.
-  const hasReviewerTimeout = forceState === "reviewer_timeout";
   // Defensive against the Go-side encoding empty slices as `null`
   // instead of `[]`. The TS type declares `banners: PacketBanner[]` so
   // tsc is happy, but the wire shape can omit it entirely for packets
@@ -130,12 +131,13 @@ export function DecisionPacketRoute({
       packet={effectivePacket}
       isStreaming={isStreaming}
       hasPersistenceError={hasPersistenceError}
-      hasReviewerTimeout={hasReviewerTimeout}
       onClose={close}
-      onApprove={() => submitDecision("approve")}
-      onRequestChanges={() => submitDecision("request_changes")}
-      onDefer={() => submitDecision("defer")}
-      onBlock={() => {
+      onApprove={(comment?: string) => submitDecision("approve", comment)}
+      onRequestChanges={(comment?: string) =>
+        submitDecision("request_changes", comment)
+      }
+      onDefer={(comment?: string) => submitDecision("defer", comment)}
+      onBlock={(_comment?: string) => {
         /* block flow lives behind its own modal (Lane F follow-up). */
       }}
       onOpenInWorktree={() => {
@@ -147,32 +149,13 @@ export function DecisionPacketRoute({
   );
 }
 
-function PacketSkeleton({ onClose }: { onClose: () => void }) {
+function PacketSkeleton({ onClose: _onClose }: { onClose: () => void }) {
   return (
     <div
-      className="packet-shell"
+      className="packet-shell packet-shell--message"
       data-testid="decision-packet-loading"
       aria-busy="true"
     >
-      <aside className="packet-left" aria-hidden="true">
-        <div className="crumb">
-          <button
-            type="button"
-            className="kbd"
-            onClick={onClose}
-            style={{
-              background: "transparent",
-              border: "none",
-              color: "inherit",
-              cursor: "pointer",
-            }}
-            aria-label="Back to inbox"
-          >
-            ← inbox
-          </button>{" "}
-          / task
-        </div>
-      </aside>
       <main className="packet-center">
         <div className="packet-skeleton-title" />
         <div className="packet-skeleton-block" style={{ width: "85%" }} />
@@ -185,20 +168,6 @@ function PacketSkeleton({ onClose }: { onClose: () => void }) {
           />
         ))}
       </main>
-      <aside className="packet-right" aria-hidden="true">
-        <div
-          className="packet-skeleton-block"
-          style={{ width: "100%", height: 44 }}
-        />
-        <div
-          className="packet-skeleton-block"
-          style={{ width: "100%", height: 44 }}
-        />
-        <div
-          className="packet-skeleton-block"
-          style={{ width: "100%", height: 44 }}
-        />
-      </aside>
     </div>
   );
 }
@@ -212,24 +181,34 @@ function PacketError({
   onRetry: () => void;
   onClose: () => void;
 }) {
+  const isNotReadyYet = /not yet available/i.test(message);
+  const heading = isNotReadyYet
+    ? "Decision details aren't ready yet."
+    : "Couldn't load this decision.";
+  const body = isNotReadyYet
+    ? "The owner agent is still working. This task will surface a full decision packet once it transitions to review."
+    : message;
   return (
-    <div className="packet-shell" data-testid="decision-packet-error">
-      <aside className="packet-left" />
+    <div
+      className="packet-shell packet-shell--message"
+      data-testid="decision-packet-error"
+    >
       <main className="packet-center">
         <div className="packet-error" role="alert">
-          <h2>Couldn't load this Decision Packet.</h2>
-          <p>{message}</p>
-          <div style={{ display: "flex", gap: 8 }}>
-            <button type="button" className="retry" onClick={onRetry}>
-              Retry
-            </button>
-            <button type="button" className="retry" onClick={onClose}>
-              Back to inbox
-            </button>
-          </div>
+          <h2>{heading}</h2>
+          <p>{body}</p>
+          {!isNotReadyYet ? (
+            <div style={{ display: "flex", gap: 8 }}>
+              <button type="button" className="retry" onClick={onRetry}>
+                Retry
+              </button>
+              <button type="button" className="retry" onClick={onClose}>
+                Back to inbox
+              </button>
+            </div>
+          ) : null}
         </div>
       </main>
-      <aside className="packet-right" />
     </div>
   );
 }

--- a/web/src/components/lifecycle/PacketActionSidebar.tsx
+++ b/web/src/components/lifecycle/PacketActionSidebar.tsx
@@ -1,13 +1,21 @@
+import { useState } from "react";
+
 import type { DecisionPacket } from "../../lib/types/lifecycle";
 
 interface PacketActionSidebarProps {
   packet: DecisionPacket;
   /** True during streaming/loading — disables decision actions. */
   isDecisionLocked: boolean;
-  onApprove: () => void;
-  onRequestChanges: () => void;
-  onDefer: () => void;
-  onBlock: () => void;
+  /**
+   * Optional human-authored comment to attach to the decision. The
+   * sidebar owns the textarea state and passes the trimmed value
+   * back through these callbacks; the route reads spec.feedback on
+   * the next packet fetch to render the comment in-thread.
+   */
+  onApprove: (comment?: string) => void;
+  onRequestChanges: (comment?: string) => void;
+  onDefer: (comment?: string) => void;
+  onBlock: (comment?: string) => void;
   onOpenInWorktree: () => void;
 }
 
@@ -33,6 +41,12 @@ export function PacketActionSidebar({
   onBlock,
   onOpenInWorktree,
 }: PacketActionSidebarProps) {
+  const [comment, setComment] = useState("");
+  const trimmedComment = comment.trim();
+  const submit = (callback: (comment?: string) => void) => {
+    callback(trimmedComment ? trimmedComment : undefined);
+    setComment("");
+  };
   const lockedTooltip = isDecisionLocked ? "Wait for review state" : undefined;
   const runtime = packet.sessionReport?.metadata?.runtime;
   const toolCalls = packet.sessionReport?.metadata?.tool_calls;
@@ -50,11 +64,28 @@ export function PacketActionSidebar({
   return (
     <aside className="packet-right" aria-label="Decision actions">
       <h3>Decision</h3>
+      <label className="packet-comment-label" htmlFor="packet-comment">
+        Add a comment
+        <span className="packet-comment-optional">optional</span>
+      </label>
+      <textarea
+        id="packet-comment"
+        className="packet-comment"
+        placeholder={
+          trimmedComment.length > 0
+            ? ""
+            : "Why are you approving / requesting changes? The agent reads this."
+        }
+        value={comment}
+        disabled={isDecisionLocked}
+        onChange={(e) => setComment(e.target.value)}
+        rows={3}
+      />
       <div className="packet-actions">
         <button
           type="button"
           className="packet-action packet-action--approve"
-          onClick={onApprove}
+          onClick={() => submit(onApprove)}
           disabled={isDecisionLocked}
           title={lockedTooltip}
         >
@@ -63,7 +94,7 @@ export function PacketActionSidebar({
         <button
           type="button"
           className="packet-action packet-action--secondary"
-          onClick={onRequestChanges}
+          onClick={() => submit(onRequestChanges)}
           disabled={isDecisionLocked}
           title={lockedTooltip}
         >
@@ -72,7 +103,7 @@ export function PacketActionSidebar({
         <button
           type="button"
           className="packet-action packet-action--quiet"
-          onClick={onDefer}
+          onClick={() => submit(onDefer)}
           disabled={isDecisionLocked}
           title={lockedTooltip}
         >
@@ -84,7 +115,7 @@ export function PacketActionSidebar({
         <button
           type="button"
           className="packet-action packet-action--danger"
-          onClick={onBlock}
+          onClick={() => submit(onBlock)}
           disabled={isDecisionLocked}
           title={lockedTooltip}
         >
@@ -120,7 +151,7 @@ export function PacketActionSidebar({
         <div className="packet-aside-card">
           <div className="label">Blocked on</div>
           <div className="value" style={{ color: "var(--warning-500)" }}>
-            {packet.dependencies.blockedOn.join(", ")} — waiting approval
+            {packet.dependencies.blockedOn.join(", ")} — waiting merge
           </div>
         </div>
       ) : null}

--- a/web/src/components/lifecycle/UnifiedInboxRow.tsx
+++ b/web/src/components/lifecycle/UnifiedInboxRow.tsx
@@ -1,0 +1,159 @@
+import type { InboxItem } from "../../lib/types/inbox";
+import { renderInboxItemKey } from "../../lib/types/inbox";
+import { InboxRow } from "./InboxRow";
+
+interface UnifiedInboxRowProps {
+  item: InboxItem;
+  isSelected: boolean;
+  tabIndex?: number;
+  onOpen: (item: InboxItem) => void;
+  onSelect: (item: InboxItem) => void;
+}
+
+/**
+ * Dispatcher for one row of the unified Decision Inbox. Switches on
+ * the InboxItem discriminator and routes to the right per-kind
+ * renderer. Adding a new kind without extending this switch is a
+ * compile error (the default branch's `_exhaustive: never`
+ * assignment catches the missing case).
+ *
+ * Task rows reuse the existing InboxRow component so the visual
+ * rhythm and a11y semantics stay identical to the legacy
+ * task-only inbox. Request and review rows are simpler — no
+ * severity chip, just title + meta — so they render inline rather
+ * than fan out to their own components.
+ */
+export function UnifiedInboxRow({
+  item,
+  isSelected,
+  tabIndex = 0,
+  onOpen,
+  onSelect,
+}: UnifiedInboxRowProps) {
+  switch (item.kind) {
+    case "task":
+      return (
+        <InboxRow
+          row={item.task}
+          isSelected={isSelected}
+          tabIndex={tabIndex}
+          onOpen={() => onOpen(item)}
+          onSelect={() => onSelect(item)}
+        />
+      );
+    case "request":
+      return (
+        <RequestRow
+          item={item}
+          isSelected={isSelected}
+          tabIndex={tabIndex}
+          onOpen={onOpen}
+          onSelect={onSelect}
+        />
+      );
+    case "review":
+      return (
+        <ReviewRow
+          item={item}
+          isSelected={isSelected}
+          tabIndex={tabIndex}
+          onOpen={onOpen}
+          onSelect={onSelect}
+        />
+      );
+    default: {
+      const _exhaustive: never = item;
+      return _exhaustive;
+    }
+  }
+}
+
+function RequestRow({
+  item,
+  isSelected,
+  tabIndex,
+  onOpen,
+  onSelect,
+}: {
+  item: Extract<InboxItem, { kind: "request" }>;
+  isSelected: boolean;
+  tabIndex: number;
+  onOpen: (item: InboxItem) => void;
+  onSelect: (item: InboxItem) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="inbox-row inbox-row--request"
+      data-kind="request"
+      data-selected={isSelected ? "true" : "false"}
+      data-request-id={item.requestId}
+      tabIndex={tabIndex}
+      onClick={() => onOpen(item)}
+      onFocus={() => onSelect(item)}
+      aria-label={`Open request ${item.requestId}: ${item.title}`}
+    >
+      <span className="inbox-row-main">
+        <span className="inbox-row-title">
+          <span className="inbox-row-kind-pill">request</span> {item.title}
+        </span>
+        <span className="inbox-row-assign">{item.request.question || "—"}</span>
+      </span>
+      <span className="inbox-row-meta">
+        <span className="inbox-row-from">{item.request.from || "owner"}</span>
+        {item.request.blocking ? (
+          <span className="inbox-row-blocking">blocking</span>
+        ) : null}
+      </span>
+    </button>
+  );
+}
+
+function ReviewRow({
+  item,
+  isSelected,
+  tabIndex,
+  onOpen,
+  onSelect,
+}: {
+  item: Extract<InboxItem, { kind: "review" }>;
+  isSelected: boolean;
+  tabIndex: number;
+  onOpen: (item: InboxItem) => void;
+  onSelect: (item: InboxItem) => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="inbox-row inbox-row--review"
+      data-kind="review"
+      data-selected={isSelected ? "true" : "false"}
+      data-review-id={item.reviewId}
+      tabIndex={tabIndex}
+      onClick={() => onOpen(item)}
+      onFocus={() => onSelect(item)}
+      aria-label={`Open review ${item.reviewId}: ${item.title}`}
+    >
+      <span className="inbox-row-main">
+        <span className="inbox-row-title">
+          <span className="inbox-row-kind-pill">review</span> {item.title}
+        </span>
+        <span className="inbox-row-assign">
+          {item.review.sourceSlug} → {item.review.targetPath}
+        </span>
+      </span>
+      <span className="inbox-row-meta">
+        <span className="inbox-row-reviewer">
+          {item.review.reviewerSlug || "—"}
+        </span>
+        <span className="inbox-row-state">{item.review.state}</span>
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Re-export for tests that want to assert on row keys without
+ * pulling in the renderer.
+ */
+export { renderInboxItemKey };

--- a/web/src/components/sidebar/AppList.tsx
+++ b/web/src/components/sidebar/AppList.tsx
@@ -1,9 +1,7 @@
 // biome-ignore-all lint/a11y/useAriaPropsSupportedByRole: Passive metadata uses accessible labels queried by screen-reader tests; visual text remains unchanged.
 import type { ComponentType } from "react";
-import { useEffect, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
-  BellNotification,
   BookStack,
   Calendar,
   CheckCircle,
@@ -20,11 +18,9 @@ import {
 } from "iconoir-react";
 
 import { getRequests } from "../../api/client";
-import { getInboxPayload } from "../../api/lifecycle";
 import { fetchReviews } from "../../api/notebook";
 import { useOverflow } from "../../hooks/useOverflow";
 import { SIDEBAR_APPS } from "../../lib/constants";
-import { playInboxDing } from "../../lib/notificationSound";
 import { navigateToSidebarApp } from "../../lib/sidebarNav";
 import { WIKI_SURFACE_APP_IDS } from "../../routes/routeRegistry";
 import {
@@ -38,7 +34,6 @@ const WIKI_SURFACE_APPS = new Set<string>(WIKI_SURFACE_APP_IDS);
 
 const APP_ICONS: Record<string, ComponentType<{ className?: string }>> = {
   studio: Play,
-  inbox: BellNotification,
   wiki: BookStack,
   console: Terminal,
   tasks: CheckCircle,
@@ -73,12 +68,6 @@ export function AppList() {
     refetchInterval: 15_000,
   });
 
-  const { data: inboxData } = useQuery({
-    queryKey: ["inbox-badge"],
-    queryFn: getInboxPayload,
-    refetchInterval: 5_000,
-  });
-
   const pendingCount = (requestsData?.requests ?? []).filter(
     (r) => !r.status || r.status === "open" || r.status === "pending",
   ).length;
@@ -90,19 +79,6 @@ export function AppList() {
       r.state === "changes-requested",
   ).length;
 
-  const inboxCount = inboxData?.counts.decisionRequired ?? 0;
-
-  // Ding when the decision-required count strictly increases. The first
-  // observation seeds the ref without playing (avoids a ding on mount).
-  const lastInboxCountRef = useRef<number | null>(null);
-  useEffect(() => {
-    const prev = lastInboxCountRef.current;
-    if (prev !== null && inboxCount > prev) {
-      playInboxDing();
-    }
-    lastInboxCountRef.current = inboxCount;
-  }, [inboxCount]);
-
   const overflowRef = useOverflow<HTMLDivElement>();
 
   return (
@@ -113,7 +89,6 @@ export function AppList() {
           if (app.id === "requests" && pendingCount > 0) badge = pendingCount;
           if (app.id === "wiki" && pendingReviewsCount > 0)
             badge = pendingReviewsCount;
-          if (app.id === "inbox" && inboxCount > 0) badge = inboxCount;
           const Icon = APP_ICONS[app.id];
           const isActive =
             app.id === "wiki"

--- a/web/src/components/sidebar/InboxButton.tsx
+++ b/web/src/components/sidebar/InboxButton.tsx
@@ -1,0 +1,53 @@
+// biome-ignore-all lint/a11y/useAriaPropsSupportedByRole: Badge mirrors AppList — aria-label on the span surfaces the pending count to assistive tech.
+import { useEffect, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { MailIn } from "iconoir-react";
+
+import { getInboxPayload } from "../../api/lifecycle";
+import { playInboxDing } from "../../lib/notificationSound";
+import { navigateToSidebarApp } from "../../lib/sidebarNav";
+import { useCurrentApp } from "../../routes/useCurrentRoute";
+
+/**
+ * Top-of-sidebar Inbox entry. Renders the same DOM/class set as every
+ * other sidebar app (AppList) so it visually belongs in the rail; the
+ * surrounding `.sidebar-primary` wrapper handles the separator that
+ * elevates it above the Agents / Channels / Tools sections.
+ */
+export function InboxButton() {
+  const currentApp = useCurrentApp();
+  const { data } = useQuery({
+    queryKey: ["inbox-badge"],
+    queryFn: getInboxPayload,
+    refetchInterval: 5_000,
+  });
+
+  const count = data?.counts.decisionRequired ?? 0;
+
+  const lastCountRef = useRef<number | null>(null);
+  useEffect(() => {
+    const prev = lastCountRef.current;
+    if (prev !== null && count > prev) {
+      playInboxDing();
+    }
+    lastCountRef.current = count;
+  }, [count]);
+
+  const isActive = currentApp === "inbox";
+
+  return (
+    <button
+      type="button"
+      className={`sidebar-item${isActive ? " active" : ""}`}
+      onClick={() => navigateToSidebarApp("inbox")}
+    >
+      <MailIn className="sidebar-item-icon" />
+      <span style={{ flex: 1 }}>Inbox</span>
+      {count > 0 ? (
+        <span className="sidebar-badge" aria-label={`${count} pending`}>
+          {count}
+        </span>
+      ) : null}
+    </button>
+  );
+}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -2,9 +2,12 @@
 // team wiki, per-agent notebooks (drafts), and the promotion review queue.
 // Each surface gets its own tab inside the Wiki app; notebooks/reviews
 // have no top-level sidebar entries of their own.
+// Inbox is hoisted out into a dedicated prominent button at the top of
+// the sidebar (see components/sidebar/InboxButton). It used to live in
+// this list as just another app; promoting it reflects that the inbox
+// is the primary attention surface, not a secondary tool.
 export const SIDEBAR_APPS = [
   { id: "overview", icon: "\uD83C\uDFE0", name: "Overview" },
-  { id: "inbox", icon: "\uD83D\uDD14", name: "Inbox" },
   { id: "wiki", icon: "\uD83D\uDCD6", name: "Wiki" },
   { id: "console", icon: ">", name: "Console" },
   { id: "tasks", icon: "\u2705", name: "Tasks" },

--- a/web/src/lib/types/inbox.test.ts
+++ b/web/src/lib/types/inbox.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import type { InboxItem, InboxItemKind } from "./inbox";
+import { renderInboxItemKey } from "./inbox";
+
+describe("InboxItem discriminated union", () => {
+  it("closes over exactly three kinds", () => {
+    const all: InboxItemKind[] = ["task", "request", "review"];
+    expect(all).toHaveLength(3);
+  });
+
+  it("renderInboxItemKey returns a stable per-kind key", () => {
+    const task: InboxItem = {
+      kind: "task",
+      taskId: "task-1",
+      title: "Approve refactor",
+      task: {
+        taskId: "task-1",
+        title: "Approve refactor",
+        assignment: "",
+        severityCounts: {
+          critical: 0,
+          major: 0,
+          minor: 0,
+          nitpick: 0,
+          skipped: 0,
+        },
+        lastChangedAt: "2026-05-11T00:00:00Z",
+        elapsed: "1m",
+        isUrgent: false,
+        state: "decision",
+      },
+    };
+    const request: InboxItem = {
+      kind: "request",
+      requestId: "req-1",
+      title: "Need a decision on Postgres bump",
+      request: {
+        kind: "approval",
+        question: "Bump Postgres to 17?",
+        from: "owner",
+      },
+    };
+    const review: InboxItem = {
+      kind: "review",
+      reviewId: "rev-1",
+      title: "Promote draft to wiki",
+      review: {
+        state: "pending",
+        reviewerSlug: "owner",
+        sourceSlug: "ada",
+        targetPath: "wiki/draft.md",
+      },
+    };
+
+    expect(renderInboxItemKey(task)).toBe("task:task-1");
+    expect(renderInboxItemKey(request)).toBe("request:req-1");
+    expect(renderInboxItemKey(review)).toBe("review:rev-1");
+  });
+
+  it("exhaustiveness gate: every kind has a renderer branch", () => {
+    const sample: InboxItem[] = [
+      {
+        kind: "task",
+        taskId: "t",
+        title: "t",
+        task: {
+          taskId: "t",
+          title: "t",
+          assignment: "",
+          severityCounts: {
+            critical: 0,
+            major: 0,
+            minor: 0,
+            nitpick: 0,
+            skipped: 0,
+          },
+          lastChangedAt: "",
+          elapsed: "",
+          isUrgent: false,
+          state: "decision",
+        },
+      },
+      {
+        kind: "request",
+        requestId: "r",
+        title: "r",
+        request: { kind: "approval", question: "q", from: "owner" },
+      },
+      {
+        kind: "review",
+        reviewId: "v",
+        title: "v",
+        review: {
+          state: "pending",
+          reviewerSlug: "owner",
+          sourceSlug: "ada",
+          targetPath: "wiki/x.md",
+        },
+      },
+    ];
+    for (const item of sample) {
+      expect(typeof renderInboxItemKey(item)).toBe("string");
+    }
+  });
+});

--- a/web/src/lib/types/inbox.ts
+++ b/web/src/lib/types/inbox.ts
@@ -1,0 +1,87 @@
+/**
+ * Phase 2 unified-inbox TS types.
+ *
+ * Mirrors the Go shapes in internal/team/broker_inbox_phase2.go:
+ * InboxItemKind is a closed string set; InboxItem is a discriminated
+ * union with the `kind` tag carrying the discriminator. The
+ * never-default branch in renderInboxItemKey enforces exhaustiveness
+ * at compile time — adding a new kind without updating the switch
+ * fails type-checking.
+ *
+ * Phase 2 ships task / request / review. Adding a fourth kind in a
+ * future phase requires touching this file, the renderer switch in
+ * the inbox list component, and the per-kind auth helper on the Go
+ * side. Compile-time exhaustiveness keeps any one of those three
+ * from drifting.
+ */
+
+import type { InboxRow } from "./lifecycle";
+
+export type InboxItemKind = "task" | "request" | "review";
+
+export interface InboxItemTask {
+  kind: "task";
+  taskId: string;
+  title: string;
+  channel?: string;
+  createdAt?: string;
+  elapsedMs?: number;
+  /** Agent who owns / sent / submitted this item. Phase 3+. */
+  agentSlug?: string;
+  task: InboxRow;
+}
+
+export interface InboxItemRequest {
+  kind: "request";
+  requestId: string;
+  title: string;
+  channel?: string;
+  createdAt?: string;
+  elapsedMs?: number;
+  agentSlug?: string;
+  request: {
+    kind: string;
+    question: string;
+    from: string;
+    blocking?: boolean;
+  };
+}
+
+export interface InboxItemReview {
+  kind: "review";
+  reviewId: string;
+  title: string;
+  channel?: string;
+  createdAt?: string;
+  elapsedMs?: number;
+  agentSlug?: string;
+  review: {
+    state: string;
+    reviewerSlug: string;
+    sourceSlug: string;
+    targetPath: string;
+  };
+}
+
+export type InboxItem = InboxItemTask | InboxItemRequest | InboxItemReview;
+
+/**
+ * Stable React key + cache key for a row. Switches on `kind` and
+ * derives the per-kind ID. Adding a new InboxItemKind without
+ * extending this switch fails compilation — the default-branch
+ * `_exhaustive: never` assignment catches the missing case.
+ */
+export function renderInboxItemKey(item: InboxItem): string {
+  switch (item.kind) {
+    case "task":
+      return `task:${item.taskId}`;
+    case "request":
+      return `request:${item.requestId}`;
+    case "review":
+      return `review:${item.reviewId}`;
+    default: {
+      const _exhaustive: never = item;
+      return _exhaustive;
+    }
+  }
+}

--- a/web/src/lib/types/inboxThread.ts
+++ b/web/src/lib/types/inboxThread.ts
@@ -1,0 +1,87 @@
+/**
+ * Phase 3 unified-inbox thread types. Mirrors the Go shapes in
+ * internal/team/broker_inbox_threads.go.
+ *
+ * A thread groups every attention item from one AI agent into a
+ * single conversation surface. The detail view interleaves agent
+ * messages with inline action cards (one card per pending item) in
+ * chronological order — the same pattern as a Slack DM or Gmail
+ * conversation that has approval requests embedded.
+ */
+
+import type { InboxItem } from "./inbox";
+import type { InboxCounts } from "./lifecycle";
+
+export interface InboxThread {
+  key: string; // "agent:<slug>"
+  agentSlug: string;
+  agentName: string;
+  agentRole?: string;
+  dmChannel?: string;
+  lastActivityAt: string; // RFC3339
+  preview: string;
+  pendingCount: number;
+  items: InboxItem[];
+}
+
+export type InboxThreadEventKind = "message" | "item";
+
+/**
+ * One event in the chat-style detail stream. Discriminated on `kind`:
+ * `message` renders as a message bubble, `item` renders as an inline
+ * approval card. Adding a third kind without extending the renderer
+ * switch fails compile via never-default.
+ */
+export type InboxThreadEvent =
+  | {
+      kind: "message";
+      timestamp: string;
+      message: {
+        id: string;
+        from: string;
+        channel?: string;
+        content: string;
+        timestamp: string;
+        kind?: string;
+        tagged?: string[];
+        replyTo?: string;
+      };
+    }
+  | {
+      kind: "item";
+      timestamp: string;
+      item: InboxItem;
+    };
+
+export interface InboxThreadDetail {
+  thread: InboxThread;
+  events: InboxThreadEvent[];
+}
+
+export interface InboxThreadsResponse {
+  threads: InboxThread[];
+  counts: InboxCounts;
+  refreshedAt: string;
+}
+
+/**
+ * Stable per-event key for React lists. Switches on kind; the
+ * default branch's `_exhaustive: never` assignment fails compile
+ * when a new kind is added without a render path.
+ */
+export function inboxThreadEventKey(event: InboxThreadEvent): string {
+  if (event.kind === "message") return `message:${event.message.id}`;
+  const it = event.item;
+  switch (it.kind) {
+    case "task":
+      return `item:task:${it.taskId}`;
+    case "request":
+      return `item:request:${it.requestId}`;
+    case "review":
+      return `item:review:${it.reviewId}`;
+    default: {
+      const _exhaustive: never = it;
+      return _exhaustive;
+    }
+  }
+}

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -410,6 +410,18 @@ html[data-theme="nex"]
   padding: 8px var(--sidebar-pad-x) 0;
   flex-shrink: 0;
 }
+
+/* Inbox sits at the top of the sidebar as the primary attention
+   surface. Mirrors .sidebar-item exactly so it gels with the rest
+   of the sidebar — just sits in its own region above the Agents /
+   Channels / Tools sections with a separator beneath. */
+.sidebar-primary {
+  padding: 4px var(--sidebar-pad-x) 8px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+
 .sidebar-section + .sidebar-section,
 .sidebar-agents + .sidebar-section,
 .sidebar-channels + .sidebar-section,
@@ -1262,19 +1274,6 @@ html[data-theme="nex"]
 }
 
 /* ─── Messages ─── */
-.conversation-shell {
-  flex: 1;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 280px;
-  background: var(--bg);
-}
-.conversation-chat {
-  min-width: 0;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
 .messages {
   flex: 1;
   overflow-y: auto;
@@ -1282,246 +1281,6 @@ html[data-theme="nex"]
   display: flex;
   flex-direction: column;
   gap: 4px;
-}
-.channel-participants {
-  min-height: 0;
-  border-left: 1px solid var(--border);
-  background: var(--bg-card);
-  display: flex;
-  flex-direction: column;
-}
-.channel-participants-header {
-  min-height: 58px;
-  padding: 14px 16px 12px;
-  border-bottom: 1px solid var(--border-light);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-}
-.channel-participants-title {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--text);
-}
-.channel-participants-subtitle {
-  margin-top: 2px;
-  font-size: 11px;
-  color: var(--text-tertiary);
-}
-.channel-participants-add {
-  width: 28px;
-  height: 28px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg);
-  color: var(--text-secondary);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  line-height: 1;
-  font-family: var(--font-sans);
-  cursor: pointer;
-}
-.channel-participants-add:hover,
-.channel-participants-add:focus-visible {
-  background: var(--bg-warm);
-  color: var(--text);
-}
-.channel-participants-add:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring-color);
-  outline-offset: var(--focus-ring-offset);
-}
-.channel-participants-add-menu {
-  border-bottom: 1px solid var(--border-light);
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.channel-participants-list {
-  min-height: 0;
-  overflow-y: auto;
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.channel-participant {
-  width: 100%;
-  min-height: 42px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 6px;
-  border-radius: 6px;
-}
-.channel-participant-main,
-.channel-participant-add-option {
-  min-width: 0;
-  min-height: 42px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-secondary);
-  display: grid;
-  grid-template-columns: 28px minmax(0, 1fr) 8px;
-  align-items: center;
-  gap: 10px;
-  padding: 7px 8px;
-  text-align: left;
-  font-family: var(--font-sans);
-  cursor: pointer;
-}
-.channel-participant-add-option {
-  width: 100%;
-}
-.channel-participant-main:hover,
-.channel-participant-main:focus-visible,
-.channel-participant-add-option:hover,
-.channel-participant-add-option:focus-visible {
-  background: var(--bg-warm);
-  color: var(--text);
-}
-.channel-participant-main:focus-visible,
-.channel-participant-add-option:focus-visible,
-.channel-participant-toggle:focus-visible,
-.channel-participant-remove:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring-color);
-  outline-offset: var(--focus-ring-offset);
-}
-.channel-participant.is-disabled {
-  opacity: 0.58;
-}
-.channel-participant-avatar {
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.channel-participant-avatar .pixel-avatar {
-  width: 24px;
-  height: 24px;
-}
-.channel-participant-body {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.channel-participant-name,
-.channel-participant-role {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.channel-participant-name {
-  font-size: 12px;
-  font-weight: 700;
-  color: var(--text);
-}
-.channel-participant-role {
-  font-size: 11px;
-  color: var(--text-tertiary);
-}
-.channel-participant-presence {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--border-strong);
-}
-.channel-participant-presence.is-active {
-  background: var(--green);
-}
-.channel-participant-controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding-right: 4px;
-}
-.channel-participant-toggle,
-.channel-participant-remove {
-  min-width: 58px;
-  height: 26px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg);
-  color: var(--text-tertiary);
-  padding: 0 8px;
-  font-family: var(--font-sans);
-  font-size: 11px;
-  cursor: pointer;
-}
-.channel-participant-remove {
-  min-width: 24px;
-  width: 24px;
-  padding: 0;
-  overflow: hidden;
-  text-indent: 100%;
-  white-space: nowrap;
-  position: relative;
-}
-.channel-participant-remove::before {
-  content: "×";
-  position: absolute;
-  inset: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  text-indent: 0;
-  color: var(--text-tertiary);
-}
-.channel-participant-remove.is-pending {
-  min-width: 34px;
-  width: 34px;
-  text-indent: 0;
-}
-.channel-participant-remove.is-pending::before {
-  content: none;
-}
-.channel-participant-toggle:hover:not(:disabled),
-.channel-participant-remove:hover:not(:disabled) {
-  border-color: var(--border-dark);
-  color: var(--text);
-  background: var(--bg-warm);
-}
-.channel-participant-remove:hover:not(:disabled)::before {
-  color: var(--red);
-}
-.channel-participant-toggle:disabled,
-.channel-participant-remove:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-.channel-participant-add-glyph {
-  font-size: 16px;
-  color: var(--text-tertiary);
-  text-align: center;
-}
-.channel-participants-empty {
-  padding: 14px 8px;
-  font-size: 12px;
-  color: var(--text-tertiary);
-}
-
-@media (max-width: 1100px) {
-  .conversation-shell {
-    grid-template-columns: minmax(0, 1fr) 224px;
-  }
-}
-
-@media (max-width: 860px) {
-  .conversation-shell {
-    display: flex;
-  }
-  .conversation-chat {
-    flex: 1;
-  }
-  .channel-participants {
-    display: none;
-  }
 }
 
 /* ─── App panels ─── */

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -14,6 +14,10 @@
       pair so `minor` severity is distinct from `major`'s warm-orange.
       Verified: AA-pass against `--bg-card` in both nex (light) and
       nex-dark (dark) themes.
+   3. `--cyan-on-pill` — text color for pills using `--cyan-500` as
+      background. cyan-500 (#069de4) is theme-invariant; white text gives
+      5.3:1 contrast (WCAG AA). Token keeps the pattern consistent with
+      yellow-aa-on-pill.
 */
 :root {
   --bg-row-active: var(--neutral-100);
@@ -22,6 +26,8 @@
   --yellow-aa-500: #806010;
   --yellow-aa-200: #fbecc6;
   --yellow-aa-on-pill: #ffffff;
+  /* cyan-500 (#069de4) is theme-invariant; 5.3:1 AA on white. */
+  --cyan-on-pill: #ffffff;
 }
 
 html[data-theme="nex-dark"] {
@@ -51,6 +57,1578 @@ html[data-theme="noir-gold"] {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+
+/* Phase 2 Gmail two-pane: thread list left, detail right.
+   Falls back to the legacy single-pane layout above when
+   inbox-shell--twopane isn't present (some screenshot harness
+   fixtures still render the older shape). */
+.inbox-shell--twopane {
+  grid-template-columns: minmax(340px, 420px) 1fr;
+}
+
+.inbox-thread-pane {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.inbox-thread-header {
+  padding: 18px 18px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.inbox-thread-title {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+  color: var(--text);
+}
+
+.inbox-thread-subtitle {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.inbox-thread-subtitle .kbd {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-row-active);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  margin: 0 1px;
+}
+
+.inbox-thread-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0 24px;
+}
+
+/* ─── Thread row (Phase 3) ────────────────────────────────────── */
+
+.inbox-thread-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.inbox-thread-row {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  width: 100%;
+  color: inherit;
+  transition: background var(--duration-base);
+}
+
+.inbox-thread-row:hover {
+  background: var(--overlay-soft);
+}
+
+.inbox-thread-row[data-selected="true"] {
+  background: var(--bg-row-active);
+  position: relative;
+}
+
+.inbox-thread-row[data-selected="true"]::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--cyan-500);
+}
+
+.inbox-thread-row:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: -2px;
+}
+
+.inbox-thread-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  background: var(--cyan-200);
+  color: var(--cyan-500);
+  font-size: 12.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  font-family: var(--font-sans);
+  flex-shrink: 0;
+}
+
+.inbox-thread-avatar--lg {
+  width: 44px;
+  height: 44px;
+  font-size: 15px;
+}
+
+.inbox-thread-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.inbox-thread-row-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.inbox-thread-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inbox-thread-elapsed {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.inbox-thread-preview {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+.inbox-thread-meta {
+  display: flex;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.inbox-thread-pending {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--error-200);
+  color: var(--error-500);
+}
+
+.inbox-thread-skeleton {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.inbox-thread-skeleton-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--radius-full);
+  background: var(--bg-row-active);
+  opacity: 0.55;
+  animation: inbox-skel-shimmer 1.4s ease-in-out infinite;
+}
+
+.inbox-thread-skeleton-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 4px;
+}
+
+/* ─── Conversation detail (Phase 3) ───────────────────────────── */
+
+.inbox-detail-pane--thread {
+  padding: 0;
+  background: var(--bg);
+}
+
+.inbox-thread-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 20px 32px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+}
+
+.inbox-thread-detail-header > div {
+  flex: 1;
+  min-width: 0;
+}
+
+.inbox-thread-detail-name {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  margin: 0 0 2px;
+  line-height: 1.2;
+}
+
+.inbox-thread-detail-role {
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+.inbox-thread-detail-pending {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  background: var(--error-200);
+  color: var(--error-500);
+  white-space: nowrap;
+}
+
+.inbox-thread-stream {
+  padding: 24px 32px 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 920px;
+}
+
+.inbox-thread-empty {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  text-align: center;
+  padding: 40px 0;
+}
+
+.inbox-thread-message {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 14px 18px;
+}
+
+.inbox-thread-message-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.inbox-thread-message-from {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.inbox-thread-message-time {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.inbox-thread-message-body {
+  font-size: 14px;
+  color: var(--text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* ─── Inline action cards ────────────────────────────────────── */
+
+.inbox-action-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  position: relative;
+}
+
+.inbox-action-card--task {
+  border-left: 3px solid var(--success-500);
+}
+
+.inbox-action-card--request {
+  border-left: 3px solid var(--cyan-500);
+}
+
+.inbox-action-card--review {
+  border-left: 3px solid var(--warning-500);
+}
+
+.inbox-action-card-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.inbox-action-card-kind {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-row-active);
+  color: var(--text-secondary);
+}
+
+.inbox-action-card--task .inbox-action-card-kind {
+  background: var(--success-200);
+  color: var(--success-500);
+}
+
+.inbox-action-card--request .inbox-action-card-kind {
+  background: var(--cyan-200);
+  color: var(--cyan-500);
+}
+
+.inbox-action-card--review .inbox-action-card-kind {
+  background: var(--warning-200);
+  color: var(--warning-500);
+}
+
+.inbox-action-card-from {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.inbox-action-card-time {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
+
+.inbox-action-card-title {
+  font-size: 15.5px;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0 0 6px;
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+}
+
+.inbox-action-card-meta {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin: 0 0 10px;
+}
+
+.inbox-action-card-meta code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg-row-active);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+}
+
+.inbox-action-card-pill {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-row-active);
+  color: var(--text);
+  margin-left: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.inbox-action-card-question {
+  font-size: 14px;
+  color: var(--text);
+  line-height: 1.5;
+  margin: 8px 0 12px;
+  white-space: pre-wrap;
+}
+
+.inbox-action-card-blocking {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  background: var(--warning-200);
+  color: var(--warning-500);
+  margin: 0 0 12px;
+}
+
+.inbox-action-card-meta-list {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 4px 12px;
+  font-size: 13px;
+  margin: 4px 0 14px;
+}
+
+.inbox-action-card-meta-list dt {
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+
+.inbox-action-card-meta-list dd {
+  margin: 0;
+  color: var(--text);
+}
+
+.inbox-action-card-meta-list dd code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg-row-active);
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+}
+
+.inbox-action-card-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+  flex-wrap: wrap;
+}
+
+.inbox-action-card-severity {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.inbox-severity-dot {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--radius-full);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  color: #ffffff;
+  line-height: 1;
+}
+
+.inbox-severity-dot--critical {
+  background: var(--error-500);
+}
+
+.inbox-severity-dot--major {
+  background: var(--warning-500);
+}
+
+.inbox-severity-dot--minor {
+  background: var(--yellow-aa-500);
+  color: var(--yellow-aa-on-pill);
+}
+
+.inbox-severity-dot--nitpick {
+  background: var(--cyan-500);
+}
+
+.inbox-action-card-error {
+  font-size: 12.5px;
+  color: var(--error-500);
+  margin: 8px 0 0;
+  padding: 6px 10px;
+  background: var(--error-200);
+  border-radius: var(--radius-sm);
+}
+
+/* ─── Outlook-style mail list (Phase 3 rev 2) ─────────────────── */
+
+.inbox-shell--mail {
+  grid-template-columns: minmax(360px, 440px) 1fr;
+}
+
+.inbox-mail-pane {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  border-right: 1px solid var(--border);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.inbox-mail-header {
+  padding: 16px 18px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.inbox-mail-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.inbox-mail-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.inbox-mail-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.inbox-mail-row {
+  display: grid;
+  grid-template-columns: 3px 1fr;
+  gap: 14px;
+  padding: 12px 16px 12px 0;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  width: 100%;
+  color: inherit;
+  transition: background var(--duration-base);
+}
+
+.inbox-mail-row:hover {
+  background: var(--overlay-soft);
+}
+
+.inbox-mail-row[data-selected="true"] {
+  background: var(--bg-row-active);
+}
+
+.inbox-mail-row[data-selected="true"] .inbox-mail-row-rail {
+  background: var(--cyan-500);
+}
+
+.inbox-mail-row:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: -2px;
+}
+
+.inbox-mail-row-rail {
+  background: transparent;
+  height: 100%;
+  min-height: 44px;
+}
+
+.inbox-mail-row-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-right: 4px;
+}
+
+.inbox-mail-row-line {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.inbox-mail-row-from {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inbox-mail-row-time {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.inbox-mail-row-subject {
+  font-size: 13px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.35;
+}
+
+.inbox-mail-row[data-selected="true"] .inbox-mail-row-subject {
+  font-weight: 500;
+}
+
+.inbox-mail-row-snippet {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  line-height: 1.35;
+}
+
+.inbox-mail-row-kind {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 5px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-row-active);
+  color: var(--text-secondary);
+  vertical-align: baseline;
+  line-height: 1.4;
+}
+
+.inbox-mail-row[data-kind="task"] .inbox-mail-row-kind {
+  background: var(--success-200);
+  color: var(--success-500);
+}
+
+.inbox-mail-row[data-kind="request"] .inbox-mail-row-kind {
+  background: var(--cyan-200);
+  color: var(--cyan-500);
+}
+
+.inbox-mail-row[data-kind="review"] .inbox-mail-row-kind {
+  background: var(--warning-200);
+  color: var(--warning-500);
+}
+
+.inbox-mail-skeleton {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+/* ─── Outlook-style mail detail ────────────────────────────────── */
+
+.inbox-detail-pane--mail {
+  padding: 0;
+}
+
+/* When a task is selected, embed the existing DecisionPacketRoute
+   wholesale — it owns its own 3-column shell. The inbox detail pane
+   just provides a host container. */
+.inbox-detail-pane--task {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* When the decision packet is embedded in the inbox right pane,
+   the side-by-side 3-column shell squeezes the center column to
+   ~360px and breaks the prose layout. Flatten to single column
+   with a sticky horizontal action bar on top. The inbox mail list
+   on the very left already gives the reader thread context, so
+   .packet-left isn't needed; the action sidebar collapses to a
+   horizontal row of buttons above the content. */
+/* Embedded decision packet in the inbox right pane.
+   Two-row layout: scrollable body on top, sticky compose dock at
+   bottom (Gmail-style). The inbox mail list on the very left
+   already provides reader context, so .packet-left is hidden. */
+.inbox-detail-pane--task .packet-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.inbox-detail-pane--task .packet-left {
+  display: none;
+}
+
+.inbox-detail-pane--task .packet-center {
+  order: 0;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 24px 32px 28px;
+  max-width: none;
+}
+
+.inbox-detail-pane--task .packet-center > * {
+  max-width: 760px;
+}
+
+.inbox-detail-pane--task .packet-right {
+  order: 1;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px 24px 16px;
+  background: var(--bg-card);
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  height: auto;
+  overflow: visible;
+  flex-shrink: 0;
+  z-index: 1;
+}
+
+.inbox-detail-pane--task .packet-right > h3:first-child {
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.inbox-detail-pane--task .packet-right > h3:not(:first-child),
+.inbox-detail-pane--task .packet-aside-card {
+  display: none;
+}
+
+.inbox-detail-pane--task .packet-comment-label {
+  display: none;
+}
+
+.inbox-detail-pane--task .packet-comment {
+  width: 100%;
+  margin: 0;
+  min-height: 52px;
+  max-height: 200px;
+  height: 52px;
+  flex: 0 0 auto;
+}
+
+.inbox-detail-pane--task .packet-actions {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0;
+}
+
+.inbox-detail-pane--task .packet-action {
+  min-height: 36px;
+  padding: 8px 14px;
+  flex: 0 0 auto;
+}
+
+/* Flat single-column shell used by loading / error / not-yet-ready
+   states so they don't render with empty side rails. */
+.packet-shell--message {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  overflow-y: auto;
+}
+
+.packet-shell--message .packet-center {
+  padding: 32px 40px;
+  max-width: 760px;
+}
+
+.inbox-detail-pane--task .packet-shell--message {
+  grid-template-columns: 1fr;
+}
+
+/* Embedded RequestItem / ReviewDetail bodies — let the embedded
+   component define its own padding/typography. We just give it a
+   page-style host. */
+.inbox-mail-detail-body--embed {
+  padding: 20px 28px 60px;
+  max-width: 880px;
+}
+
+/* ReviewDetail is normally a slide-out drawer. Embedded in the
+   inbox we kill the backdrop + drawer chrome and let the content
+   flow inline. The drawer styles are scoped under .notebook-surface,
+   so the embed wrapper carries that class for the inner action
+   buttons + body styles to apply. The compound selectors below
+   (.notebook-surface.inbox-mail-detail-body--embed) hit 3-class
+   specificity, beating the 2-class base rules without !important. */
+.inbox-mail-detail-body--embed .nb-review-drawer-backdrop,
+.inbox-mail-detail-body--embed .nb-review-drawer-close {
+  display: none;
+}
+
+.notebook-surface.inbox-mail-detail-body--embed .nb-review-drawer {
+  position: static;
+  width: 100%;
+  height: auto;
+  max-width: none;
+  box-shadow: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  transform: none;
+  inset: auto;
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer > h2 {
+  font-size: 17px;
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: var(--text);
+  letter-spacing: -0.005em;
+  line-height: 1.3;
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer-path {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin-bottom: 18px;
+}
+
+.inbox-mail-detail-body--embed .nb-review {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.inbox-mail-detail-body--embed .nb-review h3 {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  margin: 0 0 12px;
+}
+
+.inbox-mail-detail-body--embed .nb-review-empty {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0 0 16px;
+  padding: 12px 14px;
+  background: var(--bg-card);
+  border-radius: var(--radius-md);
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer-approve,
+.inbox-mail-detail-body--embed .nb-review-drawer-reject {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  font-family: inherit;
+  background: var(--bg-card);
+  color: var(--text);
+  transition: background var(--duration-base, 0.15s);
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer-approve {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer-approve:hover {
+  background: var(--accent-warm);
+  border-color: var(--accent-warm);
+}
+
+.inbox-mail-detail-body--embed .nb-review-drawer-reject:hover {
+  background: var(--overlay-soft);
+  border-color: var(--border-strong);
+}
+
+.inbox-mail-detail-header {
+  padding: 22px 32px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+}
+
+.inbox-mail-detail-subject {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 10px;
+  color: var(--text);
+  line-height: 1.25;
+}
+
+.inbox-mail-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  flex-wrap: wrap;
+}
+
+.inbox-mail-detail-from {
+  color: var(--text);
+}
+
+.inbox-mail-detail-from strong {
+  font-weight: 600;
+}
+
+.inbox-mail-detail-kind {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-row-active);
+  color: var(--text-secondary);
+}
+
+.inbox-mail-detail-kind[data-kind="task"] {
+  background: var(--success-200);
+  color: var(--success-500);
+}
+
+.inbox-mail-detail-kind[data-kind="request"] {
+  background: var(--cyan-200);
+  color: var(--cyan-500);
+}
+
+.inbox-mail-detail-kind[data-kind="review"] {
+  background: var(--warning-200);
+  color: var(--warning-500);
+}
+
+.inbox-mail-detail-time {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+}
+
+.inbox-mail-detail-body {
+  padding: 24px 32px 60px;
+  max-width: 880px;
+}
+
+.inbox-mail-detail-question {
+  font-size: 14.5px;
+  color: var(--text);
+  line-height: 1.55;
+  margin: 0 0 22px;
+  white-space: pre-wrap;
+  padding: 14px 16px;
+  background: var(--bg-card);
+  border-left: 3px solid var(--cyan-500);
+  border-radius: var(--radius-md);
+}
+
+.inbox-mail-detail-fields {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 8px 16px;
+  margin: 0 0 22px;
+  font-size: 13px;
+}
+
+.inbox-mail-detail-fields dt {
+  color: var(--text-tertiary);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  padding-top: 2px;
+}
+
+.inbox-mail-detail-fields dd {
+  margin: 0;
+  color: var(--text);
+}
+
+.inbox-mail-detail-fields dd code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-row-active);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+}
+
+.inbox-mail-state-explainer {
+  font-size: 14px;
+  color: var(--text);
+  margin: 0 0 20px;
+  padding: 14px 16px;
+  background: var(--bg-card);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-md);
+  line-height: 1.5;
+}
+
+.inbox-mail-detail-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 12px;
+}
+
+.inbox-mail-actions-bar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 14px 16px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  margin-bottom: 20px;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.inbox-mail-section {
+  margin: 0 0 22px;
+}
+
+.inbox-mail-section--banners {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.inbox-mail-banner {
+  display: flex;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  border-left: 3px solid var(--text-tertiary);
+  background: var(--bg-card);
+}
+
+.inbox-mail-banner strong {
+  font-weight: 600;
+  color: var(--text);
+  white-space: nowrap;
+}
+
+.inbox-mail-banner--persistence_error {
+  border-left-color: var(--error-500);
+  background: var(--error-200);
+  color: var(--text);
+}
+
+.inbox-mail-banner--reviewer_timeout {
+  border-left-color: var(--warning-500);
+  background: var(--warning-200);
+}
+
+.inbox-mail-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  margin: 0 0 10px;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.inbox-mail-section-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-tertiary);
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.inbox-mail-section-empty {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  padding: 16px 0;
+  font-style: italic;
+  margin: 0;
+}
+
+.inbox-mail-prose {
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--text);
+  margin: 0 0 8px;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+.inbox-mail-subsection {
+  margin-top: 14px;
+}
+
+.inbox-mail-subsection h3 {
+  font-size: 12.5px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--text-secondary);
+}
+
+.inbox-mail-subsection ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.inbox-mail-subsection li {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  color: var(--text);
+}
+
+.inbox-mail-deadend {
+  color: var(--text-secondary);
+}
+
+.inbox-mail-delta {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-row-active);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.inbox-mail-ac {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.inbox-mail-ac-item {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 13.5px;
+  color: var(--text);
+  padding: 8px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+}
+
+.inbox-mail-ac-item.done {
+  color: var(--text-secondary);
+}
+
+.inbox-mail-ac-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--success-500);
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.inbox-mail-ac-item.done .inbox-mail-ac-check {
+  background: var(--success-500);
+  color: #ffffff;
+  border-color: var(--success-500);
+}
+
+.inbox-mail-diff {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12.5px;
+  font-family: var(--font-mono);
+}
+
+.inbox-mail-diff-row {
+  display: grid;
+  grid-template-columns: 48px 48px 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.inbox-mail-diff-pos {
+  color: var(--success-500);
+  font-weight: 600;
+  text-align: right;
+}
+
+.inbox-mail-diff-neg {
+  color: var(--error-500);
+  font-weight: 600;
+  text-align: right;
+}
+
+.inbox-mail-diff-path {
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inbox-mail-diff-tag {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  background: var(--cyan-200);
+  color: var(--cyan-500);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+}
+
+.inbox-mail-grades {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inbox-mail-grade {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--text-tertiary);
+  border-radius: var(--radius-md);
+  padding: 12px 14px;
+}
+
+.inbox-mail-grade[data-severity="critical"] {
+  border-left-color: var(--error-500);
+}
+
+.inbox-mail-grade[data-severity="major"] {
+  border-left-color: var(--warning-500);
+}
+
+.inbox-mail-grade[data-severity="minor"] {
+  border-left-color: var(--yellow-aa-500);
+}
+
+.inbox-mail-grade[data-severity="nitpick"] {
+  border-left-color: var(--cyan-500);
+}
+
+.inbox-mail-grade-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.inbox-mail-grade-reviewer {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.inbox-mail-grade-severity {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  background: var(--bg-row-active);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+}
+
+.inbox-mail-grade[data-severity="critical"] .inbox-mail-grade-severity {
+  background: var(--error-500);
+  color: #ffffff;
+}
+
+.inbox-mail-grade[data-severity="major"] .inbox-mail-grade-severity {
+  background: var(--warning-500);
+  color: #ffffff;
+}
+
+.inbox-mail-grade[data-severity="minor"] .inbox-mail-grade-severity {
+  background: var(--yellow-aa-500);
+  color: var(--yellow-aa-on-pill);
+}
+
+.inbox-mail-grade[data-severity="nitpick"] .inbox-mail-grade-severity {
+  background: var(--cyan-500);
+  color: var(--cyan-on-pill);
+}
+
+.inbox-mail-grade-suggestion {
+  font-size: 13.5px;
+  color: var(--text);
+  margin: 6px 0;
+  line-height: 1.5;
+}
+
+.inbox-mail-grade-reasoning {
+  font-size: 12.5px;
+  color: var(--text-secondary);
+  margin: 0 0 6px;
+  line-height: 1.5;
+}
+
+.inbox-mail-grade-file {
+  margin: 4px 0 0;
+}
+
+.inbox-mail-grade-file code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  background: var(--bg-row-active);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+}
+
+.inbox-mail-blockedon {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.inbox-mail-blockedon code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--warning-200);
+  color: var(--warning-500);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  font-weight: 500;
+}
+
+.inbox-empty--inline {
+  text-align: left;
+  padding: 32px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.inbox-empty--inline h2 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 4px;
+  color: var(--text);
+}
+
+.inbox-empty--inline p {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.inbox-detail-pane {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  padding: 0;
+}
+
+.inbox-detail-pane--empty {
+  align-items: center;
+  justify-content: center;
+}
+
+.inbox-detail-empty {
+  text-align: center;
+  color: var(--text-tertiary);
+  max-width: 380px;
+  padding: 40px 24px;
+}
+
+.inbox-detail-empty h2 {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0 0 6px;
+  color: var(--text-secondary);
+}
+
+.inbox-detail-empty p {
+  font-size: 13px;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.inbox-detail-loading {
+  padding: 40px;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: 13px;
+}
+
+.inbox-detail-body {
+  padding: 32px 40px;
+  max-width: 760px;
+}
+
+.inbox-detail-crumb {
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  margin-bottom: 8px;
+}
+
+.inbox-detail-title {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 14px;
+  color: var(--text);
+  line-height: 1.25;
+}
+
+.inbox-detail-question {
+  font-size: 15px;
+  color: var(--text);
+  margin: 0 0 24px;
+  line-height: 1.55;
+}
+
+.inbox-detail-meta {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 8px 16px;
+  margin: 0 0 24px;
+  font-size: 13px;
+}
+
+.inbox-detail-meta dt {
+  color: var(--text-tertiary);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+}
+
+.inbox-detail-meta dd {
+  margin: 0;
+  color: var(--text);
+}
+
+.inbox-detail-meta dd code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-row-active);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+}
+
+.inbox-detail-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.inbox-detail-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  border: 1px solid var(--border);
+  color: var(--text);
+  background: var(--bg-card);
+}
+
+.inbox-detail-action:hover {
+  background: var(--overlay-soft);
+  border-color: var(--border-strong);
+}
+
+.inbox-detail-action--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #ffffff;
+}
+
+.inbox-detail-action--primary:hover {
+  background: var(--accent-warm);
+  border-color: var(--accent-warm);
 }
 
 .inbox-sidebar {
@@ -150,6 +1728,66 @@ html[data-theme="noir-gold"] {
   margin-bottom: 24px;
 }
 
+/* Chip-style filter row used by the two-pane layout — sits in
+   the thread pane header above the scrollable row list. */
+.inbox-filters--chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.inbox-filter--chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: var(--radius-full);
+  font-size: 12.5px;
+  font-weight: 500;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: inherit;
+  line-height: 1.4;
+}
+
+.inbox-filter--chip .num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-row-active);
+  padding: 0 6px;
+  border-radius: var(--radius-full);
+  min-width: 18px;
+  text-align: center;
+}
+
+.inbox-filter--chip:hover {
+  background: var(--overlay-soft);
+  color: var(--text);
+}
+
+.inbox-filter--chip.active {
+  background: var(--bg-row-active);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.inbox-filter--chip.active .num {
+  background: var(--cyan-500);
+  color: #ffffff;
+}
+
+.inbox-filter--chip:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
 .inbox-filters {
   display: flex;
   gap: 6px;
@@ -218,13 +1856,13 @@ html[data-theme="noir-gold"] {
 .inbox-row {
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 18px;
+  gap: 12px;
   align-items: center;
-  padding: 16px 18px;
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  margin-bottom: 8px;
+  padding: 11px 12px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  margin-bottom: 2px;
   cursor: pointer;
   text-align: left;
   font-family: inherit;
@@ -236,10 +1874,62 @@ html[data-theme="noir-gold"] {
     border-color var(--duration-base);
 }
 
-.inbox-row:hover,
-.inbox-row[data-selected="true"] {
+.inbox-row:hover {
   background: var(--overlay-soft);
+}
+
+.inbox-row[data-selected="true"] {
+  background: var(--bg-row-active);
   border-color: var(--border-strong);
+}
+
+/* ─── Inbox row — kind variants ───────────────────────────────── */
+
+.inbox-row-kind-pill {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-row-active);
+  color: var(--text-secondary);
+  margin-right: 6px;
+  vertical-align: middle;
+  line-height: 1.4;
+}
+
+.inbox-row--request .inbox-row-kind-pill {
+  background: var(--success-200, var(--bg-row-active));
+  color: var(--success-500, var(--text-secondary));
+}
+
+.inbox-row--review .inbox-row-kind-pill {
+  background: var(--cyan-200, var(--bg-row-active));
+  color: var(--cyan-500, var(--text-secondary));
+}
+
+.inbox-row-from,
+.inbox-row-reviewer,
+.inbox-row-state {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.inbox-row-blocking {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--warning-500);
+  background: var(--warning-200);
+  padding: 1px 6px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .inbox-row:focus-visible {
@@ -298,7 +1988,7 @@ html[data-theme="noir-gold"] {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentcolor;
+  background: currentColor;
 }
 
 .severity-summary {
@@ -480,7 +2170,7 @@ html[data-theme="noir-gold"] {
 
 .inbox-error-banner .retry {
   background: transparent;
-  border: 1px solid currentcolor;
+  border: 1px solid currentColor;
   color: inherit;
   padding: 4px 12px;
   border-radius: var(--radius-full);
@@ -617,7 +2307,7 @@ html[data-theme="noir-gold"] {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentcolor;
+  background: currentColor;
   flex-shrink: 0;
 }
 
@@ -978,6 +2668,111 @@ html[data-theme="noir-gold"] {
   margin-bottom: 12px;
 }
 
+.packet-comment-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 11.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+  margin: 4px 0 6px;
+}
+
+.packet-comment-optional {
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  text-transform: lowercase;
+}
+
+.packet-comment {
+  width: 100%;
+  padding: 10px 12px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  resize: vertical;
+  min-height: 64px;
+  margin-bottom: 12px;
+  line-height: 1.45;
+  transition: border-color var(--duration-base);
+}
+
+.packet-comment:hover:not(:disabled):not(:focus) {
+  border-color: var(--border-strong);
+}
+
+.packet-comment:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-bg);
+}
+
+.packet-comment:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.packet-comment::placeholder {
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+.packet-feedback {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.packet-feedback-item {
+  padding: 12px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-md);
+}
+
+.packet-feedback-header {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.packet-feedback-author {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.packet-feedback-time {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+
+.packet-feedback-body {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--text);
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* The embedded inbox view defines its own .packet-comment rules
+   above (under .inbox-detail-pane--task) — this older horizontal-
+   action-bar variant is superseded by the bottom-dock layout. */
+
 .packet-actions {
   display: flex;
   flex-direction: column;
@@ -1013,13 +2808,13 @@ html[data-theme="noir-gold"] {
   outline-offset: var(--focus-ring-offset);
 }
 
-.packet-action--merge {
+.packet-action--approve {
   background: var(--accent);
   color: white;
   font-weight: 600;
 }
 
-.packet-action--merge:hover:not(:disabled) {
+.packet-action--approve:hover:not(:disabled) {
   background: var(--accent-warm);
 }
 
@@ -1065,7 +2860,7 @@ html[data-theme="noir-gold"] {
   border: none;
 }
 
-.packet-action--merge .kbd {
+.packet-action--approve .kbd {
   background: rgba(0, 0, 0, 0.15);
   color: white;
 }
@@ -1124,7 +2919,7 @@ html[data-theme="noir-gold"] {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentcolor;
+  background: currentColor;
   margin-top: 7px;
   flex-shrink: 0;
 }
@@ -1198,7 +2993,7 @@ html[data-theme="noir-gold"] {
 
 .packet-error .retry {
   background: transparent;
-  border: 1px solid currentcolor;
+  border: 1px solid currentColor;
   color: inherit;
   padding: 6px 14px;
   border-radius: var(--radius-full);

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -364,7 +364,7 @@ html[data-theme="noir-gold"] {
   color: var(--text);
   line-height: 1.5;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 /* ─── Inline action cards ────────────────────────────────────── */
@@ -1208,7 +1208,7 @@ html[data-theme="noir-gold"] {
   color: var(--text);
   margin: 0 0 8px;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .inbox-mail-subsection {
@@ -2766,7 +2766,7 @@ html[data-theme="noir-gold"] {
   color: var(--text);
   margin: 0;
   white-space: pre-wrap;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 /* The embedded inbox view defines its own .packet-comment rules

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -1988,7 +1988,7 @@ html[data-theme="noir-gold"] {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
 }
 
 .severity-summary {
@@ -2170,7 +2170,7 @@ html[data-theme="noir-gold"] {
 
 .inbox-error-banner .retry {
   background: transparent;
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   color: inherit;
   padding: 4px 12px;
   border-radius: var(--radius-full);
@@ -2307,7 +2307,7 @@ html[data-theme="noir-gold"] {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
   flex-shrink: 0;
 }
 
@@ -2919,7 +2919,7 @@ html[data-theme="noir-gold"] {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: currentColor;
+  background: currentcolor;
   margin-top: 7px;
   flex-shrink: 0;
 }
@@ -2993,7 +2993,7 @@ html[data-theme="noir-gold"] {
 
 .packet-error .retry {
   background: transparent;
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   color: inherit;
   padding: 6px 14px;
   border-radius: var(--radius-full);


### PR DESCRIPTION
## Summary

Rebuilds the `/inbox` surface on a unified-feed contract on top of #798. Tasks, requests, and reviews land in one Gmail-style two-pane inbox; the detail pane embeds the full Request/Review/DecisionPacket surface inline; a per-user cursor + `GET /inbox/items` endpoint replace the legacy per-bucket queries.

Force-pushed as a single squashed commit on top of `c825f6e8` (post-#798 main) to keep the rebase clean — the original 22-commit history is preserved in branch `feat/inbox-unified-phase-2-history` if needed.

## What lands

### Backend
- `broker_inbox_phase2.go` — union iterator across tasks/requests/reviews with per-user cursor + auth filtering.
- `broker_inbox_handler_phase2.go` — `GET /inbox/items` and `/inbox/cursor` HTTP handlers.
- `broker_inbox_threads.go` — agent-thread grouping endpoint.
- `broker_decision_packet.go::RecordTaskDecisionWithComment` — appends a human-authored note to `spec.feedback` alongside the lifecycle move.
- `broker.go` — per-user cursor map + RWMutex on the Broker.

### Frontend
- `DecisionInbox.tsx` rewritten: Gmail two-pane layout (rows | detail dock), kind tabs, filter pills, keyboard nav, inline detail rendering.
- `UnifiedInboxRow.tsx` + `types/inbox.ts` + `types/inboxThread.ts` for the unioned row model and agent-thread chat-style detail.
- `DecisionPacketRoute` / `PacketActionSidebar` / `RequestsApp`: bottom compose dock for comment + action buttons.
- `InboxButton.tsx` sidebar primary surface.
- Layout + lifecycle CSS rebuilt for the new surface.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/team/... ./cmd/wuphf/...` green (180s)
- [x] `bash scripts/test-web.sh` — 1510 vitest pass / 2 skipped
- [x] `golangci-lint run ./...` — 0 issues
- [x] `bunx biome check` on changed files — 0 errors
- [ ] CI green
- [ ] CodeRabbit re-review on the rebased commit
- [ ] Manual: open `/inbox` in dev wuphf, confirm two-pane renders + filter pills work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified inbox: combined tasks, requests, and reviews with kind filtering and per-user read-state (cursor) tracking
  * Two-pane mail-style inbox, agent-grouped threads, and conversation detail view accessible from a new Inbox sidebar button
  * Optional human-authored comments on decision submissions with author attribution

* **Style**
  * New inbox/thread two-pane and mail-list UI styles, row, badge, and feedback visuals

* **Tests**
  * New inbox/thread and decision tests for contract, auth, concurrency, and performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/802?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->