### PR TITLE
chore(installer-stub): convert asar-using scripts to ESM for @electron/asar v4

### DIFF
--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -192,7 +192,7 @@ jobs:
         # it was a devDep" failure mode that the existing artifact-existence
         # checks did not.
         working-directory: apps/installer-stub
-        run: node scripts/check-packaged-runtime-deps.js dist
+        run: node scripts/check-packaged-runtime-deps.mjs dist
       - name: Staple and validate macOS DMG
         if: needs.detect-secrets.outputs.is_release == 'true'
         working-directory: apps/installer-stub
@@ -416,7 +416,7 @@ jobs:
         id: windows_runtime_deps
         continue-on-error: ${{ needs.detect-secrets.outputs.is_release != 'true' }}
         working-directory: apps/installer-stub
-        run: node scripts/check-packaged-runtime-deps.js dist
+        run: node scripts/check-packaged-runtime-deps.mjs dist
       # Post-build "Sign Windows artifacts (attempt 1/2/3)" + retry sleeps
       # + diagnostics upload were removed in #772: signing now happens
       # DURING the electron-builder packaging step above via
@@ -589,7 +589,7 @@ jobs:
         # job. Both PR and release Linux builds produce dist/linux-unpacked/,
         # so the gate runs unconditionally after either build path.
         working-directory: apps/installer-stub
-        run: node scripts/check-packaged-runtime-deps.js dist
+        run: node scripts/check-packaged-runtime-deps.mjs dist
       - name: Assert Linux artifacts
         working-directory: apps/installer-stub
         run: |

--- a/.github/workflows/release-rewrite.yml
+++ b/.github/workflows/release-rewrite.yml
@@ -101,7 +101,7 @@ jobs:
           # lives inside each platform build job (post-build, pre-sign);
           # this self-test catches regressions in the check's logic without
           # waiting for a 5-minute platform build to fail.
-          node apps/installer-stub/scripts/check-packaged-runtime-deps.test.js
+          node apps/installer-stub/scripts/check-packaged-runtime-deps.test.mjs
 
   build-mac:
     needs:

--- a/apps/installer-stub/docs/runbooks/electron-stack-maintenance.md
+++ b/apps/installer-stub/docs/runbooks/electron-stack-maintenance.md
@@ -45,7 +45,7 @@ schema:
 
 ## Windows packaging gap (release-blocking) — issue #781
 
-The `check-packaged-runtime-deps.js` post-build gate fails on **Windows**
+The `check-packaged-runtime-deps.mjs` post-build gate fails on **Windows**
 even on electron-builder 26: bun's per-workspace symlinks are created
 on Windows, but electron-builder's app-builder doesn't follow them, so
 `electron-updater` plus its 9-entry transitive closure is pruned out of

