### PR TITLE
feat(broker): event log + projections (rewrite branch 6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,20 @@ jobs:
         if: ${{ steps.desktop-changes.outputs.changed == 'true' }}
         working-directory: apps/desktop
         run: bun run build
+      - name: Build-output externalization invariants
+        # Audits `out/{main,preload}/**.js` for two regressions a green
+        # build + green tests cannot catch:
+        # 1. workspace packages (`@wuphf/*`) leaking into the build as
+        #    runtime externals — their `exports` map to raw `./src/*.ts`,
+        #    which Node 22 strip-only TS would crash on at runtime
+        #    (e.g. parameter properties on `SqliteReceiptStore`'s private
+        #    constructor).
+        # 2. `better-sqlite3` getting inlined — its `bindings()` loader
+        #    needs the JS wrapper at its npm location to find the `.node`
+        #    sibling.
+        if: ${{ steps.desktop-changes.outputs.changed == 'true' }}
+        working-directory: apps/desktop
+        run: bun run check:build-externals
 
   web:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,63 @@ jobs:
         working-directory: packages/protocol/testdata
         run: go run verifier-reference.go
 
+  broker:
+    # @wuphf/broker is the loopback HTTP/SSE/WebSocket boundary between
+    # the renderer and the broker process — DNS-rebinding guard, bearer
+    # auth, durable receipt store, cursor-paginated thread list. Local
+    # lefthook covers typecheck/test/invariants but a PR can still bypass
+    # them; this job is the CI floor. Path-gated to keep PRs that don't
+    # touch the broker fast.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version: "1.3.13"
+      - name: Detect broker changes
+        id: broker-changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${BASE_SHA}" || "${BASE_SHA}" =~ ^0+$ ]]; then
+            changed="$(git ls-files packages/broker package.json bun.lock)"
+          else
+            changed="$(git diff --name-only "${BASE_SHA}"...HEAD -- packages/broker package.json bun.lock || true)"
+          fi
+
+          if [[ -n "${changed}" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip broker job when broker inputs are unchanged
+        if: ${{ steps.broker-changes.outputs.changed != 'true' }}
+        run: echo "No packages/broker, root package.json, or bun.lock changes detected."
+      - name: Install workspace deps
+        if: ${{ steps.broker-changes.outputs.changed == 'true' }}
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        if: ${{ steps.broker-changes.outputs.changed == 'true' }}
+        working-directory: packages/broker
+        run: bun run typecheck
+      - name: Biome (lint + format check)
+        if: ${{ steps.broker-changes.outputs.changed == 'true' }}
+        working-directory: packages/broker
+        run: bun run check
+      - name: Vitest
+        if: ${{ steps.broker-changes.outputs.changed == 'true' }}
+        working-directory: packages/broker
+        run: bun run test
+      - name: Broker invariant checks
+        # No non-loopback bind constants, no electron imports, all
+        # @wuphf/protocol imports go through the package root, etc.
+        if: ${{ steps.broker-changes.outputs.changed == 'true' }}
+        working-directory: packages/broker
+        run: bun run check:invariants
+
   desktop:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
     # auth, durable receipt store, cursor-paginated thread list. Local
     # lefthook covers typecheck/test/invariants but a PR can still bypass
     # them; this job is the CI floor. Path-gated to keep PRs that don't
-    # touch the broker fast.
+    # touch the broker fast. `packages/protocol` is in the gate because
+    # broker depends on it — a protocol type/wire change can break the
+    # broker compile while the broker tree looks "unchanged."
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
@@ -120,9 +122,9 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "${BASE_SHA}" || "${BASE_SHA}" =~ ^0+$ ]]; then
-            changed="$(git ls-files packages/broker package.json bun.lock)"
+            changed="$(git ls-files packages/broker packages/protocol package.json bun.lock)"
           else
-            changed="$(git diff --name-only "${BASE_SHA}"...HEAD -- packages/broker package.json bun.lock || true)"
+            changed="$(git diff --name-only "${BASE_SHA}"...HEAD -- packages/broker packages/protocol package.json bun.lock || true)"
           fi
 
           if [[ -n "${changed}" ]]; then
@@ -132,7 +134,7 @@ jobs:
           fi
       - name: Skip broker job when broker inputs are unchanged
         if: ${{ steps.broker-changes.outputs.changed != 'true' }}
-        run: echo "No packages/broker, root package.json, or bun.lock changes detected."
+        run: echo "No packages/broker, packages/protocol, root package.json, or bun.lock changes detected."
       - name: Install workspace deps
         if: ${{ steps.broker-changes.outputs.changed == 'true' }}
         run: bun install --frozen-lockfile

--- a/apps/desktop/docs/modules/broker-spawn.md
+++ b/apps/desktop/docs/modules/broker-spawn.md
@@ -119,5 +119,25 @@ are passed through:
 | `TZ` | Time zone context for future user-facing local formatting. |
 | `WUPHF_RENDERER_DIST` | Packaged-only renderer bundle path so the broker can serve `/`. |
 | `WUPHF_DEV_RENDERER_ORIGIN` | Dev-only electron-vite renderer origin accepted by the broker's `/api-token` gate. |
+| `WUPHF_RECEIPT_STORE_PATH` | Absolute path to the durable receipt-store SQLite database. Set by main to `<userData>/event-log.sqlite`; absent → broker uses an in-memory store. |
 
-Secrets, tokens, cloud credentials, and app-data paths are not passed through.
+Secrets, tokens, and cloud credentials are not passed through. The
+`WUPHF_RECEIPT_STORE_PATH` is the one app-data path that crosses the
+boundary — it lets the utility process open the durable
+`SqliteReceiptStore`.
+
+### Receipt-store recovery
+
+If the durable store fails the broker route surface returns:
+
+- `507 store_full` — disk full or the in-memory cap exceeded.
+- `503 store_busy` with `Retry-After: 1` — transient `SQLITE_BUSY`/`LOCKED`;
+  retry typically succeeds.
+- `503 storage_error` — persistent `SQLITE_READONLY`/`SQLITE_IOERR_*`/
+  `SQLITE_CORRUPT`. Operator intervention needed.
+
+For recovery, stop the broker, move the file at `WUPHF_RECEIPT_STORE_PATH`
+aside (and its `-wal`/`-shm` sidecars), then restart the app — the broker
+will create a fresh database. Receipts in the moved file can be salvaged
+offline by reading the canonical JSON payloads in the
+`receipts_projection.payload` column.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -4,12 +4,30 @@ import { defineConfig, externalizeDepsPlugin } from "electron-vite";
 
 const rootDir = dirname(fileURLToPath(import.meta.url));
 
+// Workspace packages MUST be inlined into the build output. Their
+// package.json `exports` map to raw `./src/*.ts`, and the packaged
+// Electron utility process can't evaluate raw TS at runtime — Node's
+// strip-only TS support rejects parameter properties used by classes
+// like `SqliteReceiptStore`. Externalizing them produces an
+// `import "@wuphf/broker"` statement that crashes the utility process
+// on startup.
+const WORKSPACE_BUNDLE = ["@wuphf/broker", "@wuphf/protocol"];
+
+// Packages that MUST stay external in the main bundle even after
+// inlining the workspace deps. `better-sqlite3` is a transitive of
+// `@wuphf/broker` and pulls native bindings via `bindings()` — the
+// resolver looks for its sibling `.node` file in `node_modules/
+// better-sqlite3/`, so the JS wrapper must remain a runtime require
+// rather than getting flattened into our chunk.
+const NATIVE_EXTERNAL = ["better-sqlite3"];
+
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: WORKSPACE_BUNDLE })],
     build: {
       outDir: "out/main",
       rollupOptions: {
+        external: NATIVE_EXTERNAL,
         input: {
           index: resolve(rootDir, "src/main/index.ts"),
           "broker-entry": resolve(rootDir, "src/main/broker-entry.ts"),
@@ -22,7 +40,7 @@ export default defineConfig({
     },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: WORKSPACE_BUNDLE })],
     build: {
       outDir: "out/preload",
       rollupOptions: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,7 +19,8 @@
     "dev": "bun run electron:install && electron-vite dev",
     "preview": "bun run electron:install && electron-vite preview",
     "check:ipc-allowlist": "bash scripts/check-ipc-allowlist.sh",
-    "check:invariants": "bash scripts/check-invariants.sh"
+    "check:invariants": "bash scripts/check-invariants.sh",
+    "check:build-externals": "bash scripts/check-build-externals.sh"
   },
   "dependencies": {
     "@wuphf/broker": "workspace:*",

--- a/apps/desktop/scripts/check-build-externals.sh
+++ b/apps/desktop/scripts/check-build-externals.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Verify the desktop main+preload build doesn't re-introduce workspace
+# packages as runtime externals.
+#
+# Why this check exists:
+#
+# `electron-vite`'s default `externalizeDepsPlugin()` marks every entry
+# in `package.json#dependencies` as a runtime external. For ordinary npm
+# packages with compiled `.js` entry points that's correct. For our
+# workspace packages (`@wuphf/broker`, `@wuphf/protocol`) it is
+# **catastrophic**: their `package.json#exports` map to raw `./src/*.ts`,
+# and Node 22's strip-only TypeScript support can't transpile TS-only
+# syntax constructs like parameter properties (used in
+# `SqliteReceiptStore`'s private constructor). At packaged runtime the
+# Electron utility process would crash on the first `import` of a
+# workspace package — before the parent-port handshake — and no JS-side
+# test catches this because Vitest evaluates TS through Vite's
+# transformer.
+#
+# This check inspects the post-build artifacts and fails CI if:
+#   - any `out/{main,preload}/**.js` imports a `@wuphf/*` workspace
+#     package by name (means the workspace dep wasn't bundled), OR
+#   - any output file imports a raw `*.ts` path (means an external's
+#     `exports` field still points to source).
+#
+# It also asserts that `better-sqlite3` IS still an external — its
+# native-binding loader (`bindings()`) walks up the filesystem to find
+# its `.node` sibling, which requires the JS wrapper to live at its
+# npm location rather than getting flattened into our bundle.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+out_dir="${root_dir}/out"
+
+if [ ! -d "${out_dir}/main" ]; then
+  echo "FAIL: ${out_dir}/main does not exist. Run \`bun run build\` first." >&2
+  exit 1
+fi
+
+fail=0
+report() {
+  echo "FAIL: $1" >&2
+  fail=1
+}
+
+# Collect every emitted .js under main + preload (chunks live under
+# out/main/chunks/). Skip renderer — it's a browser bundle and its
+# externalization rules are different. `mapfile` is bash 4+; use a
+# portable read loop so this works on macOS's stock bash 3.2.
+output_files=()
+while IFS= read -r f; do
+  output_files+=("$f")
+done < <(
+  find "${out_dir}/main" "${out_dir}/preload" \
+    -type f -name '*.js' 2>/dev/null | sort
+)
+
+if [ "${#output_files[@]}" -eq 0 ]; then
+  echo "FAIL: no JS output found under ${out_dir}/{main,preload}." >&2
+  exit 1
+fi
+
+# --- Forbidden: workspace packages must be bundled, not externalized ---
+# Both static (`from "@wuphf/..."`) and dynamic (`import("@wuphf/...")`)
+# forms are checked. After a correct build, vite rewrites dynamic
+# imports of bundled packages to internal chunk paths like
+# `./chunks/sqlite-receipt-store-XYZ.js`.
+workspace_static_hits="$(grep -nE 'from "@wuphf/[^"]+"' "${output_files[@]}" 2>/dev/null || true)"
+if [ -n "${workspace_static_hits}" ]; then
+  report "workspace package imports leaked into build (workspace deps must be inlined):"
+  echo "${workspace_static_hits}" >&2
+fi
+
+workspace_dynamic_hits="$(grep -nE 'import\("@wuphf/[^"]+"\)' "${output_files[@]}" 2>/dev/null || true)"
+if [ -n "${workspace_dynamic_hits}" ]; then
+  report "workspace package dynamic imports leaked into build:"
+  echo "${workspace_dynamic_hits}" >&2
+fi
+
+# --- Forbidden: raw .ts imports at runtime ---
+# If a workspace `package.json#exports` field still points at `./src/*.ts`
+# and the package is externalized, the build output ends up with
+# `from "..../foo.ts"` literally in a .js file. Node 22 strip-only TS
+# rejects parameter properties, so this would crash at runtime.
+raw_ts_hits="$(grep -nE 'from "[^"]+\.ts"' "${output_files[@]}" 2>/dev/null || true)"
+if [ -n "${raw_ts_hits}" ]; then
+  report "raw .ts imports in build output (the runtime would attempt to evaluate TypeScript):"
+  echo "${raw_ts_hits}" >&2
+fi
+
+# --- Required: better-sqlite3 stays external ---
+# Its `bindings()` loader resolves `.node` via the npm filesystem layout.
+# If the JS wrapper got bundled, the native binding fails to load at
+# runtime even though the build succeeds.
+if ! grep -rqE 'from "better-sqlite3"' "${out_dir}/main"; then
+  report "better-sqlite3 import missing from out/main/ — the wrapper got inlined, and bindings() will fail to locate the .node sibling at runtime."
+fi
+
+if [ "${fail}" -ne 0 ]; then
+  echo >&2
+  echo "Build-output externalization check failed. See" >&2
+  echo "  apps/desktop/electron.vite.config.ts — externalizeDepsPlugin({ exclude: ... })" >&2
+  echo "  packages/broker/docs/event-log-projections-design.md § 'Package surface'" >&2
+  exit 1
+fi
+
+echo "PASS: build-output externalization invariants intact (${#output_files[@]} files inspected)."

--- a/apps/desktop/src/main/broker-entry.ts
+++ b/apps/desktop/src/main/broker-entry.ts
@@ -8,14 +8,13 @@
 // `/index.html`, and `/assets/*` return 404 — the dev server owns those
 // surfaces in dev.
 
-import { existsSync, mkdirSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
 import {
   type BrokerHandle,
   type BrokerLogger,
   createBroker,
-  type ReceiptStore,
   SqliteReceiptStore,
 } from "@wuphf/broker";
 
@@ -36,6 +35,11 @@ const RECEIPT_STORE_PATH_ENV = "WUPHF_RECEIPT_STORE_PATH";
 
 let aliveInterval: NodeJS.Timeout | null = null;
 let broker: BrokerHandle | null = null;
+// Module-scoped so `shutdown()` can close the SQLite handle after
+// `broker.stop()`. distsys triangulation R2-D2: relying on process
+// teardown to release the DB skips an explicit checkpoint and leaves
+// WAL recovery work for the next launch.
+let receiptStore: SqliteReceiptStore | null = null;
 let shuttingDown = false;
 
 function sendAlive(): void {
@@ -65,6 +69,16 @@ async function shutdown(): Promise<void> {
     } catch {
       // Broker shutdown failures must not block process exit; the supervisor
       // will SIGKILL after the force grace if needed.
+    }
+  }
+  if (receiptStore !== null) {
+    try {
+      // Triggers SQLite's WAL checkpoint + file handle release. Idempotent;
+      // safe to call even when the broker stop above failed.
+      receiptStore.close();
+    } catch {
+      // Same swallow-on-shutdown policy as broker.stop(): a failing close
+      // must not deadlock process exit.
     }
   }
   process.exit(0);
@@ -103,13 +117,27 @@ async function main(): Promise<void> {
   // fall through to createBroker's default (an in-memory store) — useful
   // for tests and the headless smoke path.
   const receiptStorePath = process.env[RECEIPT_STORE_PATH_ENV];
-  let receiptStore: ReceiptStore | undefined;
   if (typeof receiptStorePath === "string" && receiptStorePath.length > 0) {
+    const storeDir = dirname(receiptStorePath);
     // Ensure the parent directory exists. `userData` is created by
     // Electron on first launch; this guards against the host having
     // deleted it (rare but recoverable).
-    mkdirSync(dirname(receiptStorePath), { recursive: true });
+    mkdirSync(storeDir, { recursive: true });
+    // Security triangulation R2-S2: lock down the receipt store directory
+    // and DB sidecar permissions on POSIX. Receipts can contain local
+    // metadata (worktree paths, source reads, model details, error text);
+    // on shared systems the default umask may leave the DB world-readable.
+    // Windows uses ACLs and ignores chmod, so we no-op there.
+    if (process.platform !== "win32") {
+      tightenStorePermissions(storeDir, receiptStorePath);
+    }
     receiptStore = SqliteReceiptStore.open({ path: receiptStorePath });
+    // Tighten again after open — better-sqlite3 creates the DB + WAL/SHM
+    // sidecars with the process umask, so the post-open pass catches
+    // them. Idempotent on the directory.
+    if (process.platform !== "win32") {
+      tightenStorePermissions(storeDir, receiptStorePath);
+    }
   }
 
   broker = await createBroker({
@@ -117,7 +145,7 @@ async function main(): Promise<void> {
     renderer,
     logger,
     ...(trustedOrigins !== undefined ? { trustedOrigins } : {}),
-    ...(receiptStore !== undefined ? { receiptStore } : {}),
+    ...(receiptStore !== null ? { receiptStore } : {}),
   });
   sendReady(broker.url);
   sendAlive();
@@ -138,4 +166,27 @@ function isShutdownMessage(message: unknown): message is { readonly type: "shutd
     Object.hasOwn(message, "type") &&
     (message as { readonly type?: unknown }).type === "shutdown"
   );
+}
+
+// POSIX-only: tighten the receipt store directory + DB sidecars to
+// owner-only access. Best-effort — if a `chmod` fails we keep going
+// rather than refuse to start (some sandboxed filesystems error on
+// chmod). Windows uses ACLs and ignores `chmod`, so callers branch on
+// `process.platform` before calling this.
+function tightenStorePermissions(storeDir: string, dbPath: string): void {
+  const tryChmod = (path: string, mode: number): void => {
+    try {
+      chmodSync(path, mode);
+    } catch {
+      // Filesystem may refuse (network mount, sandbox, etc). Permissions
+      // are defense-in-depth on top of the userData isolation; not a
+      // showstopper.
+    }
+  };
+  tryChmod(storeDir, 0o700);
+  for (const sidecar of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`, `${dbPath}-journal`]) {
+    if (existsSync(sidecar)) {
+      tryChmod(sidecar, 0o600);
+    }
+  }
 }

--- a/apps/desktop/src/main/broker-entry.ts
+++ b/apps/desktop/src/main/broker-entry.ts
@@ -8,9 +8,16 @@
 // `/index.html`, and `/assets/*` return 404 — the dev server owns those
 // surfaces in dev.
 
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 
-import { type BrokerHandle, type BrokerLogger, createBroker } from "@wuphf/broker";
+import {
+  type BrokerHandle,
+  type BrokerLogger,
+  createBroker,
+  type ReceiptStore,
+  SqliteReceiptStore,
+} from "@wuphf/broker";
 
 const parentPort = process.parentPort;
 if (!parentPort) {
@@ -25,6 +32,7 @@ const ALIVE_INTERVAL_MS = 1_000;
 
 const RENDERER_DIST_ENV = "WUPHF_RENDERER_DIST";
 const DEV_RENDERER_ORIGIN_ENV = "WUPHF_DEV_RENDERER_ORIGIN";
+const RECEIPT_STORE_PATH_ENV = "WUPHF_RECEIPT_STORE_PATH";
 
 let aliveInterval: NodeJS.Timeout | null = null;
 let broker: BrokerHandle | null = null;
@@ -89,11 +97,27 @@ async function main(): Promise<void> {
   const devOrigin = process.env[DEV_RENDERER_ORIGIN_ENV];
   const trustedOrigins =
     typeof devOrigin === "string" && devOrigin.length > 0 ? [devOrigin] : undefined;
+
+  // Branch 6: open the durable, SQLite event-log-backed ReceiptStore at
+  // the path main/index.ts plumbed through. If the env var is absent we
+  // fall through to createBroker's default (an in-memory store) — useful
+  // for tests and the headless smoke path.
+  const receiptStorePath = process.env[RECEIPT_STORE_PATH_ENV];
+  let receiptStore: ReceiptStore | undefined;
+  if (typeof receiptStorePath === "string" && receiptStorePath.length > 0) {
+    // Ensure the parent directory exists. `userData` is created by
+    // Electron on first launch; this guards against the host having
+    // deleted it (rare but recoverable).
+    mkdirSync(dirname(receiptStorePath), { recursive: true });
+    receiptStore = SqliteReceiptStore.open({ path: receiptStorePath });
+  }
+
   broker = await createBroker({
     port: 0,
     renderer,
     logger,
     ...(trustedOrigins !== undefined ? { trustedOrigins } : {}),
+    ...(receiptStore !== undefined ? { receiptStore } : {}),
   });
   sendReady(broker.url);
   sendAlive();

--- a/apps/desktop/src/main/broker-entry.ts
+++ b/apps/desktop/src/main/broker-entry.ts
@@ -11,12 +11,14 @@
 import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 
-import {
-  type BrokerHandle,
-  type BrokerLogger,
-  createBroker,
-  SqliteReceiptStore,
-} from "@wuphf/broker";
+import { type BrokerHandle, type BrokerLogger, createBroker } from "@wuphf/broker";
+// `SqliteReceiptStore` and its native `better-sqlite3` binding are loaded
+// lazily via the `@wuphf/broker/sqlite` subpath so the utility process
+// doesn't evaluate the native addon when the durable store isn't wired
+// (e.g. headless smoke tests, or future hosts that bring their own
+// ReceiptStore). Type-only import keeps the field type narrow without
+// triggering runtime evaluation.
+import type { SqliteReceiptStore } from "@wuphf/broker/sqlite";
 
 const parentPort = process.parentPort;
 if (!parentPort) {
@@ -36,9 +38,9 @@ const RECEIPT_STORE_PATH_ENV = "WUPHF_RECEIPT_STORE_PATH";
 let aliveInterval: NodeJS.Timeout | null = null;
 let broker: BrokerHandle | null = null;
 // Module-scoped so `shutdown()` can close the SQLite handle after
-// `broker.stop()`. distsys triangulation R2-D2: relying on process
-// teardown to release the DB skips an explicit checkpoint and leaves
-// WAL recovery work for the next launch.
+// `broker.stop()`. Relying on process teardown to release the DB
+// skips an explicit WAL checkpoint and leaves recovery work for the
+// next launch.
 let receiptStore: SqliteReceiptStore | null = null;
 let shuttingDown = false;
 
@@ -112,10 +114,13 @@ async function main(): Promise<void> {
   const trustedOrigins =
     typeof devOrigin === "string" && devOrigin.length > 0 ? [devOrigin] : undefined;
 
-  // Branch 6: open the durable, SQLite event-log-backed ReceiptStore at
-  // the path main/index.ts plumbed through. If the env var is absent we
-  // fall through to createBroker's default (an in-memory store) — useful
-  // for tests and the headless smoke path.
+  // Open the durable, SQLite event-log-backed ReceiptStore at the path
+  // `main/index.ts` plumbed through. If the env var is absent we fall
+  // through to `createBroker`'s default (the in-memory store) — useful
+  // for tests and the headless smoke path. The `SqliteReceiptStore`
+  // module is loaded via dynamic import here so the native
+  // `better-sqlite3` binding is only evaluated when the durable store
+  // is actually wired.
   const receiptStorePath = process.env[RECEIPT_STORE_PATH_ENV];
   if (typeof receiptStorePath === "string" && receiptStorePath.length > 0) {
     const storeDir = dirname(receiptStorePath);
@@ -123,14 +128,15 @@ async function main(): Promise<void> {
     // Electron on first launch; this guards against the host having
     // deleted it (rare but recoverable).
     mkdirSync(storeDir, { recursive: true });
-    // Security triangulation R2-S2: lock down the receipt store directory
-    // and DB sidecar permissions on POSIX. Receipts can contain local
-    // metadata (worktree paths, source reads, model details, error text);
-    // on shared systems the default umask may leave the DB world-readable.
-    // Windows uses ACLs and ignores chmod, so we no-op there.
+    // POSIX: lock down the receipt store directory and DB sidecar
+    // permissions. Receipts can contain local metadata (worktree paths,
+    // source reads, model details, error text); on shared systems the
+    // default umask may leave the DB world-readable. Windows uses ACLs
+    // and ignores `chmod`, so we no-op there.
     if (process.platform !== "win32") {
       tightenStorePermissions(storeDir, receiptStorePath);
     }
+    const { SqliteReceiptStore } = await import("@wuphf/broker/sqlite");
     receiptStore = SqliteReceiptStore.open({ path: receiptStorePath });
     // Tighten again after open — better-sqlite3 creates the DB + WAL/SHM
     // sidecars with the process umask, so the post-open pass catches

--- a/apps/desktop/src/main/broker.ts
+++ b/apps/desktop/src/main/broker.ts
@@ -37,6 +37,9 @@ const BROKER_ENV_ALLOWLIST = [
   "TZ",
   "WUPHF_RENDERER_DIST",
   "WUPHF_DEV_RENDERER_ORIGIN",
+  // Branch 6: when set, the utility process opens `SqliteReceiptStore`
+  // at this path; absent → falls back to the in-memory store.
+  "WUPHF_RECEIPT_STORE_PATH",
 ] as const;
 const DEFAULT_STOP_GRACE_MS = 5_000;
 const DEFAULT_FORCE_STOP_GRACE_MS = 1_000;

--- a/apps/desktop/src/main/broker.ts
+++ b/apps/desktop/src/main/broker.ts
@@ -37,8 +37,8 @@ const BROKER_ENV_ALLOWLIST = [
   "TZ",
   "WUPHF_RENDERER_DIST",
   "WUPHF_DEV_RENDERER_ORIGIN",
-  // Branch 6: when set, the utility process opens `SqliteReceiptStore`
-  // at this path; absent → falls back to the in-memory store.
+  // When set, the utility process opens `SqliteReceiptStore` at this
+  // path; absent → falls back to the in-memory store.
   "WUPHF_RECEIPT_STORE_PATH",
 ] as const;
 const DEFAULT_STOP_GRACE_MS = 5_000;

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -17,6 +17,7 @@ const rendererDistDir = join(currentDir, "../renderer");
 const RENDERER_DIST_ENV = "WUPHF_RENDERER_DIST";
 const DEV_RENDERER_ORIGIN_ENV = "WUPHF_DEV_RENDERER_ORIGIN";
 const ELECTRON_RENDERER_URL_ENV = "ELECTRON_RENDERER_URL";
+const RECEIPT_STORE_PATH_ENV = "WUPHF_RECEIPT_STORE_PATH";
 
 const logger = createLogger("main");
 const brokerLogger = createLogger("broker");
@@ -100,6 +101,14 @@ app
       app.exit(1);
       return;
     }
+
+    // Branch 6: the broker utility process opens a durable, SQLite
+    // event-log-backed ReceiptStore at `<userData>/event-log.sqlite`
+    // when this env var is set; without it the broker falls back to
+    // the in-memory store. We set it unconditionally for the
+    // packaged + dev paths so receipts persist across restarts.
+    // `app.getPath("userData")` is safe inside `whenReady`.
+    process.env[RECEIPT_STORE_PATH_ENV] = join(app.getPath("userData"), "event-log.sqlite");
 
     logger.info("broker_start_requested");
     brokerSupervisor.start();

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -102,11 +102,11 @@ app
       return;
     }
 
-    // Branch 6: the broker utility process opens a durable, SQLite
-    // event-log-backed ReceiptStore at `<userData>/event-log.sqlite`
-    // when this env var is set; without it the broker falls back to
-    // the in-memory store. We set it unconditionally for the
-    // packaged + dev paths so receipts persist across restarts.
+    // The broker utility process opens a durable, SQLite event-log-
+    // backed ReceiptStore at `<userData>/event-log.sqlite` when this
+    // env var is set; without it the broker falls back to the in-
+    // memory store. We set it unconditionally for the packaged + dev
+    // paths so receipts persist across restarts.
     // `app.getPath("userData")` is safe inside `whenReady`.
     process.env[RECEIPT_STORE_PATH_ENV] = join(app.getPath("userData"), "event-log.sqlite");
 

--- a/apps/desktop/tests/main-bootstrap.spec.ts
+++ b/apps/desktop/tests/main-bootstrap.spec.ts
@@ -229,6 +229,7 @@ const initialUnhandledRejectionListeners = new Set<ProcessListener>(
 
 describe("main bootstrap", () => {
   const previousRendererUrl = process.env[RENDERER_URL_ENV_KEY];
+  const previousReceiptStorePath = process.env[RECEIPT_STORE_PATH_ENV];
 
   beforeEach(() => {
     vi.resetModules();
@@ -240,6 +241,7 @@ describe("main bootstrap", () => {
     electronMock.app.on.mockClear();
     electronMock.app.quit.mockClear();
     electronMock.app.exit.mockClear();
+    electronMock.app.getPath.mockClear();
     electronMock.showErrorBox.mockClear();
     electronMock.handle.mockClear();
     electronMock.fork.mockClear();
@@ -250,15 +252,21 @@ describe("main bootstrap", () => {
     loggerMock.createLogger.mockClear();
     cleanupProcessListeners();
     delete process.env[RENDERER_URL_ENV_KEY];
+    delete process.env[RECEIPT_STORE_PATH_ENV];
   });
 
   afterEach(() => {
     cleanupProcessListeners();
     if (previousRendererUrl === undefined) {
       delete process.env[RENDERER_URL_ENV_KEY];
-      return;
+    } else {
+      process.env[RENDERER_URL_ENV_KEY] = previousRendererUrl;
     }
-    process.env[RENDERER_URL_ENV_KEY] = previousRendererUrl;
+    if (previousReceiptStorePath === undefined) {
+      delete process.env[RECEIPT_STORE_PATH_ENV];
+    } else {
+      process.env[RECEIPT_STORE_PATH_ENV] = previousReceiptStorePath;
+    }
   });
 
   it("loads the broker URL when packaged and the broker has reported {ready}", async () => {
@@ -283,7 +291,8 @@ describe("main bootstrap", () => {
     // `whenReady` so receipts persist across restarts. Without this
     // assertion, a regression that drops the env-var line could
     // silently fall back to in-memory storage in packaged builds.
-    delete process.env[RECEIPT_STORE_PATH_ENV];
+    // `beforeEach` already deletes RECEIPT_STORE_PATH_ENV, so we
+    // assert main's `whenReady` is the one that sets it.
     electronMock.app.isPackaged = true;
     brokerMock.setBrokerUrl("http://127.0.0.1:54321");
 

--- a/apps/desktop/tests/main-bootstrap.spec.ts
+++ b/apps/desktop/tests/main-bootstrap.spec.ts
@@ -96,6 +96,11 @@ const electronMock = vi.hoisted(() => {
       on: vi.fn<(event: string, handler: (...args: readonly unknown[]) => void) => void>(),
       quit: vi.fn<() => void>(),
       exit: vi.fn<(code: number) => void>(),
+      // Branch 6: `main/index.ts` calls `app.getPath("userData")` inside
+      // `whenReady` to plumb the SQLite event-log path through to the
+      // broker utility process. Tests don't exercise the durable store;
+      // a fake path is sufficient because broker-entry.ts is mocked.
+      getPath: vi.fn<(name: string) => string>(() => "/tmp/wuphf-test-userData"),
     },
     BrowserWindow,
     browserWindowConstructorSpy,

--- a/apps/desktop/tests/main-bootstrap.spec.ts
+++ b/apps/desktop/tests/main-bootstrap.spec.ts
@@ -289,9 +289,7 @@ describe("main bootstrap", () => {
 
     await importMainBootstrap();
 
-    expect(process.env[RECEIPT_STORE_PATH_ENV]).toBe(
-      "/tmp/wuphf-test-userData/event-log.sqlite",
-    );
+    expect(process.env[RECEIPT_STORE_PATH_ENV]).toBe("/tmp/wuphf-test-userData/event-log.sqlite");
     expect(electronMock.app.getPath).toHaveBeenCalledWith("userData");
   });
 

--- a/apps/desktop/tests/main-bootstrap.spec.ts
+++ b/apps/desktop/tests/main-bootstrap.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const RENDERER_URL_ENV_KEY = "ELECTRON_RENDERER_URL";
+const RECEIPT_STORE_PATH_ENV = "WUPHF_RECEIPT_STORE_PATH";
 
 interface MockBrowserWindowInstance {
   readonly loadURL: ReturnType<typeof vi.fn<(url: string) => Promise<void>>>;
@@ -96,7 +97,7 @@ const electronMock = vi.hoisted(() => {
       on: vi.fn<(event: string, handler: (...args: readonly unknown[]) => void) => void>(),
       quit: vi.fn<() => void>(),
       exit: vi.fn<(code: number) => void>(),
-      // Branch 6: `main/index.ts` calls `app.getPath("userData")` inside
+      // `main/index.ts` calls `app.getPath("userData")` inside
       // `whenReady` to plumb the SQLite event-log path through to the
       // broker utility process. Tests don't exercise the durable store;
       // a fake path is sufficient because broker-entry.ts is mocked.
@@ -274,6 +275,24 @@ describe("main bootstrap", () => {
     const window = getOnlyWindow();
     expect(window.loadURL).toHaveBeenCalledWith("http://127.0.0.1:54321/");
     expect(window.loadFile).not.toHaveBeenCalled();
+  });
+
+  it("plumbs WUPHF_RECEIPT_STORE_PATH to <userData>/event-log.sqlite inside whenReady", async () => {
+    // The broker utility process opens `SqliteReceiptStore` when this
+    // env var is set; main MUST set it unconditionally inside
+    // `whenReady` so receipts persist across restarts. Without this
+    // assertion, a regression that drops the env-var line could
+    // silently fall back to in-memory storage in packaged builds.
+    delete process.env[RECEIPT_STORE_PATH_ENV];
+    electronMock.app.isPackaged = true;
+    brokerMock.setBrokerUrl("http://127.0.0.1:54321");
+
+    await importMainBootstrap();
+
+    expect(process.env[RECEIPT_STORE_PATH_ENV]).toBe(
+      "/tmp/wuphf-test-userData/event-log.sqlite",
+    );
+    expect(electronMock.app.getPath).toHaveBeenCalledWith("userData");
   });
 
   it("falls back to file:// in packaged mode only when the broker URL is unavailable", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -51,10 +51,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@wuphf/protocol": "workspace:*",
+        "better-sqlite3": "12.9.0",
         "ws": "8.20.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
+        "@types/better-sqlite3": "7.6.13",
         "@types/node": "^22.10.0",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "2.1.9",
@@ -423,6 +425,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
+
     "@types/cacheable-request": ["@types/cacheable-request@6.0.3", "", { "dependencies": { "@types/http-cache-semantics": "*", "@types/keyv": "^3.1.4", "@types/node": "*", "@types/responselike": "^1.0.0" } }, "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
@@ -537,7 +541,11 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
 
+    "better-sqlite3": ["better-sqlite3@12.9.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ=="],
+
     "binaryextensions": ["binaryextensions@6.11.0", "", { "dependencies": { "editions": "^6.21.0" } }, "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw=="],
+
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
@@ -587,7 +595,7 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "chromium-pickle-js": ["chromium-pickle-js@0.2.0", "", {}, "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw=="],
 
@@ -656,6 +664,8 @@
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
@@ -743,6 +753,8 @@
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
@@ -762,6 +774,8 @@
     "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "filelist": ["filelist@1.0.6", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA=="],
 
@@ -798,6 +812,8 @@
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
 
     "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
@@ -861,7 +877,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
 
@@ -1033,13 +1049,17 @@
 
     "mkdirp": ["mkdirp@1.0.4", "", { "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="],
 
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
-    "node-abi": ["node-abi@4.31.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw=="],
+    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "node-addon-api": ["node-addon-api@1.7.2", "", {}, "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg=="],
 
@@ -1105,6 +1125,8 @@
 
     "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
     "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
@@ -1124,6 +1146,8 @@
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
     "quick-lru": ["quick-lru@5.1.1", "", {}, "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "rc-config-loader": ["rc-config-loader@4.1.4", "", { "dependencies": { "debug": "^4.4.3", "js-yaml": "^4.1.1", "json5": "^2.2.3", "require-from-string": "^2.0.2" } }, "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ=="],
 
@@ -1159,7 +1183,7 @@
 
     "rollup": ["rollup@4.60.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.3", "@rollup/rollup-android-arm64": "4.60.3", "@rollup/rollup-darwin-arm64": "4.60.3", "@rollup/rollup-darwin-x64": "4.60.3", "@rollup/rollup-freebsd-arm64": "4.60.3", "@rollup/rollup-freebsd-x64": "4.60.3", "@rollup/rollup-linux-arm-gnueabihf": "4.60.3", "@rollup/rollup-linux-arm-musleabihf": "4.60.3", "@rollup/rollup-linux-arm64-gnu": "4.60.3", "@rollup/rollup-linux-arm64-musl": "4.60.3", "@rollup/rollup-linux-loong64-gnu": "4.60.3", "@rollup/rollup-linux-loong64-musl": "4.60.3", "@rollup/rollup-linux-ppc64-gnu": "4.60.3", "@rollup/rollup-linux-ppc64-musl": "4.60.3", "@rollup/rollup-linux-riscv64-gnu": "4.60.3", "@rollup/rollup-linux-riscv64-musl": "4.60.3", "@rollup/rollup-linux-s390x-gnu": "4.60.3", "@rollup/rollup-linux-x64-gnu": "4.60.3", "@rollup/rollup-linux-x64-musl": "4.60.3", "@rollup/rollup-openbsd-x64": "4.60.3", "@rollup/rollup-openharmony-arm64": "4.60.3", "@rollup/rollup-win32-arm64-msvc": "4.60.3", "@rollup/rollup-win32-ia32-msvc": "4.60.3", "@rollup/rollup-win32-x64-gnu": "4.60.3", "@rollup/rollup-win32-x64-msvc": "4.60.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A=="],
 
-    "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
@@ -1184,6 +1208,10 @@
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
+
+    "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "simple-update-notifier": ["simple-update-notifier@2.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w=="],
 
@@ -1229,6 +1257,8 @@
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "structured-source": ["structured-source@4.0.0", "", { "dependencies": { "boundary": "^2.0.0" } }, "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA=="],
 
     "sumchecker": ["sumchecker@3.0.1", "", { "dependencies": { "debug": "^4.1.0" } }, "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg=="],
@@ -1242,6 +1272,8 @@
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tar": ["tar@7.5.15", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ=="],
+
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -1280,6 +1312,8 @@
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 
@@ -1365,6 +1399,8 @@
 
     "@electron/osx-sign/plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
 
+    "@electron/rebuild/node-abi": ["node-abi@4.31.0", "", { "dependencies": { "semver": "^7.6.3" } }, "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw=="],
+
     "@electron/universal/@electron/asar": ["@electron/asar@3.4.1", "", { "dependencies": { "commander": "^5.0.0", "glob": "^7.1.6", "minimatch": "^3.0.4" }, "bin": { "asar": "bin/asar.js" } }, "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA=="],
 
     "@electron/universal/fs-extra": ["fs-extra@11.3.5", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg=="],
@@ -1386,6 +1422,8 @@
     "@textlint/linter-formatter/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "@textlint/linter-formatter/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@types/better-sqlite3/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "@types/ws/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
@@ -1459,6 +1497,8 @@
 
     "gauge/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "global-directory/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1521,8 +1561,6 @@
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "string_decoder/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
-
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "supports-hyperlinks/has-flag": ["has-flag@5.0.1", "", {}, "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA=="],
@@ -1534,6 +1572,8 @@
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "table/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "test-exclude/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -1580,6 +1620,8 @@
     "@textlint/linter-formatter/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "@textlint/linter-formatter/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@types/better-sqlite3/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@types/ws/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1634,6 +1676,8 @@
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "archiver-utils/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "archiver-utils/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
@@ -1690,6 +1734,8 @@
     "gauge/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "lazystream/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
     "lazystream/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
@@ -1778,8 +1824,6 @@
     "electron-builder-squirrel-windows/app-builder-lib/@electron/osx-sign/isbinaryfile": ["isbinaryfile@4.0.10", "", {}, "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/osx-sign/plist": ["plist@3.1.1", "", { "dependencies": { "@xmldom/xmldom": "^0.9.10", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA=="],
-
-    "electron-builder-squirrel-windows/app-builder-lib/@electron/rebuild/node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "electron-builder-squirrel-windows/app-builder-lib/@electron/rebuild/node-gyp": ["node-gyp@9.4.1", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "glob": "^7.1.4", "graceful-fs": "^4.2.6", "make-fetch-happen": "^10.0.3", "nopt": "^6.0.0", "npmlog": "^6.0.0", "rimraf": "^3.0.2", "semver": "^7.3.5", "tar": "^6.1.2", "which": "^2.0.2" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ=="],
 

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -44,10 +44,20 @@ await broker.stop();
 | GET | `/api/events` | bearer | SSE stream; emits `ready` then keepalive comments. |
 | POST | `/api/receipts` | bearer | Body: receipt JSON. 201 + canonical body on insert, 409 on `id` collision, 400 on parse/validation, 413 on `> 1 MiB`, 415 on non-JSON content-type, 507 `{"error":"store_full"}` when the in-memory store reaches `maxReceipts`. |
 | GET | `/api/receipts/:id` | bearer | 200 + receipt JSON on hit, 404 on miss or malformed id. |
-| GET | `/api/threads/:tid/receipts` | bearer | JSON array of V2 receipts in the thread (truncated at 1000 items; cursor pagination lands in branch 6, so clients seeing a 1000-item array should treat it as "more may exist"), 404 on malformed thread id. |
+| GET | `/api/threads/:tid/receipts` | bearer | JSON array of V2 receipts in the thread. Supports `?cursor=<opaque>` and `?limit=<positive integer>` pagination; responses include `Link: <...>; rel="next"` when another page exists. Returns 400 on invalid cursor/limit and 404 on malformed thread id. |
 | GET | `/`, `/index.html` | none (loopback) | Renderer bundle (404 if `renderer: null`). |
 | GET | `/assets/*` | none (loopback) | Static assets under the renderer dir. |
 | WS | `/terminal/agents/:slug?token=` | token + loopback origin | Branch-4 closes with `1011 not_implemented`. |
+
+Receipt thread-list pagination keeps the response body as a bare JSON array. Follow
+the RFC 8288 `Link` header to continue:
+
+```http
+GET /api/threads/01ARZ3NDEKTSV4RRFFQ69G5FAZ/receipts?limit=2
+Link: </api/threads/01ARZ3NDEKTSV4RRFFQ69G5FAZ/receipts?cursor=bHNuOjI&limit=2>; rel="next"
+
+GET /api/threads/01ARZ3NDEKTSV4RRFFQ69G5FAZ/receipts?cursor=bHNuOjI&limit=2
+```
 
 ## Invariants
 

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -40,9 +40,9 @@ await broker.stop();
 | Method | Path | Auth | Notes |
 |---|---|---|---|
 | GET | `/api-token` | none (loopback only) | Returns `{ token, broker_url }` (snake_case wire). |
-| GET | `/api/health` | bearer | Returns `{ "ok": true }`. |
+| GET | `/api/health` | bearer | Returns `{ "ok": true }`. Process-only liveness — does NOT probe the receipt store. Storage failures surface on `/api/receipts` writes (see R2-SRE3 follow-up). |
 | GET | `/api/events` | bearer | SSE stream; emits `ready` then keepalive comments. |
-| POST | `/api/receipts` | bearer | Body: receipt JSON. 201 + canonical body on insert, 409 on `id` collision, 400 on parse/validation, 413 on `> 1 MiB`, 415 on non-JSON content-type, 507 `{"error":"store_full"}` when the in-memory store reaches `maxReceipts` or `SqliteReceiptStore` hits `SQLITE_FULL`. |
+| POST | `/api/receipts` | bearer | Body: receipt JSON. 201 + canonical body on insert, 409 on `id` collision, 400 on parse/validation, 413 on `> 1 MiB`, 415 on non-JSON content-type, 507 `{"error":"store_full"}` when the store reaches `maxReceipts` or `SqliteReceiptStore` hits `SQLITE_FULL`, 503 `{"error":"store_busy"}` + `Retry-After: 1` for transient `SQLITE_BUSY`/`LOCKED`, 503 `{"error":"storage_error"}` for persistent `SQLITE_READONLY`/`SQLITE_IOERR_*`/`SQLITE_CORRUPT`. |
 | GET | `/api/receipts/:id` | bearer | 200 + receipt JSON on hit, 404 on miss or malformed id. |
 | GET | `/api/threads/:tid/receipts` | bearer | JSON array of V2 receipts in the thread. Supports `?cursor=<opaque>` (empty string ≡ absent) and `?limit=<positive integer>` (1–1000; default `MAX_LIST_LIMIT=1000`). Responses include `Link: <...>; rel="next"` when another page exists. Returns 400 on invalid cursor/limit and 404 on malformed thread id. |
 | GET | `/`, `/index.html` | none (loopback) | Renderer bundle (404 if `renderer: null`). |

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -3,18 +3,25 @@
 WUPHF v1 broker — loopback HTTP + SSE + WebSocket listener with a DNS-rebinding
 guard, bearer-token auth, and the `/api-token` bootstrap. Pure Node; no Electron.
 
-This is the **branch-4 + branch-5 slice** of the rewrite. It owns the boundary
-between the renderer (Electron WebView or a regular browser tab) and any later
-broker functionality (event log, projections, agent runners, AI gateway).
-Everything above this layer is **app data** that travels HTTP/SSE/WebSocket
-only — `contextBridge` carries OS verbs, never broker state.
+This package is the boundary between the renderer (Electron WebView or a regular
+browser tab) and the broker's own state (receipt store, agent runners, AI
+gateway). Everything above this layer is **app data** that travels
+HTTP/SSE/WebSocket only — `contextBridge` carries OS verbs, never broker
+state.
 
-Branch 5 adds the first real `/api/*` mutations: the receipt write path. A
-receipt is a tamper-evident record of an agent run (see `@wuphf/protocol`'s
-`ReceiptSnapshot`); the broker exposes it via REST so hosts can persist runs
-behind a loopback boundary. The current storage is an in-memory map per
-`createBroker()` call. Branch 6 (`feat/event-log-projections`) will swap a
-durable event-log-backed `ReceiptStore` in behind the same interface.
+Receipts are the broker's first persistent surface. A receipt is a
+tamper-evident record of an agent run (see `@wuphf/protocol`'s
+`ReceiptSnapshot`); the broker exposes the receipt write path via REST so
+hosts can persist runs behind a loopback boundary. Two `ReceiptStore`
+implementations:
+
+- `InMemoryReceiptStore` (default) — process-local; lost across restarts.
+  Useful for tests and headless smoke runs.
+- `SqliteReceiptStore` from `@wuphf/broker/sqlite` — durable, SQLite
+  event-log-backed. Loads the native `better-sqlite3` binding only when
+  imported, so consumers that only need the in-memory path don't pay the
+  cost. Hosts (e.g. the Electron utility process) wire this in by
+  passing `receiptStore: SqliteReceiptStore.open({ path })`.
 
 ## API
 
@@ -25,7 +32,6 @@ const broker = await createBroker({
   port: 0, // ephemeral; broker.port reports the assigned value
   renderer: { dir: "/abs/path/to/renderer/dist" }, // or null to disable static
   // Optional. Defaults to a fresh InMemoryReceiptStore per createBroker call.
-  // Branch 6 hosts will supply an event-log-backed implementation here.
   receiptStore: new InMemoryReceiptStore(),
 });
 
@@ -35,19 +41,37 @@ const broker = await createBroker({
 await broker.stop();
 ```
 
+Hosts that supply their own `receiptStore` own its lifecycle: `broker.stop()`
+closes the HTTP/WebSocket surface and the WS server, but it does NOT close
+the injected store. Call `store.close()` (or equivalent) after `broker.stop()`
+to release any underlying handle.
+
+For the durable store:
+
+```ts
+import { createBroker } from "@wuphf/broker";
+import { SqliteReceiptStore } from "@wuphf/broker/sqlite";
+
+const store = SqliteReceiptStore.open({ path: "/abs/path/event-log.sqlite" });
+const broker = await createBroker({ port: 0, receiptStore: store });
+// ...
+await broker.stop();
+store.close();
+```
+
 ## Routes
 
 | Method | Path | Auth | Notes |
 |---|---|---|---|
 | GET | `/api-token` | none (loopback only) | Returns `{ token, broker_url }` (snake_case wire). |
-| GET | `/api/health` | bearer | Returns `{ "ok": true }`. Process-only liveness — does NOT probe the receipt store. Storage failures surface on `/api/receipts` writes (see R2-SRE3 follow-up). |
+| GET | `/api/health` | bearer | Returns `{ "ok": true }`. Process-only liveness — does NOT probe the receipt store. Storage failures surface on the receipt routes themselves. A dedicated storage-diagnostics endpoint is tracked as future work. |
 | GET | `/api/events` | bearer | SSE stream; emits `ready` then keepalive comments. |
 | POST | `/api/receipts` | bearer | Body: receipt JSON. 201 + canonical body on insert, 409 on `id` collision, 400 on parse/validation, 413 on `> 1 MiB`, 415 on non-JSON content-type, 507 `{"error":"store_full"}` when the store reaches `maxReceipts` or `SqliteReceiptStore` hits `SQLITE_FULL`, 503 `{"error":"store_busy"}` + `Retry-After: 1` for transient `SQLITE_BUSY`/`LOCKED`, 503 `{"error":"storage_error"}` for persistent `SQLITE_READONLY`/`SQLITE_IOERR_*`/`SQLITE_CORRUPT`. |
 | GET | `/api/receipts/:id` | bearer | 200 + receipt JSON on hit, 404 on miss or malformed id. |
 | GET | `/api/threads/:tid/receipts` | bearer | JSON array of V2 receipts in the thread. Supports `?cursor=<opaque>` (empty string ≡ absent) and `?limit=<positive integer>` (1–1000; default `MAX_LIST_LIMIT=1000`). Responses include `Link: <...>; rel="next"` when another page exists. Returns 400 on invalid cursor/limit and 404 on malformed thread id. |
 | GET | `/`, `/index.html` | none (loopback) | Renderer bundle (404 if `renderer: null`). |
 | GET | `/assets/*` | none (loopback) | Static assets under the renderer dir. |
-| WS | `/terminal/agents/:slug?token=` | token + loopback origin | Branch-4 closes with `1011 not_implemented`. |
+| WS | `/terminal/agents/:slug?token=` | token + loopback origin | Currently closes with `1011 not_implemented`; the agent stdio bridge replaces this in a later branch. |
 
 Receipt thread-list pagination keeps the response body as a bare JSON array. Follow
 the RFC 8288 `Link` header to continue:
@@ -71,9 +95,9 @@ GET /api/threads/01ARZ3NDEKTSV4RRFFQ69G5FAZ/receipts?cursor=bHNuOjI&limit=2
    first same-origin caller.
 5. **No app data over `contextBridge`.** This package never imports `electron`.
 6. **Receipts are insert-if-absent.** A POST with an `id` that already exists
-   returns 409 and the stored value is **not** overwritten. Idempotency keys
-   (same id + byte-identical payload → 200 no-op) land in branch 6 alongside
-   the durable event log.
+   returns 409 and the stored value is **not** overwritten. Idempotency-key
+   semantics (same id + byte-identical payload → 200 no-op) are deferred to a
+   future widening of `put`'s return shape.
 7. **Receipts go through the protocol codec.** `receiptFromJson` runs the full
    validator (boundary budget, frozen-args canonicalization, shape, branded
    ids) before the broker even touches the store. There is no fast-path that

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -42,9 +42,9 @@ await broker.stop();
 | GET | `/api-token` | none (loopback only) | Returns `{ token, broker_url }` (snake_case wire). |
 | GET | `/api/health` | bearer | Returns `{ "ok": true }`. |
 | GET | `/api/events` | bearer | SSE stream; emits `ready` then keepalive comments. |
-| POST | `/api/receipts` | bearer | Body: receipt JSON. 201 + canonical body on insert, 409 on `id` collision, 400 on parse/validation, 413 on `> 1 MiB`, 415 on non-JSON content-type, 507 `{"error":"store_full"}` when the in-memory store reaches `maxReceipts`. |
+| POST | `/api/receipts` | bearer | Body: receipt JSON. 201 + canonical body on insert, 409 on `id` collision, 400 on parse/validation, 413 on `> 1 MiB`, 415 on non-JSON content-type, 507 `{"error":"store_full"}` when the in-memory store reaches `maxReceipts` or `SqliteReceiptStore` hits `SQLITE_FULL`. |
 | GET | `/api/receipts/:id` | bearer | 200 + receipt JSON on hit, 404 on miss or malformed id. |
-| GET | `/api/threads/:tid/receipts` | bearer | JSON array of V2 receipts in the thread. Supports `?cursor=<opaque>` and `?limit=<positive integer>` pagination; responses include `Link: <...>; rel="next"` when another page exists. Returns 400 on invalid cursor/limit and 404 on malformed thread id. |
+| GET | `/api/threads/:tid/receipts` | bearer | JSON array of V2 receipts in the thread. Supports `?cursor=<opaque>` (empty string ≡ absent) and `?limit=<positive integer>` (1–1000; default `MAX_LIST_LIMIT=1000`). Responses include `Link: <...>; rel="next"` when another page exists. Returns 400 on invalid cursor/limit and 404 on malformed thread id. |
 | GET | `/`, `/index.html` | none (loopback) | Renderer bundle (404 if `renderer: null`). |
 | GET | `/assets/*` | none (loopback) | Static assets under the renderer dir. |
 | WS | `/terminal/agents/:slug?token=` | token + loopback origin | Branch-4 closes with `1011 not_implemented`. |

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -1,0 +1,309 @@
+# Event log + projections — design contract (branch 6)
+
+**Branch**: `feat/event-log-projections`
+**Status**: implementation contract — both parallel workers MUST agree on the shapes here.
+**Last updated**: 2026-05-11
+
+## Goal
+
+Replace the in-memory `ReceiptStore` with a durable, event-log-backed implementation while preserving the branch-5 wire and interface contracts. Add cursor pagination to the thread-list endpoint so the 1000-item truncation can go away.
+
+## Non-goals (deferred)
+
+- Idempotency keys (same id + byte-identical payload → 200 no-op). Branch 6 still returns 409 on id collision regardless of payload identity.
+- Hash-chained audit (per-install signed Merkle root) — separate downstream branch.
+- Multi-process writers. SQLite handle is owned by the broker process; renderer never opens the DB.
+
+## Files (final layout — both workers respect this)
+
+```
+packages/broker/
+├── package.json                              # +better-sqlite3 dep (Worker A)
+├── src/
+│   ├── event-log/                            # Worker A
+│   │   ├── index.ts                          # re-exports
+│   │   ├── event-log.ts                      # append, readFromLsn, openDatabase
+│   │   ├── migrations.ts                     # forward-only migration runner
+│   │   └── 001_initial.sql                   # schema
+│   ├── sqlite-receipt-store.ts               # Worker A — implements ReceiptStore
+│   ├── receipt-store.ts                      # Worker B extends interface (list signature change)
+│   ├── receipts.ts                           # Worker B — cursor handling on /api/threads/:tid/receipts
+│   ├── listener.ts                           # untouched (route shape unchanged)
+│   ├── index.ts                              # Worker A adds SqliteReceiptStore export
+│   └── ...
+├── tests/
+│   ├── event-log.spec.ts                     # Worker A
+│   ├── sqlite-receipt-store.spec.ts          # Worker A
+│   ├── receipt-store-parity.spec.ts          # Worker A — runs the same suite against both stores
+│   └── receipts.spec.ts                      # Worker B — adds cursor pagination tests
+├── docs/
+│   └── event-log-projections-design.md       # this file
+└── README.md                                 # Worker B updates route table
+```
+
+**Hard rule**: Worker A and Worker B do NOT overlap on file changes except for:
+- `packages/broker/src/receipt-store.ts` — Worker B owns the interface change (new `list` signature). Worker A consumes it.
+- `packages/broker/src/index.ts` — Worker A adds the `SqliteReceiptStore` export. Worker B does not touch.
+
+If a file is in both columns, escalate to the integration step — do not race the edit.
+
+## Event log schema (SQLite, `STRICT` mode, WAL)
+
+```sql
+-- One forward-only migration: 001_initial.sql
+
+CREATE TABLE event_log (
+  lsn        INTEGER PRIMARY KEY AUTOINCREMENT,    -- ordered append-only sequence
+  ts_ms      INTEGER NOT NULL,                     -- ms since epoch at append time
+  type       TEXT NOT NULL,                        -- 'receipt.put' for branch 6
+  payload    BLOB NOT NULL                         -- canonical JSON bytes (UTF-8)
+) STRICT;
+
+CREATE TABLE receipts_projection (
+  receipt_id      TEXT PRIMARY KEY,                -- ReceiptId branded string
+  thread_id       TEXT,                            -- ThreadId branded string, NULL for V1 receipts
+  schema_version  INTEGER NOT NULL,                -- 1 or 2
+  lsn             INTEGER NOT NULL UNIQUE,         -- pointer into event_log
+  payload         BLOB NOT NULL,                   -- duplicate of event_log.payload for fast reads
+  FOREIGN KEY (lsn) REFERENCES event_log(lsn) ON DELETE RESTRICT
+) STRICT;
+
+CREATE INDEX receipts_projection_thread_lsn
+  ON receipts_projection(thread_id, lsn)
+  WHERE thread_id IS NOT NULL;
+
+-- Schema version pin (used by migration runner)
+PRAGMA user_version = 1;
+```
+
+### PRAGMAs at open time
+
+```
+PRAGMA journal_mode = WAL;            -- concurrent reader during writes
+PRAGMA synchronous = NORMAL;          -- WAL-safe durability without fsync-per-commit
+PRAGMA foreign_keys = ON;             -- enforce projection→event_log integrity
+PRAGMA busy_timeout = 5000;           -- 5s wait on SQLITE_BUSY
+```
+
+Bench guard: the broker is the only writer. If multi-writer ever shows up, switch synchronous to FULL and re-bench.
+
+## Public TypeScript API
+
+### `event-log/event-log.ts`
+
+```ts
+import type Database from "better-sqlite3";
+
+export type EventType = "receipt.put";   // branch-6 only event; expand later
+
+export interface EventLogRecord {
+  readonly lsn: number;
+  readonly tsMs: number;
+  readonly type: EventType;
+  readonly payload: Buffer;              // canonical JSON bytes
+}
+
+export interface AppendArgs {
+  readonly type: EventType;
+  readonly payload: Buffer;
+}
+
+export interface EventLog {
+  /**
+   * Append-only. Returns the assigned LSN. Synchronous — better-sqlite3
+   * does not expose an async API and the broker is the sole writer.
+   *
+   * MUST be invoked inside a containing transaction when the caller is
+   * also writing to a projection table (see SqliteReceiptStore.put).
+   */
+  append(args: AppendArgs): number;
+
+  /**
+   * Read events with lsn > `fromLsn`, in LSN order, up to `limit` rows.
+   * Used by replay-from-LSN bootstrap.
+   */
+  readFromLsn(fromLsn: number, limit: number): readonly EventLogRecord[];
+
+  /**
+   * Highest assigned LSN, or 0 if the log is empty. Used by tests + diagnostics.
+   */
+  highestLsn(): number;
+}
+
+export interface OpenDatabaseArgs {
+  /** Absolute path. ":memory:" is accepted for tests. */
+  readonly path: string;
+}
+
+export function openDatabase(args: OpenDatabaseArgs): Database.Database;
+export function createEventLog(db: Database.Database): EventLog;
+```
+
+### `event-log/migrations.ts`
+
+```ts
+import type Database from "better-sqlite3";
+
+/**
+ * Apply all forward-only migrations whose number > current `PRAGMA user_version`.
+ * Runs each migration in its own transaction; sets `user_version` on success.
+ * Throws on first failure — caller MUST treat the DB as uninitialized.
+ */
+export function runMigrations(db: Database.Database): void;
+
+export const CURRENT_SCHEMA_VERSION: number;  // = 1
+```
+
+### `sqlite-receipt-store.ts`
+
+```ts
+import type Database from "better-sqlite3";
+import type { ReceiptSnapshot } from "@wuphf/protocol";
+import type { ReceiptStore } from "./receipt-store.ts";
+
+export interface SqliteReceiptStoreConfig {
+  /** Absolute path or ":memory:". */
+  readonly path: string;
+}
+
+export class SqliteReceiptStore implements ReceiptStore {
+  static open(config: SqliteReceiptStoreConfig): SqliteReceiptStore;
+  // (constructor takes a db; static `open` runs migrations + wires the event log)
+  put(receipt: ReceiptSnapshot): Promise<{ readonly existed: boolean }>;
+  get(id: ReceiptId): Promise<ReceiptSnapshot | null>;
+  list(filter?: ListFilter): Promise<ListPage>;     // see below — interface evolves
+  size(): number;
+  close(): void;                                    // releases the SQLite handle
+}
+```
+
+### Interface evolution: `ReceiptStore.list` (owned by Worker B)
+
+The branch-5 signature is:
+
+```ts
+list(filter?: { readonly threadId?: ThreadId }): Promise<readonly ReceiptSnapshot[]>;
+```
+
+Branch-6 signature:
+
+```ts
+export interface ListFilter {
+  readonly threadId?: ThreadId;
+  /** Opaque continuation token returned from a prior list call. */
+  readonly cursor?: string;
+  /** Default 100, max 1000. Implementations MUST clamp out-of-range values. */
+  readonly limit?: number;
+}
+
+export interface ListPage {
+  readonly items: readonly ReceiptSnapshot[];
+  /** `null` when no more pages; opaque otherwise. */
+  readonly nextCursor: string | null;
+}
+
+list(filter?: ListFilter): Promise<ListPage>;
+```
+
+**Cursor opacity**: cursors are base64-encoded `lsn:<n>` strings. The shape is an implementation detail — callers MUST treat them as opaque tokens. Both stores produce cursors with the same format so tests can mix-and-match, but no production code parses them.
+
+**Ordering**: LSN ascending. For the in-memory store, LSN is replaced by insertion order (1-indexed). Same `${type}:${value}` shape.
+
+## HTTP wire change — `GET /api/threads/:tid/receipts` (owned by Worker B)
+
+### Query parameters
+
+| Param | Type | Default | Notes |
+|---|---|---|---|
+| `cursor` | string | — | Opaque base64 token from prior response's `Link: rel="next"`. |
+| `limit` | integer | 100 | Clamped to [1, 1000]. Invalid → 400. |
+
+### Response
+
+- **Body unchanged**: same bare JSON array of receipts, in LSN order.
+- **`Link` header added** when more pages exist:
+
+  ```
+  Link: </api/threads/<tid>/receipts?cursor=<base64>&limit=<n>>; rel="next"
+  ```
+
+  No `Link` header on the last page. Clients that ignore the header degrade to "first page only" behavior — no breakage.
+
+- **`MAX_THREAD_LIST_RECEIPTS` truncation goes away**. With pagination, there is no need for a hard cap on `list.length`. The clamped `limit` is the only ceiling per response.
+
+### Status codes
+
+- 200 + body — happy path (with or without next page).
+- 400 — invalid `limit` (non-integer, ≤ 0) or invalid `cursor` (malformed base64, malformed `lsn:<n>` shape after decode, or LSN that doesn't belong to this thread).
+- 404 — malformed thread id (unchanged from branch 5).
+- 401 — missing bearer (unchanged).
+
+### Why `Link` header instead of changing the body shape
+
+- Backward-compatible: existing branch-5 clients (the renderer dev fetch path) keep working.
+- Standardized: RFC 8288 is the boring-tech default; both `fetch` and any HTTP library can pluck the header.
+- The bare-array body keeps the JSON-by-default ergonomics from branch 5.
+
+## Storage location (Worker A)
+
+- Default path: `<app.getPath("userData")>/event-log.sqlite`
+- For `createBroker` callers that don't supply a `receiptStore`, the broker still defaults to `InMemoryReceiptStore` (unchanged). The durable store is opt-in via host wiring — the Electron main process is responsible for constructing it. Branch 6 does NOT change the default.
+- Wiring to `apps/desktop/src/main/` is OUT OF SCOPE for the parallel workers and lands in the integration commit.
+
+## Test plan
+
+### Worker A — sqlite-receipt-store.spec.ts
+
+1. `put` returns `{existed: false}`, then `get` round-trips the receipt.
+2. Duplicate `put` returns `{existed: true}`; event_log row count stays at 1.
+3. `list({ threadId })` returns receipts for that thread only, in LSN order.
+4. `list({ threadId, limit: 5 })` returns ≤5 items and a `nextCursor` when more exist.
+5. `list({ threadId, cursor: <from prior call> })` skips already-seen items.
+6. `list({ limit: 9999 })` clamps to 1000.
+7. `list({ limit: 0 })` rejects with a thrown error (the HTTP layer surfaces 400).
+8. `list({ cursor: "not-base64-!@#" })` rejects (HTTP → 400).
+9. `close()` is idempotent.
+10. After restart (open + close + open the same file): receipts persist, LSN sequence continues from highest+1.
+11. WAL rollback safety: a `put` that fails mid-transaction (force-thrown after event_log insert, before projection insert) MUST leave both tables empty. Use a transaction-instrumented mock.
+
+### Worker A — event-log.spec.ts
+
+1. `append` assigns monotonically increasing LSNs.
+2. `readFromLsn(0, 10)` returns first 10 events; `readFromLsn(5, 10)` skips lsn ≤ 5.
+3. `readFromLsn(huge, 10)` returns `[]`.
+4. `highestLsn()` matches the last appended LSN.
+5. Migrations run idempotently — open the same file twice; second open is a no-op.
+
+### Worker A — receipt-store-parity.spec.ts
+
+Reusable test suite that takes a `ReceiptStore` factory and runs the same 8–10 contract tests against both `InMemoryReceiptStore` and `SqliteReceiptStore`. Confirms interface parity.
+
+### Worker B — receipts.spec.ts additions
+
+1. First page: `GET /api/threads/<tid>/receipts?limit=2` with 5 receipts → 200, body has 2, `Link` header present.
+2. Last page: follow the `Link` cursor twice → 200, body has 1, no `Link` header.
+3. Default limit: with 150 receipts, no `limit` query → returns 100, has `Link`.
+4. Invalid limit: `?limit=0` → 400 with `{ "error": "invalid_limit" }`.
+5. Invalid cursor: `?cursor=not%21base64` → 400.
+6. Empty thread: `?cursor=` (absent) → 200, empty array, no `Link`.
+
+## Verification commands (both workers MUST run before commit)
+
+```bash
+cd packages/broker && bunx tsc --noEmit
+cd packages/broker && bun run test
+cd packages/broker && bunx biome check src/ tests/
+bunx secretlint
+```
+
+## Disposition reporting
+
+Each worker ends its run with:
+
+```markdown
+| # | Finding | Status | Notes |
+|---|---------|--------|-------|
+| 1 | <short> | FIXED   | commit <sha> |
+| 2 | <short> | SKIPPED | <reason> |
+| 3 | <short> | DEFERRED | <issue / next branch> |
+```

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -98,7 +98,24 @@ client believed the write was durable. `synchronous=FULL` pays one fsync
 per commit (~5–10ms on commodity SSDs); on the receipt-write hot path
 that's one fsync per agent-run, well below the dominant LLM latency.
 
-## Public TypeScript API
+## Package surface
+
+Branch 6 exposes ONE public class from `@wuphf/broker`: `SqliteReceiptStore`
+(plus `SqliteReceiptStoreConfig`, the cursor error classes, and limit
+constants — all re-exported from `src/index.ts`). The event-log module
+under `src/event-log/` is **internal**: callers MUST use
+`SqliteReceiptStore` rather than touching `openDatabase` / `createEventLog`
+/ `runMigrations` directly. This keeps the append-plus-projection
+invariant inside one owner and prevents orphan event_log rows (distsys
+triangulation R2-A3 + T10).
+
+The cross-language stability surface is the **SQLite schema** in
+`001_initial.sql` plus the canonical receipt JSON payload defined by
+`@wuphf/protocol#receiptToJson`. A Go or Rust implementer reads/writes
+those bytes directly against the documented schema; they do NOT need
+to mirror the TypeScript class structure.
+
+## Internal TypeScript API (subject to change)
 
 ### `event-log/event-log.ts`
 

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -45,7 +45,7 @@ packages/broker/
 -- monotonically increasing rowids on append-only inserts without the
 -- `sqlite_sequence` write that AUTOINCREMENT requires. We never delete
 -- events, so the "never reuse after delete" guarantee AUTOINCREMENT
--- provides isn't load-bearing here. (perf triangulation T4.)
+-- provides isn't load-bearing here.
 CREATE TABLE event_log (
   lsn        INTEGER PRIMARY KEY,                  -- ordered append-only sequence
   ts_ms      INTEGER NOT NULL,                     -- ms since epoch at append time
@@ -79,7 +79,7 @@ PRAGMA foreign_keys = ON;             -- enforce projection→event_log integrit
 PRAGMA busy_timeout = 5000;           -- 5s wait on SQLITE_BUSY
 ```
 
-Durability choice (distsys triangulation T3): the HTTP `201` on `POST
+Durability choice: the HTTP `201` on `POST
 /api/receipts` is returned **after** the store's `put` resolves; callers
 race the 201 against follow-up reads. `synchronous=NORMAL` would lose
 recently committed transactions on power/OS failure even though the
@@ -89,14 +89,30 @@ that's one fsync per agent-run, well below the dominant LLM latency.
 
 ## Package surface
 
-Branch 6 exposes ONE public class from `@wuphf/broker`: `SqliteReceiptStore`
-(plus `SqliteReceiptStoreConfig`, the cursor error classes, and limit
-constants — all re-exported from `src/index.ts`). The event-log module
-under `src/event-log/` is **internal**: callers MUST use
-`SqliteReceiptStore` rather than touching `openDatabase` / `createEventLog`
-/ `runMigrations` directly. This keeps the append-plus-projection
-invariant inside one owner and prevents orphan event_log rows (distsys
-triangulation R2-A3 + T10).
+The broker package exposes two import paths:
+
+- `@wuphf/broker` (the root) — `createBroker`, `ReceiptStore`,
+  `InMemoryReceiptStore`, `ListFilter`/`ListPage` types, cursor + limit
+  helpers and error classes, and the broker config types. No native
+  binding is loaded by importing the root.
+- `@wuphf/broker/sqlite` — `SqliteReceiptStore` and
+  `SqliteReceiptStoreConfig`. Importing this subpath evaluates
+  `better-sqlite3`'s native binding, so hosts that don't need the
+  durable store skip the cost by not importing it.
+
+`SqliteReceiptStore`'s constructor is `private`; the only supported
+construction path is `SqliteReceiptStore.open(config)` so
+`openDatabase` + `runMigrations` always run together. Tests reach a
+private-constructor seam through
+`src/internal/sqlite-receipt-store-testing.ts`, which is not exposed
+in `package.json` `exports` and therefore not reachable by any package
+consumer.
+
+The event-log module under `src/event-log/` is internal: callers MUST
+go through `SqliteReceiptStore` rather than touching `openDatabase` /
+`createEventLog` / `runMigrations` directly. This keeps the
+append-plus-projection invariant inside one owner and prevents orphan
+event_log rows.
 
 The cross-language stability surface is the **SQLite schema** in
 `001_initial.sql` plus the canonical receipt JSON payload defined by
@@ -194,7 +210,7 @@ export class SqliteReceiptStore implements ReceiptStore {
 }
 ```
 
-### Interface evolution: `ReceiptStore.list` (owned by Worker B)
+### Interface evolution: `ReceiptStore.list`
 
 The branch-5 signature is:
 
@@ -222,9 +238,9 @@ export interface ListPage {
 list(filter?: ListFilter): Promise<ListPage>;
 ```
 
-**Cursor wire shape** (api/security triangulation T5, T15): cursors are **RFC 4648 §5 base64url, unpadded**, of ASCII `lsn:<decimal>`. The decimal MUST be a positive `Number.isSafeInteger` (no leading zeros, no `+`, no whitespace, no scientific notation). Callers MUST treat the cursor as opaque — there is no stability guarantee on the inner encoding — but the shape is pinned so Go/Rust implementers can produce byte-identical tokens for the same logical LSN.
+**Cursor wire shape**: cursors are **RFC 4648 §5 base64url, unpadded**, of ASCII `lsn:<decimal>`. The decimal MUST be a positive `Number.isSafeInteger` (no leading zeros, no `+`, no whitespace, no scientific notation). Callers MUST treat the cursor as opaque — there is no stability guarantee on the inner encoding — but the shape is pinned so Go/Rust implementers can produce byte-identical tokens for the same logical LSN.
 
-**Cursor scope** (api/architecture/distsys triangulation T1): cursors are **global LSN seek positions**. They are NOT thread-bound. A cursor produced by listing thread A and replayed against thread B will simply skip everything at LSN ≤ that value in thread B — there is no "wrong thread → 400" rejection, and exposing the LSN this way is intentional (the LSN is a global monotonic position and is not a secret). If you later add cross-thread isolation guarantees (e.g. tenant boundaries), revisit this — for branch 6, single-process single-tenant means global LSN seek is fine.
+**Cursor scope**: cursors are **global LSN seek positions**. They are NOT thread-bound. A cursor produced by listing thread A and replayed against thread B will simply skip everything at LSN ≤ that value in thread B — there is no "wrong thread → 400" rejection, and exposing the LSN this way is intentional (the LSN is a global monotonic position and is not a secret). If a future change adds cross-thread isolation guarantees (e.g. tenant boundaries), revisit this — for single-process single-tenant, global LSN seek is fine.
 
 **Ordering**: LSN ascending. For the in-memory store, LSN is replaced by insertion order (1-indexed). Same wire shape.
 
@@ -237,7 +253,7 @@ list(filter?: ListFilter): Promise<ListPage>;
 | `cursor` | string | — | Opaque base64url token from prior response's `Link: rel="next"`. Absent or empty → no cursor. |
 | `limit` | integer | **`MAX_LIST_LIMIT` (1000)** | Clamped to [1, 1000]. Invalid → 400. The route's default matches the branch-5 ceiling so existing clients that ignore `Link` continue to see the same page they did before. |
 
-The default-limit choice (api/architecture triangulation T2): the store's `DEFAULT_LIST_LIMIT = 100` only applies to direct programmatic callers. The HTTP route MUST pass `limit: MAX_LIST_LIMIT` explicitly when the caller didn't supply one. Otherwise clients ignoring `Link` silently lose receipts 101–1000 that branch 5 returned in one shot.
+The default-limit choice: the store's `DEFAULT_LIST_LIMIT = 100` only applies to direct programmatic callers. The HTTP route MUST pass `limit: MAX_LIST_LIMIT` explicitly when the caller didn't supply one. Otherwise clients ignoring `Link` silently lose receipts 101–1000 that the pre-pagination route returned in one shot.
 
 ### Response
 

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -16,7 +16,7 @@ Replace the in-memory `ReceiptStore` with a durable, event-log-backed implementa
 
 ## Files (final layout — both workers respect this)
 
-```
+```text
 packages/broker/
 ├── package.json                              # +better-sqlite3 dep (Worker A)
 ├── src/
@@ -83,7 +83,7 @@ PRAGMA user_version = 1;
 
 ### PRAGMAs at open time
 
-```
+```sql
 PRAGMA journal_mode = WAL;            -- concurrent reader during writes
 PRAGMA synchronous = FULL;            -- fsync every commit; the 201 ack must outlive a power-cut
 PRAGMA foreign_keys = ON;             -- enforce projection→event_log integrity
@@ -255,7 +255,7 @@ The default-limit choice (api/architecture triangulation T2): the store's `DEFAU
 - **Body unchanged**: same bare JSON array of receipts, in LSN order.
 - **`Link` header added** when more pages exist:
 
-  ```
+  ```http
   Link: </api/threads/<tid>/receipts?cursor=<base64url>&limit=<n>>; rel="next"
   ```
 

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -52,8 +52,13 @@ If a file is in both columns, escalate to the integration step — do not race t
 ```sql
 -- One forward-only migration: 001_initial.sql
 
+-- `lsn INTEGER PRIMARY KEY` (no `AUTOINCREMENT`) — SQLite hands out
+-- monotonically increasing rowids on append-only inserts without the
+-- `sqlite_sequence` write that AUTOINCREMENT requires. We never delete
+-- events, so the "never reuse after delete" guarantee AUTOINCREMENT
+-- provides isn't load-bearing here. (perf triangulation T4.)
 CREATE TABLE event_log (
-  lsn        INTEGER PRIMARY KEY AUTOINCREMENT,    -- ordered append-only sequence
+  lsn        INTEGER PRIMARY KEY,                  -- ordered append-only sequence
   ts_ms      INTEGER NOT NULL,                     -- ms since epoch at append time
   type       TEXT NOT NULL,                        -- 'receipt.put' for branch 6
   payload    BLOB NOT NULL                         -- canonical JSON bytes (UTF-8)
@@ -80,12 +85,18 @@ PRAGMA user_version = 1;
 
 ```
 PRAGMA journal_mode = WAL;            -- concurrent reader during writes
-PRAGMA synchronous = NORMAL;          -- WAL-safe durability without fsync-per-commit
+PRAGMA synchronous = FULL;            -- fsync every commit; the 201 ack must outlive a power-cut
 PRAGMA foreign_keys = ON;             -- enforce projection→event_log integrity
 PRAGMA busy_timeout = 5000;           -- 5s wait on SQLITE_BUSY
 ```
 
-Bench guard: the broker is the only writer. If multi-writer ever shows up, switch synchronous to FULL and re-bench.
+Durability choice (distsys triangulation T3): the HTTP `201` on `POST
+/api/receipts` is returned **after** the store's `put` resolves; callers
+race the 201 against follow-up reads. `synchronous=NORMAL` would lose
+recently committed transactions on power/OS failure even though the
+client believed the write was durable. `synchronous=FULL` pays one fsync
+per commit (~5–10ms on commodity SSDs); on the receipt-write hot path
+that's one fsync per agent-run, well below the dominant LLM latency.
 
 ## Public TypeScript API
 
@@ -205,9 +216,11 @@ export interface ListPage {
 list(filter?: ListFilter): Promise<ListPage>;
 ```
 
-**Cursor opacity**: cursors are base64-encoded `lsn:<n>` strings. The shape is an implementation detail — callers MUST treat them as opaque tokens. Both stores produce cursors with the same format so tests can mix-and-match, but no production code parses them.
+**Cursor wire shape** (api/security triangulation T5, T15): cursors are **RFC 4648 §5 base64url, unpadded**, of ASCII `lsn:<decimal>`. The decimal MUST be a positive `Number.isSafeInteger` (no leading zeros, no `+`, no whitespace, no scientific notation). Callers MUST treat the cursor as opaque — there is no stability guarantee on the inner encoding — but the shape is pinned so Go/Rust implementers can produce byte-identical tokens for the same logical LSN.
 
-**Ordering**: LSN ascending. For the in-memory store, LSN is replaced by insertion order (1-indexed). Same `${type}:${value}` shape.
+**Cursor scope** (api/architecture/distsys triangulation T1): cursors are **global LSN seek positions**. They are NOT thread-bound. A cursor produced by listing thread A and replayed against thread B will simply skip everything at LSN ≤ that value in thread B — there is no "wrong thread → 400" rejection, and exposing the LSN this way is intentional (the LSN is a global monotonic position and is not a secret). If you later add cross-thread isolation guarantees (e.g. tenant boundaries), revisit this — for branch 6, single-process single-tenant means global LSN seek is fine.
+
+**Ordering**: LSN ascending. For the in-memory store, LSN is replaced by insertion order (1-indexed). Same wire shape.
 
 ## HTTP wire change — `GET /api/threads/:tid/receipts` (owned by Worker B)
 
@@ -215,8 +228,10 @@ list(filter?: ListFilter): Promise<ListPage>;
 
 | Param | Type | Default | Notes |
 |---|---|---|---|
-| `cursor` | string | — | Opaque base64 token from prior response's `Link: rel="next"`. |
-| `limit` | integer | 100 | Clamped to [1, 1000]. Invalid → 400. |
+| `cursor` | string | — | Opaque base64url token from prior response's `Link: rel="next"`. Absent or empty → no cursor. |
+| `limit` | integer | **`MAX_LIST_LIMIT` (1000)** | Clamped to [1, 1000]. Invalid → 400. The route's default matches the branch-5 ceiling so existing clients that ignore `Link` continue to see the same page they did before. |
+
+The default-limit choice (api/architecture triangulation T2): the store's `DEFAULT_LIST_LIMIT = 100` only applies to direct programmatic callers. The HTTP route MUST pass `limit: MAX_LIST_LIMIT` explicitly when the caller didn't supply one. Otherwise clients ignoring `Link` silently lose receipts 101–1000 that branch 5 returned in one shot.
 
 ### Response
 
@@ -224,17 +239,17 @@ list(filter?: ListFilter): Promise<ListPage>;
 - **`Link` header added** when more pages exist:
 
   ```
-  Link: </api/threads/<tid>/receipts?cursor=<base64>&limit=<n>>; rel="next"
+  Link: </api/threads/<tid>/receipts?cursor=<base64url>&limit=<n>>; rel="next"
   ```
 
   No `Link` header on the last page. Clients that ignore the header degrade to "first page only" behavior — no breakage.
 
-- **`MAX_THREAD_LIST_RECEIPTS` truncation goes away**. With pagination, there is no need for a hard cap on `list.length`. The clamped `limit` is the only ceiling per response.
+- **`MAX_THREAD_LIST_RECEIPTS` truncation goes away**. With pagination, the route's clamped `limit` is the only per-response item ceiling.
 
 ### Status codes
 
 - 200 + body — happy path (with or without next page).
-- 400 — invalid `limit` (non-integer, ≤ 0) or invalid `cursor` (malformed base64, malformed `lsn:<n>` shape after decode, or LSN that doesn't belong to this thread).
+- 400 — invalid `limit` (non-integer, ≤ 0, > 1000, or syntactically malformed) or invalid `cursor` (not canonical unpadded base64url, doesn't decode to `lsn:<n>`, or LSN ≤ 0 / > `Number.MAX_SAFE_INTEGER`). The 400 body is `{"error":"invalid_cursor"}` or `{"error":"invalid_limit"}` — see receipts.spec.ts for fixtures.
 - 404 — malformed thread id (unchanged from branch 5).
 - 401 — missing bearer (unchanged).
 

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -1,51 +1,40 @@
-# Event log + projections — design contract (branch 6)
-
-**Branch**: `feat/event-log-projections`
-**Status**: implementation contract — both parallel workers MUST agree on the shapes here.
-**Last updated**: 2026-05-11
+# Event log + projections — design
 
 ## Goal
 
-Replace the in-memory `ReceiptStore` with a durable, event-log-backed implementation while preserving the branch-5 wire and interface contracts. Add cursor pagination to the thread-list endpoint so the 1000-item truncation can go away.
+Replace the in-memory `ReceiptStore` with a durable, event-log-backed implementation while preserving the prior wire and interface contracts. Add cursor pagination to the thread-list endpoint so the historical 1000-item truncation goes away.
 
 ## Non-goals (deferred)
 
-- Idempotency keys (same id + byte-identical payload → 200 no-op). Branch 6 still returns 409 on id collision regardless of payload identity.
-- Hash-chained audit (per-install signed Merkle root) — separate downstream branch.
-- Multi-process writers. SQLite handle is owned by the broker process; renderer never opens the DB.
+- Idempotency keys (same id + byte-identical payload → 200 no-op). Today the store returns 409 on id collision regardless of payload identity.
+- Hash-chained audit (per-install signed Merkle root) — separate downstream work.
+- Multi-process writers. The SQLite handle is owned by the broker process; the renderer never opens the DB.
 
-## Files (final layout — both workers respect this)
+## Files
 
 ```text
 packages/broker/
-├── package.json                              # +better-sqlite3 dep (Worker A)
+├── package.json                              # better-sqlite3 dep
 ├── src/
-│   ├── event-log/                            # Worker A
-│   │   ├── index.ts                          # re-exports
+│   ├── event-log/                            # internal — append, replay, migrations
+│   │   ├── index.ts                          # internal re-exports
 │   │   ├── event-log.ts                      # append, readFromLsn, openDatabase
 │   │   ├── migrations.ts                     # forward-only migration runner
 │   │   └── 001_initial.sql                   # schema
-│   ├── sqlite-receipt-store.ts               # Worker A — implements ReceiptStore
-│   ├── receipt-store.ts                      # Worker B extends interface (list signature change)
-│   ├── receipts.ts                           # Worker B — cursor handling on /api/threads/:tid/receipts
-│   ├── listener.ts                           # untouched (route shape unchanged)
-│   ├── index.ts                              # Worker A adds SqliteReceiptStore export
-│   └── ...
+│   ├── sqlite-receipt-store.ts               # public via `@wuphf/broker/sqlite` subpath
+│   ├── receipt-store.ts                      # ReceiptStore interface + InMemory impl + cursor helpers
+│   ├── receipts.ts                           # cursor handling on /api/threads/:tid/receipts
+│   ├── listener.ts                           # routes
+│   └── index.ts                              # `@wuphf/broker` root surface (does NOT re-export SqliteReceiptStore)
 ├── tests/
-│   ├── event-log.spec.ts                     # Worker A
-│   ├── sqlite-receipt-store.spec.ts          # Worker A
-│   ├── receipt-store-parity.spec.ts          # Worker A — runs the same suite against both stores
-│   └── receipts.spec.ts                      # Worker B — adds cursor pagination tests
+│   ├── event-log.spec.ts
+│   ├── sqlite-receipt-store.spec.ts
+│   ├── receipt-store-parity.spec.ts          # same suite against both stores
+│   └── receipts.spec.ts
 ├── docs/
 │   └── event-log-projections-design.md       # this file
-└── README.md                                 # Worker B updates route table
+└── README.md
 ```
-
-**Hard rule**: Worker A and Worker B do NOT overlap on file changes except for:
-- `packages/broker/src/receipt-store.ts` — Worker B owns the interface change (new `list` signature). Worker A consumes it.
-- `packages/broker/src/index.ts` — Worker A adds the `SqliteReceiptStore` export. Worker B does not touch.
-
-If a file is in both columns, escalate to the integration step — do not race the edit.
 
 ## Event log schema (SQLite, `STRICT` mode, WAL)
 
@@ -239,7 +228,7 @@ list(filter?: ListFilter): Promise<ListPage>;
 
 **Ordering**: LSN ascending. For the in-memory store, LSN is replaced by insertion order (1-indexed). Same wire shape.
 
-## HTTP wire change — `GET /api/threads/:tid/receipts` (owned by Worker B)
+## HTTP wire change — `GET /api/threads/:tid/receipts`
 
 ### Query parameters
 
@@ -276,66 +265,16 @@ The default-limit choice (api/architecture triangulation T2): the store's `DEFAU
 - Standardized: RFC 8288 is the boring-tech default; both `fetch` and any HTTP library can pluck the header.
 - The bare-array body keeps the JSON-by-default ergonomics from branch 5.
 
-## Storage location (Worker A)
+## Storage location
 
-- Default path: `<app.getPath("userData")>/event-log.sqlite`
-- For `createBroker` callers that don't supply a `receiptStore`, the broker still defaults to `InMemoryReceiptStore` (unchanged). The durable store is opt-in via host wiring — the Electron main process is responsible for constructing it. Branch 6 does NOT change the default.
-- Wiring to `apps/desktop/src/main/` is OUT OF SCOPE for the parallel workers and lands in the integration commit.
+- Default path: `<app.getPath("userData")>/event-log.sqlite`.
+- For `createBroker` callers that don't supply a `receiptStore`, the broker defaults to `InMemoryReceiptStore`. The durable store is opt-in via host wiring — the Electron main process plumbs the path through `WUPHF_RECEIPT_STORE_PATH` and the utility process dynamic-imports `SqliteReceiptStore` from `@wuphf/broker/sqlite` (so the native binding is only loaded when actually used).
 
-## Test plan
+## Test coverage
 
-### Worker A — sqlite-receipt-store.spec.ts
+The implementation covers:
 
-1. `put` returns `{existed: false}`, then `get` round-trips the receipt.
-2. Duplicate `put` returns `{existed: true}`; event_log row count stays at 1.
-3. `list({ threadId })` returns receipts for that thread only, in LSN order.
-4. `list({ threadId, limit: 5 })` returns ≤5 items and a `nextCursor` when more exist.
-5. `list({ threadId, cursor: <from prior call> })` skips already-seen items.
-6. `list({ limit: 9999 })` clamps to 1000.
-7. `list({ limit: 0 })` rejects with a thrown error (the HTTP layer surfaces 400).
-8. `list({ cursor: "not-base64-!@#" })` rejects (HTTP → 400).
-9. `close()` is idempotent.
-10. After restart (open + close + open the same file): receipts persist, LSN sequence continues from highest+1.
-11. WAL rollback safety: a `put` that fails mid-transaction (force-thrown after event_log insert, before projection insert) MUST leave both tables empty. Use a transaction-instrumented mock.
-
-### Worker A — event-log.spec.ts
-
-1. `append` assigns monotonically increasing LSNs.
-2. `readFromLsn(0, 10)` returns first 10 events; `readFromLsn(5, 10)` skips lsn ≤ 5.
-3. `readFromLsn(huge, 10)` returns `[]`.
-4. `highestLsn()` matches the last appended LSN.
-5. Migrations run idempotently — open the same file twice; second open is a no-op.
-
-### Worker A — receipt-store-parity.spec.ts
-
-Reusable test suite that takes a `ReceiptStore` factory and runs the same 8–10 contract tests against both `InMemoryReceiptStore` and `SqliteReceiptStore`. Confirms interface parity.
-
-### Worker B — receipts.spec.ts additions
-
-1. First page: `GET /api/threads/<tid>/receipts?limit=2` with 5 receipts → 200, body has 2, `Link` header present.
-2. Last page: follow the `Link` cursor twice → 200, body has 1, no `Link` header.
-3. Default limit: with 150 receipts, no `limit` query → returns 100, has `Link`.
-4. Invalid limit: `?limit=0` → 400 with `{ "error": "invalid_limit" }`.
-5. Invalid cursor: `?cursor=not%21base64` → 400.
-6. Empty thread: `?cursor=` (absent) → 200, empty array, no `Link`.
-
-## Verification commands (both workers MUST run before commit)
-
-```bash
-cd packages/broker && bunx tsc --noEmit
-cd packages/broker && bun run test
-cd packages/broker && bunx biome check src/ tests/
-bunx secretlint
-```
-
-## Disposition reporting
-
-Each worker ends its run with:
-
-```markdown
-| # | Finding | Status | Notes |
-|---|---------|--------|-------|
-| 1 | <short> | FIXED   | commit <sha> |
-| 2 | <short> | SKIPPED | <reason> |
-| 3 | <short> | DEFERRED | <issue / next branch> |
-```
+- `sqlite-receipt-store.spec.ts`: put + get round-trip, duplicate → existed:true with event_log row count unchanged, threadId filtering in LSN order, cursor pagination correctness, limit clamping (>1000 → 1000), limit/cursor validation errors, idempotent `close()`, persistence + LSN-continuation across open/close cycles, WAL rollback safety, `maxReceipts` cap.
+- `event-log.spec.ts`: monotonic LSN assignment, `readFromLsn` skip + limit semantics, `readFromLsn(huge)` returns `[]`, `highestLsn` correctness, idempotent migrations.
+- `receipt-store-parity.spec.ts`: a shared contract suite runs against both `InMemoryReceiptStore` and `SqliteReceiptStore` to prove interface parity.
+- `receipts.spec.ts`: first-page emits `Link`, last-page omits it, route default returns up to `MAX_LIST_LIMIT`, `?limit=0` → 400, malformed `?cursor=` → 400, empty `?cursor=` normalizes to "no cursor", `?limit=9999` clamps to 1000 in the next-page `Link` URL, 503 `store_busy`/`storage_error` mappings.

--- a/packages/broker/docs/modules/listener.md
+++ b/packages/broker/docs/modules/listener.md
@@ -23,9 +23,9 @@ flowchart LR
   dispatch -- "/api-token" --> bootstrap["GET/HEAD only · bootstrap JSON"]
   dispatch -- "/api/health" --> health["GET/HEAD only · {ok:true}"]
   dispatch -- "/api/events" --> events["GET/HEAD only · SSE ready"]
-  dispatch -- "POST /api/receipts" --> create["receiptFromJson → ReceiptStore.put<br/>201 / 400 / 409 / 413 / 415"]
+  dispatch -- "POST /api/receipts" --> create["receiptFromJson → ReceiptStore.put<br/>201 / 400 / 409 / 413 / 415 / 503 / 507"]
   dispatch -- "GET /api/receipts/:id" --> read["ReceiptStore.get<br/>200 / 404"]
-  dispatch -- "GET /api/threads/:tid/receipts" --> list["ReceiptStore.list({threadId})<br/>200 JSON array"]
+  dispatch -- "GET /api/threads/:tid/receipts" --> list["ReceiptStore.list({threadId, cursor?, limit?})<br/>200 JSON array (+ Link rel=next when more pages)<br/>400 on invalid cursor/limit"]
   dispatch -- "unknown /api/*" --> apinotfound["404"]
   dispatch -- "/, /index.html, /assets/*" --> static["GET/HEAD only · RendererBundleSource"]
   dispatch -- "other" --> notfound["404"]
@@ -46,6 +46,35 @@ falling into static dispatch.
 The broker emits this through `apiBootstrapToJson` from `@wuphf/protocol`; that
 codec is the single source of truth for the wire shape and is round-trip
 verified by both packages' tests.
+
+### Receipt write-path status codes
+
+`POST /api/receipts` distinguishes failure modes so callers can act on them:
+
+| Status | Body | Meaning |
+|---|---|---|
+| 201 | canonical receipt JSON | inserted |
+| 400 | `{"error":"invalid_receipt", reason}` | shape/validator failure |
+| 409 | `{"error":"receipt_id_exists", id}` | duplicate `id`; stored value not overwritten |
+| 413 | `body_too_large` | body exceeded 1 MiB pre-parse cap |
+| 415 | `unsupported_media_type` | non-`application/json` content-type |
+| 503 | `{"error":"store_busy"}` + `Retry-After: 1` | transient `SQLITE_BUSY`/`LOCKED`; retry |
+| 503 | `{"error":"storage_error"}` | persistent `SQLITE_READONLY`/`IOERR_*`/`CORRUPT`; operator intervention |
+| 507 | `{"error":"store_full"}` | `maxReceipts` reached or `SQLITE_FULL` |
+
+### Thread-list pagination
+
+`GET /api/threads/:tid/receipts` accepts `?cursor=<opaque>` (empty value
+≡ absent) and `?limit=<positive integer>` (clamped to 1–1000, default
+1000). When more pages exist, the response carries:
+
+```http
+Link: </api/threads/<tid>/receipts?cursor=<base64url>&limit=<n>>; rel="next"
+```
+
+Cursors are opaque RFC 4648 §5 base64url tokens; clients MUST NOT parse
+them. The body shape stays a bare JSON array — callers ignoring `Link`
+simply see the first page.
 
 ## WebSocket upgrade
 

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./sqlite": "./src/sqlite-receipt-store.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -21,10 +21,12 @@
   },
   "dependencies": {
     "@wuphf/protocol": "workspace:*",
+    "better-sqlite3": "12.9.0",
     "ws": "8.20.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
+    "@types/better-sqlite3": "7.6.13",
     "@types/node": "^22.10.0",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "2.1.9",

--- a/packages/broker/src/event-log/001_initial.sql
+++ b/packages/broker/src/event-log/001_initial.sql
@@ -1,7 +1,12 @@
 PRAGMA foreign_keys = ON;
 
+-- `lsn INTEGER PRIMARY KEY` (no AUTOINCREMENT) — append-only inserts get
+-- monotonically increasing rowids without the `sqlite_sequence` table
+-- write that AUTOINCREMENT requires. We never delete events, so the
+-- "never reuse after delete" guarantee AUTOINCREMENT provides isn't
+-- load-bearing here. (perf triangulation T4.)
 CREATE TABLE event_log (
-  lsn        INTEGER PRIMARY KEY AUTOINCREMENT,
+  lsn        INTEGER PRIMARY KEY,
   ts_ms      INTEGER NOT NULL,
   type       TEXT NOT NULL,
   payload    BLOB NOT NULL

--- a/packages/broker/src/event-log/001_initial.sql
+++ b/packages/broker/src/event-log/001_initial.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE event_log (
+  lsn        INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_ms      INTEGER NOT NULL,
+  type       TEXT NOT NULL,
+  payload    BLOB NOT NULL
+) STRICT;
+
+CREATE TABLE receipts_projection (
+  receipt_id      TEXT PRIMARY KEY,
+  thread_id       TEXT,
+  schema_version  INTEGER NOT NULL,
+  lsn             INTEGER NOT NULL UNIQUE,
+  payload         BLOB NOT NULL,
+  FOREIGN KEY (lsn) REFERENCES event_log(lsn) ON DELETE RESTRICT
+) STRICT;
+
+CREATE INDEX receipts_projection_thread_lsn
+  ON receipts_projection(thread_id, lsn)
+  WHERE thread_id IS NOT NULL;
+
+PRAGMA user_version = 1;

--- a/packages/broker/src/event-log/001_initial.sql
+++ b/packages/broker/src/event-log/001_initial.sql
@@ -4,7 +4,7 @@ PRAGMA foreign_keys = ON;
 -- monotonically increasing rowids without the `sqlite_sequence` table
 -- write that AUTOINCREMENT requires. We never delete events, so the
 -- "never reuse after delete" guarantee AUTOINCREMENT provides isn't
--- load-bearing here. (perf triangulation T4.)
+-- load-bearing here.
 CREATE TABLE event_log (
   lsn        INTEGER PRIMARY KEY,
   ts_ms      INTEGER NOT NULL,

--- a/packages/broker/src/event-log/event-log.ts
+++ b/packages/broker/src/event-log/event-log.ts
@@ -43,13 +43,13 @@ interface HighestLsnRow {
 export function openDatabase(args: OpenDatabaseArgs): Database.Database {
   const db = new BetterSqlite3(args.path);
   db.pragma("journal_mode = WAL");
-  // `synchronous = FULL` (distsys triangulation T3): the broker returns
-  // HTTP 201 on POST /api/receipts AFTER `store.put` resolves; the client
-  // races the 201 against follow-up reads. `synchronous = NORMAL` would
-  // lose recently committed transactions on power/OS failure even though
-  // the client believed the write was durable. FULL pays one fsync per
-  // commit — on the receipt-write hot path that's one fsync per agent
-  // run, well below the dominant LLM latency.
+  // `synchronous = FULL` because the broker returns HTTP 201 on
+  // POST /api/receipts AFTER `store.put` resolves; the client races
+  // the 201 against follow-up reads. `synchronous = NORMAL` would
+  // lose recently committed transactions on power/OS failure even
+  // though the client believed the write was durable. FULL pays one
+  // fsync per commit — on the receipt-write hot path that's one
+  // fsync per agent run, well below the dominant LLM latency.
   db.pragma("synchronous = FULL");
   db.pragma("foreign_keys = ON");
   db.pragma("busy_timeout = 5000");

--- a/packages/broker/src/event-log/event-log.ts
+++ b/packages/broker/src/event-log/event-log.ts
@@ -43,7 +43,14 @@ interface HighestLsnRow {
 export function openDatabase(args: OpenDatabaseArgs): Database.Database {
   const db = new BetterSqlite3(args.path);
   db.pragma("journal_mode = WAL");
-  db.pragma("synchronous = NORMAL");
+  // `synchronous = FULL` (distsys triangulation T3): the broker returns
+  // HTTP 201 on POST /api/receipts AFTER `store.put` resolves; the client
+  // races the 201 against follow-up reads. `synchronous = NORMAL` would
+  // lose recently committed transactions on power/OS failure even though
+  // the client believed the write was durable. FULL pays one fsync per
+  // commit — on the receipt-write hot path that's one fsync per agent
+  // run, well below the dominant LLM latency.
+  db.pragma("synchronous = FULL");
   db.pragma("foreign_keys = ON");
   db.pragma("busy_timeout = 5000");
   return db;

--- a/packages/broker/src/event-log/event-log.ts
+++ b/packages/broker/src/event-log/event-log.ts
@@ -1,0 +1,106 @@
+import type Database from "better-sqlite3";
+import BetterSqlite3 from "better-sqlite3";
+
+export type EventType = "receipt.put";
+
+export interface EventLogRecord {
+  readonly lsn: number;
+  readonly tsMs: number;
+  readonly type: EventType;
+  readonly payload: Buffer;
+}
+
+export interface AppendArgs {
+  readonly type: EventType;
+  readonly payload: Buffer;
+}
+
+export interface EventLog {
+  append(args: AppendArgs): number;
+  readFromLsn(fromLsn: number, limit: number): readonly EventLogRecord[];
+  highestLsn(): number;
+}
+
+export interface OpenDatabaseArgs {
+  readonly path: string;
+}
+
+interface InsertedLsnRow {
+  readonly lsn: number;
+}
+
+interface EventLogRow {
+  readonly lsn: number;
+  readonly tsMs: number;
+  readonly type: string;
+  readonly payload: Buffer;
+}
+
+interface HighestLsnRow {
+  readonly lsn: number;
+}
+
+export function openDatabase(args: OpenDatabaseArgs): Database.Database {
+  const db = new BetterSqlite3(args.path);
+  db.pragma("journal_mode = WAL");
+  db.pragma("synchronous = NORMAL");
+  db.pragma("foreign_keys = ON");
+  db.pragma("busy_timeout = 5000");
+  return db;
+}
+
+export function createEventLog(db: Database.Database): EventLog {
+  const appendStmt = db.prepare<[number, EventType, Buffer], InsertedLsnRow>(
+    "INSERT INTO event_log (ts_ms, type, payload) VALUES (?, ?, ?) RETURNING lsn",
+  );
+  const readFromLsnStmt = db.prepare<[number, number], EventLogRow>(
+    "SELECT lsn, ts_ms AS tsMs, type, payload FROM event_log WHERE lsn > ? ORDER BY lsn ASC LIMIT ?",
+  );
+  const highestLsnStmt = db.prepare<[], HighestLsnRow>(
+    "SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log",
+  );
+
+  return {
+    append(args: AppendArgs): number {
+      const row = appendStmt.get(Date.now(), args.type, args.payload);
+      if (row === undefined) {
+        throw new Error("event_log append returned no LSN");
+      }
+      return row.lsn;
+    },
+
+    readFromLsn(fromLsn: number, limit: number): readonly EventLogRecord[] {
+      if (!Number.isInteger(fromLsn) || fromLsn < 0) {
+        throw new Error(`fromLsn must be a non-negative integer, got ${fromLsn}`);
+      }
+      if (!Number.isInteger(limit) || limit < 0) {
+        throw new Error(`limit must be a non-negative integer, got ${limit}`);
+      }
+      return readFromLsnStmt.all(fromLsn, limit).map(rowToEventLogRecord);
+    },
+
+    highestLsn(): number {
+      const row = highestLsnStmt.get();
+      if (row === undefined) {
+        throw new Error("event_log highestLsn query returned no row");
+      }
+      return row.lsn;
+    },
+  };
+}
+
+function rowToEventLogRecord(row: EventLogRow): EventLogRecord {
+  return {
+    lsn: row.lsn,
+    tsMs: row.tsMs,
+    type: toEventType(row.type),
+    payload: Buffer.from(row.payload),
+  };
+}
+
+function toEventType(type: string): EventType {
+  if (type === "receipt.put") {
+    return type;
+  }
+  throw new Error(`Unknown event_log type: ${type}`);
+}

--- a/packages/broker/src/event-log/index.ts
+++ b/packages/broker/src/event-log/index.ts
@@ -1,0 +1,12 @@
+export type {
+  AppendArgs,
+  EventLog,
+  EventLogRecord,
+  EventType,
+  OpenDatabaseArgs,
+} from "./event-log.ts";
+export {
+  createEventLog,
+  openDatabase,
+} from "./event-log.ts";
+export { CURRENT_SCHEMA_VERSION, runMigrations } from "./migrations.ts";

--- a/packages/broker/src/event-log/migrations.ts
+++ b/packages/broker/src/event-log/migrations.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+
+import type Database from "better-sqlite3";
+
+export const CURRENT_SCHEMA_VERSION = 1;
+
+interface Migration {
+  readonly version: number;
+  readonly sql: string;
+}
+
+const MIGRATIONS: readonly Migration[] = [
+  {
+    version: 1,
+    sql: readFileSync(new URL("./001_initial.sql", import.meta.url), "utf8"),
+  },
+];
+
+export function runMigrations(db: Database.Database): void {
+  db.pragma("foreign_keys = ON");
+
+  const currentVersion = readUserVersion(db);
+  if (currentVersion > CURRENT_SCHEMA_VERSION) {
+    throw new Error(
+      `Database schema version ${currentVersion} is newer than supported version ${CURRENT_SCHEMA_VERSION}`,
+    );
+  }
+
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= currentVersion) continue;
+    const applyMigration = db.transaction(() => {
+      db.exec(migration.sql);
+      db.pragma(`user_version = ${migration.version}`);
+    });
+    applyMigration();
+  }
+}
+
+function readUserVersion(db: Database.Database): number {
+  const value = db.pragma("user_version", { simple: true });
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    throw new Error(`Invalid SQLite user_version: ${String(value)}`);
+  }
+  return value;
+}

--- a/packages/broker/src/event-log/migrations.ts
+++ b/packages/broker/src/event-log/migrations.ts
@@ -19,21 +19,27 @@ const MIGRATIONS: readonly Migration[] = [
 export function runMigrations(db: Database.Database): void {
   db.pragma("foreign_keys = ON");
 
-  const currentVersion = readUserVersion(db);
-  if (currentVersion > CURRENT_SCHEMA_VERSION) {
-    throw new Error(
-      `Database schema version ${currentVersion} is newer than supported version ${CURRENT_SCHEMA_VERSION}`,
-    );
-  }
-
-  for (const migration of MIGRATIONS) {
-    if (migration.version <= currentVersion) continue;
-    const applyMigration = db.transaction(() => {
+  // Distsys triangulation R2-D1: read `user_version` AFTER acquiring an
+  // EXCLUSIVE write lock and apply pending migrations inside the same
+  // transaction. Otherwise two broker processes opening a fresh DB
+  // concurrently can both observe `user_version = 0`, race the
+  // `CREATE TABLE` statements, and one or both fail mid-startup with
+  // "table already exists" or lock errors. EXCLUSIVE blocks readers and
+  // writers; cheap because migrations only run on schema upgrades.
+  const applyPending = db.transaction(() => {
+    const currentVersion = readUserVersion(db);
+    if (currentVersion > CURRENT_SCHEMA_VERSION) {
+      throw new Error(
+        `Database schema version ${currentVersion} is newer than supported version ${CURRENT_SCHEMA_VERSION}`,
+      );
+    }
+    for (const migration of MIGRATIONS) {
+      if (migration.version <= currentVersion) continue;
       db.exec(migration.sql);
       db.pragma(`user_version = ${migration.version}`);
-    });
-    applyMigration();
-  }
+    }
+  });
+  applyPending.exclusive();
 }
 
 function readUserVersion(db: Database.Database): number {

--- a/packages/broker/src/event-log/migrations.ts
+++ b/packages/broker/src/event-log/migrations.ts
@@ -19,13 +19,13 @@ const MIGRATIONS: readonly Migration[] = [
 export function runMigrations(db: Database.Database): void {
   db.pragma("foreign_keys = ON");
 
-  // Distsys triangulation R2-D1: read `user_version` AFTER acquiring an
-  // EXCLUSIVE write lock and apply pending migrations inside the same
-  // transaction. Otherwise two broker processes opening a fresh DB
-  // concurrently can both observe `user_version = 0`, race the
-  // `CREATE TABLE` statements, and one or both fail mid-startup with
-  // "table already exists" or lock errors. EXCLUSIVE blocks readers and
-  // writers; cheap because migrations only run on schema upgrades.
+  // Read `user_version` AFTER acquiring an EXCLUSIVE write lock and
+  // apply pending migrations inside the same transaction. Otherwise
+  // two broker processes opening a fresh DB concurrently can both
+  // observe `user_version = 0`, race the `CREATE TABLE` statements,
+  // and one or both fail mid-startup with "table already exists" or
+  // lock errors. EXCLUSIVE blocks readers and writers; cheap because
+  // migrations only run on schema upgrades.
   const applyPending = db.transaction(() => {
     const currentVersion = readUserVersion(db);
     if (currentVersion > CURRENT_SCHEMA_VERSION) {

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -6,6 +6,8 @@
 export { createBroker } from "./listener.ts";
 export type { ReceiptStore } from "./receipt-store.ts";
 export { InMemoryReceiptStore } from "./receipt-store.ts";
+export type { SqliteReceiptStoreConfig } from "./sqlite-receipt-store.ts";
+export { SqliteReceiptStore } from "./sqlite-receipt-store.ts";
 export { generateApiToken } from "./token.ts";
 export type {
   BrokerConfig,

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -4,8 +4,20 @@
 // import `createBroker` and ignore the rest of the module graph.
 
 export { createBroker } from "./listener.ts";
-export type { ReceiptStore } from "./receipt-store.ts";
-export { InMemoryReceiptStore } from "./receipt-store.ts";
+export type {
+  InMemoryReceiptStoreConfig,
+  ListFilter,
+  ListPage,
+  ReceiptStore,
+} from "./receipt-store.ts";
+export {
+  DEFAULT_LIST_LIMIT,
+  InMemoryReceiptStore,
+  InvalidListCursorError,
+  InvalidListLimitError,
+  MAX_LIST_LIMIT,
+  ReceiptStoreFullError,
+} from "./receipt-store.ts";
 export type { SqliteReceiptStoreConfig } from "./sqlite-receipt-store.ts";
 export { SqliteReceiptStore } from "./sqlite-receipt-store.ts";
 export { generateApiToken } from "./token.ts";

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -20,8 +20,12 @@ export {
   ReceiptStoreFullError,
   ReceiptStoreUnavailableError,
 } from "./receipt-store.ts";
-export type { SqliteReceiptStoreConfig } from "./sqlite-receipt-store.ts";
-export { SqliteReceiptStore } from "./sqlite-receipt-store.ts";
+// `SqliteReceiptStore` is intentionally NOT re-exported from the root.
+// It pulls in the native `better-sqlite3` binding via static import,
+// which evaluates at module load. Hosts that want the durable store
+// import it from the `@wuphf/broker/sqlite` subpath so consumers that
+// only need the listener + in-memory store don't pay the native-load
+// cost. See `docs/event-log-projections-design.md` § "Package surface".
 export { generateApiToken } from "./token.ts";
 export type {
   BrokerConfig,

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -16,7 +16,9 @@ export {
   InvalidListCursorError,
   InvalidListLimitError,
   MAX_LIST_LIMIT,
+  ReceiptStoreBusyError,
   ReceiptStoreFullError,
+  ReceiptStoreUnavailableError,
 } from "./receipt-store.ts";
 export type { SqliteReceiptStoreConfig } from "./sqlite-receipt-store.ts";
 export { SqliteReceiptStore } from "./sqlite-receipt-store.ts";

--- a/packages/broker/src/internal/sqlite-receipt-store-testing.ts
+++ b/packages/broker/src/internal/sqlite-receipt-store-testing.ts
@@ -1,0 +1,34 @@
+// Test-only construction helper for `SqliteReceiptStore`. NOT exposed
+// via the `@wuphf/broker/sqlite` subpath — production callers cannot
+// reach this file. Tests inside the broker package import via the
+// relative path.
+//
+// The helper exists so spec files can construct a store against a
+// caller-supplied `Database` handle (pre-migrated `:memory:` DB, stubbed
+// `EventLog`) without going through `SqliteReceiptStore.open()` and its
+// `openDatabase` + `runMigrations` chain. Outside test code, the only
+// supported construction path is `SqliteReceiptStore.open(config)` so
+// migrations always run before any read or write.
+
+import type Database from "better-sqlite3";
+
+import type { EventLog } from "../event-log/index.ts";
+import { SqliteReceiptStore } from "../sqlite-receipt-store.ts";
+
+// Constructor shape captured here so the cast below is `unknown` →
+// typed-constructor rather than `unknown` → `any`. The private modifier
+// on `SqliteReceiptStore`'s constructor is a TypeScript-level fence;
+// the call below bypasses it deliberately for test-only construction.
+type SqliteReceiptStoreCtor = new (
+  db: Database.Database,
+  eventLog?: EventLog,
+  maxReceipts?: number,
+) => SqliteReceiptStore;
+
+export function constructSqliteReceiptStoreForTesting(
+  db: Database.Database,
+  eventLog?: EventLog,
+  maxReceipts?: number,
+): SqliteReceiptStore {
+  return new (SqliteReceiptStore as unknown as SqliteReceiptStoreCtor)(db, eventLog, maxReceipts);
+}

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -217,7 +217,7 @@ async function routeRequest(
       methodNotAllowed(res);
       return;
     }
-    await handleThreadReceiptsList(pathname, res, { receiptStore: deps.receiptStore });
+    await handleThreadReceiptsList(req, res, { receiptStore: deps.receiptStore });
     return;
   }
   // Authenticated catch-all for unknown `/api/*` routes. Without this,

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -209,7 +209,10 @@ async function routeRequest(
       methodNotAllowed(res);
       return;
     }
-    await handleReceiptGet(pathname, res, { receiptStore: deps.receiptStore });
+    await handleReceiptGet(pathname, res, {
+      receiptStore: deps.receiptStore,
+      logger: deps.logger,
+    });
     return;
   }
   if (pathname.startsWith("/api/threads/") && pathname.endsWith("/receipts")) {
@@ -217,7 +220,10 @@ async function routeRequest(
       methodNotAllowed(res);
       return;
     }
-    await handleThreadReceiptsList(req, res, { receiptStore: deps.receiptStore });
+    await handleThreadReceiptsList(req, res, {
+      receiptStore: deps.receiptStore,
+      logger: deps.logger,
+    });
     return;
   }
   // Authenticated catch-all for unknown `/api/*` routes. Without this,

--- a/packages/broker/src/receipt-store.ts
+++ b/packages/broker/src/receipt-store.ts
@@ -1,17 +1,17 @@
 // In-process receipt storage interface.
 //
-// Branch 5 ships an in-memory implementation only — the wire path is the
-// load-bearing concern here. Branch 6 (`feat/event-log-projections`) will
-// add a durable event-log impl. The store interface and the route's
-// handling of conflicts will both evolve in that branch — the current
-// `{ existed: boolean }` return cannot express the "byte-identical retry
-// returns 200 no-op vs. different payload returns 409" semantics branch 6
-// needs. Treat the interface here as branch-5-stable, NOT as the final
-// shape for branch-6 idempotency-key semantics.
+// Branch 5 shipped an in-memory implementation only; branch 6
+// (`feat/event-log-projections`) adds a durable, SQLite event-log-backed
+// `SqliteReceiptStore` behind this same interface. The `list` method
+// evolved in branch 6 to return a paginated `ListPage` with an opaque
+// cursor — see `docs/event-log-projections-design.md` for the contract
+// both implementations satisfy. Idempotency-key semantics (byte-identical
+// retry returns 200 no-op) are still deferred to a later branch; the
+// current `{ existed: boolean }` return is unchanged.
 //
-// Idempotency note (branch 5): `put` is "insert if absent" — the same id
-// with a different payload returns `existed:true` and the stored value is
-// NOT replaced. This is a deliberate choice so a misbehaving client (or a
+// Idempotency note: `put` is "insert if absent" — the same id with a
+// different payload returns `existed:true` and the stored value is NOT
+// replaced. This is a deliberate choice so a misbehaving client (or a
 // retry-after-network-flake) cannot silently overwrite a previously
 // stored receipt.
 //
@@ -21,10 +21,38 @@
 // The HTTP path (`packages/broker/src/receipts.ts`) is safe by construction
 // because `receiptFromJson` produces a fresh frozen-args object on every
 // parse; only direct programmatic callers (tests, future host code) need
-// to honor this rule. Durable backends in branch 6 will sidestep this by
-// storing canonical bytes and re-parsing on read.
+// to honor this rule. `SqliteReceiptStore` sidesteps this by storing
+// canonical bytes and re-parsing on read.
 
 import type { ReceiptId, ReceiptSnapshot, ThreadId } from "@wuphf/protocol";
+
+/**
+ * Filter + pagination arguments for `ReceiptStore.list`.
+ */
+export interface ListFilter {
+  /** Restrict to V2 receipts whose `threadId` matches. */
+  readonly threadId?: ThreadId;
+  /** Opaque continuation token from a prior list call's `nextCursor`. */
+  readonly cursor?: string;
+  /**
+   * Max items in the returned page. Defaults to `DEFAULT_LIST_LIMIT`.
+   * Values above `MAX_LIST_LIMIT` are silently clamped down; values
+   * ≤ 0 or non-integer throw `InvalidListLimitError`.
+   */
+  readonly limit?: number;
+}
+
+/**
+ * One page of receipts from `ReceiptStore.list`.
+ */
+export interface ListPage {
+  readonly items: readonly ReceiptSnapshot[];
+  /** `null` when no more pages. Otherwise an opaque token to pass back as `cursor`. */
+  readonly nextCursor: string | null;
+}
+
+export const DEFAULT_LIST_LIMIT = 100;
+export const MAX_LIST_LIMIT = 1_000;
 
 export interface ReceiptStore {
   /**
@@ -36,9 +64,8 @@ export interface ReceiptStore {
    * `{ existed: false }` and any subsequent caller observes
    * `{ existed: true }`. `InMemoryReceiptStore` satisfies this via Node's
    * single-threaded event loop (the `has`/`set` pair runs without an
-   * await between); durable backends MUST use a unique-constraint
-   * INSERT, `ON CONFLICT DO NOTHING` + affected-rows check, or an
-   * equivalent serializable primitive.
+   * await between); `SqliteReceiptStore` uses a `BEGIN IMMEDIATE`
+   * transaction with the projection's PK as the unique constraint.
    *
    * Read-your-write: once `put` resolves with `{ existed: false }`, an
    * immediate `get(receipt.id)` MUST return the inserted receipt, and an
@@ -54,12 +81,18 @@ export interface ReceiptStore {
    */
   get(id: ReceiptId): Promise<ReceiptSnapshot | null>;
   /**
-   * List receipts. With `filter.threadId`, returns only V2 receipts whose
-   * `threadId` matches. Without a filter, returns every receipt in
-   * insertion order. Branch 6 will replace ordering with event-log order;
-   * callers MUST NOT rely on cross-restart stability of order today.
+   * List receipts in LSN-ascending order, paginated. With `filter.threadId`,
+   * returns only V2 receipts whose `threadId` matches. Cursors are opaque
+   * — callers MUST NOT parse them; pass `nextCursor` from a prior page
+   * back as `cursor` to fetch the next page. The wire-shape of the cursor
+   * is identical across implementations so a test can mix-and-match, but
+   * production code MUST treat it as opaque.
+   *
+   * Throws `InvalidListCursorError` for malformed cursors and
+   * `InvalidListLimitError` for `limit <= 0` or non-integer limits.
+   * Limits above `MAX_LIST_LIMIT` are silently clamped.
    */
-  list(filter?: { readonly threadId?: ThreadId }): Promise<readonly ReceiptSnapshot[]>;
+  list(filter?: ListFilter): Promise<ListPage>;
   /**
    * Total count. Used by tests + the /api/health diagnostic surface.
    */
@@ -69,11 +102,95 @@ export interface ReceiptStore {
 /**
  * Error thrown by `InMemoryReceiptStore.put` when the process-wide receipt
  * cap is exceeded. Routes catch this and respond with `507 Insufficient
- * Storage`. Branch 6's durable backend replaces this with quota-aware
- * persistence and removes the in-process ceiling.
+ * Storage`. `SqliteReceiptStore` replaces this with disk-quota-aware
+ * persistence and does NOT raise `ReceiptStoreFullError`.
  */
 export class ReceiptStoreFullError extends Error {
   override readonly name = "ReceiptStoreFullError";
+}
+
+/**
+ * Error thrown by `list()` when `filter.cursor` is structurally invalid
+ * (malformed base64 or doesn't decode to the expected `lsn:<n>` shape).
+ * The HTTP route catches and responds 400.
+ */
+export class InvalidListCursorError extends Error {
+  override readonly name = "InvalidListCursorError";
+  constructor(cursor: string) {
+    super(`Invalid list cursor: ${cursor}`);
+  }
+}
+
+/**
+ * Error thrown by `list()` when `filter.limit` is ≤ 0 or not an integer.
+ * Limits above `MAX_LIST_LIMIT` are silently clamped and do NOT throw.
+ */
+export class InvalidListLimitError extends Error {
+  override readonly name = "InvalidListLimitError";
+  constructor(limit: number) {
+    super(`Invalid list limit: ${limit} (must be a positive integer)`);
+  }
+}
+
+/**
+ * Internal helper — encode a numeric LSN into the opaque base64 cursor
+ * wire shape. Exported for `SqliteReceiptStore` and the in-memory store
+ * to share one implementation; callers outside the package MUST treat
+ * cursors as opaque.
+ *
+ * @internal
+ */
+export function encodeListCursor(lsn: number): string {
+  if (!Number.isInteger(lsn) || lsn < 0) {
+    throw new Error(`encodeListCursor: lsn must be a non-negative integer, got ${lsn}`);
+  }
+  return Buffer.from(`lsn:${lsn}`, "utf8").toString("base64url");
+}
+
+/**
+ * Internal helper — decode an opaque cursor to its LSN, or throw
+ * `InvalidListCursorError` on malformed input.
+ *
+ * @internal
+ */
+export function decodeListCursor(cursor: string): number {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, "base64url").toString("utf8");
+  } catch {
+    throw new InvalidListCursorError(cursor);
+  }
+  const prefix = "lsn:";
+  if (!decoded.startsWith(prefix)) {
+    throw new InvalidListCursorError(cursor);
+  }
+  const tail = decoded.slice(prefix.length);
+  // Reject empty, leading +, hex, scientific notation, etc.
+  if (!/^[0-9]+$/.test(tail)) {
+    throw new InvalidListCursorError(cursor);
+  }
+  const lsn = Number(tail);
+  if (!Number.isInteger(lsn) || lsn < 0) {
+    throw new InvalidListCursorError(cursor);
+  }
+  return lsn;
+}
+
+/**
+ * Internal helper — validate + clamp `limit`. Throws on invalid values;
+ * silently clamps values above `MAX_LIST_LIMIT`. Returns the resolved
+ * effective limit. `undefined` resolves to `DEFAULT_LIST_LIMIT`.
+ *
+ * @internal
+ */
+export function resolveListLimit(limit: number | undefined): number {
+  if (limit === undefined) {
+    return DEFAULT_LIST_LIMIT;
+  }
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new InvalidListLimitError(limit);
+  }
+  return Math.min(limit, MAX_LIST_LIMIT);
 }
 
 // Default ceiling for the in-memory store. Sized to comfortably exceed a
@@ -87,16 +204,27 @@ export interface InMemoryReceiptStoreConfig {
   readonly maxReceipts?: number;
 }
 
+interface InMemoryEntry {
+  readonly receipt: ReceiptSnapshot;
+  /**
+   * Monotonic counter assigned at insertion. Mirrors the LSN that
+   * `SqliteReceiptStore` derives from the event log, so cursors are
+   * structurally identical across both implementations.
+   */
+  readonly lsn: number;
+}
+
 export class InMemoryReceiptStore implements ReceiptStore {
   // Map preserves insertion order — the `list()` contract documents that
   // ordering is non-durable but consistent within a single process lifetime.
-  private readonly byId = new Map<ReceiptId, ReceiptSnapshot>();
+  private readonly byId = new Map<ReceiptId, InMemoryEntry>();
   // Secondary index for `list({ threadId })`. Only V2 receipts (which carry
   // a `threadId`) are inserted; V1 receipts are absent here and therefore
   // never returned by a thread-scoped list. That's the intended semantic —
   // V1 predates threads.
   private readonly byThread = new Map<ThreadId, Set<ReceiptId>>();
   private readonly maxReceipts: number;
+  private nextLsn = 1;
 
   constructor(config: InMemoryReceiptStoreConfig = {}) {
     const requested = config.maxReceipts ?? DEFAULT_MAX_RECEIPTS;
@@ -118,7 +246,8 @@ export class InMemoryReceiptStore implements ReceiptStore {
     if (this.byId.size >= this.maxReceipts) {
       throw new ReceiptStoreFullError(`InMemoryReceiptStore at capacity (${this.maxReceipts})`);
     }
-    this.byId.set(receipt.id, receipt);
+    const lsn = this.nextLsn++;
+    this.byId.set(receipt.id, { receipt, lsn });
     if (receipt.schemaVersion === 2 && receipt.threadId !== undefined) {
       const existing = this.byThread.get(receipt.threadId);
       if (existing === undefined) {
@@ -131,23 +260,39 @@ export class InMemoryReceiptStore implements ReceiptStore {
   }
 
   async get(id: ReceiptId): Promise<ReceiptSnapshot | null> {
-    return this.byId.get(id) ?? null;
+    return this.byId.get(id)?.receipt ?? null;
   }
 
-  async list(filter?: { readonly threadId?: ThreadId }): Promise<readonly ReceiptSnapshot[]> {
-    if (filter?.threadId !== undefined) {
-      const ids = this.byThread.get(filter.threadId);
-      if (ids === undefined) return [];
-      const out: ReceiptSnapshot[] = [];
-      for (const id of ids) {
-        const r = this.byId.get(id);
-        // The secondary index is populated in lockstep with `byId`, so a
-        // missing primary entry would be a structural bug. Defensive guard.
-        if (r !== undefined) out.push(r);
+  async list(filter?: ListFilter): Promise<ListPage> {
+    const limit = resolveListLimit(filter?.limit);
+    const afterLsn = filter?.cursor !== undefined ? decodeListCursor(filter.cursor) : 0;
+
+    const candidateIds: readonly ReceiptId[] =
+      filter?.threadId !== undefined
+        ? Array.from(this.byThread.get(filter.threadId) ?? [])
+        : Array.from(this.byId.keys());
+
+    const out: ReceiptSnapshot[] = [];
+    let lastLsn = 0;
+    let hasMore = false;
+    for (const id of candidateIds) {
+      const entry = this.byId.get(id);
+      // The secondary index is populated in lockstep with `byId`; a
+      // missing primary entry would be a structural bug. Defensive guard.
+      if (entry === undefined) continue;
+      if (entry.lsn <= afterLsn) continue;
+      if (out.length >= limit) {
+        hasMore = true;
+        break;
       }
-      return out;
+      out.push(entry.receipt);
+      lastLsn = entry.lsn;
     }
-    return Array.from(this.byId.values());
+
+    return {
+      items: out,
+      nextCursor: hasMore ? encodeListCursor(lastLsn) : null,
+    };
   }
 
   size(): number {

--- a/packages/broker/src/receipt-store.ts
+++ b/packages/broker/src/receipt-store.ts
@@ -1,13 +1,17 @@
 // In-process receipt storage interface.
 //
-// Branch 5 shipped an in-memory implementation only; branch 6
-// (`feat/event-log-projections`) adds a durable, SQLite event-log-backed
-// `SqliteReceiptStore` behind this same interface. The `list` method
-// evolved in branch 6 to return a paginated `ListPage` with an opaque
-// cursor — see `docs/event-log-projections-design.md` for the contract
-// both implementations satisfy. Idempotency-key semantics (byte-identical
-// retry returns 200 no-op) are still deferred to a later branch; the
-// current `{ existed: boolean }` return is unchanged.
+// Two implementations satisfy this contract:
+//   - `InMemoryReceiptStore` — process-local, lost across restarts.
+//     Default when `createBroker` is called without a `receiptStore`.
+//   - `SqliteReceiptStore` (in `@wuphf/broker/sqlite`) — durable,
+//     event-log-backed. Loaded lazily so consumers that only need the
+//     in-memory store don't pay the native-binding cost.
+//
+// `list` returns a paginated `ListPage` with an opaque cursor; see
+// `docs/event-log-projections-design.md` for the wire contract.
+// Idempotency-key semantics (byte-identical retry returns 200 no-op)
+// are deferred — `put`'s current `{ existed: boolean }` return is the
+// established shape.
 //
 // Idempotency note: `put` is "insert if absent" — the same id with a
 // different payload returns `existed:true` and the stored value is NOT
@@ -114,8 +118,6 @@ export class ReceiptStoreFullError extends Error {
  * busy timeout, or other transient contention). Routes catch this and
  * respond with `503 Service Unavailable` + `Retry-After: 1`. The
  * distinction from `ReceiptStoreUnavailableError` is retryability.
- *
- * sre triangulation R2-SRE2.
  */
 export class ReceiptStoreBusyError extends Error {
   override readonly name = "ReceiptStoreBusyError";
@@ -126,7 +128,7 @@ export class ReceiptStoreBusyError extends Error {
  * client cannot recover from with a retry (SQLITE_READONLY,
  * SQLITE_IOERR_*, schema mismatch). Routes catch this and respond with
  * `503 Service Unavailable` (no `Retry-After`); the operator must
- * intervene. sre triangulation R2-SRE2.
+ * intervene.
  */
 export class ReceiptStoreUnavailableError extends Error {
   override readonly name = "ReceiptStoreUnavailableError";
@@ -137,7 +139,7 @@ export class ReceiptStoreUnavailableError extends Error {
  * (malformed base64url or doesn't decode to the expected `lsn:<n>` shape).
  * The HTTP route catches and responds 400. Intentionally carries NO
  * attacker-controlled content — the raw cursor is hostile input and
- * MUST NOT be echoed into log payloads (see security triangulation T6).
+ * MUST NOT be echoed into log payloads.
  */
 export class InvalidListCursorError extends Error {
   override readonly name = "InvalidListCursorError";
@@ -157,11 +159,11 @@ export class InvalidListLimitError extends Error {
   }
 }
 
-// RFC 4648 §5 base64url alphabet, unpadded — the only canonical form this
-// package accepts for cursors. Node's `Buffer.from(_, "base64url")` is
-// permissive and accepts trailing junk + non-canonical aliases (e.g.
-// `bHNuOjE!` decodes to `lsn:1`); we pre-validate the alphabet first
-// (security triangulation T5).
+// RFC 4648 §5 base64url alphabet, unpadded — the only canonical form
+// this package accepts for cursors. Node's `Buffer.from(_, "base64url")`
+// is permissive and accepts trailing junk + non-canonical aliases
+// (e.g. `bHNuOjE!` decodes to `lsn:1`); pre-validate the alphabet first
+// so a strict Go/Rust decoder doesn't diverge from us.
 const CURSOR_WIRE_PATTERN = /^[A-Za-z0-9_-]+$/;
 const CURSOR_LSN_TAIL_PATTERN = /^[1-9][0-9]*$/;
 
@@ -187,8 +189,7 @@ export function encodeListCursor(lsn: number): string {
 
 /**
  * Decode an opaque cursor to its LSN, or throw `InvalidListCursorError`
- * on malformed input. Strict validation rules (api/security triangulation
- * T5, T7):
+ * on malformed input. Strict validation rules:
  *
  * - Empty string is rejected (HTTP `?cursor=` is normalized to "no
  *   cursor" by the route handler; an empty cursor reaching the store
@@ -225,14 +226,13 @@ export function decodeListCursor(cursor: string): number {
   if (!Number.isSafeInteger(lsn) || lsn <= 0) {
     throw new InvalidListCursorError();
   }
-  // Canonical round-trip check (api triangulation R2-A1). Node's
-  // base64url decoder accepts non-canonical inputs that share a
-  // prefix's bit pattern: e.g. `bHNuOjE` is canonical for `lsn:1`,
-  // but `bHNuOjF`, `bHNuOjG`, `bHNuOjH` all decode to the same bytes.
-  // A strict Go/Rust implementer using raw_url decoding rejects those;
-  // we must too, or the same logical LSN has multiple equally-valid
-  // wire forms and Go/JS implementations disagree on the validation
-  // surface.
+  // Canonical round-trip check. Node's base64url decoder accepts
+  // non-canonical inputs that share a prefix's bit pattern: e.g.
+  // `bHNuOjE` is canonical for `lsn:1`, but `bHNuOjF`, `bHNuOjG`,
+  // `bHNuOjH` all decode to the same bytes. A strict Go/Rust decoder
+  // using raw_url alphabet rules rejects those; we must too, or the
+  // same logical LSN has multiple equally-valid wire forms and
+  // cross-language implementations disagree on the validation surface.
   if (Buffer.from(decoded, "utf8").toString("base64url") !== cursor) {
     throw new InvalidListCursorError();
   }
@@ -332,9 +332,8 @@ export class InMemoryReceiptStore implements ReceiptStore {
 
     // Iterate the underlying Map/Set directly — no `Array.from` snapshot —
     // so the per-call work is O(skipped + page). Maps preserve insertion
-    // order in V8, and our `byThread` Set is populated in lockstep with
-    // the LSN assignment in `put`, so iteration order is the LSN order.
-    // (perf triangulation T8.)
+    // order in V8, and the `byThread` Set is populated in lockstep with
+    // the LSN assignment in `put`, so iteration order matches LSN order.
     const out: ReceiptSnapshot[] = [];
     let lastLsn = 0;
     let hasMore = false;

--- a/packages/broker/src/receipt-store.ts
+++ b/packages/broker/src/receipt-store.ts
@@ -100,13 +100,36 @@ export interface ReceiptStore {
 }
 
 /**
- * Error thrown by `InMemoryReceiptStore.put` when the process-wide receipt
- * cap is exceeded. Routes catch this and respond with `507 Insufficient
- * Storage`. `SqliteReceiptStore` replaces this with disk-quota-aware
- * persistence and does NOT raise `ReceiptStoreFullError`.
+ * Error thrown when the store has reached its configured receipt cap or
+ * the underlying storage is exhausted (`SQLITE_FULL` for the durable
+ * store). Routes catch this and respond with `507 Insufficient Storage`.
  */
 export class ReceiptStoreFullError extends Error {
   override readonly name = "ReceiptStoreFullError";
+}
+
+/**
+ * Error thrown when the store is temporarily unable to accept a write
+ * but the client should retry (SQLITE_BUSY / SQLITE_LOCKED beyond the
+ * busy timeout, or other transient contention). Routes catch this and
+ * respond with `503 Service Unavailable` + `Retry-After: 1`. The
+ * distinction from `ReceiptStoreUnavailableError` is retryability.
+ *
+ * sre triangulation R2-SRE2.
+ */
+export class ReceiptStoreBusyError extends Error {
+  override readonly name = "ReceiptStoreBusyError";
+}
+
+/**
+ * Error thrown when the store is in a persistent failure mode the
+ * client cannot recover from with a retry (SQLITE_READONLY,
+ * SQLITE_IOERR_*, schema mismatch). Routes catch this and respond with
+ * `503 Service Unavailable` (no `Retry-After`); the operator must
+ * intervene. sre triangulation R2-SRE2.
+ */
+export class ReceiptStoreUnavailableError extends Error {
+  override readonly name = "ReceiptStoreUnavailableError";
 }
 
 /**
@@ -200,6 +223,17 @@ export function decodeListCursor(cursor: string): number {
   }
   const lsn = Number(tail);
   if (!Number.isSafeInteger(lsn) || lsn <= 0) {
+    throw new InvalidListCursorError();
+  }
+  // Canonical round-trip check (api triangulation R2-A1). Node's
+  // base64url decoder accepts non-canonical inputs that share a
+  // prefix's bit pattern: e.g. `bHNuOjE` is canonical for `lsn:1`,
+  // but `bHNuOjF`, `bHNuOjG`, `bHNuOjH` all decode to the same bytes.
+  // A strict Go/Rust implementer using raw_url decoding rejects those;
+  // we must too, or the same logical LSN has multiple equally-valid
+  // wire forms and Go/JS implementations disagree on the validation
+  // surface.
+  if (Buffer.from(decoded, "utf8").toString("base64url") !== cursor) {
     throw new InvalidListCursorError();
   }
   return lsn;

--- a/packages/broker/src/receipt-store.ts
+++ b/packages/broker/src/receipt-store.ts
@@ -111,13 +111,15 @@ export class ReceiptStoreFullError extends Error {
 
 /**
  * Error thrown by `list()` when `filter.cursor` is structurally invalid
- * (malformed base64 or doesn't decode to the expected `lsn:<n>` shape).
- * The HTTP route catches and responds 400.
+ * (malformed base64url or doesn't decode to the expected `lsn:<n>` shape).
+ * The HTTP route catches and responds 400. Intentionally carries NO
+ * attacker-controlled content — the raw cursor is hostile input and
+ * MUST NOT be echoed into log payloads (see security triangulation T6).
  */
 export class InvalidListCursorError extends Error {
   override readonly name = "InvalidListCursorError";
-  constructor(cursor: string) {
-    super(`Invalid list cursor: ${cursor}`);
+  constructor() {
+    super("invalid_list_cursor");
   }
 }
 
@@ -132,46 +134,73 @@ export class InvalidListLimitError extends Error {
   }
 }
 
+// RFC 4648 §5 base64url alphabet, unpadded — the only canonical form this
+// package accepts for cursors. Node's `Buffer.from(_, "base64url")` is
+// permissive and accepts trailing junk + non-canonical aliases (e.g.
+// `bHNuOjE!` decodes to `lsn:1`); we pre-validate the alphabet first
+// (security triangulation T5).
+const CURSOR_WIRE_PATTERN = /^[A-Za-z0-9_-]+$/;
+const CURSOR_LSN_TAIL_PATTERN = /^[1-9][0-9]*$/;
+
 /**
- * Internal helper — encode a numeric LSN into the opaque base64 cursor
- * wire shape. Exported for `SqliteReceiptStore` and the in-memory store
- * to share one implementation; callers outside the package MUST treat
- * cursors as opaque.
+ * Encode a numeric LSN into the opaque cursor wire shape. The shape is
+ * RFC 4648 §5 base64url (unpadded) of ASCII `lsn:<decimal>`. Callers
+ * outside this package MUST treat cursors as opaque — there is no
+ * stability guarantee on the inner encoding.
+ *
+ * Throws if `lsn` is not a positive safe integer (LSN 0 is never a
+ * legitimate cursor — cursors are always derived from an emitted
+ * `nextCursor`, which only fires after at least one item has been
+ * returned, so the smallest meaningful LSN is 1).
  *
  * @internal
  */
 export function encodeListCursor(lsn: number): string {
-  if (!Number.isInteger(lsn) || lsn < 0) {
-    throw new Error(`encodeListCursor: lsn must be a non-negative integer, got ${lsn}`);
+  if (!Number.isSafeInteger(lsn) || lsn <= 0) {
+    throw new Error(`encodeListCursor: lsn must be a positive safe integer, got ${lsn}`);
   }
   return Buffer.from(`lsn:${lsn}`, "utf8").toString("base64url");
 }
 
 /**
- * Internal helper — decode an opaque cursor to its LSN, or throw
- * `InvalidListCursorError` on malformed input.
+ * Decode an opaque cursor to its LSN, or throw `InvalidListCursorError`
+ * on malformed input. Strict validation rules (api/security triangulation
+ * T5, T7):
+ *
+ * - Empty string is rejected (HTTP `?cursor=` is normalized to "no
+ *   cursor" by the route handler; an empty cursor reaching the store
+ *   is a contract bug).
+ * - Outer wire MUST match `[A-Za-z0-9_-]+` (canonical unpadded base64url).
+ *   Node's decoder accepts `+`/`/` and trailing junk; we don't.
+ * - Decoded content MUST start with `lsn:` followed by a canonical
+ *   decimal (no leading zeros, no `+`, no whitespace, no scientific
+ *   notation).
+ * - LSN MUST be a positive `Number.isSafeInteger` (≤ 2^53 - 1) so that
+ *   round-trip ordering is stable across all comparisons.
  *
  * @internal
  */
 export function decodeListCursor(cursor: string): number {
+  if (cursor.length === 0 || !CURSOR_WIRE_PATTERN.test(cursor)) {
+    throw new InvalidListCursorError();
+  }
   let decoded: string;
   try {
     decoded = Buffer.from(cursor, "base64url").toString("utf8");
   } catch {
-    throw new InvalidListCursorError(cursor);
+    throw new InvalidListCursorError();
   }
   const prefix = "lsn:";
   if (!decoded.startsWith(prefix)) {
-    throw new InvalidListCursorError(cursor);
+    throw new InvalidListCursorError();
   }
   const tail = decoded.slice(prefix.length);
-  // Reject empty, leading +, hex, scientific notation, etc.
-  if (!/^[0-9]+$/.test(tail)) {
-    throw new InvalidListCursorError(cursor);
+  if (!CURSOR_LSN_TAIL_PATTERN.test(tail)) {
+    throw new InvalidListCursorError();
   }
   const lsn = Number(tail);
-  if (!Number.isInteger(lsn) || lsn < 0) {
-    throw new InvalidListCursorError(cursor);
+  if (!Number.isSafeInteger(lsn) || lsn <= 0) {
+    throw new InvalidListCursorError();
   }
   return lsn;
 }
@@ -267,14 +296,19 @@ export class InMemoryReceiptStore implements ReceiptStore {
     const limit = resolveListLimit(filter?.limit);
     const afterLsn = filter?.cursor !== undefined ? decodeListCursor(filter.cursor) : 0;
 
-    const candidateIds: readonly ReceiptId[] =
-      filter?.threadId !== undefined
-        ? Array.from(this.byThread.get(filter.threadId) ?? [])
-        : Array.from(this.byId.keys());
-
+    // Iterate the underlying Map/Set directly — no `Array.from` snapshot —
+    // so the per-call work is O(skipped + page). Maps preserve insertion
+    // order in V8, and our `byThread` Set is populated in lockstep with
+    // the LSN assignment in `put`, so iteration order is the LSN order.
+    // (perf triangulation T8.)
     const out: ReceiptSnapshot[] = [];
     let lastLsn = 0;
     let hasMore = false;
+    const candidateIds: Iterable<ReceiptId> =
+      filter?.threadId !== undefined
+        ? (this.byThread.get(filter.threadId) ?? new Set<ReceiptId>())
+        : this.byId.keys();
+
     for (const id of candidateIds) {
       const entry = this.byId.get(id);
       // The secondary index is populated in lockstep with `byId`; a

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -28,6 +28,7 @@ import {
 import {
   InvalidListCursorError,
   InvalidListLimitError,
+  MAX_LIST_LIMIT,
   type ReceiptStore,
   ReceiptStoreFullError,
 } from "./receipt-store.ts";
@@ -236,16 +237,29 @@ export async function handleThreadReceiptsList(
     return;
   }
 
-  const cursor = url.searchParams.has("cursor")
-    ? (url.searchParams.get("cursor") ?? "")
-    : undefined;
+  // The route's default `limit` (when the caller didn't supply one) is
+  // `MAX_LIST_LIMIT`, NOT the store's `DEFAULT_LIST_LIMIT`. Branch 5
+  // returned up to 1000 receipts in a single call without a continuation
+  // token; clients that ignore `Link` still see the same first-page count
+  // they did before, so the pagination roll-out doesn't silently lose
+  // receipts 101-1000 (api/architecture triangulation T2).
+  const effectiveLimit = limitParam !== undefined ? limitParam.value : MAX_LIST_LIMIT;
+
+  // Empty `?cursor=` is normalized to "no cursor" (architecture
+  // triangulation T9). The store throws `InvalidListCursorError` for `""`
+  // which is the right semantic for a programmatic caller, but at the
+  // HTTP boundary `?cursor=` (a present-but-blank query value) is
+  // ergonomically indistinguishable from "no cursor" and clients should
+  // not have to omit the param entirely just to start at the beginning.
+  const cursorRaw = url.searchParams.get("cursor");
+  const cursor = cursorRaw !== null && cursorRaw.length > 0 ? cursorRaw : undefined;
 
   let page: Awaited<ReturnType<ReceiptStore["list"]>>;
   try {
     page = await deps.receiptStore.list({
       threadId,
       ...(cursor !== undefined ? { cursor } : {}),
-      ...(limitParam !== undefined ? { limit: limitParam.value } : {}),
+      limit: effectiveLimit,
     });
   } catch (err) {
     if (err instanceof InvalidListCursorError) {

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -44,9 +44,10 @@ const MAX_RECEIPT_BODY_BYTES = 1_048_576;
 // Hard ceiling for thread-scoped list responses. Without a limit a single
 // thread can accumulate enough receipts to make `GET /api/threads/:tid/
 // receipts` a memory-pressure path (the response is materialized as one
-// JSON-array string before send). Branch 6 will replace this with cursor
-// pagination; for branch 5 the cap is coarse but bounded. A 200 response
-// at or near the cap is the signal that pagination will be needed.
+// JSON-array string before send). Cursor-aware pagination handling on
+// this route lands in a follow-up commit in branch 6 (along with `Link:
+// rel="next"`); until then the route requests the first page from the
+// store at the maximum allowed limit, preserving the branch-5 wire shape.
 const MAX_THREAD_LIST_RECEIPTS = 1_000;
 
 interface ReceiptRouteDeps {
@@ -230,18 +231,12 @@ export async function handleThreadReceiptsList(
     return;
   }
 
-  const list = await deps.receiptStore.list({ threadId });
-  // Cap the response size: a single thread can otherwise accumulate
-  // enough receipts to make this a memory pressure path. Branch 6 adds
-  // cursor pagination; for now we truncate at the ceiling so the response
-  // stays bounded. Clients hitting the cap will see exactly
-  // MAX_THREAD_LIST_RECEIPTS receipts — there is no continuation token
-  // yet (added in branch 6).
-  const truncated =
-    list.length > MAX_THREAD_LIST_RECEIPTS ? list.slice(0, MAX_THREAD_LIST_RECEIPTS) : list;
-  // Serialize each via the codec so the wire shape is identical to the
-  // single-receipt GET response. Concatenate as a JSON array.
-  const body = `[${truncated.map((r) => receiptToJson(r)).join(",")}]`;
+  const page = await deps.receiptStore.list({ threadId, limit: MAX_THREAD_LIST_RECEIPTS });
+  // Branch-5 wire shape is a bare JSON array. The cursor-aware route
+  // signature (`?cursor=&limit=`, `Link: rel="next"` header) lands in a
+  // follow-up commit on this branch — until then we always request the
+  // first page at the max limit so behavior is identical to before.
+  const body = `[${page.items.map((r) => receiptToJson(r)).join(",")}]`;
   writeJsonResponse(res, 200, body);
 }
 

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -148,11 +148,11 @@ export async function handleReceiptCreate(
       writeJsonResponse(res, 507, JSON.stringify({ error: "store_full" }));
       return;
     }
-    // sre triangulation R2-SRE2: classify storage failures so on-call
-    // sees a structured reason instead of a generic 500. Busy → 503 +
-    // `Retry-After: 1` (retry will likely succeed once write lock
-    // clears). Unavailable → 503 with no `Retry-After` (operator
-    // intervention needed for readonly/IOERR/corruption).
+    // Classify storage failures so on-call sees a structured reason
+    // instead of a generic 500. Busy → 503 + `Retry-After: 1` (retry
+    // will likely succeed once the write lock clears). Unavailable →
+    // 503 with no `Retry-After` (operator intervention needed for
+    // readonly/IOERR/corruption).
     if (err instanceof ReceiptStoreBusyError) {
       deps.logger.warn("receipt_post_rejected", { reason: "store_busy" });
       writeJsonResponse(res, 503, JSON.stringify({ error: "store_busy" }), {
@@ -257,26 +257,26 @@ export async function handleThreadReceiptsList(
   }
 
   // The route's default `limit` (when the caller didn't supply one) is
-  // `MAX_LIST_LIMIT`, NOT the store's `DEFAULT_LIST_LIMIT`. Branch 5
-  // returned up to 1000 receipts in a single call without a continuation
-  // token; clients that ignore `Link` still see the same first-page count
-  // they did before, so the pagination roll-out doesn't silently lose
-  // receipts 101-1000 (api/architecture triangulation T2).
+  // `MAX_LIST_LIMIT`, NOT the store's `DEFAULT_LIST_LIMIT`. The pre-
+  // pagination route returned up to 1000 receipts in a single call
+  // without a continuation token; clients that ignore `Link` still
+  // see the same first-page count they did before, so the pagination
+  // roll-out doesn't silently lose receipts 101-1000.
   //
-  // Canonicalize the effective limit before passing it to the store and
-  // before emitting `Link` (api triangulation R2-A2). The store already
-  // clamps internally, but the public route contract says `limit` is
-  // 1–1000; echoing `?limit=9999` back in a `Link` URL diverges from
-  // that contract and confuses Go/Rust client generators.
+  // Canonicalize the effective limit before passing it to the store
+  // and before emitting `Link`. The store already clamps internally,
+  // but the public route contract says `limit` is 1–1000; echoing
+  // `?limit=9999` back in a `Link` URL diverges from that contract
+  // and confuses Go/Rust client generators.
   const effectiveLimit =
     limitParam !== undefined ? Math.min(limitParam.value, MAX_LIST_LIMIT) : MAX_LIST_LIMIT;
 
-  // Empty `?cursor=` is normalized to "no cursor" (architecture
-  // triangulation T9). The store throws `InvalidListCursorError` for `""`
-  // which is the right semantic for a programmatic caller, but at the
-  // HTTP boundary `?cursor=` (a present-but-blank query value) is
-  // ergonomically indistinguishable from "no cursor" and clients should
-  // not have to omit the param entirely just to start at the beginning.
+  // Empty `?cursor=` is normalized to "no cursor". The store throws
+  // `InvalidListCursorError` for `""` which is the right semantic for
+  // a programmatic caller, but at the HTTP boundary `?cursor=` (a
+  // present-but-blank query value) is ergonomically indistinguishable
+  // from "no cursor" and clients should not have to omit the param
+  // entirely just to start at the beginning.
   const cursorRaw = url.searchParams.get("cursor");
   const cursor = cursorRaw !== null && cursorRaw.length > 0 ? cursorRaw : undefined;
 
@@ -302,8 +302,8 @@ export async function handleThreadReceiptsList(
   const body = `[${page.items.map((r) => receiptToJson(r)).join(",")}]`;
   // Emit the clamped effective limit in the next-page `Link` URL, not
   // the caller's raw value, so an over-cap `?limit=9999` doesn't echo
-  // back as a contract-violating cursor (R2-A2). If the caller didn't
-  // supply `limit`, omit it from the URL so the next call inherits the
+  // back as a contract-violating cursor. If the caller didn't supply
+  // `limit`, omit it from the URL so the next call inherits the
   // route's default.
   const linkLimit = limitParam !== undefined ? String(effectiveLimit) : undefined;
   const headers =

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -25,7 +25,12 @@ import {
   type ThreadId,
 } from "@wuphf/protocol";
 
-import { type ReceiptStore, ReceiptStoreFullError } from "./receipt-store.ts";
+import {
+  InvalidListCursorError,
+  InvalidListLimitError,
+  type ReceiptStore,
+  ReceiptStoreFullError,
+} from "./receipt-store.ts";
 import type { BrokerLogger } from "./types.ts";
 
 // 1 MiB body budget. This is the broker's wire-layer pre-parse cap and is
@@ -40,15 +45,7 @@ import type { BrokerLogger } from "./types.ts";
 // this value if a future use case needs to submit larger receipts over
 // HTTP, but do NOT raise it past the protocol cap.
 const MAX_RECEIPT_BODY_BYTES = 1_048_576;
-
-// Hard ceiling for thread-scoped list responses. Without a limit a single
-// thread can accumulate enough receipts to make `GET /api/threads/:tid/
-// receipts` a memory-pressure path (the response is materialized as one
-// JSON-array string before send). Cursor-aware pagination handling on
-// this route lands in a follow-up commit in branch 6 (along with `Link:
-// rel="next"`); until then the route requests the first page from the
-// store at the maximum allowed limit, preserving the branch-5 wire shape.
-const MAX_THREAD_LIST_RECEIPTS = 1_000;
+const LIST_LIMIT_PARAM = /^[1-9][0-9]*$/;
 
 interface ReceiptRouteDeps {
   readonly receiptStore: ReceiptStore;
@@ -198,11 +195,13 @@ export async function handleReceiptGet(
 }
 
 export async function handleThreadReceiptsList(
-  pathname: string,
+  req: IncomingMessage,
   res: ServerResponse,
   deps: { readonly receiptStore: ReceiptStore },
 ): Promise<void> {
   // /api/threads/:tid/receipts — extract :tid and require an exact match.
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+  const pathname = url.pathname;
   const prefix = "/api/threads/";
   const suffix = "/receipts";
   if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) {
@@ -231,13 +230,68 @@ export async function handleThreadReceiptsList(
     return;
   }
 
-  const page = await deps.receiptStore.list({ threadId, limit: MAX_THREAD_LIST_RECEIPTS });
-  // Branch-5 wire shape is a bare JSON array. The cursor-aware route
-  // signature (`?cursor=&limit=`, `Link: rel="next"` header) lands in a
-  // follow-up commit on this branch — until then we always request the
-  // first page at the max limit so behavior is identical to before.
+  const limitParam = parseListLimitParam(url.searchParams);
+  if (limitParam === "invalid") {
+    writeJsonResponse(res, 400, JSON.stringify({ error: "invalid_limit" }));
+    return;
+  }
+
+  const cursor = url.searchParams.has("cursor")
+    ? (url.searchParams.get("cursor") ?? "")
+    : undefined;
+
+  let page: Awaited<ReturnType<ReceiptStore["list"]>>;
+  try {
+    page = await deps.receiptStore.list({
+      threadId,
+      ...(cursor !== undefined ? { cursor } : {}),
+      ...(limitParam !== undefined ? { limit: limitParam.value } : {}),
+    });
+  } catch (err) {
+    if (err instanceof InvalidListCursorError) {
+      writeJsonResponse(res, 400, JSON.stringify({ error: "invalid_cursor" }));
+      return;
+    }
+    if (err instanceof InvalidListLimitError) {
+      writeJsonResponse(res, 400, JSON.stringify({ error: "invalid_limit" }));
+      return;
+    }
+    throw err;
+  }
+
   const body = `[${page.items.map((r) => receiptToJson(r)).join(",")}]`;
-  writeJsonResponse(res, 200, body);
+  const headers =
+    page.nextCursor === null
+      ? {}
+      : {
+          Link: buildThreadReceiptsNextLink(threadId, page.nextCursor, limitParam?.raw),
+        };
+  writeJsonResponse(res, 200, body, headers);
+}
+
+function parseListLimitParam(
+  searchParams: URLSearchParams,
+): { readonly raw: string; readonly value: number } | "invalid" | undefined {
+  if (!searchParams.has("limit")) {
+    return undefined;
+  }
+  const raw = searchParams.get("limit") ?? "";
+  if (!LIST_LIMIT_PARAM.test(raw)) {
+    return "invalid";
+  }
+  return { raw, value: Number(raw) };
+}
+
+function buildThreadReceiptsNextLink(
+  threadId: ThreadId,
+  cursor: string,
+  limit: string | undefined,
+): string {
+  const query = [`cursor=${encodeURIComponent(cursor)}`];
+  if (limit !== undefined) {
+    query.push(`limit=${encodeURIComponent(limit)}`);
+  }
+  return `</api/threads/${encodeURIComponent(threadId)}/receipts?${query.join("&")}>; rel="next"`;
 }
 
 function notFoundJson(res: ServerResponse): void {

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -30,7 +30,9 @@ import {
   InvalidListLimitError,
   MAX_LIST_LIMIT,
   type ReceiptStore,
+  ReceiptStoreBusyError,
   ReceiptStoreFullError,
+  ReceiptStoreUnavailableError,
 } from "./receipt-store.ts";
 import type { BrokerLogger } from "./types.ts";
 
@@ -146,6 +148,23 @@ export async function handleReceiptCreate(
       writeJsonResponse(res, 507, JSON.stringify({ error: "store_full" }));
       return;
     }
+    // sre triangulation R2-SRE2: classify storage failures so on-call
+    // sees a structured reason instead of a generic 500. Busy → 503 +
+    // `Retry-After: 1` (retry will likely succeed once write lock
+    // clears). Unavailable → 503 with no `Retry-After` (operator
+    // intervention needed for readonly/IOERR/corruption).
+    if (err instanceof ReceiptStoreBusyError) {
+      deps.logger.warn("receipt_post_rejected", { reason: "store_busy" });
+      writeJsonResponse(res, 503, JSON.stringify({ error: "store_busy" }), {
+        "Retry-After": "1",
+      });
+      return;
+    }
+    if (err instanceof ReceiptStoreUnavailableError) {
+      deps.logger.error("receipt_post_rejected", { reason: "storage_error" });
+      writeJsonResponse(res, 503, JSON.stringify({ error: "storage_error" }));
+      return;
+    }
     throw err;
   }
   if (result.existed) {
@@ -243,7 +262,14 @@ export async function handleThreadReceiptsList(
   // token; clients that ignore `Link` still see the same first-page count
   // they did before, so the pagination roll-out doesn't silently lose
   // receipts 101-1000 (api/architecture triangulation T2).
-  const effectiveLimit = limitParam !== undefined ? limitParam.value : MAX_LIST_LIMIT;
+  //
+  // Canonicalize the effective limit before passing it to the store and
+  // before emitting `Link` (api triangulation R2-A2). The store already
+  // clamps internally, but the public route contract says `limit` is
+  // 1–1000; echoing `?limit=9999` back in a `Link` URL diverges from
+  // that contract and confuses Go/Rust client generators.
+  const effectiveLimit =
+    limitParam !== undefined ? Math.min(limitParam.value, MAX_LIST_LIMIT) : MAX_LIST_LIMIT;
 
   // Empty `?cursor=` is normalized to "no cursor" (architecture
   // triangulation T9). The store throws `InvalidListCursorError` for `""`
@@ -274,11 +300,17 @@ export async function handleThreadReceiptsList(
   }
 
   const body = `[${page.items.map((r) => receiptToJson(r)).join(",")}]`;
+  // Emit the clamped effective limit in the next-page `Link` URL, not
+  // the caller's raw value, so an over-cap `?limit=9999` doesn't echo
+  // back as a contract-violating cursor (R2-A2). If the caller didn't
+  // supply `limit`, omit it from the URL so the next call inherits the
+  // route's default.
+  const linkLimit = limitParam !== undefined ? String(effectiveLimit) : undefined;
   const headers =
     page.nextCursor === null
       ? {}
       : {
-          Link: buildThreadReceiptsNextLink(threadId, page.nextCursor, limitParam?.raw),
+          Link: buildThreadReceiptsNextLink(threadId, page.nextCursor, linkLimit),
         };
   writeJsonResponse(res, 200, body, headers);
 }

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -148,21 +148,7 @@ export async function handleReceiptCreate(
       writeJsonResponse(res, 507, JSON.stringify({ error: "store_full" }));
       return;
     }
-    // Classify storage failures so on-call sees a structured reason
-    // instead of a generic 500. Busy → 503 + `Retry-After: 1` (retry
-    // will likely succeed once the write lock clears). Unavailable →
-    // 503 with no `Retry-After` (operator intervention needed for
-    // readonly/IOERR/corruption).
-    if (err instanceof ReceiptStoreBusyError) {
-      deps.logger.warn("receipt_post_rejected", { reason: "store_busy" });
-      writeJsonResponse(res, 503, JSON.stringify({ error: "store_busy" }), {
-        "Retry-After": "1",
-      });
-      return;
-    }
-    if (err instanceof ReceiptStoreUnavailableError) {
-      deps.logger.error("receipt_post_rejected", { reason: "storage_error" });
-      writeJsonResponse(res, 503, JSON.stringify({ error: "storage_error" }));
+    if (writeStorageErrorResponse(res, err, deps.logger, "receipt_post_rejected")) {
       return;
     }
     throw err;
@@ -182,7 +168,7 @@ export async function handleReceiptCreate(
 export async function handleReceiptGet(
   pathname: string,
   res: ServerResponse,
-  deps: { readonly receiptStore: ReceiptStore },
+  deps: ReceiptRouteDeps,
 ): Promise<void> {
   const idSegment = pathname.slice("/api/receipts/".length);
   if (idSegment.length === 0 || idSegment.includes("/")) {
@@ -206,7 +192,15 @@ export async function handleReceiptGet(
     return;
   }
 
-  const receipt = await deps.receiptStore.get(id);
+  let receipt: ReceiptSnapshot | null;
+  try {
+    receipt = await deps.receiptStore.get(id);
+  } catch (err) {
+    if (writeStorageErrorResponse(res, err, deps.logger, "receipt_get_rejected")) {
+      return;
+    }
+    throw err;
+  }
   if (receipt === null) {
     notFoundJson(res);
     return;
@@ -217,7 +211,7 @@ export async function handleReceiptGet(
 export async function handleThreadReceiptsList(
   req: IncomingMessage,
   res: ServerResponse,
-  deps: { readonly receiptStore: ReceiptStore },
+  deps: ReceiptRouteDeps,
 ): Promise<void> {
   // /api/threads/:tid/receipts — extract :tid and require an exact match.
   const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -296,6 +290,9 @@ export async function handleThreadReceiptsList(
       writeJsonResponse(res, 400, JSON.stringify({ error: "invalid_limit" }));
       return;
     }
+    if (writeStorageErrorResponse(res, err, deps.logger, "receipt_list_rejected")) {
+      return;
+    }
     throw err;
   }
 
@@ -342,6 +339,34 @@ function buildThreadReceiptsNextLink(
 
 function notFoundJson(res: ServerResponse): void {
   writeJsonResponse(res, 404, JSON.stringify({ error: "not_found" }));
+}
+
+// Shared storage-error → HTTP response mapper used by every receipt
+// route. Returns `true` when the error was classified + handled (the
+// response is now written); returns `false` if the error wasn't a
+// storage-error class (caller should `throw` to surface a 500).
+// Busy → 503 + `Retry-After: 1` (retry will likely succeed once the
+// write lock clears). Unavailable → 503 with no `Retry-After`
+// (operator intervention needed for readonly/IOERR/corruption).
+function writeStorageErrorResponse(
+  res: ServerResponse,
+  err: unknown,
+  logger: BrokerLogger,
+  rejectedEvent: string,
+): boolean {
+  if (err instanceof ReceiptStoreBusyError) {
+    logger.warn(rejectedEvent, { reason: "store_busy" });
+    writeJsonResponse(res, 503, JSON.stringify({ error: "store_busy" }), {
+      "Retry-After": "1",
+    });
+    return true;
+  }
+  if (err instanceof ReceiptStoreUnavailableError) {
+    logger.error(rejectedEvent, { reason: "storage_error" });
+    writeJsonResponse(res, 503, JSON.stringify({ error: "storage_error" }));
+    return true;
+  }
+  return false;
 }
 
 // Shared JSON response helper. Sets `Content-Type: application/json;

--- a/packages/broker/src/serve-static.ts
+++ b/packages/broker/src/serve-static.ts
@@ -25,6 +25,7 @@ import { realpathSync } from "node:fs";
 import { type FileHandle, open, realpath } from "node:fs/promises";
 import type { ServerResponse } from "node:http";
 import { isAbsolute, resolve, sep } from "node:path";
+import { pipeline } from "node:stream/promises";
 
 import type { RendererBundleSource } from "./types.ts";
 
@@ -134,7 +135,8 @@ export function createStaticHandler(source: RendererBundleSource | null): Static
       // operates on the inode that existed at open() time, so an attacker
       // swapping the path target between the realpath check and the read
       // can't redirect the bytes — the inode behind the FD is locked.
-      // `handle.createReadStream` auto-closes on stream end/error.
+      // `pipeFromHandle` leaves the opened FileHandle alive; the finally block
+      // below is the single owner responsible for closing it.
       let handle: FileHandle;
       try {
         handle = await open(realAbsolute, "r");
@@ -142,7 +144,6 @@ export function createStaticHandler(source: RendererBundleSource | null): Static
         notFound(res);
         return true;
       }
-      let handleClosed = false;
       try {
         const info = await handle.stat();
         if (!info.isFile()) {
@@ -164,7 +165,6 @@ export function createStaticHandler(source: RendererBundleSource | null): Static
         // server header takes precedence.
         res.setHeader("Content-Security-Policy", RENDERER_CSP);
         await pipeFromHandle(handle, res);
-        handleClosed = true; // createReadStream auto-closes on end.
       } catch {
         // pipeFromHandle may have already flushed headers + bytes before
         // the stream errored mid-pipe (e.g., disk read failure on a large
@@ -180,9 +180,7 @@ export function createStaticHandler(source: RendererBundleSource | null): Static
           res.end();
         }
       } finally {
-        if (!handleClosed) {
-          await handle.close().catch(() => undefined);
-        }
+        await handle.close().catch(() => undefined);
       }
       return true;
     },
@@ -228,11 +226,6 @@ function notFound(res: ServerResponse): void {
   res.end("not_found");
 }
 
-function pipeFromHandle(handle: FileHandle, res: ServerResponse): Promise<void> {
-  return new Promise((resolveFn, rejectFn) => {
-    const stream = handle.createReadStream();
-    stream.on("error", rejectFn);
-    stream.on("end", () => resolveFn());
-    stream.pipe(res);
-  });
+async function pipeFromHandle(handle: FileHandle, res: ServerResponse): Promise<void> {
+  await pipeline(handle.createReadStream({ autoClose: false }), res);
 }

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -1,0 +1,173 @@
+import {
+  type ReceiptId,
+  type ReceiptSnapshot,
+  receiptFromJson,
+  receiptToJson,
+  type ThreadId,
+} from "@wuphf/protocol";
+import type Database from "better-sqlite3";
+import BetterSqlite3 from "better-sqlite3";
+
+import { createEventLog, type EventLog, openDatabase, runMigrations } from "./event-log/index.ts";
+import {
+  decodeListCursor,
+  encodeListCursor,
+  type ListFilter,
+  type ListPage,
+  type ReceiptStore,
+  resolveListLimit,
+} from "./receipt-store.ts";
+
+export interface SqliteReceiptStoreConfig {
+  readonly path: string;
+}
+
+interface ReceiptExistsRow {
+  readonly present: 1;
+}
+
+interface ProjectionPayloadRow {
+  readonly lsn: number;
+  readonly payload: Buffer;
+}
+
+interface CountRow {
+  readonly count: number;
+}
+
+type ProjectionInsertParams = [ReceiptId, ThreadId | null, number, number, Buffer];
+
+export class SqliteReceiptStore implements ReceiptStore {
+  private readonly eventLog: EventLog;
+  private readonly receiptExistsStmt: Database.Statement<[ReceiptId], ReceiptExistsRow>;
+  private readonly insertProjectionStmt: Database.Statement<ProjectionInsertParams>;
+  private readonly getPayloadStmt: Database.Statement<[ReceiptId], ProjectionPayloadRow>;
+  private readonly listAllStmt: Database.Statement<[number, number], ProjectionPayloadRow>;
+  private readonly listThreadStmt: Database.Statement<
+    [ThreadId, number, number],
+    ProjectionPayloadRow
+  >;
+  private readonly countStmt: Database.Statement<[], CountRow>;
+  private readonly putTransaction: Database.Transaction<
+    (receipt: ReceiptSnapshot) => { readonly existed: boolean }
+  >;
+  private closed = false;
+
+  static open(config: SqliteReceiptStoreConfig): SqliteReceiptStore {
+    const db = openDatabase(config);
+    try {
+      runMigrations(db);
+      return new SqliteReceiptStore(db);
+    } catch (err) {
+      db.close();
+      throw err;
+    }
+  }
+
+  constructor(
+    private readonly db: Database.Database,
+    eventLog: EventLog = createEventLog(db),
+  ) {
+    this.eventLog = eventLog;
+    this.receiptExistsStmt = db.prepare<[ReceiptId], ReceiptExistsRow>(
+      "SELECT 1 AS present FROM receipts_projection WHERE receipt_id = ?",
+    );
+    this.insertProjectionStmt = db.prepare<ProjectionInsertParams>(
+      "INSERT INTO receipts_projection (receipt_id, thread_id, schema_version, lsn, payload) VALUES (?, ?, ?, ?, ?)",
+    );
+    this.getPayloadStmt = db.prepare<[ReceiptId], ProjectionPayloadRow>(
+      "SELECT lsn, payload FROM receipts_projection WHERE receipt_id = ?",
+    );
+    this.listAllStmt = db.prepare<[number, number], ProjectionPayloadRow>(
+      "SELECT lsn, payload FROM receipts_projection WHERE lsn > ? ORDER BY lsn ASC LIMIT ?",
+    );
+    this.listThreadStmt = db.prepare<[ThreadId, number, number], ProjectionPayloadRow>(
+      "SELECT lsn, payload FROM receipts_projection WHERE thread_id = ? AND lsn > ? ORDER BY lsn ASC LIMIT ?",
+    );
+    this.countStmt = db.prepare<[], CountRow>("SELECT COUNT(*) AS count FROM receipts_projection");
+    this.putTransaction = db.transaction((receipt: ReceiptSnapshot) => {
+      if (this.receiptExistsStmt.get(receipt.id) !== undefined) {
+        return { existed: true };
+      }
+
+      const payload = Buffer.from(receiptToJson(receipt), "utf8");
+      const lsn = this.eventLog.append({ type: "receipt.put", payload });
+      this.insertProjectionStmt.run(
+        receipt.id,
+        projectionThreadId(receipt),
+        receipt.schemaVersion,
+        lsn,
+        payload,
+      );
+      return { existed: false };
+    });
+  }
+
+  async put(receipt: ReceiptSnapshot): Promise<{ readonly existed: boolean }> {
+    try {
+      return this.putTransaction.immediate(receipt);
+    } catch (err) {
+      if (isReceiptIdConstraintError(err)) {
+        return { existed: true };
+      }
+      throw err;
+    }
+  }
+
+  async get(id: ReceiptId): Promise<ReceiptSnapshot | null> {
+    const row = this.getPayloadStmt.get(id);
+    if (row === undefined) {
+      return null;
+    }
+    return receiptFromJson(row.payload.toString("utf8"));
+  }
+
+  async list(filter?: ListFilter): Promise<ListPage> {
+    const limit = resolveListLimit(filter?.limit);
+    const afterLsn = filter?.cursor !== undefined ? decodeListCursor(filter.cursor) : 0;
+    const rows =
+      filter?.threadId === undefined
+        ? this.listAllStmt.all(afterLsn, limit + 1)
+        : this.listThreadStmt.all(filter.threadId, afterLsn, limit + 1);
+    const visibleRows = rows.slice(0, limit);
+    const items = visibleRows.map((row) => receiptFromJson(row.payload.toString("utf8")));
+    const lastRow = visibleRows.at(-1);
+
+    return {
+      items,
+      nextCursor:
+        rows.length > limit && lastRow !== undefined ? encodeListCursor(lastRow.lsn) : null,
+    };
+  }
+
+  size(): number {
+    const row = this.countStmt.get();
+    if (row === undefined) {
+      throw new Error("receipts_projection count query returned no row");
+    }
+    return row.count;
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    this.db.close();
+    this.closed = true;
+  }
+}
+
+function projectionThreadId(receipt: ReceiptSnapshot): ThreadId | null {
+  if (receipt.schemaVersion === 2 && receipt.threadId !== undefined) {
+    return receipt.threadId;
+  }
+  return null;
+}
+
+function isReceiptIdConstraintError(err: unknown): boolean {
+  return (
+    err instanceof BetterSqlite3.SqliteError &&
+    (err.code === "SQLITE_CONSTRAINT_PRIMARYKEY" || err.code === "SQLITE_CONSTRAINT_UNIQUE") &&
+    err.message.includes("receipts_projection.receipt_id")
+  );
+}

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -170,7 +170,12 @@ export class SqliteReceiptStore implements ReceiptStore {
   }
 
   async get(id: ReceiptId): Promise<ReceiptSnapshot | null> {
-    const row = this.getPayloadStmt.get(id);
+    let row: ProjectionPayloadRow | undefined;
+    try {
+      row = this.getPayloadStmt.get(id);
+    } catch (err) {
+      throw classifySqliteReadError(err);
+    }
     if (row === undefined) {
       return null;
     }
@@ -180,10 +185,15 @@ export class SqliteReceiptStore implements ReceiptStore {
   async list(filter?: ListFilter): Promise<ListPage> {
     const limit = resolveListLimit(filter?.limit);
     const afterLsn = filter?.cursor !== undefined ? decodeListCursor(filter.cursor) : 0;
-    const rows =
-      filter?.threadId === undefined
-        ? this.listAllStmt.all(afterLsn, limit + 1)
-        : this.listThreadStmt.all(filter.threadId, afterLsn, limit + 1);
+    let rows: ProjectionPayloadRow[];
+    try {
+      rows =
+        filter?.threadId === undefined
+          ? this.listAllStmt.all(afterLsn, limit + 1)
+          : this.listThreadStmt.all(filter.threadId, afterLsn, limit + 1);
+    } catch (err) {
+      throw classifySqliteReadError(err);
+    }
     const visibleRows = rows.slice(0, limit);
     const items = visibleRows.map((row) => receiptFromJson(row.payload.toString("utf8")));
     const lastRow = visibleRows.at(-1);
@@ -196,7 +206,12 @@ export class SqliteReceiptStore implements ReceiptStore {
   }
 
   size(): number {
-    const row = this.countStmt.get();
+    let row: CountRow | undefined;
+    try {
+      row = this.countStmt.get();
+    } catch (err) {
+      throw classifySqliteReadError(err);
+    }
     if (row === undefined) {
       throw new Error("receipts_projection count query returned no row");
     }
@@ -210,6 +225,26 @@ export class SqliteReceiptStore implements ReceiptStore {
     this.db.close();
     this.closed = true;
   }
+}
+
+// Map SQLite errors raised by read-path statements (`get`/`list`/`size`)
+// into the same classified error hierarchy `put` uses. Without this,
+// transient `SQLITE_BUSY` on a read returns a generic 500 from the
+// route — clients can't distinguish "retry will help" from "DB is
+// corrupt". `SQLITE_FULL` is not handled here because reads don't
+// allocate pages.
+function classifySqliteReadError(err: unknown): Error {
+  if (isSqliteBusyError(err)) {
+    return new ReceiptStoreBusyError("SqliteReceiptStore: database busy (SQLITE_BUSY/LOCKED)");
+  }
+  if (isSqliteUnavailableError(err)) {
+    return new ReceiptStoreUnavailableError(
+      `SqliteReceiptStore: storage error (${
+        err instanceof BetterSqlite3.SqliteError ? err.code : "unknown"
+      })`,
+    );
+  }
+  return err instanceof Error ? err : new Error(String(err));
 }
 
 function projectionThreadId(receipt: ReceiptSnapshot): ThreadId | null {

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -15,6 +15,7 @@ import {
   type ListFilter,
   type ListPage,
   type ReceiptStore,
+  ReceiptStoreFullError,
   resolveListLimit,
 } from "./receipt-store.ts";
 
@@ -110,6 +111,15 @@ export class SqliteReceiptStore implements ReceiptStore {
       if (isReceiptIdConstraintError(err)) {
         return { existed: true };
       }
+      // SQLITE_FULL = filesystem out of space (or page-cache limit hit).
+      // Surface as `ReceiptStoreFullError` so the HTTP route reuses the
+      // same 507 path the in-memory store uses for its byte-count cap
+      // (security triangulation T12). Without this mapping the route
+      // would log a 500 and the operator would have to read the stack
+      // trace to learn that a disk-full condition was the cause.
+      if (isSqliteFullError(err)) {
+        throw new ReceiptStoreFullError("SqliteReceiptStore: database full (SQLITE_FULL)");
+      }
       throw err;
     }
   }
@@ -170,4 +180,8 @@ function isReceiptIdConstraintError(err: unknown): boolean {
     (err.code === "SQLITE_CONSTRAINT_PRIMARYKEY" || err.code === "SQLITE_CONSTRAINT_UNIQUE") &&
     err.message.includes("receipts_projection.receipt_id")
   );
+}
+
+function isSqliteFullError(err: unknown): boolean {
+  return err instanceof BetterSqlite3.SqliteError && err.code === "SQLITE_FULL";
 }

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -81,20 +81,6 @@ export class SqliteReceiptStore implements ReceiptStore {
     }
   }
 
-  /**
-   * Test-only factory that constructs a store against a caller-supplied
-   * `Database` handle, skipping migrations. Tests use this to inject a
-   * pre-migrated `:memory:` DB or to stub the event log. Production
-   * callers MUST use `static open()` so migrations always run.
-   */
-  static forTesting(
-    db: Database.Database,
-    eventLog?: EventLog,
-    maxReceipts?: number,
-  ): SqliteReceiptStore {
-    return new SqliteReceiptStore(db, eventLog, maxReceipts);
-  }
-
   private constructor(
     private readonly db: Database.Database,
     eventLog: EventLog = createEventLog(db),

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -15,12 +15,27 @@ import {
   type ListFilter,
   type ListPage,
   type ReceiptStore,
+  ReceiptStoreBusyError,
   ReceiptStoreFullError,
+  ReceiptStoreUnavailableError,
   resolveListLimit,
 } from "./receipt-store.ts";
 
+// Default receipt count cap for the durable store. Sized 10x the
+// `InMemoryReceiptStore` default to reflect the additional headroom of
+// disk-backed storage, while still bounding an authenticated hostile
+// client's disk-fill DoS (security triangulation R2-S1). Hosts can raise
+// or lower via `SqliteReceiptStore.open({ path, maxReceipts })`.
+const DEFAULT_SQLITE_MAX_RECEIPTS = 100_000;
+
 export interface SqliteReceiptStoreConfig {
   readonly path: string;
+  /**
+   * Maximum number of receipts the store will accept. `put` throws
+   * `ReceiptStoreFullError` once the projection table holds this many
+   * rows. Defaults to `DEFAULT_SQLITE_MAX_RECEIPTS` (100_000).
+   */
+  readonly maxReceipts?: number;
 }
 
 interface ReceiptExistsRow {
@@ -40,6 +55,7 @@ type ProjectionInsertParams = [ReceiptId, ThreadId | null, number, number, Buffe
 
 export class SqliteReceiptStore implements ReceiptStore {
   private readonly eventLog: EventLog;
+  private readonly maxReceipts: number;
   private readonly receiptExistsStmt: Database.Statement<[ReceiptId], ReceiptExistsRow>;
   private readonly insertProjectionStmt: Database.Statement<ProjectionInsertParams>;
   private readonly getPayloadStmt: Database.Statement<[ReceiptId], ProjectionPayloadRow>;
@@ -58,7 +74,7 @@ export class SqliteReceiptStore implements ReceiptStore {
     const db = openDatabase(config);
     try {
       runMigrations(db);
-      return new SqliteReceiptStore(db);
+      return new SqliteReceiptStore(db, undefined, config.maxReceipts);
     } catch (err) {
       db.close();
       throw err;
@@ -68,8 +84,16 @@ export class SqliteReceiptStore implements ReceiptStore {
   constructor(
     private readonly db: Database.Database,
     eventLog: EventLog = createEventLog(db),
+    maxReceipts: number | undefined = undefined,
   ) {
     this.eventLog = eventLog;
+    const requestedMax = maxReceipts ?? DEFAULT_SQLITE_MAX_RECEIPTS;
+    if (!Number.isInteger(requestedMax) || requestedMax <= 0) {
+      throw new Error(
+        `SqliteReceiptStore: maxReceipts must be a positive integer, got ${requestedMax}`,
+      );
+    }
+    this.maxReceipts = requestedMax;
     this.receiptExistsStmt = db.prepare<[ReceiptId], ReceiptExistsRow>(
       "SELECT 1 AS present FROM receipts_projection WHERE receipt_id = ?",
     );
@@ -89,6 +113,15 @@ export class SqliteReceiptStore implements ReceiptStore {
     this.putTransaction = db.transaction((receipt: ReceiptSnapshot) => {
       if (this.receiptExistsStmt.get(receipt.id) !== undefined) {
         return { existed: true };
+      }
+      // Cap check runs AFTER the existence check (mirrors the in-memory
+      // store, T12 + R2-S1): a duplicate POST against a store at capacity
+      // still returns 409, not 507. The count query inside the
+      // `BEGIN IMMEDIATE` transaction is serialized against concurrent
+      // writers, so the check + insert are atomic.
+      const countRow = this.countStmt.get();
+      if (countRow !== undefined && countRow.count >= this.maxReceipts) {
+        throw new ReceiptStoreFullError(`SqliteReceiptStore at capacity (${this.maxReceipts})`);
       }
 
       const payload = Buffer.from(receiptToJson(receipt), "utf8");
@@ -114,11 +147,24 @@ export class SqliteReceiptStore implements ReceiptStore {
       // SQLITE_FULL = filesystem out of space (or page-cache limit hit).
       // Surface as `ReceiptStoreFullError` so the HTTP route reuses the
       // same 507 path the in-memory store uses for its byte-count cap
-      // (security triangulation T12). Without this mapping the route
-      // would log a 500 and the operator would have to read the stack
-      // trace to learn that a disk-full condition was the cause.
+      // (security triangulation T12).
       if (isSqliteFullError(err)) {
         throw new ReceiptStoreFullError("SqliteReceiptStore: database full (SQLITE_FULL)");
+      }
+      // sre triangulation R2-SRE2: classify the remaining SQLite error
+      // codes so the route can map them to 503 (busy = retryable;
+      // readonly/IOERR = persistent) instead of a generic 500. The
+      // operator's on-call view goes from "internal_error" to a
+      // structured reason that tells them whether a retry will help.
+      if (isSqliteBusyError(err)) {
+        throw new ReceiptStoreBusyError("SqliteReceiptStore: database busy (SQLITE_BUSY/LOCKED)");
+      }
+      if (isSqliteUnavailableError(err)) {
+        throw new ReceiptStoreUnavailableError(
+          `SqliteReceiptStore: storage error (${
+            err instanceof BetterSqlite3.SqliteError ? err.code : "unknown"
+          })`,
+        );
       }
       throw err;
     }
@@ -184,4 +230,33 @@ function isReceiptIdConstraintError(err: unknown): boolean {
 
 function isSqliteFullError(err: unknown): boolean {
   return err instanceof BetterSqlite3.SqliteError && err.code === "SQLITE_FULL";
+}
+
+function isSqliteBusyError(err: unknown): boolean {
+  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
+  // SQLITE_BUSY / SQLITE_LOCKED + extended-code variants. The base
+  // codes also surface as extended codes like `SQLITE_BUSY_SNAPSHOT`.
+  return (
+    err.code === "SQLITE_BUSY" ||
+    err.code === "SQLITE_LOCKED" ||
+    err.code.startsWith("SQLITE_BUSY_") ||
+    err.code.startsWith("SQLITE_LOCKED_")
+  );
+}
+
+function isSqliteUnavailableError(err: unknown): boolean {
+  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
+  // Persistent / operator-intervention failure modes: read-only DB,
+  // I/O errors at any layer, corruption, can't-open. SQLITE_FULL is
+  // handled separately because it maps to 507 (out of space, distinct
+  // from "store is broken").
+  return (
+    err.code === "SQLITE_READONLY" ||
+    err.code === "SQLITE_CANTOPEN" ||
+    err.code === "SQLITE_CORRUPT" ||
+    err.code.startsWith("SQLITE_READONLY_") ||
+    err.code.startsWith("SQLITE_IOERR") ||
+    err.code.startsWith("SQLITE_CANTOPEN_") ||
+    err.code.startsWith("SQLITE_CORRUPT_")
+  );
 }

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -24,8 +24,8 @@ import {
 // Default receipt count cap for the durable store. Sized 10x the
 // `InMemoryReceiptStore` default to reflect the additional headroom of
 // disk-backed storage, while still bounding an authenticated hostile
-// client's disk-fill DoS (security triangulation R2-S1). Hosts can raise
-// or lower via `SqliteReceiptStore.open({ path, maxReceipts })`.
+// client's disk-fill DoS. Hosts can raise or lower via
+// `SqliteReceiptStore.open({ path, maxReceipts })`.
 const DEFAULT_SQLITE_MAX_RECEIPTS = 100_000;
 
 export interface SqliteReceiptStoreConfig {
@@ -81,7 +81,21 @@ export class SqliteReceiptStore implements ReceiptStore {
     }
   }
 
-  constructor(
+  /**
+   * Test-only factory that constructs a store against a caller-supplied
+   * `Database` handle, skipping migrations. Tests use this to inject a
+   * pre-migrated `:memory:` DB or to stub the event log. Production
+   * callers MUST use `static open()` so migrations always run.
+   */
+  static forTesting(
+    db: Database.Database,
+    eventLog?: EventLog,
+    maxReceipts?: number,
+  ): SqliteReceiptStore {
+    return new SqliteReceiptStore(db, eventLog, maxReceipts);
+  }
+
+  private constructor(
     private readonly db: Database.Database,
     eventLog: EventLog = createEventLog(db),
     maxReceipts: number | undefined = undefined,
@@ -115,8 +129,8 @@ export class SqliteReceiptStore implements ReceiptStore {
         return { existed: true };
       }
       // Cap check runs AFTER the existence check (mirrors the in-memory
-      // store, T12 + R2-S1): a duplicate POST against a store at capacity
-      // still returns 409, not 507. The count query inside the
+      // store): a duplicate POST against a store at capacity still
+      // returns 409, not 507. The count query inside the
       // `BEGIN IMMEDIATE` transaction is serialized against concurrent
       // writers, so the check + insert are atomic.
       const countRow = this.countStmt.get();
@@ -146,16 +160,15 @@ export class SqliteReceiptStore implements ReceiptStore {
       }
       // SQLITE_FULL = filesystem out of space (or page-cache limit hit).
       // Surface as `ReceiptStoreFullError` so the HTTP route reuses the
-      // same 507 path the in-memory store uses for its byte-count cap
-      // (security triangulation T12).
+      // same 507 path the in-memory store uses for its byte-count cap.
       if (isSqliteFullError(err)) {
         throw new ReceiptStoreFullError("SqliteReceiptStore: database full (SQLITE_FULL)");
       }
-      // sre triangulation R2-SRE2: classify the remaining SQLite error
-      // codes so the route can map them to 503 (busy = retryable;
-      // readonly/IOERR = persistent) instead of a generic 500. The
-      // operator's on-call view goes from "internal_error" to a
-      // structured reason that tells them whether a retry will help.
+      // Classify the remaining SQLite error codes so the route can map
+      // them to 503 (busy = retryable; readonly/IOERR = persistent)
+      // instead of a generic 500. The operator's on-call view goes
+      // from "internal_error" to a structured reason that tells them
+      // whether a retry will help.
       if (isSqliteBusyError(err)) {
         throw new ReceiptStoreBusyError("SqliteReceiptStore: database busy (SQLITE_BUSY/LOCKED)");
       }

--- a/packages/broker/src/types.ts
+++ b/packages/broker/src/types.ts
@@ -62,6 +62,12 @@ export interface BrokerConfig {
    * `@wuphf/broker/sqlite`. The interface is intentionally minimal:
    * idempotency-key semantics (byte-identical retry returns 200 no-op)
    * are deferred to a future widening of `put`'s return shape.
+   *
+   * Ownership: when a host supplies its own `receiptStore`, the host
+   * owns its lifecycle. `broker.stop()` closes the HTTP/WebSocket
+   * surface and the WS server but does NOT close the injected store —
+   * call `store.close()` (or equivalent) after `broker.stop()` to
+   * release any underlying handle.
    */
   readonly receiptStore?: ReceiptStore;
 }

--- a/packages/broker/src/types.ts
+++ b/packages/broker/src/types.ts
@@ -58,11 +58,10 @@ export interface BrokerConfig {
   /**
    * Receipt persistence backend. When absent, `createBroker` constructs
    * an in-memory store (`InMemoryReceiptStore`) — process-local, lost
-   * across restarts. Branch 6 (`feat/event-log-projections`) will ship a
-   * durable event-log implementation. The interface in branch 5 is
-   * intentionally minimal; branch 6 will widen `put`'s return shape to
-   * express byte-identical-retry semantics (which the current
-   * `{ existed: boolean }` cannot represent without route-handler help).
+   * across restarts. Durable hosts pass a `SqliteReceiptStore` from
+   * `@wuphf/broker/sqlite`. The interface is intentionally minimal:
+   * idempotency-key semantics (byte-identical retry returns 200 no-op)
+   * are deferred to a future widening of `put`'s return shape.
    */
   readonly receiptStore?: ReceiptStore;
 }

--- a/packages/broker/tests/event-log.spec.ts
+++ b/packages/broker/tests/event-log.spec.ts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createEventLog, openDatabase, runMigrations } from "../src/event-log/index.ts";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "wuphf-event-log-"));
+  tempDirs.push(dir);
+  return join(dir, "event-log.sqlite");
+}
+
+describe("event log", () => {
+  it("append assigns monotonically increasing LSNs", () => {
+    const db = openDatabase({ path: ":memory:" });
+    try {
+      runMigrations(db);
+      const eventLog = createEventLog(db);
+
+      const first = eventLog.append({ type: "receipt.put", payload: Buffer.from("one") });
+      const second = eventLog.append({ type: "receipt.put", payload: Buffer.from("two") });
+      const third = eventLog.append({ type: "receipt.put", payload: Buffer.from("three") });
+
+      expect([first, second, third]).toEqual([1, 2, 3]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("readFromLsn skips rows at or before fromLsn and honors limit", () => {
+    const db = openDatabase({ path: ":memory:" });
+    try {
+      runMigrations(db);
+      const eventLog = createEventLog(db);
+      for (let i = 1; i <= 12; i += 1) {
+        eventLog.append({ type: "receipt.put", payload: Buffer.from(`payload-${i}`) });
+      }
+
+      expect(eventLog.readFromLsn(0, 10).map((record) => record.lsn)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      ]);
+      expect(eventLog.readFromLsn(5, 10).map((record) => record.lsn)).toEqual([
+        6, 7, 8, 9, 10, 11, 12,
+      ]);
+      expect(eventLog.readFromLsn(9_999, 10)).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("highestLsn returns zero for an empty log and then tracks the last append", () => {
+    const db = openDatabase({ path: ":memory:" });
+    try {
+      runMigrations(db);
+      const eventLog = createEventLog(db);
+
+      expect(eventLog.highestLsn()).toBe(0);
+      eventLog.append({ type: "receipt.put", payload: Buffer.from("one") });
+      const last = eventLog.append({ type: "receipt.put", payload: Buffer.from("two") });
+
+      expect(eventLog.highestLsn()).toBe(last);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("migrations are idempotent across repeated opens", () => {
+    const path = tempDbPath();
+    const first = openDatabase({ path });
+    try {
+      runMigrations(first);
+      expect(first.pragma("user_version", { simple: true })).toBe(1);
+      expect(
+        first
+          .prepare<[], { readonly name: string }>(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'event_log'",
+          )
+          .get()?.name,
+      ).toBe("event_log");
+    } finally {
+      first.close();
+    }
+
+    const second = openDatabase({ path });
+    try {
+      runMigrations(second);
+      expect(second.pragma("user_version", { simple: true })).toBe(1);
+      expect(
+        second
+          .prepare<[], { readonly name: string }>(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'receipts_projection'",
+          )
+          .get()?.name,
+      ).toBe("receipts_projection");
+    } finally {
+      second.close();
+    }
+  });
+});

--- a/packages/broker/tests/receipt-store-parity.spec.ts
+++ b/packages/broker/tests/receipt-store-parity.spec.ts
@@ -1,0 +1,238 @@
+import {
+  asAgentSlug,
+  asProviderKind,
+  asReceiptId,
+  asTaskId,
+  asThreadId,
+  type ReceiptSnapshot,
+  SanitizedString,
+  sha256Hex,
+} from "@wuphf/protocol";
+import { describe, expect, it } from "vitest";
+
+import {
+  encodeListCursor,
+  InMemoryReceiptStore,
+  MAX_LIST_LIMIT,
+  type ReceiptStore,
+} from "../src/receipt-store.ts";
+import { SqliteReceiptStore } from "../src/sqlite-receipt-store.ts";
+
+const TASK_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
+const THREAD_A = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
+const THREAD_B = "01ARZ3NDEKTSV4RRFFQ69G5FB0";
+const ULID_TIME_PREFIX = "01ARZ3NDEK";
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+function minimalReceiptV1(id: string): ReceiptSnapshot {
+  return {
+    id: asReceiptId(id),
+    agentSlug: asAgentSlug("a"),
+    taskId: asTaskId(TASK_ID),
+    triggerKind: "human_message",
+    triggerRef: "m",
+    startedAt: new Date("2026-01-01T00:00:00.000Z"),
+    finishedAt: new Date("2026-01-01T00:01:00.000Z"),
+    status: "ok",
+    providerKind: asProviderKind("anthropic"),
+    model: "m",
+    promptHash: sha256Hex("p"),
+    toolManifest: sha256Hex("t"),
+    toolCalls: [],
+    approvals: [],
+    filesChanged: [],
+    commits: [],
+    sourceReads: [],
+    writes: [],
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    finalMessage: SanitizedString.fromUnknown(""),
+    error: SanitizedString.fromUnknown(""),
+    notebookWrites: [],
+    wikiWrites: [],
+    schemaVersion: 1,
+  };
+}
+
+function minimalReceiptV2(id: string, threadIdStr: string): ReceiptSnapshot {
+  return { ...minimalReceiptV1(id), threadId: asThreadId(threadIdStr), schemaVersion: 2 };
+}
+
+function receiptIdAt(index: number): string {
+  let value = index;
+  let suffix = "";
+  for (let i = 0; i < 16; i += 1) {
+    suffix = ULID_ALPHABET[value % ULID_ALPHABET.length] + suffix;
+    value = Math.floor(value / ULID_ALPHABET.length);
+  }
+  return `${ULID_TIME_PREFIX}${suffix}`;
+}
+
+function closeStore(store: ReceiptStore): void {
+  if (hasClose(store)) {
+    store.close();
+  }
+}
+
+function hasClose(store: ReceiptStore): store is ReceiptStore & { readonly close: () => void } {
+  const candidate = store as { readonly close?: unknown };
+  return typeof candidate.close === "function";
+}
+
+function runReceiptStoreContractTests(factory: () => Promise<ReceiptStore>): void {
+  it("put + get round-trips a receipt", async () => {
+    const store = await factory();
+    try {
+      const receipt = minimalReceiptV1(receiptIdAt(1));
+
+      expect(await store.put(receipt)).toEqual({ existed: false });
+      expect(await store.get(receipt.id)).toEqual(receipt);
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it("duplicate put returns existed:true and does not overwrite", async () => {
+    const store = await factory();
+    try {
+      const first = minimalReceiptV1(receiptIdAt(1));
+      const second = { ...first, model: "different" };
+
+      await store.put(first);
+      expect(await store.put(second)).toEqual({ existed: true });
+      expect(await store.get(first.id)).toEqual(first);
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it("list returns receipts in insertion/LSN order", async () => {
+    const store = await factory();
+    try {
+      const receipts = [
+        minimalReceiptV1(receiptIdAt(1)),
+        minimalReceiptV1(receiptIdAt(2)),
+        minimalReceiptV1(receiptIdAt(3)),
+      ];
+      for (const receipt of receipts) {
+        await store.put(receipt);
+      }
+
+      const page = await store.list();
+
+      expect(page.items.map((receipt) => receipt.id)).toEqual(
+        receipts.map((receipt) => receipt.id),
+      );
+      expect(page.nextCursor).toBeNull();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it("cursor pagination returns byte-identical cursors for the same logical LSN", async () => {
+    const store = await factory();
+    try {
+      const receipts = [
+        minimalReceiptV1(receiptIdAt(1)),
+        minimalReceiptV1(receiptIdAt(2)),
+        minimalReceiptV1(receiptIdAt(3)),
+        minimalReceiptV1(receiptIdAt(4)),
+        minimalReceiptV1(receiptIdAt(5)),
+      ];
+      for (const receipt of receipts) {
+        await store.put(receipt);
+      }
+
+      const firstPage = await store.list({ limit: 2 });
+      expect(firstPage.items.map((receipt) => receipt.id)).toEqual(
+        receipts.slice(0, 2).map((receipt) => receipt.id),
+      );
+      expect(firstPage.nextCursor).toBe(encodeListCursor(2));
+      if (firstPage.nextCursor === null) {
+        throw new Error("expected first page cursor");
+      }
+
+      const secondPage = await store.list({ limit: 2, cursor: firstPage.nextCursor });
+      expect(secondPage.items.map((receipt) => receipt.id)).toEqual(
+        receipts.slice(2, 4).map((receipt) => receipt.id),
+      );
+      expect(secondPage.nextCursor).toBe(encodeListCursor(4));
+      if (secondPage.nextCursor === null) {
+        throw new Error("expected second page cursor");
+      }
+
+      const thirdPage = await store.list({ limit: 2, cursor: secondPage.nextCursor });
+      expect(thirdPage.items.map((receipt) => receipt.id)).toEqual(
+        receipts.slice(4).map((receipt) => receipt.id),
+      );
+      expect(thirdPage.nextCursor).toBeNull();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it("threadId filter returns only that thread in LSN order", async () => {
+    const store = await factory();
+    try {
+      const a1 = minimalReceiptV2(receiptIdAt(1), THREAD_A);
+      const b1 = minimalReceiptV2(receiptIdAt(2), THREAD_B);
+      const a2 = minimalReceiptV2(receiptIdAt(3), THREAD_A);
+      await store.put(a1);
+      await store.put(b1);
+      await store.put(a2);
+
+      const page = await store.list({ threadId: asThreadId(THREAD_A) });
+
+      expect(page.items.map((receipt) => receipt.id)).toEqual([a1.id, a2.id]);
+      expect(page.nextCursor).toBeNull();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it("threadId filter excludes V1 receipts", async () => {
+    const store = await factory();
+    try {
+      const v1 = minimalReceiptV1(receiptIdAt(1));
+      const v2 = minimalReceiptV2(receiptIdAt(2), THREAD_A);
+      await store.put(v1);
+      await store.put(v2);
+
+      const page = await store.list({ threadId: asThreadId(THREAD_A) });
+
+      expect(page.items.map((receipt) => receipt.id)).toEqual([v2.id]);
+      expect(page.nextCursor).toBeNull();
+    } finally {
+      closeStore(store);
+    }
+  });
+
+  it("limit clamping returns at most MAX_LIST_LIMIT rows and a cursor when more exist", async () => {
+    const store = await factory();
+    try {
+      for (let i = 1; i <= MAX_LIST_LIMIT + 1; i += 1) {
+        await store.put(minimalReceiptV1(receiptIdAt(i)));
+      }
+
+      const page = await store.list({ limit: MAX_LIST_LIMIT + 5_000 });
+
+      expect(page.items).toHaveLength(MAX_LIST_LIMIT);
+      expect(page.nextCursor).toBe(encodeListCursor(MAX_LIST_LIMIT));
+    } finally {
+      closeStore(store);
+    }
+  });
+}
+
+describe("ReceiptStore parity", () => {
+  describe("InMemoryReceiptStore", () => {
+    runReceiptStoreContractTests(async () => new InMemoryReceiptStore());
+  });
+
+  describe("SqliteReceiptStore", () => {
+    runReceiptStoreContractTests(async () => SqliteReceiptStore.open({ path: ":memory:" }));
+  });
+});

--- a/packages/broker/tests/receipt-store.spec.ts
+++ b/packages/broker/tests/receipt-store.spec.ts
@@ -180,10 +180,53 @@ describe("InMemoryReceiptStore", () => {
     await expect(store.list({ cursor: "not-base64-!@#" })).rejects.toBeInstanceOf(
       InvalidListCursorError,
     );
-    // Base64 of "foo:1" — wrong prefix.
+    // Base64url of "foo:1" — wrong prefix.
     await expect(
       store.list({ cursor: Buffer.from("foo:1", "utf8").toString("base64url") }),
     ).rejects.toBeInstanceOf(InvalidListCursorError);
+    // Non-canonical base64url: `bHNuOjE!` decodes to `lsn:1` via Node's
+    // permissive `Buffer.from(_, "base64url")`. Strict alphabet validation
+    // rejects this (triangulation T5).
+    await expect(store.list({ cursor: "bHNuOjE!" })).rejects.toBeInstanceOf(InvalidListCursorError);
+    // Trailing padding (`=`) is not part of canonical unpadded base64url.
+    const padded = `${Buffer.from("lsn:1", "utf8").toString("base64url")}=`;
+    await expect(store.list({ cursor: padded })).rejects.toBeInstanceOf(InvalidListCursorError);
+    // LSN with leading zeros — not canonical decimal.
+    await expect(
+      store.list({ cursor: Buffer.from("lsn:01", "utf8").toString("base64url") }),
+    ).rejects.toBeInstanceOf(InvalidListCursorError);
+    // LSN zero — cursors are issued only after at least one item is returned,
+    // so the smallest legal LSN inside a cursor is 1.
+    await expect(
+      store.list({ cursor: Buffer.from("lsn:0", "utf8").toString("base64url") }),
+    ).rejects.toBeInstanceOf(InvalidListCursorError);
+    // LSN above MAX_SAFE_INTEGER — JS rounding makes comparisons unstable.
+    const unsafe = `${String(Number.MAX_SAFE_INTEGER)}0`; // 9_007_199_254_740_9910
+    await expect(
+      store.list({ cursor: Buffer.from(`lsn:${unsafe}`, "utf8").toString("base64url") }),
+    ).rejects.toBeInstanceOf(InvalidListCursorError);
+  });
+
+  it("InvalidListCursorError carries a constant message (no echoed input)", async () => {
+    const store = new InMemoryReceiptStore();
+    const hostile = "<script>alert('xss')</script>";
+    try {
+      await store.list({ cursor: hostile });
+      throw new Error("expected InvalidListCursorError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidListCursorError);
+      // Security T6: the raw cursor MUST NOT appear in the error message
+      // — it is hostile input and could land in log payloads.
+      expect((err as Error).message).toBe("invalid_list_cursor");
+      expect((err as Error).message).not.toContain(hostile);
+    }
+  });
+
+  it("encodeListCursor rejects non-positive or unsafe LSNs", () => {
+    expect(() => encodeListCursor(0)).toThrow(/positive safe integer/);
+    expect(() => encodeListCursor(-1)).toThrow(/positive safe integer/);
+    expect(() => encodeListCursor(1.5)).toThrow(/positive safe integer/);
+    expect(() => encodeListCursor(Number.MAX_SAFE_INTEGER + 1)).toThrow(/positive safe integer/);
   });
 
   it("encodeListCursor round-trip skips items at or before the encoded LSN", async () => {

--- a/packages/broker/tests/receipt-store.spec.ts
+++ b/packages/broker/tests/receipt-store.spec.ts
@@ -185,8 +185,8 @@ describe("InMemoryReceiptStore", () => {
       store.list({ cursor: Buffer.from("foo:1", "utf8").toString("base64url") }),
     ).rejects.toBeInstanceOf(InvalidListCursorError);
     // Non-canonical base64url: `bHNuOjE!` decodes to `lsn:1` via Node's
-    // permissive `Buffer.from(_, "base64url")`. Strict alphabet validation
-    // rejects this (triangulation T5).
+    // permissive `Buffer.from(_, "base64url")`. Strict alphabet
+    // validation rejects this.
     await expect(store.list({ cursor: "bHNuOjE!" })).rejects.toBeInstanceOf(InvalidListCursorError);
     // Trailing padding (`=`) is not part of canonical unpadded base64url.
     const padded = `${Buffer.from("lsn:1", "utf8").toString("base64url")}=`;
@@ -206,7 +206,7 @@ describe("InMemoryReceiptStore", () => {
       store.list({ cursor: Buffer.from(`lsn:${unsafe}`, "utf8").toString("base64url") }),
     ).rejects.toBeInstanceOf(InvalidListCursorError);
     // Non-canonical base64url aliases that decode to `lsn:1` via Node's
-    // permissive decoder but fail strict round-trip (R2-A1). The
+    // permissive decoder but fail strict round-trip. The
     // canonical cursor for LSN 1 is `bHNuOjE`; these are aliases that
     // a strict Go/Rust raw_url decoder would reject.
     for (const alias of ["bHNuOjF", "bHNuOjG", "bHNuOjH"]) {

--- a/packages/broker/tests/receipt-store.spec.ts
+++ b/packages/broker/tests/receipt-store.spec.ts
@@ -205,6 +205,13 @@ describe("InMemoryReceiptStore", () => {
     await expect(
       store.list({ cursor: Buffer.from(`lsn:${unsafe}`, "utf8").toString("base64url") }),
     ).rejects.toBeInstanceOf(InvalidListCursorError);
+    // Non-canonical base64url aliases that decode to `lsn:1` via Node's
+    // permissive decoder but fail strict round-trip (R2-A1). The
+    // canonical cursor for LSN 1 is `bHNuOjE`; these are aliases that
+    // a strict Go/Rust raw_url decoder would reject.
+    for (const alias of ["bHNuOjF", "bHNuOjG", "bHNuOjH"]) {
+      await expect(store.list({ cursor: alias })).rejects.toBeInstanceOf(InvalidListCursorError);
+    }
   });
 
   it("InvalidListCursorError carries a constant message (no echoed input)", async () => {

--- a/packages/broker/tests/receipt-store.spec.ts
+++ b/packages/broker/tests/receipt-store.spec.ts
@@ -10,7 +10,14 @@ import {
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
 
-import { InMemoryReceiptStore, ReceiptStoreFullError } from "../src/receipt-store.ts";
+import {
+  encodeListCursor,
+  InMemoryReceiptStore,
+  InvalidListCursorError,
+  InvalidListLimitError,
+  MAX_LIST_LIMIT,
+  ReceiptStoreFullError,
+} from "../src/receipt-store.ts";
 
 const TASK_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
 const THREAD_A = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
@@ -77,7 +84,7 @@ describe("InMemoryReceiptStore", () => {
     expect(await store.get(asReceiptId("01ARZ3NDEKTSV4RRFFQ69G5FAV"))).toBeNull();
   });
 
-  it("list() returns receipts in insertion order", async () => {
+  it("list() returns receipts in insertion (LSN) order", async () => {
     const store = new InMemoryReceiptStore();
     const a = minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAV");
     const b = minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAY");
@@ -86,7 +93,8 @@ describe("InMemoryReceiptStore", () => {
     await store.put(b);
     await store.put(c);
     const all = await store.list();
-    expect(all.map((r) => r.id)).toEqual([a.id, b.id, c.id]);
+    expect(all.items.map((r) => r.id)).toEqual([a.id, b.id, c.id]);
+    expect(all.nextCursor).toBeNull();
   });
 
   it("list({threadId}) filters to v2 receipts of that thread", async () => {
@@ -98,7 +106,8 @@ describe("InMemoryReceiptStore", () => {
     await store.put(b);
     await store.put(c);
     const inA = await store.list({ threadId: asThreadId(THREAD_A) });
-    expect(inA.map((r) => r.id).sort()).toEqual([a.id, c.id].sort());
+    expect(inA.items.map((r) => r.id)).toEqual([a.id, c.id]);
+    expect(inA.nextCursor).toBeNull();
   });
 
   it("list({threadId}) excludes v1 receipts (no threadId)", async () => {
@@ -106,14 +115,89 @@ describe("InMemoryReceiptStore", () => {
     await store.put(minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAV"));
     await store.put(minimalReceiptV2("01ARZ3NDEKTSV4RRFFQ69G5FAY", THREAD_A));
     const inA = await store.list({ threadId: asThreadId(THREAD_A) });
-    expect(inA.map((r) => r.id)).toEqual(["01ARZ3NDEKTSV4RRFFQ69G5FAY"]);
+    expect(inA.items.map((r) => r.id)).toEqual(["01ARZ3NDEKTSV4RRFFQ69G5FAY"]);
+    expect(inA.nextCursor).toBeNull();
   });
 
-  it("list({threadId}) returns [] for unknown thread", async () => {
+  it("list({threadId}) returns empty page for unknown thread", async () => {
     const store = new InMemoryReceiptStore();
     await store.put(minimalReceiptV2("01ARZ3NDEKTSV4RRFFQ69G5FAV", THREAD_A));
     const inB = await store.list({ threadId: asThreadId(THREAD_B) });
-    expect(inB).toEqual([]);
+    expect(inB.items).toEqual([]);
+    expect(inB.nextCursor).toBeNull();
+  });
+
+  it("list paginates with cursor + limit and exposes a nextCursor for more pages", async () => {
+    const store = new InMemoryReceiptStore();
+    const ids = [
+      "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+      "01ARZ3NDEKTSV4RRFFQ69G5FAY",
+      "01ARZ3NDEKTSV4RRFFQ69G5FB1",
+      "01ARZ3NDEKTSV4RRFFQ69G5FB2",
+      "01ARZ3NDEKTSV4RRFFQ69G5FB3",
+    ];
+    for (const id of ids) {
+      await store.put(minimalReceiptV2(id, THREAD_A));
+    }
+    const page1 = await store.list({ threadId: asThreadId(THREAD_A), limit: 2 });
+    expect(page1.items.map((r) => r.id)).toEqual([ids[0], ids[1]]);
+    expect(page1.nextCursor).not.toBeNull();
+    const page2 = await store.list({
+      threadId: asThreadId(THREAD_A),
+      limit: 2,
+      cursor: page1.nextCursor as string,
+    });
+    expect(page2.items.map((r) => r.id)).toEqual([ids[2], ids[3]]);
+    expect(page2.nextCursor).not.toBeNull();
+    const page3 = await store.list({
+      threadId: asThreadId(THREAD_A),
+      limit: 2,
+      cursor: page2.nextCursor as string,
+    });
+    expect(page3.items.map((r) => r.id)).toEqual([ids[4]]);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  it("list clamps limit above MAX_LIST_LIMIT instead of throwing", async () => {
+    const store = new InMemoryReceiptStore();
+    const r = minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+    await store.put(r);
+    const page = await store.list({ limit: MAX_LIST_LIMIT + 5_000 });
+    expect(page.items).toHaveLength(1);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("list throws InvalidListLimitError for non-positive or non-integer limits", async () => {
+    const store = new InMemoryReceiptStore();
+    await expect(store.list({ limit: 0 })).rejects.toBeInstanceOf(InvalidListLimitError);
+    await expect(store.list({ limit: -1 })).rejects.toBeInstanceOf(InvalidListLimitError);
+    await expect(store.list({ limit: 1.5 })).rejects.toBeInstanceOf(InvalidListLimitError);
+  });
+
+  it("list throws InvalidListCursorError for malformed cursors", async () => {
+    const store = new InMemoryReceiptStore();
+    await expect(store.list({ cursor: "" })).rejects.toBeInstanceOf(InvalidListCursorError);
+    await expect(store.list({ cursor: "not-base64-!@#" })).rejects.toBeInstanceOf(
+      InvalidListCursorError,
+    );
+    // Base64 of "foo:1" — wrong prefix.
+    await expect(
+      store.list({ cursor: Buffer.from("foo:1", "utf8").toString("base64url") }),
+    ).rejects.toBeInstanceOf(InvalidListCursorError);
+  });
+
+  it("encodeListCursor round-trip skips items at or before the encoded LSN", async () => {
+    const store = new InMemoryReceiptStore();
+    await store.put(minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAV"));
+    await store.put(minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAY"));
+    await store.put(minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FB1"));
+    // LSN 1 means "skip the first item, return everything after".
+    const after1 = await store.list({ cursor: encodeListCursor(1) });
+    expect(after1.items.map((r) => r.id)).toEqual([
+      "01ARZ3NDEKTSV4RRFFQ69G5FAY",
+      "01ARZ3NDEKTSV4RRFFQ69G5FB1",
+    ]);
+    expect(after1.nextCursor).toBeNull();
   });
 
   it("size reflects byId count, not thread-index count", async () => {

--- a/packages/broker/tests/receipts.spec.ts
+++ b/packages/broker/tests/receipts.spec.ts
@@ -675,6 +675,84 @@ describe("receipts API", () => {
       expect(await res.json()).toEqual({ error: "storage_error" });
     });
 
+    it("GET /api/receipts/:id maps ReceiptStoreBusyError to 503 + Retry-After", async () => {
+      const store: ReceiptStore = {
+        async put() {
+          return { existed: false };
+        },
+        async get() {
+          throw new ReceiptStoreBusyError("test busy");
+        },
+        async list() {
+          return { items: [], nextCursor: null };
+        },
+        size() {
+          return 0;
+        },
+      };
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/receipts/${RECEIPT_ID_A}`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+      expect(await res.json()).toEqual({ error: "store_busy" });
+    });
+
+    it("GET /api/receipts/:id maps ReceiptStoreUnavailableError to 503 storage_error", async () => {
+      const store: ReceiptStore = {
+        async put() {
+          return { existed: false };
+        },
+        async get() {
+          throw new ReceiptStoreUnavailableError("test readonly");
+        },
+        async list() {
+          return { items: [], nextCursor: null };
+        },
+        size() {
+          return 0;
+        },
+      };
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/receipts/${RECEIPT_ID_A}`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBeNull();
+      expect(await res.json()).toEqual({ error: "storage_error" });
+    });
+
+    it("GET /api/threads/:tid/receipts maps storage errors to 503", async () => {
+      const store: ReceiptStore = {
+        async put() {
+          return { existed: false };
+        },
+        async get() {
+          return null;
+        },
+        async list() {
+          throw new ReceiptStoreBusyError("test busy");
+        },
+        size() {
+          return 0;
+        },
+      };
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+      expect(await res.json()).toEqual({ error: "store_busy" });
+    });
+
     it("excludes V1 receipts (which have no threadId)", async () => {
       broker = await createBroker({ port: 0, token: FIXED_TOKEN });
       // V1 has no threadId; the secondary index never sees it. Storing

--- a/packages/broker/tests/receipts.spec.ts
+++ b/packages/broker/tests/receipts.spec.ts
@@ -15,7 +15,12 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import type { BrokerHandle } from "../src/index.ts";
 import { createBroker } from "../src/index.ts";
-import { InMemoryReceiptStore } from "../src/receipt-store.ts";
+import {
+  InMemoryReceiptStore,
+  type ReceiptStore,
+  ReceiptStoreBusyError,
+  ReceiptStoreUnavailableError,
+} from "../src/receipt-store.ts";
 
 const FIXED_TOKEN = asApiToken("test-token-with-enough-entropy-AAAAAAAAA");
 const RECEIPT_ID_A = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
@@ -585,6 +590,88 @@ describe("receipts API", () => {
 
       expect(res.status).toBe(400);
       expect(await res.json()).toEqual({ error: "invalid_cursor" });
+    });
+
+    it("clamps oversized ?limit= in the Link header (R2-A2)", async () => {
+      // The store already clamps internally, but the route must echo
+      // the CLAMPED value in the next-page Link URL — not the caller's
+      // raw `?limit=9999`. Otherwise the route's public contract
+      // (`limit` is 1-1000) is violated and Go/Rust client generators
+      // disagree on the wire shape.
+      const store = new InMemoryReceiptStore({ maxReceipts: 2000 });
+      const template = minimalReceiptV2(RECEIPT_ID_A, THREAD_ID_A);
+      const ALPH = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+      for (let i = 0; i < 1001; i++) {
+        let suffix = "";
+        for (let k = 3; k >= 0; k--) {
+          suffix += ALPH[(i >> (k * 5)) & 31];
+        }
+        const id = `01ARZ3NDEKTSV4RRFFQ69G${suffix}`;
+        await store.put({ ...template, id: asReceiptId(id) });
+      }
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts?limit=9999`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(await res.text()) as unknown[];
+      expect(parsed).toHaveLength(1000); // store clamps to MAX_LIST_LIMIT
+      const linkPath = nextLinkPath(res.headers);
+      // Effective limit (1000) goes into Link, NOT the raw 9999.
+      expect(linkPath).toContain("limit=1000");
+      expect(linkPath).not.toContain("limit=9999");
+    });
+
+    it("maps ReceiptStoreBusyError to 503 + Retry-After (R2-SRE2)", async () => {
+      // Stub a ReceiptStore that throws the new error class on put.
+      // The route should classify it as transient and emit Retry-After.
+      const store: ReceiptStore = {
+        async put() {
+          throw new ReceiptStoreBusyError("test busy");
+        },
+        async get() {
+          return null;
+        },
+        async list() {
+          return { items: [], nextCursor: null };
+        },
+        size() {
+          return 0;
+        },
+      };
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await postReceipt(broker.url, receiptToJson(minimalReceiptV1(RECEIPT_ID_A)));
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBe("1");
+      expect(await res.json()).toEqual({ error: "store_busy" });
+    });
+
+    it("maps ReceiptStoreUnavailableError to 503 without Retry-After (R2-SRE2)", async () => {
+      const store: ReceiptStore = {
+        async put() {
+          throw new ReceiptStoreUnavailableError("test readonly");
+        },
+        async get() {
+          return null;
+        },
+        async list() {
+          return { items: [], nextCursor: null };
+        },
+        size() {
+          return 0;
+        },
+      };
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await postReceipt(broker.url, receiptToJson(minimalReceiptV1(RECEIPT_ID_A)));
+
+      expect(res.status).toBe(503);
+      expect(res.headers.get("retry-after")).toBeNull();
+      expect(await res.json()).toEqual({ error: "storage_error" });
     });
 
     it("excludes V1 receipts (which have no threadId)", async () => {

--- a/packages/broker/tests/receipts.spec.ts
+++ b/packages/broker/tests/receipts.spec.ts
@@ -489,7 +489,13 @@ describe("receipts API", () => {
       expect(last.headers.get("link")).toBeNull();
     });
 
-    it("uses the default list limit when no limit query is present", async () => {
+    it("route default returns up to MAX_LIST_LIMIT receipts when no limit query is present", async () => {
+      // Triangulation T2: the route's default `limit` is `MAX_LIST_LIMIT`
+      // (1000), NOT the store's `DEFAULT_LIST_LIMIT` (100). 150 receipts
+      // fit in a single page so no `Link` header is emitted — this
+      // matches branch-5 behavior where the route returned up to 1000
+      // receipts in one call. Without this, branch-5 callers that ignore
+      // `Link` silently lose receipts 101-1000.
       const store = new InMemoryReceiptStore({ maxReceipts: 200 });
       await seedThreadReceipts(store, 150);
       broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
@@ -500,9 +506,60 @@ describe("receipts API", () => {
 
       expect(res.status).toBe(200);
       const parsed = JSON.parse(await res.text()) as Array<{ id: string }>;
-      expect(parsed.length).toBe(100);
+      expect(parsed.length).toBe(150);
+      expect(res.headers.get("link")).toBeNull();
+    });
+
+    it("route default caps at MAX_LIST_LIMIT (1000) and emits Link when more remain", async () => {
+      // Push past 1000 receipts to prove the default ceiling holds. We
+      // need 1001 valid ULIDs; generate them deterministically via the
+      // Crockford base32 alphabet (ULID-compatible) so each id is
+      // structurally valid for asReceiptId.
+      const store = new InMemoryReceiptStore({ maxReceipts: 2000 });
+      const template = minimalReceiptV2(RECEIPT_ID_A, THREAD_ID_A);
+      const ALPH = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+      for (let i = 0; i < 1001; i++) {
+        let suffix = "";
+        for (let k = 3; k >= 0; k--) {
+          suffix += ALPH[(i >> (k * 5)) & 31];
+        }
+        const id = `01ARZ3NDEKTSV4RRFFQ69G${suffix}`;
+        await store.put({ ...template, id: asReceiptId(id) });
+      }
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(await res.text()) as Array<{ id: string }>;
+      expect(parsed.length).toBe(1000);
+      // Link header present — clients with >1000 receipts must paginate.
+      expect(res.headers.get("link")).not.toBeNull();
+      // Default-limit page omits `limit=` from the Link URL so the next
+      // call inherits the same default.
       const linkPath = nextLinkPath(res.headers);
       expect(linkPath).not.toContain("limit=");
+    });
+
+    it("empty `?cursor=` is treated as no cursor (T9)", async () => {
+      // Architecture triangulation T9: an empty `?cursor=` query value is
+      // ergonomically indistinguishable from "no cursor" at the HTTP
+      // boundary; clients should not have to omit the param entirely
+      // just to start at the beginning. The store still rejects `""`
+      // for direct programmatic callers.
+      const store = new InMemoryReceiptStore();
+      await seedThreadReceipts(store, 3);
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts?cursor=`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(await res.text()) as unknown[];
+      expect(parsed).toHaveLength(3);
     });
 
     it("returns invalid_limit for a zero limit query", async () => {

--- a/packages/broker/tests/receipts.spec.ts
+++ b/packages/broker/tests/receipts.spec.ts
@@ -31,8 +31,9 @@ const THREAD_ID_B = "01ARZ3NDEKTSV4RRFFQ69G5FB0";
 const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 // Builds a minimal valid Receipt v1 (no thread). Receipt validation is
-// strict; every required field must be present. Branch 5 covers the wire
-// path, not receipt content semantics — so this stays small and reusable.
+// strict; every required field must be present. These tests cover the
+// wire path, not receipt content semantics — so this stays small and
+// reusable.
 function minimalReceiptV1(idStr: string): ReceiptSnapshot {
   const id = asReceiptId(idStr);
   return {
@@ -549,11 +550,11 @@ describe("receipts API", () => {
     });
 
     it("empty `?cursor=` is treated as no cursor (T9)", async () => {
-      // Architecture triangulation T9: an empty `?cursor=` query value is
-      // ergonomically indistinguishable from "no cursor" at the HTTP
-      // boundary; clients should not have to omit the param entirely
-      // just to start at the beginning. The store still rejects `""`
-      // for direct programmatic callers.
+      // An empty `?cursor=` query value is ergonomically
+      // indistinguishable from "no cursor" at the HTTP boundary;
+      // clients should not have to omit the param entirely just to
+      // start at the beginning. The store still rejects `""` for
+      // direct programmatic callers.
       const store = new InMemoryReceiptStore();
       await seedThreadReceipts(store, 3);
       broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
@@ -592,7 +593,7 @@ describe("receipts API", () => {
       expect(await res.json()).toEqual({ error: "invalid_cursor" });
     });
 
-    it("clamps oversized ?limit= in the Link header (R2-A2)", async () => {
+    it("clamps oversized ?limit= in the Link header", async () => {
       // The store already clamps internally, but the route must echo
       // the CLAMPED value in the next-page Link URL — not the caller's
       // raw `?limit=9999`. Otherwise the route's public contract
@@ -624,7 +625,7 @@ describe("receipts API", () => {
       expect(linkPath).not.toContain("limit=9999");
     });
 
-    it("maps ReceiptStoreBusyError to 503 + Retry-After (R2-SRE2)", async () => {
+    it("maps ReceiptStoreBusyError to 503 + Retry-After", async () => {
       // Stub a ReceiptStore that throws the new error class on put.
       // The route should classify it as transient and emit Retry-After.
       const store: ReceiptStore = {
@@ -650,7 +651,7 @@ describe("receipts API", () => {
       expect(await res.json()).toEqual({ error: "store_busy" });
     });
 
-    it("maps ReceiptStoreUnavailableError to 503 without Retry-After (R2-SRE2)", async () => {
+    it("maps ReceiptStoreUnavailableError to 503 without Retry-After", async () => {
       const store: ReceiptStore = {
         async put() {
           throw new ReceiptStoreUnavailableError("test readonly");
@@ -744,7 +745,7 @@ describe("receipts API", () => {
     });
   });
 
-  describe("triangulation pass-1 follow-ups", () => {
+  describe("hardened paths (POST 503 mappings + edge cases)", () => {
     it("returns 415 for application/jsonp (not a JSON-prefix collision)", async () => {
       broker = await createBroker({ port: 0, token: FIXED_TOKEN });
       const res = await postReceipt(broker.url, "{}", {

--- a/packages/broker/tests/receipts.spec.ts
+++ b/packages/broker/tests/receipts.spec.ts
@@ -23,6 +23,7 @@ const RECEIPT_ID_B = "01ARZ3NDEKTSV4RRFFQ69G5FAY";
 const TASK_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
 const THREAD_ID_A = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
 const THREAD_ID_B = "01ARZ3NDEKTSV4RRFFQ69G5FB0";
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 // Builds a minimal valid Receipt v1 (no thread). Receipt validation is
 // strict; every required field must be present. Branch 5 covers the wire
@@ -94,6 +95,33 @@ function minimalReceiptV2(idStr: string, threadIdStr: string): ReceiptSnapshot {
     wikiWrites: [],
     schemaVersion: 2,
   };
+}
+
+function indexedReceiptId(index: number): string {
+  let suffix = "";
+  for (let k = 3; k >= 0; k--) {
+    suffix += ULID_ALPHABET[(index >> (k * 5)) & 31];
+  }
+  return `01ARZ3NDEKTSV4RRFFQ69G${suffix}`;
+}
+
+async function seedThreadReceipts(
+  store: InMemoryReceiptStore,
+  count: number,
+  threadId: string = THREAD_ID_A,
+): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await store.put(minimalReceiptV2(indexedReceiptId(i), threadId));
+  }
+}
+
+function nextLinkPath(headers: Headers): string {
+  const link = headers.get("link");
+  const match = link === null ? null : /^<([^>]+)>; rel="next"$/.exec(link);
+  if (match === null || match[1] === undefined) {
+    throw new Error(`bad Link header: ${link ?? "<missing>"}`);
+  }
+  return match[1];
 }
 
 // Raw node:http POST that returns just the response status. The
@@ -422,6 +450,86 @@ describe("receipts API", () => {
       }
     });
 
+    it("returns a Link header on the first page when more receipts exist", async () => {
+      const store = new InMemoryReceiptStore();
+      await seedThreadReceipts(store, 5);
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts?limit=2`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(await res.text()) as Array<{ id: string }>;
+      expect(parsed.length).toBe(2);
+      const next = new URL(nextLinkPath(res.headers), broker.url);
+      expect(next.pathname).toBe(`/api/threads/${THREAD_ID_A}/receipts`);
+      expect(next.searchParams.get("cursor")).toBeTruthy();
+      expect(next.searchParams.get("limit")).toBe("2");
+    });
+
+    it("omits the Link header on the last page", async () => {
+      const store = new InMemoryReceiptStore();
+      await seedThreadReceipts(store, 5);
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const first = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts?limit=2`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+      const second = await fetch(new URL(nextLinkPath(first.headers), broker.url).toString(), {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+      const last = await fetch(new URL(nextLinkPath(second.headers), broker.url).toString(), {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(last.status).toBe(200);
+      const parsed = JSON.parse(await last.text()) as Array<{ id: string }>;
+      expect(parsed.length).toBe(1);
+      expect(last.headers.get("link")).toBeNull();
+    });
+
+    it("uses the default list limit when no limit query is present", async () => {
+      const store = new InMemoryReceiptStore({ maxReceipts: 200 });
+      await seedThreadReceipts(store, 150);
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(200);
+      const parsed = JSON.parse(await res.text()) as Array<{ id: string }>;
+      expect(parsed.length).toBe(100);
+      const linkPath = nextLinkPath(res.headers);
+      expect(linkPath).not.toContain("limit=");
+    });
+
+    it("returns invalid_limit for a zero limit query", async () => {
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN });
+
+      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts?limit=0`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      });
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "invalid_limit" });
+    });
+
+    it("returns invalid_cursor for a malformed cursor query", async () => {
+      broker = await createBroker({ port: 0, token: FIXED_TOKEN });
+
+      const res = await fetch(
+        `${broker.url}/api/threads/${THREAD_ID_A}/receipts?cursor=not%21base64`,
+        {
+          headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+        },
+      );
+
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "invalid_cursor" });
+    });
+
     it("excludes V1 receipts (which have no threadId)", async () => {
       broker = await createBroker({ port: 0, token: FIXED_TOKEN });
       // V1 has no threadId; the secondary index never sees it. Storing
@@ -442,6 +550,7 @@ describe("receipts API", () => {
       });
       expect(res.status).toBe(200);
       expect(await res.text()).toBe("[]");
+      expect(res.headers.get("link")).toBeNull();
     });
 
     it("returns 404 for a malformed thread id (not a ULID)", async () => {
@@ -488,37 +597,6 @@ describe("receipts API", () => {
         req.end();
       });
       expect(status).toBe(403);
-    });
-
-    it("truncates the list response at MAX_THREAD_LIST_RECEIPTS (1000)", async () => {
-      // Insert 1001 V2 receipts in the same thread via a direct store, then
-      // route the list through the broker. The truncation cap is enforced
-      // at the route layer (the store has no list-size cap), so we need to
-      // push past 1000 to observe the slice fire. 1001 in-memory inserts
-      // run in ~10ms; cheap enough for a deterministic assertion.
-      const store = new InMemoryReceiptStore({ maxReceipts: 2000 });
-      const template = minimalReceiptV2(RECEIPT_ID_A, THREAD_ID_A);
-      // Crockford base32 alphabet (ULID-compatible).
-      const ALPH = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
-      const seen = new Set<string>();
-      for (let i = 0; i < 1001; i++) {
-        // 22-char prefix + 4-char index suffix = 26-char ULID.
-        let suffix = "";
-        for (let k = 3; k >= 0; k--) {
-          suffix += ALPH[(i >> (k * 5)) & 31];
-        }
-        const id = `01ARZ3NDEKTSV4RRFFQ69G${suffix}`;
-        seen.add(id);
-        await store.put({ ...template, id: asReceiptId(id) });
-      }
-      expect(seen.size).toBe(1001); // sanity: ULID generator produces unique ids
-      broker = await createBroker({ port: 0, token: FIXED_TOKEN, receiptStore: store });
-      const res = await fetch(`${broker.url}/api/threads/${THREAD_ID_A}/receipts`, {
-        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
-      });
-      expect(res.status).toBe(200);
-      const arr = JSON.parse(await res.text()) as unknown[];
-      expect(arr.length).toBe(1000);
     });
   });
 

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -1,0 +1,308 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  asAgentSlug,
+  asProviderKind,
+  asReceiptId,
+  asTaskId,
+  asThreadId,
+  type ReceiptSnapshot,
+  SanitizedString,
+  sha256Hex,
+} from "@wuphf/protocol";
+import type Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { openDatabase, runMigrations } from "../src/event-log/index.ts";
+import { InvalidListCursorError, InvalidListLimitError } from "../src/receipt-store.ts";
+import { SqliteReceiptStore } from "../src/sqlite-receipt-store.ts";
+
+const TASK_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
+const THREAD_A = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
+const THREAD_B = "01ARZ3NDEKTSV4RRFFQ69G5FB0";
+const ULID_TIME_PREFIX = "01ARZ3NDEK";
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function minimalReceiptV1(id: string): ReceiptSnapshot {
+  return {
+    id: asReceiptId(id),
+    agentSlug: asAgentSlug("a"),
+    taskId: asTaskId(TASK_ID),
+    triggerKind: "human_message",
+    triggerRef: "m",
+    startedAt: new Date("2026-01-01T00:00:00.000Z"),
+    finishedAt: new Date("2026-01-01T00:01:00.000Z"),
+    status: "ok",
+    providerKind: asProviderKind("anthropic"),
+    model: "m",
+    promptHash: sha256Hex("p"),
+    toolManifest: sha256Hex("t"),
+    toolCalls: [],
+    approvals: [],
+    filesChanged: [],
+    commits: [],
+    sourceReads: [],
+    writes: [],
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    finalMessage: SanitizedString.fromUnknown(""),
+    error: SanitizedString.fromUnknown(""),
+    notebookWrites: [],
+    wikiWrites: [],
+    schemaVersion: 1,
+  };
+}
+
+function minimalReceiptV2(id: string, threadIdStr: string): ReceiptSnapshot {
+  return { ...minimalReceiptV1(id), threadId: asThreadId(threadIdStr), schemaVersion: 2 };
+}
+
+function openStore(): { readonly db: Database.Database; readonly store: SqliteReceiptStore } {
+  const db = openDatabase({ path: ":memory:" });
+  runMigrations(db);
+  return { db, store: new SqliteReceiptStore(db) };
+}
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "wuphf-sqlite-store-"));
+  tempDirs.push(dir);
+  return join(dir, "event-log.sqlite");
+}
+
+function countRows(db: Database.Database, tableName: "event_log" | "receipts_projection"): number {
+  const row = db
+    .prepare<[], { readonly count: number }>(`SELECT COUNT(*) AS count FROM ${tableName}`)
+    .get();
+  if (row === undefined) {
+    throw new Error(`count query returned no row for ${tableName}`);
+  }
+  return row.count;
+}
+
+function maxEventLogLsn(db: Database.Database): number {
+  const row = db
+    .prepare<[], { readonly lsn: number }>("SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log")
+    .get();
+  if (row === undefined) {
+    throw new Error("max lsn query returned no row");
+  }
+  return row.lsn;
+}
+
+function receiptIdAt(index: number): string {
+  let value = index;
+  let suffix = "";
+  for (let i = 0; i < 16; i += 1) {
+    suffix = ULID_ALPHABET[value % ULID_ALPHABET.length] + suffix;
+    value = Math.floor(value / ULID_ALPHABET.length);
+  }
+  return `${ULID_TIME_PREFIX}${suffix}`;
+}
+
+describe("SqliteReceiptStore", () => {
+  it("put returns existed:false, then get and list immediately include the receipt", async () => {
+    const { store } = openStore();
+    try {
+      const receipt = minimalReceiptV2(receiptIdAt(1), THREAD_A);
+
+      await expect(store.put(receipt)).resolves.toEqual({ existed: false });
+      await expect(store.get(receipt.id)).resolves.toEqual(receipt);
+      await expect(store.list({ threadId: asThreadId(THREAD_A) })).resolves.toMatchObject({
+        items: [receipt],
+        nextCursor: null,
+      });
+    } finally {
+      store.close();
+    }
+  });
+
+  it("duplicate put returns existed:true and leaves event_log at one row", async () => {
+    const { db, store } = openStore();
+    try {
+      const first = minimalReceiptV1(receiptIdAt(1));
+      const second = { ...first, model: "different" };
+
+      expect(await store.put(first)).toEqual({ existed: false });
+      expect(await store.put(second)).toEqual({ existed: true });
+
+      expect(await store.get(first.id)).toEqual(first);
+      expect(countRows(db, "event_log")).toBe(1);
+      expect(countRows(db, "receipts_projection")).toBe(1);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("list({ threadId }) returns receipts for that thread only in LSN order", async () => {
+    const { store } = openStore();
+    try {
+      const a1 = minimalReceiptV2(receiptIdAt(1), THREAD_A);
+      const b1 = minimalReceiptV2(receiptIdAt(2), THREAD_B);
+      const a2 = minimalReceiptV2(receiptIdAt(3), THREAD_A);
+      const v1 = minimalReceiptV1(receiptIdAt(4));
+      await store.put(a1);
+      await store.put(b1);
+      await store.put(a2);
+      await store.put(v1);
+
+      const page = await store.list({ threadId: asThreadId(THREAD_A) });
+
+      expect(page.items.map((receipt) => receipt.id)).toEqual([a1.id, a2.id]);
+      expect(page.nextCursor).toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("list({ threadId, limit }) returns a bounded page and nextCursor when more rows exist", async () => {
+    const { store } = openStore();
+    try {
+      const receipts = Array.from({ length: 6 }, (_, index) =>
+        minimalReceiptV2(receiptIdAt(index + 1), THREAD_A),
+      );
+      for (const receipt of receipts) {
+        await store.put(receipt);
+      }
+
+      const page = await store.list({ threadId: asThreadId(THREAD_A), limit: 5 });
+
+      expect(page.items.map((receipt) => receipt.id)).toEqual(
+        receipts.slice(0, 5).map((receipt) => receipt.id),
+      );
+      expect(page.nextCursor).not.toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("list({ cursor }) skips already-seen items", async () => {
+    const { store } = openStore();
+    try {
+      const receipts = Array.from({ length: 5 }, (_, index) =>
+        minimalReceiptV2(receiptIdAt(index + 1), THREAD_A),
+      );
+      for (const receipt of receipts) {
+        await store.put(receipt);
+      }
+
+      const firstPage = await store.list({ threadId: asThreadId(THREAD_A), limit: 2 });
+      expect(firstPage.nextCursor).not.toBeNull();
+      const secondPage = await store.list({
+        threadId: asThreadId(THREAD_A),
+        limit: 2,
+        cursor: firstPage.nextCursor as string,
+      });
+
+      expect(secondPage.items.map((receipt) => receipt.id)).toEqual(
+        receipts.slice(2, 4).map((receipt) => receipt.id),
+      );
+      expect(secondPage.nextCursor).not.toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("list({ limit: 9999 }) clamps to 1000", async () => {
+    const { store } = openStore();
+    try {
+      for (let i = 1; i <= 1_001; i += 1) {
+        await store.put(minimalReceiptV1(receiptIdAt(i)));
+      }
+
+      const page = await store.list({ limit: 9_999 });
+
+      expect(page.items).toHaveLength(1_000);
+      expect(page.nextCursor).not.toBeNull();
+    } finally {
+      store.close();
+    }
+  });
+
+  it("list({ limit: 0 }) rejects", async () => {
+    const { store } = openStore();
+    try {
+      await expect(store.list({ limit: 0 })).rejects.toBeInstanceOf(InvalidListLimitError);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("list({ cursor: malformed }) rejects", async () => {
+    const { store } = openStore();
+    try {
+      await expect(store.list({ cursor: "not-base64-!@#" })).rejects.toBeInstanceOf(
+        InvalidListCursorError,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it("close is idempotent", () => {
+    const { store } = openStore();
+
+    store.close();
+    expect(() => store.close()).not.toThrow();
+  });
+
+  it("persists receipts across restart and continues the LSN sequence", async () => {
+    const path = tempDbPath();
+    const firstDb = openDatabase({ path });
+    runMigrations(firstDb);
+    const firstStore = new SqliteReceiptStore(firstDb);
+    const first = minimalReceiptV2(receiptIdAt(1), THREAD_A);
+    await firstStore.put(first);
+    firstStore.close();
+
+    const secondDb = openDatabase({ path });
+    runMigrations(secondDb);
+    const secondStore = new SqliteReceiptStore(secondDb);
+    try {
+      const second = minimalReceiptV2(receiptIdAt(2), THREAD_A);
+
+      expect(await secondStore.get(first.id)).toEqual(first);
+      expect(await secondStore.put(second)).toEqual({ existed: false });
+      expect(maxEventLogLsn(secondDb)).toBe(2);
+      expect((await secondStore.list()).items.map((receipt) => receipt.id)).toEqual([
+        first.id,
+        second.id,
+      ]);
+    } finally {
+      secondStore.close();
+    }
+  });
+
+  it("rolls back event_log when projection insert fails in the same transaction", async () => {
+    const { db, store } = openStore();
+    try {
+      db.exec(`
+        CREATE TRIGGER fail_receipts_projection_insert
+        BEFORE INSERT ON receipts_projection
+        BEGIN
+          SELECT RAISE(ABORT, 'forced_projection_failure');
+        END;
+      `);
+
+      await expect(store.put(minimalReceiptV2(receiptIdAt(1), THREAD_A))).rejects.toThrow(
+        /forced_projection_failure/,
+      );
+      expect(countRows(db, "event_log")).toBe(0);
+      expect(countRows(db, "receipts_projection")).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -280,8 +280,11 @@ describe("SqliteReceiptStore", () => {
     runMigrations(firstDb);
     const firstStore = constructSqliteReceiptStoreForTesting(firstDb);
     const first = minimalReceiptV2(receiptIdAt(1), THREAD_A);
-    await firstStore.put(first);
-    firstStore.close();
+    try {
+      await firstStore.put(first);
+    } finally {
+      firstStore.close();
+    }
 
     const secondDb = openDatabase({ path });
     runMigrations(secondDb);

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -86,12 +86,23 @@ function tempDbPath(): string {
   return join(dir, "event-log.sqlite");
 }
 
-function countRows(db: Database.Database, tableName: "event_log" | "receipts_projection"): number {
+// SQL interpolation guard: route the table name through an allowlist
+// map so the prepared statement never sees an unbounded string, even
+// though the TypeScript union already constrains the call sites. Belt-
+// and-braces — if a future change widens the parameter type, the
+// allowlist still rejects unknown values at compile time.
+const COUNT_ROWS_TABLES = {
+  event_log: "event_log",
+  receipts_projection: "receipts_projection",
+} as const;
+
+function countRows(db: Database.Database, tableName: keyof typeof COUNT_ROWS_TABLES): number {
+  const safeTable = COUNT_ROWS_TABLES[tableName];
   const row = db
-    .prepare<[], { readonly count: number }>(`SELECT COUNT(*) AS count FROM ${tableName}`)
+    .prepare<[], { readonly count: number }>(`SELECT COUNT(*) AS count FROM ${safeTable}`)
     .get();
   if (row === undefined) {
-    throw new Error(`count query returned no row for ${tableName}`);
+    throw new Error(`count query returned no row for ${safeTable}`);
   }
   return row.count;
 }

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -16,7 +16,11 @@ import type Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { openDatabase, runMigrations } from "../src/event-log/index.ts";
-import { InvalidListCursorError, InvalidListLimitError } from "../src/receipt-store.ts";
+import {
+  InvalidListCursorError,
+  InvalidListLimitError,
+  ReceiptStoreFullError,
+} from "../src/receipt-store.ts";
 import { SqliteReceiptStore } from "../src/sqlite-receipt-store.ts";
 
 const TASK_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
@@ -303,6 +307,52 @@ describe("SqliteReceiptStore", () => {
       expect(countRows(db, "receipts_projection")).toBe(0);
     } finally {
       store.close();
+    }
+  });
+
+  it("throws ReceiptStoreFullError when maxReceipts is exceeded (R2-S1 quota)", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const store = new SqliteReceiptStore(db, undefined, 2);
+    try {
+      await store.put(minimalReceiptV2(receiptIdAt(1), THREAD_A));
+      await store.put(minimalReceiptV2(receiptIdAt(2), THREAD_A));
+      await expect(store.put(minimalReceiptV2(receiptIdAt(3), THREAD_A))).rejects.toBeInstanceOf(
+        ReceiptStoreFullError,
+      );
+      // The 507 path rolls back: third receipt didn't land in either table.
+      expect(countRows(db, "event_log")).toBe(2);
+      expect(countRows(db, "receipts_projection")).toBe(2);
+    } finally {
+      store.close();
+    }
+  });
+
+  it("returns existed:true (not 507) when a duplicate hits at capacity (R2-S1)", async () => {
+    // Mirror the in-memory cap-vs-collision invariant: the existence
+    // check runs BEFORE the count check, so a retry of an already-stored
+    // receipt at capacity returns 409 not 507.
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const store = new SqliteReceiptStore(db, undefined, 1);
+    try {
+      const r = minimalReceiptV1(receiptIdAt(1));
+      await store.put(r);
+      expect(await store.put(r)).toEqual({ existed: true });
+    } finally {
+      store.close();
+    }
+  });
+
+  it("rejects non-positive or non-integer maxReceipts at construction (R2-S1)", () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    try {
+      expect(() => new SqliteReceiptStore(db, undefined, 0)).toThrow(/positive integer/);
+      expect(() => new SqliteReceiptStore(db, undefined, -1)).toThrow(/positive integer/);
+      expect(() => new SqliteReceiptStore(db, undefined, 1.5)).toThrow(/positive integer/);
+    } finally {
+      db.close();
     }
   });
 });

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -16,12 +16,13 @@ import type Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { openDatabase, runMigrations } from "../src/event-log/index.ts";
+import { constructSqliteReceiptStoreForTesting } from "../src/internal/sqlite-receipt-store-testing.ts";
 import {
   InvalidListCursorError,
   InvalidListLimitError,
   ReceiptStoreFullError,
 } from "../src/receipt-store.ts";
-import { SqliteReceiptStore } from "../src/sqlite-receipt-store.ts";
+import type { SqliteReceiptStore } from "../src/sqlite-receipt-store.ts";
 
 const TASK_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAW";
 const THREAD_A = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
@@ -77,7 +78,7 @@ function minimalReceiptV2(id: string, threadIdStr: string): ReceiptSnapshot {
 function openStore(): { readonly db: Database.Database; readonly store: SqliteReceiptStore } {
   const db = openDatabase({ path: ":memory:" });
   runMigrations(db);
-  return { db, store: SqliteReceiptStore.forTesting(db) };
+  return { db, store: constructSqliteReceiptStoreForTesting(db) };
 }
 
 function tempDbPath(): string {
@@ -277,14 +278,14 @@ describe("SqliteReceiptStore", () => {
     const path = tempDbPath();
     const firstDb = openDatabase({ path });
     runMigrations(firstDb);
-    const firstStore = SqliteReceiptStore.forTesting(firstDb);
+    const firstStore = constructSqliteReceiptStoreForTesting(firstDb);
     const first = minimalReceiptV2(receiptIdAt(1), THREAD_A);
     await firstStore.put(first);
     firstStore.close();
 
     const secondDb = openDatabase({ path });
     runMigrations(secondDb);
-    const secondStore = SqliteReceiptStore.forTesting(secondDb);
+    const secondStore = constructSqliteReceiptStoreForTesting(secondDb);
     try {
       const second = minimalReceiptV2(receiptIdAt(2), THREAD_A);
 
@@ -324,7 +325,7 @@ describe("SqliteReceiptStore", () => {
   it("throws ReceiptStoreFullError when maxReceipts is exceeded", async () => {
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
-    const store = SqliteReceiptStore.forTesting(db, undefined, 2);
+    const store = constructSqliteReceiptStoreForTesting(db, undefined, 2);
     try {
       await store.put(minimalReceiptV2(receiptIdAt(1), THREAD_A));
       await store.put(minimalReceiptV2(receiptIdAt(2), THREAD_A));
@@ -345,7 +346,7 @@ describe("SqliteReceiptStore", () => {
     // receipt at capacity returns 409 not 507.
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
-    const store = SqliteReceiptStore.forTesting(db, undefined, 1);
+    const store = constructSqliteReceiptStoreForTesting(db, undefined, 1);
     try {
       const r = minimalReceiptV1(receiptIdAt(1));
       await store.put(r);
@@ -359,9 +360,15 @@ describe("SqliteReceiptStore", () => {
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
     try {
-      expect(() => SqliteReceiptStore.forTesting(db, undefined, 0)).toThrow(/positive integer/);
-      expect(() => SqliteReceiptStore.forTesting(db, undefined, -1)).toThrow(/positive integer/);
-      expect(() => SqliteReceiptStore.forTesting(db, undefined, 1.5)).toThrow(/positive integer/);
+      expect(() => constructSqliteReceiptStoreForTesting(db, undefined, 0)).toThrow(
+        /positive integer/,
+      );
+      expect(() => constructSqliteReceiptStoreForTesting(db, undefined, -1)).toThrow(
+        /positive integer/,
+      );
+      expect(() => constructSqliteReceiptStoreForTesting(db, undefined, 1.5)).toThrow(
+        /positive integer/,
+      );
     } finally {
       db.close();
     }

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -77,7 +77,7 @@ function minimalReceiptV2(id: string, threadIdStr: string): ReceiptSnapshot {
 function openStore(): { readonly db: Database.Database; readonly store: SqliteReceiptStore } {
   const db = openDatabase({ path: ":memory:" });
   runMigrations(db);
-  return { db, store: new SqliteReceiptStore(db) };
+  return { db, store: SqliteReceiptStore.forTesting(db) };
 }
 
 function tempDbPath(): string {
@@ -277,14 +277,14 @@ describe("SqliteReceiptStore", () => {
     const path = tempDbPath();
     const firstDb = openDatabase({ path });
     runMigrations(firstDb);
-    const firstStore = new SqliteReceiptStore(firstDb);
+    const firstStore = SqliteReceiptStore.forTesting(firstDb);
     const first = minimalReceiptV2(receiptIdAt(1), THREAD_A);
     await firstStore.put(first);
     firstStore.close();
 
     const secondDb = openDatabase({ path });
     runMigrations(secondDb);
-    const secondStore = new SqliteReceiptStore(secondDb);
+    const secondStore = SqliteReceiptStore.forTesting(secondDb);
     try {
       const second = minimalReceiptV2(receiptIdAt(2), THREAD_A);
 
@@ -321,10 +321,10 @@ describe("SqliteReceiptStore", () => {
     }
   });
 
-  it("throws ReceiptStoreFullError when maxReceipts is exceeded (R2-S1 quota)", async () => {
+  it("throws ReceiptStoreFullError when maxReceipts is exceeded", async () => {
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
-    const store = new SqliteReceiptStore(db, undefined, 2);
+    const store = SqliteReceiptStore.forTesting(db, undefined, 2);
     try {
       await store.put(minimalReceiptV2(receiptIdAt(1), THREAD_A));
       await store.put(minimalReceiptV2(receiptIdAt(2), THREAD_A));
@@ -339,13 +339,13 @@ describe("SqliteReceiptStore", () => {
     }
   });
 
-  it("returns existed:true (not 507) when a duplicate hits at capacity (R2-S1)", async () => {
+  it("returns existed:true (not 507) when a duplicate hits at capacity", async () => {
     // Mirror the in-memory cap-vs-collision invariant: the existence
     // check runs BEFORE the count check, so a retry of an already-stored
     // receipt at capacity returns 409 not 507.
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
-    const store = new SqliteReceiptStore(db, undefined, 1);
+    const store = SqliteReceiptStore.forTesting(db, undefined, 1);
     try {
       const r = minimalReceiptV1(receiptIdAt(1));
       await store.put(r);
@@ -355,13 +355,13 @@ describe("SqliteReceiptStore", () => {
     }
   });
 
-  it("rejects non-positive or non-integer maxReceipts at construction (R2-S1)", () => {
+  it("rejects non-positive or non-integer maxReceipts at construction", () => {
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
     try {
-      expect(() => new SqliteReceiptStore(db, undefined, 0)).toThrow(/positive integer/);
-      expect(() => new SqliteReceiptStore(db, undefined, -1)).toThrow(/positive integer/);
-      expect(() => new SqliteReceiptStore(db, undefined, 1.5)).toThrow(/positive integer/);
+      expect(() => SqliteReceiptStore.forTesting(db, undefined, 0)).toThrow(/positive integer/);
+      expect(() => SqliteReceiptStore.forTesting(db, undefined, -1)).toThrow(/positive integer/);
+      expect(() => SqliteReceiptStore.forTesting(db, undefined, 1.5)).toThrow(/positive integer/);
     } finally {
       db.close();
     }


### PR DESCRIPTION
## Summary

Stream A branch 6 of the WUPHF v1 greenfield rewrite. Replaces the in-memory `ReceiptStore` with a durable SQLite event-log-backed implementation, adds cursor pagination on `GET /api/threads/:tid/receipts`, wires the durable store into the Electron utility process, and adds a path-gated broker CI job + build-output externalization invariant check.

Closes the receipts-as-Day-1-substrate work from the RFC.

## What landed

13 commits since `origin/main`:

| # | Commit | Notes |
|---|---|---|
| 1 | `90591043` | scaffold: DESIGN.md + `ListPage` interface |
| 2 | `ef7faa14` | triangulation pass-1 scaffolding fixes (T1, T5–T8) |
| 3 | `951d7094` | codex worker A: sqlite event-log + `SqliteReceiptStore` + parity tests |
| 4 | `0a5dbb03` | codex worker B: cursor pagination route + Link header |
| 5 | `0bafd045` | integration + triangulation pass-1 follow-ups |
| 6 | `2d542b30` | triangulation pass-2 follow-ups |
| 7 | `0450ab7b` | coderabbit pass-1 (language tags on fenced blocks) |
| 8 | `31c785de` | orthogonal-pr-review pass-1 follow-ups (subpath export, private constructor, CI gate) |
| 9 | `e07949d1` | orthogonal-pr-review pass-2 follow-ups (testing-seam moved out of public exports) |
| 10 | `77eb546b` | coderabbit pass-2 (test isolation + resource cleanup) |
| 11 | `7dcc0d31` | final triangulation moderation fixes (CRITICAL packaging bug + read-path 503) |
| 12 | `26bdd978` | ci: build-output externalization invariant check |

## Wire shape

- `POST /api/receipts` — 201 / 409 / 400 / 413 / 415 / 503 `store_busy`+`Retry-After: 1` / 503 `storage_error` / 507 `store_full`.
- `GET /api/receipts/:id` — 200 / 404 / 503 (same mapping as POST).
- `GET /api/threads/:tid/receipts?cursor=&limit=` — bare JSON array body; `Link: rel="next"` header when more pages exist; 400 on invalid cursor/limit; 503 on storage errors.
- Cursor wire: RFC 4648 §5 unpadded base64url of ASCII `lsn:<decimal>`, with strict canonical round-trip + safe-integer LSN.

```mermaid
flowchart LR
  R[Renderer]
  M[Electron main]
  U[Broker utility process]
  D[(SQLite event-log.sqlite)]

  R -->|HTTP loopback| U
  M -->|spawn + env| U
  U -->|BEGIN IMMEDIATE<br/>WAL + sync=FULL| D
```

## Public package surface

- `@wuphf/broker` — `createBroker`, `ReceiptStore`, `InMemoryReceiptStore`, `ListFilter`/`ListPage` types, cursor + limit helpers, error classes. No native binding loaded.
- `@wuphf/broker/sqlite` — `SqliteReceiptStore` + config. Importing this subpath evaluates `better-sqlite3`'s native binding, so consumers that only need the in-memory path skip the cost by not importing it.

## Review history (8 passes)

| Pass | Reviewer | Output |
|---|---|---|
| Triangulation r1 | 5 codex (security/distsys/perf/api/architecture) | [INTEGRATION_NOTES](https://github.com/nex-crm/wuphf/tree/feat/event-log-projections) addressed in commits 2 + 5 |
| Triangulation r2 | 5 codex (security/distsys/perf/api/sre) | addressed in commit 6 |
| CodeRabbit r1 | bot | 4 nits, all FIXED in commit 7 |
| Orthogonal r1 | 6 codex + Claude staff-code-reviewer (scope) | 8 findings → 5 FIXED, 3 SKIPPED/DEFERRED in commit 8 |
| Orthogonal r2 | 4 codex (types/build-parity/conventions/adversarial) | 5 findings, all FIXED in commit 9 |
| CodeRabbit r2 | bot | 5 findings → 3 FIXED, 2 SKIPPED with reason in commit 10 |
| **Final triangulation** | **5 codex + Claude staff-code-reviewer moderator** | **2 blockers, 3 nits FIXED in commit 11** |
| CI gate hardening | self | build-externals invariant in commit 12 |

The final moderation pass caught a CRITICAL packaging bug 7 prior rounds missed: `electron-vite`'s `externalizeDepsPlugin()` was leaving `@wuphf/broker` as a runtime external, which would have resolved to raw `./src/*.ts` and crashed the packaged Electron utility process on startup (Node 22 strip-only TS can't transpile parameter properties on `SqliteReceiptStore`'s private constructor). Now caught statically by the new `check:build-externals` CI gate.

## Verification

- `packages/broker`: tsc, 157 vitest tests, biome, invariants — all green.
- `apps/desktop`: tsc, 229 vitest tests, lint, build, build-externals — all green.
- secretlint clean.
- All 28 CI checks SUCCESS on HEAD.

## Deferred (tracked for follow-up)

- Response byte budget on the thread-list route.
- Cross-language wire golden vectors for cursor + event payload.
- Open-time log/projection consistency check.
- Branded cursor type / domain-disambiguated `ReceiptId`/`ThreadId`.
- Dedicated `/api/storage` diagnostics endpoint (`/api/health` is documented as process-only).
- Supervisor `fatalReason` propagation for permanent DB startup failures.
- Electron-rebuild + asar-unpack gate for `better-sqlite3` before first desktop release.

## Spec anchors

- `business-musings/wuphf-greenfield-rewrite-rfc-2026-05.md` §15 Stream A row `feat/event-log-projections`.
- Preserves PR #791 (branch 5) `ReceiptStore` interface contracts: atomicity, read-your-write, mutability.
- README + DESIGN.md updated in the same commits as wire-shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)