### PR TITLE
docs: adopt html agent artifacts

### DIFF
--- a/docs/agent-artifacts/2026-05-11-html-artifacts-adoption.html
+++ b/docs/agent-artifacts/2026-05-11-html-artifacts-adoption.html
@@ -1,0 +1,491 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Adopting HTML Artifacts in WUPHF</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #1a1610;
+        --surface: #242018;
+        --surface-high: #2e2820;
+        --border: #3a3028;
+        --text: #f0ebd8;
+        --muted: #a89a84;
+        --faint: #6f6254;
+        --amber: #ecb22e;
+        --blue: #5a9ac8;
+        --green: #5aaa7a;
+        --red: #d66a5c;
+        --shadow: rgba(0, 0, 0, 0.28);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: "DM Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        line-height: 1.55;
+      }
+
+      a {
+        color: var(--blue);
+      }
+
+      .shell {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 32px 20px 60px;
+      }
+
+      .hero,
+      .panel,
+      .lane,
+      .artifact-card {
+        border: 1px solid var(--border);
+        background: var(--surface);
+        box-shadow: 0 18px 60px var(--shadow);
+      }
+
+      .hero {
+        padding: 26px;
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        color: var(--amber);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+      }
+
+      h1 {
+        margin: 0;
+        max-width: 850px;
+        font-size: 56px;
+        line-height: 1.02;
+      }
+
+      .lede {
+        max-width: 840px;
+        margin: 18px 0 0;
+        color: var(--muted);
+        font-size: 16px;
+      }
+
+      .meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 8px;
+        margin-top: 22px;
+      }
+
+      .meta div {
+        border: 1px solid var(--border);
+        background: var(--surface-high);
+        padding: 12px;
+      }
+
+      .meta strong {
+        display: block;
+        color: var(--faint);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+      }
+
+      section {
+        margin-top: 30px;
+      }
+
+      h2 {
+        margin: 0 0 14px;
+        font-size: 22px;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        color: var(--amber);
+        font-size: 15px;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      ul {
+        margin: 10px 0 0;
+        padding-left: 20px;
+      }
+
+      li + li {
+        margin-top: 6px;
+      }
+
+      .decision {
+        display: grid;
+        grid-template-columns: minmax(0, 1.2fr) minmax(260px, 0.8fr);
+        gap: 14px;
+      }
+
+      .panel {
+        padding: 18px;
+      }
+
+      .callout {
+        border-left: 4px solid var(--amber);
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 14px;
+      }
+
+      .flow {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(140px, 1fr));
+        gap: 10px;
+        overflow-x: auto;
+        padding-bottom: 6px;
+      }
+
+      .lane {
+        min-height: 150px;
+        padding: 14px;
+      }
+
+      .lane strong {
+        display: block;
+        color: var(--amber);
+        margin-bottom: 8px;
+      }
+
+      .lane span {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      .matrix {
+        width: 100%;
+        border-collapse: collapse;
+        overflow: hidden;
+      }
+
+      .matrix th,
+      .matrix td {
+        border: 1px solid var(--border);
+        padding: 12px;
+        vertical-align: top;
+        text-align: left;
+      }
+
+      .matrix th {
+        color: var(--amber);
+        background: var(--surface-high);
+      }
+
+      .status-yes {
+        color: var(--green);
+        font-weight: 700;
+      }
+
+      .status-no {
+        color: var(--red);
+        font-weight: 700;
+      }
+
+      .artifact-card {
+        padding: 16px;
+      }
+
+      .artifact-card small {
+        display: block;
+        color: var(--faint);
+        margin-top: 8px;
+      }
+
+      .progression {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(180px, 1fr));
+        gap: 10px;
+      }
+
+      .step {
+        border: 1px solid var(--border);
+        background: var(--surface-high);
+        padding: 14px;
+      }
+
+      .step strong {
+        display: block;
+        color: var(--amber);
+        margin-bottom: 6px;
+      }
+
+      .copy-row {
+        display: flex;
+        gap: 10px;
+        align-items: center;
+        flex-wrap: wrap;
+        margin-top: 14px;
+      }
+
+      button {
+        border: 1px solid var(--amber);
+        background: #120f0b;
+        color: var(--amber);
+        padding: 8px 12px;
+        cursor: pointer;
+      }
+
+      button:focus-visible {
+        outline: 2px solid var(--amber);
+        outline-offset: 3px;
+      }
+
+      textarea {
+        width: 100%;
+        min-height: 124px;
+        margin-top: 12px;
+        border: 1px solid var(--border);
+        background: #120f0b;
+        color: var(--text);
+        padding: 12px;
+        resize: vertical;
+      }
+
+      code {
+        background: #120f0b;
+        color: #fff6d8;
+        padding: 2px 4px;
+      }
+
+      @media (max-width: 860px) {
+        h1 {
+          font-size: 34px;
+        }
+
+        .decision {
+          grid-template-columns: 1fr;
+        }
+
+        .flow {
+          grid-template-columns: 1fr;
+        }
+
+        .progression {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="hero">
+        <p class="eyebrow">WUPHF adoption artifact</p>
+        <h1>Use HTML when agents need humans to inspect shape, not just prose.</h1>
+        <p class="lede">
+          The linked article's useful idea is not "replace markdown everywhere." For WUPHF,
+          the useful move is to add a first-class review artifact format for dense plans,
+          PR explainers, diagrams, reports, and custom editors while keeping the wiki's
+          markdown rebuild contract intact.
+        </p>
+        <div class="meta" aria-label="Artifact metadata">
+          <div><strong>Date</strong><span>2026-05-11</span></div>
+          <div><strong>Branch</strong><span>codex/html-artifacts-adoption</span></div>
+          <div><strong>Sources</strong><span>article text, examples index, repo docs</span></div>
+          <div><strong>Scope</strong><span>docs and agent workflow only</span></div>
+        </div>
+      </header>
+
+      <section class="decision" aria-labelledby="decision">
+        <article class="panel callout">
+          <h2 id="decision">Decision</h2>
+          <p>
+            Adopt self-contained HTML artifacts as the preferred format for large
+            agent-produced review surfaces. Do not make HTML the canonical memory or wiki
+            substrate yet. The first implementation is a repo convention, a starter
+            template, and an agent instruction update.
+          </p>
+        </article>
+        <aside class="panel">
+          <h3>Why this boundary</h3>
+          <ul>
+            <li>Markdown stays diffable and rebuildable for facts.</li>
+            <li>HTML makes dense reviews more likely to be read.</li>
+            <li>Self-contained files need no app runtime.</li>
+            <li>Interactive artifacts can export back to text or JSON.</li>
+          </ul>
+        </aside>
+      </section>
+
+      <section aria-labelledby="human-io">
+        <h2 id="human-io">Human I/O Thesis</h2>
+        <div class="panel">
+          <p>
+            The Karpathy framing makes the rule sharper: audio, pointing, screenshots,
+            and gestures are becoming natural human input to agents, while visual media
+            is the better output channel back to humans. HTML is the useful current
+            bridge because it is still exact and inspectable, but it can carry layout,
+            diagrams, animation, and interaction.
+          </p>
+          <div class="progression" aria-label="Agent output progression">
+            <div class="step">
+              <strong>1. Raw text</strong>
+              <span>Compact, diffable, but effortful for dense plans and reviews.</span>
+            </div>
+            <div class="step">
+              <strong>2. Markdown</strong>
+              <span>Good current default for structured prose and canonical facts.</span>
+            </div>
+            <div class="step">
+              <strong>3. HTML</strong>
+              <span>Better for spatial review, comparisons, visual state, and interaction.</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="workflow">
+        <h2 id="workflow">Operating Flow</h2>
+        <div class="flow" role="list">
+          <div class="lane" role="listitem">
+            <strong>1. Agent reads context</strong>
+            <span>Code, docs, git history, Nex context, screenshots, and command output.</span>
+          </div>
+          <div class="lane" role="listitem">
+            <strong>2. Agent renders HTML</strong>
+            <span>Self-contained page with diagrams, tables, annotated code, and controls.</span>
+          </div>
+          <div class="lane" role="listitem">
+            <strong>3. Human reviews visually</strong>
+            <span>Open locally, attach to PR, or share as a static file.</span>
+          </div>
+          <div class="lane" role="listitem">
+            <strong>4. Artifact exports text</strong>
+            <span>Copy PR body, JSON diff, prompt, decision table, or markdown summary.</span>
+          </div>
+          <div class="lane" role="listitem">
+            <strong>5. Durable state lands</strong>
+            <span>Markdown wiki, code, tests, PR description, or tracked docs record the result.</span>
+          </div>
+        </div>
+      </section>
+
+      <section aria-labelledby="matrix">
+        <h2 id="matrix">Where HTML Belongs</h2>
+        <table class="matrix">
+          <thead>
+            <tr>
+              <th>Surface</th>
+              <th>Use HTML?</th>
+              <th>Reason</th>
+              <th>Guardrail</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Implementation plans</td>
+              <td class="status-yes">Yes</td>
+              <td>Plans often need timelines, dependency maps, data flow, and risk grouping.</td>
+              <td>Keep a compact markdown summary if the decision is durable.</td>
+            </tr>
+            <tr>
+              <td>PR review/explainer</td>
+              <td class="status-yes">Yes</td>
+              <td>Diffs, call graphs, and reviewer focus areas are spatial.</td>
+              <td>Do not replace required PR checklist or dispositions.</td>
+            </tr>
+            <tr>
+              <td>Design exploration</td>
+              <td class="status-yes">Yes</td>
+              <td>Variants, states, and tokens need side-by-side inspection.</td>
+              <td>Use repo design tokens and include mobile states.</td>
+            </tr>
+            <tr>
+              <td>Custom editor</td>
+              <td class="status-yes">Yes</td>
+              <td>Drag, sliders, toggles, previews, and export buttons close the loop.</td>
+              <td>Always include a copy/export path.</td>
+            </tr>
+            <tr>
+              <td>Wiki facts and entity logs</td>
+              <td class="status-no">No</td>
+              <td>The wiki rebuild contract depends on markdown and JSONL as source material.</td>
+              <td>Link HTML from wiki pages; do not make it authoritative.</td>
+            </tr>
+            <tr>
+              <td>Short notes</td>
+              <td class="status-no">No</td>
+              <td>HTML generation cost and noisy diffs are not worth it.</td>
+              <td>Use markdown unless visual structure changes the review outcome.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section aria-labelledby="starter">
+        <h2 id="starter">Starter Artifact Types</h2>
+        <div class="grid">
+          <article class="artifact-card">
+            <h3>Plan Map</h3>
+            <p>Timeline, dependency graph, file ownership, test matrix, and risks.</p>
+            <small>Use before substantial implementation or multi-agent dispatch.</small>
+          </article>
+          <article class="artifact-card">
+            <h3>PR Explainer</h3>
+            <p>Annotated diff, changed-file tour, reviewer checklist, and copyable PR body.</p>
+            <small>Use for PRs where GitHub's linear diff hides the concept.</small>
+          </article>
+          <article class="artifact-card">
+            <h3>System Explainer</h3>
+            <p>Flow diagram, hot path, code snippets, glossary, and gotchas.</p>
+            <small>Use when onboarding a human or a verification agent.</small>
+          </article>
+          <article class="artifact-card">
+            <h3>Throwaway Editor</h3>
+            <p>Purpose-built interface for sorting, tuning, tagging, or selecting data.</p>
+            <small>Use when text prompting is a poor input device.</small>
+          </article>
+        </div>
+      </section>
+
+      <section aria-labelledby="prompt">
+        <h2 id="prompt">Copyable Prompt Seed</h2>
+        <div class="panel">
+          <p>
+            This prompt keeps the practice lightweight. It asks for HTML only when the output
+            needs visual review and preserves WUPHF's markdown source-of-truth boundary.
+          </p>
+          <textarea id="promptText" spellcheck="false">Create a self-contained HTML artifact for this WUPHF task. Use it only because the result benefits from visual structure: diagrams, tables, side-by-side comparisons, annotated snippets, or interactive controls. Include provenance, the decision or recommendation, risks, verification, and a copy/export affordance if the artifact is interactive. Keep canonical facts and final durable decisions discoverable in markdown; do not make HTML the source of truth for the wiki.</textarea>
+          <div class="copy-row">
+            <button type="button" id="copyPrompt">Copy prompt</button>
+            <span id="copyStatus" aria-live="polite"></span>
+          </div>
+        </div>
+      </section>
+    </main>
+    <script>
+      const copyButton = document.getElementById("copyPrompt");
+      const copyStatus = document.getElementById("copyStatus");
+      const promptText = document.getElementById("promptText");
+
+      copyButton.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(promptText.value);
+          copyStatus.textContent = "Copied.";
+        } catch (_error) {
+          promptText.focus();
+          promptText.select();
+          copyStatus.textContent = "Select text and copy manually.";
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/docs/agent-artifacts/README.md
+++ b/docs/agent-artifacts/README.md
@@ -1,0 +1,99 @@
+# Agent HTML Artifacts
+
+WUPHF keeps the team wiki git-native and markdown-first. That remains the
+source of truth for durable facts, briefs, and playbooks. HTML artifacts are a
+companion format for work that humans need to inspect, compare, tune, or share
+without reading a long linear markdown file.
+
+Use HTML artifacts when the output benefits from visual structure:
+
+- implementation plans with timelines, risk maps, data flow, or mockups
+- PR explainers with annotated diffs, call graphs, and review focus areas
+- design explorations, component sheets, and interaction prototypes
+- incident reports, status reports, research explainers, and diagrams
+- throwaway editors that export a prompt, JSON, markdown, or patch summary
+
+Keep markdown for:
+
+- canonical wiki articles and facts
+- short notes that are naturally linear
+- files humans are expected to edit by hand
+- contracts where a compact text diff matters more than visual review
+
+## Human I/O Rationale
+
+Treat HTML artifacts as a better output channel, not just a richer file
+extension. A useful current-stage pattern is: humans often prefer high-bandwidth
+input to agents through speech, pointing, screenshots, and gestures, while
+agents should increasingly return high-bandwidth visual output: layout,
+diagrams, animation, simulation, and interaction.
+
+The progression is practical:
+
+1. raw text for compact answers
+2. markdown for structured prose
+3. HTML for visual, spatial, and interactive review
+
+WUPHF adopts step 3 where it helps humans stay in the loop. The goal is not to
+make every response decorative. The goal is to use the browser as a review
+surface when code, architecture, planning, or product decisions are easier to
+understand visually than linearly.
+
+## Repository Convention
+
+Store durable repo-local HTML artifacts under `docs/agent-artifacts/` with a
+date-prefixed filename:
+
+```text
+docs/agent-artifacts/2026-05-11-runtime-explainer.html
+```
+
+If an HTML artifact makes a decision durable, add a short markdown summary or
+link from the owning doc. The HTML can carry the readable argument, but the
+canonical decision needs to remain discoverable by text search and wiki
+ingestion.
+
+Use `scripts/new-html-artifact.sh` to start from the repo template:
+
+```bash
+bash scripts/new-html-artifact.sh runtime-explainer "Runtime explainer"
+```
+
+The script writes `docs/agent-artifacts/YYYY-MM-DD-runtime-explainer.html`.
+Open the file directly in a browser for local review.
+
+## Artifact Rules
+
+- Make the artifact self-contained: inline CSS and JavaScript, no build step.
+- Prefer no network dependencies. If an external image, script, or font is
+  necessary, document why in the artifact metadata.
+- Do not include secrets, bearer tokens, private customer data, or raw logs
+  with credentials. Redact before rendering.
+- Include provenance: source files, commands, PR number, issue, or user prompt.
+- Include an export path for interactive editors, such as "copy JSON", "copy
+  markdown", or "copy prompt".
+- Keep generated artifacts reviewable. Split a very large artifact into a
+  small index page plus focused linked pages.
+- Use accessible structure: semantic headings, labels, visible focus states,
+  keyboard-operable controls, and sufficient contrast.
+- Keep WUPHF product language precise. Nex is a context graph platform for AI
+  agents, not a CRM.
+
+## Recommended Shapes
+
+| Use case | Artifact shape | Required affordance |
+|---|---|---|
+| Implementation plan | Timeline, dependency map, risk table, code snippets | decision log and verification plan |
+| PR explainer | File tour, annotated diff, reviewer checklist | copyable PR summary |
+| Architecture review | System diagram, boundary table, failure modes | source references |
+| Design exploration | Side-by-side variants, token swatches, state sheets | tradeoff labels |
+| Incident report | Timeline, blast radius, evidence, follow-up table | owner/status export |
+| Custom editor | Form, board, sliders, preview | copy/export button |
+
+## Adoption Boundary
+
+This convention does not change the wiki rebuild contract in
+`docs/specs/WIKI-SCHEMA.md`: markdown remains the durable source of truth for
+the local wiki. HTML artifacts can be linked from wiki pages, attached to PRs,
+or used as review material, but they are not the authoritative fact store unless
+a future product change explicitly adds that contract.

--- a/docs/agent-artifacts/html-artifact-template.html
+++ b/docs/agent-artifacts/html-artifact-template.html
@@ -1,0 +1,223 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{TITLE}}</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #1a1610;
+        --surface: #242018;
+        --surface-high: #2e2820;
+        --border: #3a3028;
+        --text: #f0ebd8;
+        --muted: #a89a84;
+        --faint: #6f6254;
+        --amber: #ecb22e;
+        --blue: #5a9ac8;
+        --green: #5aaa7a;
+        --red: #d66a5c;
+        --shadow: rgba(0, 0, 0, 0.28);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: "DM Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        line-height: 1.6;
+      }
+
+      a {
+        color: var(--blue);
+      }
+
+      button,
+      input,
+      select,
+      textarea {
+        font: inherit;
+      }
+
+      button:focus-visible,
+      a:focus-visible,
+      input:focus-visible,
+      textarea:focus-visible {
+        outline: 2px solid var(--amber);
+        outline-offset: 3px;
+      }
+
+      .shell {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 32px 20px 56px;
+      }
+
+      .hero {
+        border: 1px solid var(--border);
+        background: var(--surface);
+        box-shadow: 0 18px 60px var(--shadow);
+        padding: 24px;
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        color: var(--amber);
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 44px;
+        line-height: 1.05;
+      }
+
+      .lede {
+        max-width: 780px;
+        margin: 16px 0 0;
+        color: var(--muted);
+        font-size: 16px;
+      }
+
+      .meta {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 8px;
+        margin-top: 20px;
+      }
+
+      .meta div,
+      .panel {
+        border: 1px solid var(--border);
+        background: var(--surface-high);
+        padding: 14px;
+      }
+
+      .meta strong {
+        display: block;
+        color: var(--faint);
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+      }
+
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 14px;
+        margin-top: 18px;
+      }
+
+      section {
+        margin-top: 28px;
+      }
+
+      h2 {
+        margin: 0 0 12px;
+        font-size: 20px;
+      }
+
+      h3 {
+        margin: 0 0 8px;
+        font-size: 15px;
+        color: var(--amber);
+      }
+
+      ul {
+        padding-left: 20px;
+      }
+
+      code,
+      pre {
+        background: #120f0b;
+        color: #fff6d8;
+      }
+
+      code {
+        padding: 2px 4px;
+      }
+
+      pre {
+        overflow: auto;
+        padding: 14px;
+        border: 1px solid var(--border);
+      }
+
+      .tag {
+        display: inline-block;
+        border: 1px solid var(--border);
+        padding: 2px 8px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .status-good {
+        color: var(--green);
+      }
+
+      .status-risk {
+        color: var(--red);
+      }
+
+      @media (max-width: 700px) {
+        .shell {
+          padding: 18px 12px 40px;
+        }
+
+        .hero {
+          padding: 18px;
+        }
+
+        h1 {
+          font-size: 30px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="hero">
+        <p class="eyebrow">WUPHF HTML artifact</p>
+        <h1>{{TITLE}}</h1>
+        <p class="lede">{{SUMMARY}}</p>
+        <div class="meta" aria-label="Artifact metadata">
+          <div><strong>Date</strong><span>{{DATE}}</span></div>
+          <div><strong>Owner</strong><span>{{OWNER}}</span></div>
+          <div><strong>Sources</strong><span>{{SOURCES}}</span></div>
+        </div>
+      </header>
+
+      <section aria-labelledby="decision">
+        <h2 id="decision">Decision</h2>
+        <div class="panel">
+          <p>Replace this section with the core decision, result, or recommendation.</p>
+        </div>
+      </section>
+
+      <section aria-labelledby="details">
+        <h2 id="details">Details</h2>
+        <div class="grid">
+          <article class="panel">
+            <h3>Context</h3>
+            <p>Summarize the source material and why this artifact exists.</p>
+          </article>
+          <article class="panel">
+            <h3>Tradeoffs</h3>
+            <p>List the meaningful tradeoffs. Avoid decorative cards with no job.</p>
+          </article>
+          <article class="panel">
+            <h3>Verification</h3>
+            <p>Show commands, screenshots, links, or review evidence.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/agents/INSTRUCTIONS.md
+++ b/docs/agents/INSTRUCTIONS.md
@@ -161,6 +161,40 @@ Bun's native test runner instead of the repo's Vitest setup.
   the diff is purely test/doc/build config, or the same feature is
   already covered by a linked sibling PR's screenshots.
 
+### Rich HTML Artifacts
+
+Use self-contained HTML artifacts when an agent output needs visual inspection
+more than linear reading: substantial implementation plans, PR explainers,
+architecture maps, design explorations, incident reports, status reports,
+research explainers, annotated diffs, or throwaway editors with copy/export
+buttons.
+
+Use the browser as a high-bandwidth visual output channel when layout,
+diagrams, animation, simulation, or interaction would make the result easier to
+inspect. Do not use HTML just to decorate a short text answer.
+
+Markdown remains the source of truth for wiki facts, briefs, playbooks, and
+short hand-edited notes. HTML artifacts are review surfaces and shareable
+explainers, not a replacement for the wiki rebuild contract.
+
+Repository convention:
+
+- Store durable HTML artifacts under `docs/agent-artifacts/` with a
+  date-prefixed filename.
+- Start from `docs/agent-artifacts/html-artifact-template.html` or run
+  `bash scripts/new-html-artifact.sh <slug> "Title"`.
+- Make artifacts self-contained unless an external dependency is explicitly
+  justified in the artifact metadata.
+- Include provenance: source files, commands, PR number, issue, context source,
+  or prompt.
+- Include an export path for interactive artifacts, such as copy JSON, copy
+  markdown, copy prompt, or copy PR summary.
+- Do not include secrets, bearer tokens, private customer data, or raw logs with
+  credentials.
+- If the artifact establishes a durable decision, link it from the owning
+  markdown doc or summarize the decision there so text search and wiki
+  ingestion still find it.
+
 ### Multi-round review rhythm
 
 Use this heavier rhythm for substantial changes such as new packages,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -56,3 +56,17 @@ Some branches include `scripts/dispatch-codex.sh` as a general implementation
 dispatcher for writable Codex agents. Use that kind of wrapper for isolated
 implementation batches in worktrees. Use the verification and triangulation
 wrappers above when the goal is read-only review rather than editing.
+
+## `new-html-artifact.sh`
+
+Creates a dated self-contained HTML artifact from
+`docs/agent-artifacts/html-artifact-template.html`.
+
+```bash
+bash scripts/new-html-artifact.sh runtime-explainer "Runtime explainer"
+```
+
+Use HTML artifacts for dense agent outputs that benefit from visual structure:
+plans, PR explainers, architecture maps, design explorations, reports, and
+throwaway editors with an export button. Markdown remains the canonical wiki
+and fact substrate.

--- a/scripts/new-html-artifact.sh
+++ b/scripts/new-html-artifact.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Create a dated self-contained HTML artifact from the repo template.
+
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/new-html-artifact.sh <slug> [title]
+
+Examples:
+  bash scripts/new-html-artifact.sh runtime-explainer "Runtime explainer"
+  ARTIFACT_DATE=2026-05-11 bash scripts/new-html-artifact.sh pr-42-review
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+slug="${1:-}"
+title="${2:-}"
+
+if [[ -z "$slug" ]]; then
+  usage >&2
+  exit 2
+fi
+
+if [[ ! "$slug" =~ ^[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "new-html-artifact: slug must be lowercase kebab-case" >&2
+  exit 2
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+template="$repo_root/docs/agent-artifacts/html-artifact-template.html"
+
+if [[ ! -f "$template" ]]; then
+  echo "new-html-artifact: missing template at $template" >&2
+  exit 1
+fi
+
+date_part="${ARTIFACT_DATE:-$(date +%F)}"
+out_dir="$repo_root/docs/agent-artifacts"
+out="$out_dir/${date_part}-${slug}.html"
+
+if [[ -e "$out" ]]; then
+  echo "new-html-artifact: refusing to overwrite $out" >&2
+  exit 1
+fi
+
+if [[ -z "$title" ]]; then
+  title="$(printf '%s' "$slug" | tr '-' ' ')"
+fi
+
+escape_sed() {
+  printf '%s' "$1" | sed 's/[\/&]/\\&/g'
+}
+
+summary="Replace with a one-sentence summary."
+owner="${USER:-agent}"
+sources="Replace with source files, commands, links, or prompts."
+
+sed \
+  -e "s/{{TITLE}}/$(escape_sed "$title")/g" \
+  -e "s/{{SUMMARY}}/$(escape_sed "$summary")/g" \
+  -e "s/{{DATE}}/$(escape_sed "$date_part")/g" \
+  -e "s/{{OWNER}}/$(escape_sed "$owner")/g" \
+  -e "s/{{SOURCES}}/$(escape_sed "$sources")/g" \
+  "$template" > "$out"
+
+echo "$out"


### PR DESCRIPTION
## Summary
- add a WUPHF convention for self-contained HTML agent artifacts
- add a reusable HTML artifact template and scaffold script
- include a concrete adoption artifact for plans, PR explainers, reports, and custom editors

## Verification
- git diff --check origin/main..HEAD
- bash -n scripts/new-html-artifact.sh
- shellcheck scripts/new-html-artifact.sh
- ARTIFACT_DATE=2099-01-02 bash scripts/new-html-artifact.sh smoke-test "Smoke Test"

## Screenshots
Skipped: docs/script-only change with no web UI delta.