--- a/apps/installer-stub/package.json
+++ b/apps/installer-stub/package.json
@@ -16,9 +16,9 @@
   "wuphfBuildChannel": "dev",
   "scripts": {
     "start": "electron .",
-    "lint": "biome check src/ scripts/*.js build/*.js package.json",
-    "lint:fix": "biome check --write src/ scripts/*.js build/*.js package.json",
-    "format": "biome format --write src/ scripts/*.js build/*.js package.json",
+    "lint": "biome check src/ scripts/*.js scripts/*.mjs build/*.js package.json",
+    "lint:fix": "biome check --write src/ scripts/*.js scripts/*.mjs build/*.js package.json",
+    "format": "biome format --write src/ scripts/*.js scripts/*.mjs build/*.js package.json",
     "build:current": "node scripts/run-current-build.js",
     "build:mac": "node scripts/run-builder.js --mac --config electron-builder.yml --publish=never",
     "build:win": "node scripts/run-builder.js --win --config electron-builder.yml --publish=never",
@@ -26,7 +26,7 @@
     "build:dry-run": "node scripts/run-dry-run.js",
     "check:secrets": "bash scripts/detect-signing-secrets.sh",
     "check:invariants": "bash scripts/check-invariants.sh",
-    "test": "bash scripts/check-invariants-self-test.sh && WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 bash scripts/verify-latest-yml.sh && bun test scripts/refresh-latest-yml.test.js && node scripts/normalize-package-version.test.js && node scripts/run-builder.test.js && node scripts/check-packaged-runtime-deps.test.js",
+    "test": "bash scripts/check-invariants-self-test.sh && WUPHF_VERIFY_LATEST_YML_RUN_SELF_TEST=1 WUPHF_VERIFY_LATEST_YML_SELF_TEST_ONLY=1 bash scripts/verify-latest-yml.sh && bun test scripts/refresh-latest-yml.test.js && node scripts/normalize-package-version.test.js && node scripts/run-builder.test.js && node scripts/check-packaged-runtime-deps.test.mjs",
     "verify:latest-yml": "bash scripts/verify-latest-yml.sh"
   },
   "dependencies": {

--- a/apps/installer-stub/scripts/check-packaged-runtime-deps.mjs
+++ b/apps/installer-stub/scripts/check-packaged-runtime-deps.mjs
@@ -14,24 +14,28 @@
 //   # 1. Build with `--dir` first so the unpacked dist exists.
 //   #    e.g. `node scripts/run-builder.js --linux --dir`
 //   # 2. Then point this script at the dist directory:
-//   node scripts/check-packaged-runtime-deps.js apps/installer-stub/dist
+//   node scripts/check-packaged-runtime-deps.mjs apps/installer-stub/dist
 //
 // Exit codes:
 //   0 = all allowlisted deps found in either app.asar or app.asar.unpacked/
 //   1 = a dep is missing (the bug)
 //   2 = the dist directory does not contain a recognizable app bundle
 
-const fs = require("node:fs");
-const path = require("node:path");
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-// @electron/asar ships a Node API used here directly so we don't depend on
-// a `node_modules/.bin/asar` shim that bun lays out differently from npm.
-const asarApi = require("@electron/asar");
+// @electron/asar v4 is ESM-only; we import the API directly so we don't
+// depend on a `node_modules/.bin/asar` shim that bun lays out differently
+// from npm.
+import { listPackage } from "@electron/asar";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function main() {
   const distArg = process.argv[2];
   if (!distArg) {
-    console.error("usage: check-packaged-runtime-deps.js <dist-dir>");
+    console.error("usage: check-packaged-runtime-deps.mjs <dist-dir>");
     process.exit(2);
   }
 
@@ -66,7 +70,7 @@ function main() {
   const installerStubRoot = seamStubRoot ?? path.resolve(__dirname, "..");
   const packageJsonPath = seamPackageJson ?? path.join(installerStubRoot, "package.json");
 
-  const packageJson = require(path.resolve(packageJsonPath));
+  const packageJson = JSON.parse(fs.readFileSync(path.resolve(packageJsonPath), "utf8"));
   const allowlist = packageJson.wuphfRuntimeDependenciesAllowlist;
   // FAIL CLOSED: a missing or empty allowlist with non-empty `dependencies`
   // is a contract bug, not a no-op. The companion check-invariants.sh
@@ -255,7 +259,7 @@ function listAsarEntries(asarPath) {
   // @electron/asar.listPackage returns one entry per file/directory inside
   // the asar with a leading slash, e.g. "/node_modules/electron-updater/package.json".
   // Strip the leading slash so callers can use a forward-slash relative key.
-  const lines = asarApi.listPackage(asarPath, { isPack: false });
+  const lines = listPackage(asarPath, { isPack: false });
   const entries = new Set();
   for (const line of lines) {
     const trimmed = line.trim();

--- a/apps/installer-stub/scripts/check-packaged-runtime-deps.test.mjs
+++ b/apps/installer-stub/scripts/check-packaged-runtime-deps.test.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
-const { spawnSync } = require("node:child_process");
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { createPackage } from "@electron/asar";
 
-const scriptPath = path.resolve(__dirname, "check-packaged-runtime-deps.js");
-const asarApi = require("@electron/asar");
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.resolve(__dirname, "check-packaged-runtime-deps.mjs");
 
 function runCheck(distDir, env = {}) {
   return spawnSync(process.execPath, [scriptPath, distDir], {
@@ -100,7 +102,7 @@ async function makeFakeBundle(rootDir, layout) {
       );
     }
     fs.writeFileSync(path.join(stagingDir, "package.json"), JSON.stringify({ name: "stub" }));
-    await asarApi.createPackage(stagingDir, path.join(resourcesDir, "app.asar"));
+    await createPackage(stagingDir, path.join(resourcesDir, "app.asar"));
   }
 
   if (Array.isArray(layout.unpackedDeps)) {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -284,7 +284,7 @@ pre-push:
         node apps/installer-stub/scripts/run-builder.test.js
         # Issue #771: self-test for the packaged-runtime-deps check (the real
         # post-build gate lives in release-rewrite.yml's per-platform jobs).
-        node apps/installer-stub/scripts/check-packaged-runtime-deps.test.js
+        node apps/installer-stub/scripts/check-packaged-runtime-deps.test.mjs
     file-size:
       # Enforce CONTRIBUTING.md's file-size budget: warn at 800 LOC, fail
       # at 1500 LOC unless the file is on scripts/file-size-allowlist.txt


### PR DESCRIPTION
Follow-up to the merged dep rollup #811, addressing CodeRabbit's review of that PR.

## CodeRabbit disposition table

| # | Finding | Disposition | Notes |
|---|---|---|---|
| 1 | `apps/installer-stub/package.json:37` — \"@electron/asar v4 is ESM-only and requires Node >=22.12.0, but code uses CommonJS \`require()\`\" | **FIXED** | This PR. See \"What this changes\" below. |
| 2 | `packages/protocol/package.json:24` — \"canonicalize 3.0.0 switched to ES modules; verify no CommonJS callers and that circular references are handled\" | **SKIPPED** | False positive on inspection. `packages/protocol/src/canonical-json.ts:1` already imports it as ESM (`import canonicalize from \"canonicalize\";`); no `require(\"canonicalize\")` anywhere in the workspace. Circular refs are structurally impossible at the call site — input is gated through `FrozenArgs.freeze()`, which serializes via `JSON.stringify` and rejects anything non-JSON-able before canonicalize sees it. Coverage on `canonical-json.ts` stays at 95.37% on this branch and on main. |

## What this changes (Finding #1)

The `@electron/asar` v4 release notes are clear: ESM-only export, `engines.node >= 22.12.0`. The two consumers in `apps/installer-stub/scripts/` were CommonJS:

```js
// before
const asarApi = require(\"@electron/asar\");
asarApi.listPackage(asarPath, { isPack: false });
```

CI passed on #811 because Node 22.12+'s `require()`-of-ESM compat is on by default, but that's runtime-version-fragile and obscures the actual contract. Converting both files to per-file ESM (`.mjs`) lines the code up with what the package exports.

**Renames:**
- `apps/installer-stub/scripts/check-packaged-runtime-deps.js` → `.mjs`
- `apps/installer-stub/scripts/check-packaged-runtime-deps.test.js` → `.mjs`

**In the renamed scripts:**
- `require(\"@electron/asar\")` → `import { listPackage } from \"@electron/asar\"` (and `createPackage` in the test)
- `__dirname` → derived from `import.meta.url` via `fileURLToPath`
- `require(packageJsonPath)` for the workspace package.json → `JSON.parse(fs.readFileSync(...))` (ESM doesn't carry `require`, and using `import \"...\" with { type: \"json\" }` would force this read into module-load time when it needs to be runtime-overridable for the test seam)

**Callers updated:**
- `apps/installer-stub/package.json` — `scripts.test` references `.mjs`; biome `lint`/`lint:fix`/`format` globs add `.mjs`
- `.github/workflows/release-rewrite.yml` — 3 callers (per-platform post-build gate)
- `apps/installer-stub/docs/runbooks/electron-stack-maintenance.md` — runbook reference
- `lefthook.yml` — pre-push installer-invariants step

The other `.js` files in `apps/installer-stub/scripts/` stay CJS — they don't pull in any ESM-only packages, and a wholesale workspace flip to `\"type\": \"module\"` is out of scope.

## Verification

| Gate | Result |
|---|---|
| `node apps/installer-stub/scripts/check-packaged-runtime-deps.test.mjs` (direct invocation) | `check-packaged-runtime-deps self-test OK` |
| `bun run --cwd apps/installer-stub test` | all 5 sub-suites pass |
| `bun run --cwd apps/installer-stub lint` | 14 files clean |
| `bun run --cwd apps/installer-stub check:invariants` | passed |
| pre-push `lefthook` installer-invariants step | passed |

## Test plan

- [ ] CI green on this PR (notably `installer-invariants` and `release-rewrite` workflow validations)
- [ ] No regression to the `check-packaged-runtime-deps` post-build gate in the release pipeline
- [ ] Resolve CodeRabbit finding #1 on #811 (this PR)
- [ ] Acknowledge CodeRabbit finding #2 as already-correct (no action required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build tooling and continuous integration configurations to use modern module format, improving consistency across development and testing workflows.
  * Expanded code quality checks to include additional build and configuration files.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/812)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->