### PR TITLE
feat(llm-router): AI gateway, caps, §10.4 burn-down (branch 7 PR B)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,24 @@
         "vitest": "^2.1.0",
       },
     },
+    "packages/llm-router": {
+      "name": "@wuphf/llm-router",
+      "version": "0.0.0",
+      "dependencies": {
+        "@wuphf/broker": "workspace:*",
+        "@wuphf/protocol": "workspace:*",
+        "better-sqlite3": "12.9.0",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.4.15",
+        "@types/better-sqlite3": "7.6.13",
+        "@types/node": "^22.10.0",
+        "@vitest/coverage-v8": "2.1.9",
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0",
+      },
+    },
     "packages/protocol": {
       "name": "@wuphf/protocol",
       "version": "0.0.0",
@@ -481,6 +499,8 @@
 
     "@wuphf/installer-stub": ["@wuphf/installer-stub@workspace:apps/installer-stub"],
 
+    "@wuphf/llm-router": ["@wuphf/llm-router@workspace:packages/llm-router"],
+
     "@wuphf/protocol": ["@wuphf/protocol@workspace:packages/protocol"],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
@@ -810,6 +830,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "git-raw-commits": ["git-raw-commits@5.0.1", "", { "dependencies": { "@conventional-changelog/git-client": "^2.6.0", "meow": "^13.0.0" }, "bin": { "git-raw-commits": "src/cli.js" } }, "sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ=="],
 
@@ -1169,6 +1191,8 @@
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "responselike": ["responselike@2.0.1", "", { "dependencies": { "lowercase-keys": "^2.0.0" } }, "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw=="],
 
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
@@ -1312,6 +1336,8 @@
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
@@ -1579,6 +1605,8 @@
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
+    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
     "vite-node/cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "vite-node/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
@@ -1778,6 +1806,58 @@
     "test-exclude/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -32,6 +32,22 @@ export type {
 export { createCostLedger } from "./cost-ledger/index.ts";
 export type { ReplayCheckReport, ReplayDiscrepancy } from "./cost-ledger/replay-check.ts";
 export { runReplayCheck } from "./cost-ledger/replay-check.ts";
+// Event log primitives. Hosts constructing a cost ledger need these to
+// open the database, apply migrations, and instantiate the event log
+// the ledger writes through.
+export type {
+  AppendArgs,
+  EventLog,
+  EventLogRecord,
+  EventType,
+  OpenDatabaseArgs,
+} from "./event-log/index.ts";
+export {
+  CURRENT_SCHEMA_VERSION,
+  createEventLog,
+  openDatabase,
+  runMigrations,
+} from "./event-log/index.ts";
 export { createBroker } from "./listener.ts";
 export type {
   InMemoryReceiptStoreConfig,

--- a/packages/llm-router/AGENTS.md
+++ b/packages/llm-router/AGENTS.md
@@ -1,0 +1,77 @@
+# @wuphf/llm-router — Agent Guidelines
+
+Branch-7 slice: the single in-process AI gateway. All agent runners go
+through `Gateway.complete()` — there is no other call path to a provider
+SDK in the broker process. Branch-7 PR B (`feat/cost-ceiling-supervisor-core`)
+is where the gateway, cost-event emission, cap enforcement, and the §10.4
+burn-down land.
+
+## Hard rules
+
+1. **Every successful `Gateway.complete()` writes one `cost_event` BEFORE
+   returning.** No row, no response. The return value carries
+   `costEventLsn: EventLsn` so the caller can prove the write happened.
+   If `ledger.appendCostEvent` throws, the response is discarded.
+2. **All amounts are integer `MicroUsd`.** Per `@wuphf/protocol/cost.ts`
+   the §15.A sum invariant is only decidable on integers. Pricing
+   tables are `Record<string, MicroUsdPerUnit>` lookups. Never use
+   float dollars.
+3. **The daily cap reads from `cost_by_agent`, not from in-memory
+   counters.** The projection is the source of truth; in-memory state
+   would diverge after a broker restart. Wake caps and the breaker may
+   stay process-local (they reset on restart by design).
+4. **No `Date.now()` for ordering or identity.** Per protocol AGENTS.md
+   rule 14. Wake-cap timestamps and breaker state may use the wall
+   clock for "did this happen in the last 10 minutes," but the
+   cost_event LSN comes from the ledger and `crossedAt` is the
+   triggering event's `occurredAt`.
+5. **Identical-payload dedupe uses a content hash, not a sequence
+   number.** SHA-256 of the canonical request bytes. The 60s window is
+   a sliding window: an entry expires when the wall clock crosses its
+   stored deadline.
+6. **The stub provider is deterministic.** §10.4 (`ci:burn:nightly`)
+   asserts $5.00 ± $0.05 across 60 minutes; that contract requires
+   exact-amount predictability. `stub-fixed-cost` returns 10000
+   micro-USD/call with zero variance.
+7. **No `electron`, no renderer code.** The gateway is pure Node.
+   Renderer surfaces (cost tile, throttle banners) live in PR C
+   `feat/cost-ceiling-supervisor-ui`.
+8. **Type-system enforcement of "row before response."** The gateway's
+   public return type couples to the ledger write: `GatewayCompletionResult`
+   carries `costEventLsn`, and the only code that mints one is the
+   gateway implementation calling `ledger.appendCostEvent`. Do not
+   widen the return type to make tests pass.
+
+## Cap classes and error mapping
+
+| Cap | Throws | HTTP equivalent (PR C wire) |
+|---|---|---|
+| Per-office daily cap | `CapExceededError("daily")` | 429 Retry-After: tomorrow 00:00 UTC |
+| Per-agent wake cap | `CapExceededError("wake")` | 429 Retry-After: window-end |
+| Circuit breaker open | `CircuitBreakerOpenError` | 503 Retry-After: breaker-cooldown-end |
+| Idle mode | `IdleModeError` | 423 Locked |
+| Provider error | `ProviderError` | 502 Bad Gateway |
+| Dedupe replay | (no throw — returns cached `GatewayCompletionResult`) | 200 with `X-Dedupe-Replay: true` |
+
+## Adding a new provider
+
+1. Implement `Provider` in `src/providers/<name>.ts`.
+2. Register a `CostEstimator` for every model the provider exposes; pricing
+   tables MUST be integer micro-USD per token.
+3. Add a unit test that asserts deterministic cost given fixed usage.
+4. Add the `ProviderKind` literal to `@wuphf/protocol`'s `PROVIDER_KIND_VALUES`
+   if it isn't already there (closed enum — see protocol AGENTS.md).
+
+## Validation
+
+```bash
+bun run typecheck
+bun run test
+bun run check
+```
+
+Burn-down (slow, separate command):
+
+```bash
+bun run burn:nightly
+```

--- a/packages/llm-router/README.md
+++ b/packages/llm-router/README.md
@@ -1,0 +1,75 @@
+# @wuphf/llm-router
+
+WUPHF v1 AI gateway — single in-process cost chokepoint. Per RFC §7.5,
+every agent runner proxies through one `Gateway.complete()` call. The
+gateway:
+
+- enforces the per-office daily token ceiling ($5/day default, reads
+  `cost_by_agent` from `@wuphf/broker`'s cost ledger)
+- enforces the per-agent wake cap (12/hr default, in-memory)
+- deduplicates identical payloads within a 60s window (SHA-256 of
+  canonical request bytes)
+- runs a circuit breaker (2 escalations in 10 min → opens for a
+  cool-down period)
+- short-circuits when idle mode is active (5 min of zero activity)
+- writes one `cost_event` row **before** the response returns; the
+  return value carries `costEventLsn` so the caller has proof
+
+Direct provider SDKs are loaded by the gateway, never by agent
+runners — there is no parallel call path to an LLM in this codebase.
+
+## Providers
+
+- `stub-fixed-cost` — deterministic test target for the §10.4 nightly
+  burn-down. Every call costs 10000 micro-USD (= $0.01) and returns a
+  canned response.
+- `anthropic` (PR B.2 follow-up) — `@anthropic-ai/sdk` adapter.
+- `openai` (PR B.3 follow-up) — `openai` SDK adapter.
+- `ollama` (PR B.3 follow-up) — local model adapter.
+
+## Usage
+
+```ts
+import { createGateway } from "@wuphf/llm-router";
+import { createCostLedger, createCommandIdempotencyStore } from "@wuphf/broker";
+
+const gateway = createGateway({
+  ledger,                             // from @wuphf/broker
+  providers: [createStubProvider()],
+  caps: {
+    dailyMicroUsd: 5_000_000,         // $5/day per RFC §8
+    wakeCapPerHour: 12,
+    breakerErrorThreshold: 2,
+    breakerWindowMs: 10 * 60 * 1000,
+    breakerCooldownMs: 5 * 60 * 1000,
+    idleThresholdMs: 5 * 60 * 1000,
+    dedupeWindowMs: 60 * 1000,
+  },
+  nowMs: () => Date.now(),
+});
+
+const result = await gateway.complete(ctx, request);
+// result.costEventLsn is the proof the cost row was written.
+```
+
+## §10.4 nightly burn-down
+
+```bash
+bun run burn:nightly
+```
+
+Runs 10 wakes/minute × 60 minutes against `stub-fixed-cost`. Asserts:
+
+- Final spend is **$5.00 ± $0.05** (read-only ceiling held)
+- Per-agent wake cap throttles **before** the office-daily cap
+- Circuit breaker fires within **3 consecutive failures**
+
+Per RFC §10.4 these assertions are CI-blocking.
+
+## Validation
+
+```bash
+bun run typecheck
+bun run test
+bun run check
+```

--- a/packages/llm-router/biome.json
+++ b/packages/llm-router/biome.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": [
+      "src/**/*.ts",
+      "tests/**/*.ts",
+      "scripts/**/*.ts",
+      "*.json",
+      "*.ts",
+      "!node_modules",
+      "!dist",
+      "!coverage"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUndeclaredDependencies": "error"
+      },
+      "performance": {
+        "noReExportAll": "error"
+      },
+      "style": {
+        "useImportType": "error",
+        "useExportType": "error",
+        "noEnum": "error",
+        "noCommonJs": "error",
+        "useThrowOnlyError": "error",
+        "useFilenamingConvention": {
+          "level": "error",
+          "options": {
+            "filenameCases": ["kebab-case"],
+            "requireAscii": true
+          }
+        }
+      },
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noTsIgnore": "error",
+        "noEvolvingTypes": "error",
+        "noConsole": "error",
+        "useErrorMessage": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all",
+      "semicolons": "always"
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["scripts/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noConsole": "off"
+          },
+          "correctness": {
+            "noUndeclaredDependencies": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["tests/**/*.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUndeclaredDependencies": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/llm-router/package.json
+++ b/packages/llm-router/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@wuphf/llm-router",
+  "version": "0.0.0",
+  "private": true,
+  "description": "WUPHF v1 AI gateway — single in-process cost chokepoint enforcing per-office daily cap, per-agent wake cap, identical-payload dedupe, and circuit breaker. Every provider call writes a cost_event before returning. Branch-7 slice.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "biome check src/ tests/ scripts/",
+    "lint:fix": "biome check --write src/ tests/ scripts/",
+    "format": "biome format --write src/ tests/ scripts/",
+    "check": "biome check src/ tests/ scripts/",
+    "burn:nightly": "tsx scripts/ci-burn-nightly.ts"
+  },
+  "dependencies": {
+    "@wuphf/broker": "workspace:*",
+    "@wuphf/protocol": "workspace:*",
+    "better-sqlite3": "12.9.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.15",
+    "@types/better-sqlite3": "7.6.13",
+    "@types/node": "^22.10.0",
+    "@vitest/coverage-v8": "2.1.9",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/llm-router/scripts/ci-burn-nightly.ts
+++ b/packages/llm-router/scripts/ci-burn-nightly.ts
@@ -1,0 +1,264 @@
+// §10.4 nightly burn-down. CI-blocking when wired into the
+// nightly.yml workflow (PR C). Contract from RFC §10.4:
+//
+//   ci:burn:nightly --wakes-per-minute 10 --minutes 60 --model stub-fixed-cost
+//
+// Asserts:
+//   1. Read-only at $5.00 ± $0.05 — total office spend lands inside that
+//      band after 60 minutes of throttled traffic.
+//   2. Per-agent wake cap throttles BEFORE the office daily cap. (Confirmed
+//      directly by counting calls a single agent landed before its wake
+//      cap rejected it; this number must be `wakeCapPerHour`, not the
+//      full minute-by-minute throughput.)
+//   3. Circuit breaker fires within 3 consecutive failures.
+//
+// The §10.4 assertion of "cost tile updates every 30s" is a renderer-side
+// SLO (PR C). We approximate it here by calling `gateway.inspect()` every
+// 30s and confirming the call is constant-time and reflects current state;
+// the real wire emission is PR C's responsibility.
+//
+// Running:
+//   bun run packages/llm-router/scripts/ci-burn-nightly.ts
+//
+// Exits 0 on all assertions passing; 1 on any failure.
+
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { asAgentSlug } from "@wuphf/protocol";
+
+import {
+  CapExceededError,
+  CircuitBreakerOpenError,
+  createGateway,
+  createStubProvider,
+  type Gateway,
+  STUB_FIXED_COST_MICRO_USD,
+  STUB_MODEL_ERROR,
+  STUB_MODEL_FIXED_COST,
+  type SupervisorContext,
+} from "../src/index.ts";
+
+interface BurnConfig {
+  readonly wakesPerMinute: number;
+  readonly minutes: number;
+  readonly dailyMicroUsd: number;
+  readonly wakeCapPerHour: number;
+}
+
+const CONFIG: BurnConfig = {
+  wakesPerMinute: 10,
+  minutes: 60,
+  dailyMicroUsd: 5_000_000, // $5
+  wakeCapPerHour: 12,
+};
+
+const DAILY_TOLERANCE_MICRO_USD = 50_000; // ± $0.05
+
+interface BurnResult {
+  readonly name: string;
+  readonly passed: boolean;
+  readonly observed: string;
+  readonly expected: string;
+}
+
+const results: BurnResult[] = [];
+
+function record(name: string, passed: boolean, observed: string, expected: string): void {
+  results.push({ name, passed, observed, expected });
+  // eslint-disable-next-line no-console
+  console.log(`${passed ? "PASS" : "FAIL"} ${name}`);
+  // eslint-disable-next-line no-console
+  console.log(`     observed: ${observed}`);
+  // eslint-disable-next-line no-console
+  console.log(`     expected: ${expected}`);
+}
+
+interface Clock {
+  now: number;
+}
+
+function buildGateway(): {
+  gateway: Gateway;
+  clock: Clock;
+  ledger: ReturnType<typeof createCostLedger>;
+  close: () => void;
+} {
+  const db = openDatabase({ path: ":memory:" });
+  runMigrations(db);
+  const eventLog = createEventLog(db);
+  const ledger = createCostLedger(db, eventLog);
+  const clock: Clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+  const gateway = createGateway({
+    ledger,
+    providers: [createStubProvider()],
+    nowMs: () => clock.now,
+    config: {
+      caps: {
+        dailyMicroUsd: CONFIG.dailyMicroUsd,
+        wakeCapPerHour: CONFIG.wakeCapPerHour,
+      },
+    },
+  });
+  return { gateway, clock, ledger, close: () => db.close() };
+}
+
+async function assertion1ReadOnlyAtCap(): Promise<void> {
+  const { gateway, clock, ledger, close } = buildGateway();
+  try {
+    // Spread the load across enough agents so the per-agent wake cap
+    // doesn't dominate. ceil(daily_cap / per_call_cost / wake_cap) =
+    // 5_000_000 / 10_000 / 12 = 42 agents lets us land ~500 successful
+    // calls = $5.00 even with the wake-cap throttle per agent.
+    const totalWakes = CONFIG.wakesPerMinute * CONFIG.minutes;
+    const agentCount = Math.ceil(totalWakes / CONFIG.wakeCapPerHour);
+    const agents: SupervisorContext[] = Array.from({ length: agentCount }, (_, i) => ({
+      agentSlug: asAgentSlug(`agent_${String(i).padStart(3, "0")}`),
+    }));
+
+    let cappedCount = 0;
+    for (let minute = 0; minute < CONFIG.minutes; minute += 1) {
+      for (let wake = 0; wake < CONFIG.wakesPerMinute; wake += 1) {
+        const agent = agents[(minute * CONFIG.wakesPerMinute + wake) % agentCount];
+        if (agent === undefined) continue;
+        // Note human activity each minute to keep the idle gate open.
+        if (wake === 0) gateway.noteHumanActivity();
+        try {
+          await gateway.complete(agent, {
+            model: STUB_MODEL_FIXED_COST,
+            // Distinct prompt per call so dedupe never short-circuits.
+            prompt: `burn-${minute}-${wake}`,
+            maxOutputTokens: 8,
+          });
+        } catch (err) {
+          if (err instanceof CapExceededError) {
+            cappedCount += 1;
+          } else {
+            throw err;
+          }
+        }
+        clock.now += 1; // tick a millisecond between calls so wake-cap timestamps differ
+      }
+      clock.now += 60_000 - CONFIG.wakesPerMinute; // advance to the next minute boundary
+    }
+
+    const totalSpend = ledger
+      .listAgentSpend({ dayUtc: "2026-05-12" })
+      .reduce((acc, row) => acc + (row.totalMicroUsd as number), 0);
+
+    const inBand =
+      totalSpend >= CONFIG.dailyMicroUsd - DAILY_TOLERANCE_MICRO_USD &&
+      totalSpend <= CONFIG.dailyMicroUsd + DAILY_TOLERANCE_MICRO_USD;
+
+    record(
+      "read-only at $5.00 ± $0.05",
+      inBand,
+      `total_spend=${totalSpend} μUSD, capped_count=${cappedCount}`,
+      `total_spend in [${CONFIG.dailyMicroUsd - DAILY_TOLERANCE_MICRO_USD}, ${CONFIG.dailyMicroUsd + DAILY_TOLERANCE_MICRO_USD}]`,
+    );
+  } finally {
+    close();
+  }
+}
+
+async function assertion2WakeCapBeforeDaily(): Promise<void> {
+  const { gateway, clock, close } = buildGateway();
+  try {
+    const single: SupervisorContext = { agentSlug: asAgentSlug("solo_agent") };
+    let successes = 0;
+    let wakeCapReached = false;
+    let wakeCapHitAtCall: number | null = null;
+
+    // Try far more wakes than either cap allows; the wake cap (12/hr)
+    // should reject us long before the daily cap (500 calls).
+    for (let i = 0; i < 100; i += 1) {
+      gateway.noteHumanActivity();
+      try {
+        await gateway.complete(single, {
+          model: STUB_MODEL_FIXED_COST,
+          prompt: `solo-${i}`,
+          maxOutputTokens: 8,
+        });
+        successes += 1;
+      } catch (err) {
+        if (err instanceof CapExceededError && err.cap === "wake") {
+          wakeCapReached = true;
+          wakeCapHitAtCall = i;
+          break;
+        }
+        if (err instanceof CapExceededError && err.cap === "daily") {
+          break;
+        }
+        throw err;
+      }
+      clock.now += 1;
+    }
+
+    const dailyCallCap = Math.floor(CONFIG.dailyMicroUsd / STUB_FIXED_COST_MICRO_USD);
+    const passed =
+      wakeCapReached && successes === CONFIG.wakeCapPerHour && successes < dailyCallCap;
+    record(
+      "per-agent wake cap throttles before daily cap",
+      passed,
+      `successes=${successes}, wake_cap_hit_at=${wakeCapHitAtCall}`,
+      `successes == wake_cap (${CONFIG.wakeCapPerHour}) and successes < daily_call_cap (${dailyCallCap})`,
+    );
+  } finally {
+    close();
+  }
+}
+
+async function assertion3BreakerWithinThreeFailures(): Promise<void> {
+  const { gateway, clock, close } = buildGateway();
+  try {
+    const agent: SupervisorContext = { agentSlug: asAgentSlug("breaker_test") };
+    let breakerTrippedAtFailure: number | null = null;
+
+    for (let i = 0; i < 5; i += 1) {
+      gateway.noteHumanActivity();
+      try {
+        await gateway.complete(agent, {
+          model: STUB_MODEL_ERROR,
+          prompt: `breaker-${i}`,
+          maxOutputTokens: 8,
+        });
+      } catch (err) {
+        if (err instanceof CircuitBreakerOpenError) {
+          breakerTrippedAtFailure = i;
+          break;
+        }
+        // Provider error is expected for stub-error; keep going until breaker opens.
+      }
+      clock.now += 1;
+    }
+
+    const passed = breakerTrippedAtFailure !== null && breakerTrippedAtFailure <= 3;
+    record(
+      "circuit breaker fires within 3 consecutive failures",
+      passed,
+      `breaker_tripped_at_failure=${breakerTrippedAtFailure}`,
+      `breaker_tripped_at_failure <= 3`,
+    );
+  } finally {
+    close();
+  }
+}
+
+async function main(): Promise<void> {
+  // eslint-disable-next-line no-console
+  console.log(
+    `@wuphf/llm-router — §10.4 burn-down\n` +
+      `--wakes-per-minute ${CONFIG.wakesPerMinute} ` +
+      `--minutes ${CONFIG.minutes} ` +
+      `--model ${STUB_MODEL_FIXED_COST}\n`,
+  );
+
+  await assertion1ReadOnlyAtCap();
+  await assertion2WakeCapBeforeDaily();
+  await assertion3BreakerWithinThreeFailures();
+
+  const failed = results.filter((r) => !r.passed).length;
+  // eslint-disable-next-line no-console
+  console.log(`\n${results.length - failed}/${results.length} assertions passed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+await main();

--- a/packages/llm-router/src/caps.ts
+++ b/packages/llm-router/src/caps.ts
@@ -1,0 +1,228 @@
+// Cap enforcement: per-office daily cap (from the ledger), per-agent wake
+// cap (in-memory sliding window), per-agent circuit breaker (in-memory),
+// process-wide idle mode (in-memory).
+//
+// Daily cap reads `cost_by_agent` because the projection is the source of
+// truth and survives broker restarts. Wake cap, breaker, and idle mode are
+// process-local on purpose — they reset on restart (a crash that loses one
+// minute of wake-cap state is harmless; reading from disk every call would
+// be costly).
+//
+// Idle mode: any call goes through `preflightIdle`. Human activity calls
+// `noteHumanActivity` to reset the clock. Agent-initiated activity does NOT
+// reset the clock; otherwise an agent loop would keep itself awake.
+
+import type { CostLedger } from "@wuphf/broker";
+
+import { CapExceededError, CircuitBreakerOpenError, IdleModeError } from "./errors.ts";
+import type { AgentInspection, BreakerState, GatewayInspection } from "./types.ts";
+
+export interface CapsConfig {
+  /** Per-office daily cap in micro-USD. RFC §8 default: 5_000_000 ($5/day). */
+  readonly dailyMicroUsd: number;
+  /** Per-agent wake cap. RFC §8 default: 12/hr. */
+  readonly wakeCapPerHour: number;
+  /** Sliding-window size for wake cap. Default 60 * 60 * 1000 (1h). */
+  readonly wakeWindowMs: number;
+  /** Errors-in-window threshold for breaker. RFC §8 default: 2. */
+  readonly breakerErrorThreshold: number;
+  /** Breaker error window. RFC §8 default: 10 * 60 * 1000 (10min). */
+  readonly breakerWindowMs: number;
+  /** Cool-down once breaker opens. Default 5 * 60 * 1000 (5min). */
+  readonly breakerCooldownMs: number;
+  /** Idle threshold. RFC §8 default: 5 * 60 * 1000 (5min). */
+  readonly idleThresholdMs: number;
+}
+
+export const DEFAULT_CAPS_CONFIG: CapsConfig = Object.freeze({
+  dailyMicroUsd: 5_000_000,
+  wakeCapPerHour: 12,
+  wakeWindowMs: 60 * 60 * 1000,
+  breakerErrorThreshold: 2,
+  breakerWindowMs: 10 * 60 * 1000,
+  breakerCooldownMs: 5 * 60 * 1000,
+  idleThresholdMs: 5 * 60 * 1000,
+});
+
+export interface CapsDeps {
+  readonly ledger: CostLedger;
+  readonly config: CapsConfig;
+  readonly nowMs: () => number;
+}
+
+interface AgentRuntimeState {
+  /** Wake timestamps (ms). Pruned on each cap check. */
+  wakes: number[];
+  /** Error timestamps (ms). Pruned on each cap check. */
+  errorTimestamps: number[];
+  /** Current breaker state. */
+  breaker: BreakerState;
+}
+
+export class Caps {
+  private readonly ledger: CostLedger;
+  private readonly config: CapsConfig;
+  private readonly nowMs: () => number;
+  private readonly agents = new Map<string, AgentRuntimeState>();
+  /**
+   * Last "activity" timestamp for the idle gate. Initialised to construction
+   * time so the gateway starts active; `noteHumanActivity` resets it on
+   * every inbound human-driven event.
+   */
+  private lastActivityMs: number;
+
+  constructor(deps: CapsDeps) {
+    this.ledger = deps.ledger;
+    this.config = deps.config;
+    this.nowMs = deps.nowMs;
+    this.lastActivityMs = deps.nowMs();
+  }
+
+  noteHumanActivity(): void {
+    this.lastActivityMs = this.nowMs();
+  }
+
+  /**
+   * Throw `IdleModeError` if the broker has been idle past the threshold.
+   * Idle does NOT account for agent-initiated activity by design.
+   */
+  preflightIdle(): void {
+    const now = this.nowMs();
+    if (now - this.lastActivityMs > this.config.idleThresholdMs) {
+      throw new IdleModeError(this.lastActivityMs);
+    }
+  }
+
+  /**
+   * Reject if today's office spend already meets or exceeds the cap. We
+   * do NOT pre-charge for the call we're about to make; the ±$0.05
+   * tolerance in §10.4 covers one in-flight call going over.
+   */
+  preflightDailyCap(): void {
+    const today = isoDateUtc(new Date(this.nowMs()));
+    const total = this.officeSpendMicroUsd(today);
+    if (total >= this.config.dailyMicroUsd) {
+      const retryAfterMs = msUntilNextUtcMidnight(this.nowMs());
+      throw new CapExceededError("daily", total, this.config.dailyMicroUsd, retryAfterMs);
+    }
+  }
+
+  preflightWakeCap(agentSlug: string): void {
+    const now = this.nowMs();
+    const state = this.stateFor(agentSlug);
+    pruneTimestamps(state.wakes, now - this.config.wakeWindowMs);
+    if (state.wakes.length >= this.config.wakeCapPerHour) {
+      const oldest = state.wakes[0] ?? now;
+      const retryAfterMs = Math.max(0, oldest + this.config.wakeWindowMs - now);
+      throw new CapExceededError(
+        "wake",
+        state.wakes.length,
+        this.config.wakeCapPerHour,
+        retryAfterMs,
+      );
+    }
+  }
+
+  /**
+   * Record a wake. Call AFTER pre-flight succeeds so a rejected call
+   * doesn't consume a slot in the window.
+   */
+  recordWake(agentSlug: string): void {
+    this.stateFor(agentSlug).wakes.push(this.nowMs());
+  }
+
+  preflightBreaker(agentSlug: string): void {
+    const state = this.stateFor(agentSlug);
+    if (state.breaker.status === "open") {
+      const now = this.nowMs();
+      if (now < state.breaker.cooldownEndsMs) {
+        throw new CircuitBreakerOpenError(state.breaker.cooldownEndsMs);
+      }
+      // Cool-down elapsed — half-open: clear errors and let the next call
+      // try. A successful call closes; another error re-opens.
+      state.breaker = { status: "closed", recentErrors: 0 };
+      state.errorTimestamps = [];
+    }
+  }
+
+  recordSuccess(agentSlug: string): void {
+    const state = this.stateFor(agentSlug);
+    state.errorTimestamps = [];
+    state.breaker = { status: "closed", recentErrors: 0 };
+  }
+
+  recordError(agentSlug: string): void {
+    const now = this.nowMs();
+    const state = this.stateFor(agentSlug);
+    pruneTimestamps(state.errorTimestamps, now - this.config.breakerWindowMs);
+    state.errorTimestamps.push(now);
+    if (state.errorTimestamps.length >= this.config.breakerErrorThreshold) {
+      state.breaker = {
+        status: "open",
+        openedAtMs: now,
+        cooldownEndsMs: now + this.config.breakerCooldownMs,
+      };
+    } else {
+      state.breaker = { status: "closed", recentErrors: state.errorTimestamps.length };
+    }
+  }
+
+  inspect(): GatewayInspection {
+    const now = this.nowMs();
+    const perAgent = new Map<string, AgentInspection>();
+    for (const [slug, state] of this.agents) {
+      pruneTimestamps(state.wakes, now - this.config.wakeWindowMs);
+      perAgent.set(slug, {
+        recentWakeCount: state.wakes.length,
+        breaker: state.breaker,
+      });
+    }
+    const idleFor = now - this.lastActivityMs;
+    return {
+      idleSinceMs: this.lastActivityMs,
+      idle: idleFor > this.config.idleThresholdMs,
+      perAgent,
+    };
+  }
+
+  /**
+   * Sum `cost_by_agent.total_micro_usd` across every agent for the given
+   * UTC day. The cap is per-office, not per-agent; this is the office.
+   */
+  private officeSpendMicroUsd(dayUtc: string): number {
+    let total = 0;
+    for (const row of this.ledger.listAgentSpend({ dayUtc })) {
+      total += row.totalMicroUsd as number;
+    }
+    return total;
+  }
+
+  private stateFor(agentSlug: string): AgentRuntimeState {
+    let state = this.agents.get(agentSlug);
+    if (state === undefined) {
+      state = {
+        wakes: [],
+        errorTimestamps: [],
+        breaker: { status: "closed", recentErrors: 0 },
+      };
+      this.agents.set(agentSlug, state);
+    }
+    return state;
+  }
+}
+
+function pruneTimestamps(buf: number[], cutoffMs: number): void {
+  while (buf.length > 0 && (buf[0] ?? Number.POSITIVE_INFINITY) < cutoffMs) {
+    buf.shift();
+  }
+}
+
+function isoDateUtc(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function msUntilNextUtcMidnight(nowMs: number): number {
+  const d = new Date(nowMs);
+  const next = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1, 0, 0, 0, 0);
+  return Math.max(0, next - nowMs);
+}

--- a/packages/llm-router/src/dedupe.ts
+++ b/packages/llm-router/src/dedupe.ts
@@ -1,0 +1,106 @@
+// Identical-payload dedupe (RFC §7.5). Within `windowMs`, two calls
+// whose canonical request bytes hash to the same SHA-256 share one
+// response: the second call returns the cached `GatewayCompletionResult`
+// (with `dedupeReplay: true`) and does NOT consume wake/daily cap budget
+// or call the provider again. The original cost_event is the one the
+// ledger has on file.
+//
+// Why content-hash (not idempotency key): the gateway's caller surface is
+// internal (agent runners), and we want dedupe to fire even if a runner
+// re-issues a request with the same payload but didn't think to mint an
+// idempotency key. Content-hashing the request bytes is the floor.
+
+import { canonicalJSON, type Sha256Hex, sha256Hex } from "@wuphf/protocol";
+
+import type { GatewayCompletionResult, ProviderRequest } from "./types.ts";
+
+export interface DedupeConfig {
+  /** Sliding window. RFC §7.5 default: 60_000 (60s). */
+  readonly windowMs: number;
+}
+
+export const DEFAULT_DEDUPE_CONFIG: DedupeConfig = Object.freeze({
+  windowMs: 60_000,
+});
+
+interface DedupeEntry {
+  readonly result: GatewayCompletionResult;
+  readonly expiresAtMs: number;
+}
+
+/**
+ * In-memory dedupe cache. Keyed by SHA-256 of canonical JSON of the
+ * request. The result is the original (non-replay) gateway result; we
+ * flip `dedupeReplay: true` on every read so callers can log the replay.
+ */
+export class DedupeCache {
+  private readonly entries = new Map<Sha256Hex, DedupeEntry>();
+  private readonly nowMs: () => number;
+  private readonly windowMs: number;
+
+  constructor(deps: { readonly nowMs: () => number; readonly config?: DedupeConfig }) {
+    this.nowMs = deps.nowMs;
+    this.windowMs = deps.config?.windowMs ?? DEFAULT_DEDUPE_CONFIG.windowMs;
+  }
+
+  /**
+   * Look up a cached response. Returns the cached `GatewayCompletionResult`
+   * with `dedupeReplay: true`, or `null` if no live entry exists.
+   * Side effect: prunes expired entries it encounters.
+   */
+  lookup(req: ProviderRequest): GatewayCompletionResult | null {
+    const key = hashRequest(req);
+    const entry = this.entries.get(key);
+    if (entry === undefined) return null;
+    const now = this.nowMs();
+    if (entry.expiresAtMs <= now) {
+      this.entries.delete(key);
+      return null;
+    }
+    return { ...entry.result, dedupeReplay: true };
+  }
+
+  /**
+   * Store a fresh result. Call after the gateway produces a real result
+   * (with `dedupeReplay: false`). The cache stores the result as-is and
+   * flips the flag on lookup.
+   */
+  store(req: ProviderRequest, result: GatewayCompletionResult): void {
+    const key = hashRequest(req);
+    this.entries.set(key, {
+      result,
+      expiresAtMs: this.nowMs() + this.windowMs,
+    });
+  }
+
+  /**
+   * Prune entries whose deadline has passed. Called by the gateway on a
+   * timer or before inspection; the lookup path also self-prunes on miss.
+   */
+  pruneExpired(): void {
+    const now = this.nowMs();
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAtMs <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+}
+
+/**
+ * SHA-256 of the request's canonical-JSON projection. `canonicalJSON`
+ * is RFC 8785 — key order is deterministic. The same logical request
+ * with different key insertion orders hashes identically.
+ */
+export function hashRequest(req: ProviderRequest): Sha256Hex {
+  const canonical = canonicalJSON({
+    model: req.model,
+    prompt: req.prompt,
+    maxOutputTokens: req.maxOutputTokens,
+  });
+  return sha256Hex(canonical);
+}

--- a/packages/llm-router/src/dedupe.ts
+++ b/packages/llm-router/src/dedupe.ts
@@ -12,7 +12,7 @@
 
 import { canonicalJSON, type Sha256Hex, sha256Hex } from "@wuphf/protocol";
 
-import type { GatewayCompletionResult, ProviderRequest } from "./types.ts";
+import type { GatewayCompletionResult, ProviderRequest, SupervisorContext } from "./types.ts";
 
 export interface DedupeConfig {
   /** Sliding window. RFC §7.5 default: 60_000 (60s). */
@@ -47,9 +47,14 @@ export class DedupeCache {
    * Look up a cached response. Returns the cached `GatewayCompletionResult`
    * with `dedupeReplay: true`, or `null` if no live entry exists.
    * Side effect: prunes expired entries it encounters.
+   *
+   * The key includes `SupervisorContext` so two different agents (or two
+   * tasks under one agent) with the same prompt do NOT share an LSN.
+   * Without the context, replay leaks cost attribution and bypasses the
+   * second caller's wake-cap accounting.
    */
-  lookup(req: ProviderRequest): GatewayCompletionResult | null {
-    const key = hashRequest(req);
+  lookup(ctx: SupervisorContext, req: ProviderRequest): GatewayCompletionResult | null {
+    const key = hashRequest(ctx, req);
     const entry = this.entries.get(key);
     if (entry === undefined) return null;
     const now = this.nowMs();
@@ -65,8 +70,8 @@ export class DedupeCache {
    * (with `dedupeReplay: false`). The cache stores the result as-is and
    * flips the flag on lookup.
    */
-  store(req: ProviderRequest, result: GatewayCompletionResult): void {
-    const key = hashRequest(req);
+  store(ctx: SupervisorContext, req: ProviderRequest, result: GatewayCompletionResult): void {
+    const key = hashRequest(ctx, req);
     this.entries.set(key, {
       result,
       expiresAtMs: this.nowMs() + this.windowMs,
@@ -92,12 +97,24 @@ export class DedupeCache {
 }
 
 /**
- * SHA-256 of the request's canonical-JSON projection. `canonicalJSON`
- * is RFC 8785 — key order is deterministic. The same logical request
- * with different key insertion orders hashes identically.
+ * SHA-256 of the (context, request) canonical-JSON projection.
+ * `canonicalJSON` is RFC 8785 — key order is deterministic.
+ *
+ * The context fields (`agentSlug`, `taskId`, `receiptId`) are part of
+ * the key so dedupe stays scoped to one caller. Without them the same
+ * prompt from a different agent would replay the original caller's
+ * `costEventLsn` — leaking cost attribution AND bypassing wake-cap
+ * accounting for the second caller. See triangulation finding B3.
+ *
+ * `null` is used for absent optional fields so the canonical JSON shape
+ * stays stable across callers; `omitUndefined` would shift key ordering
+ * between presence/absence callers.
  */
-export function hashRequest(req: ProviderRequest): Sha256Hex {
+export function hashRequest(ctx: SupervisorContext, req: ProviderRequest): Sha256Hex {
   const canonical = canonicalJSON({
+    agentSlug: ctx.agentSlug as string,
+    taskId: (ctx.taskId as string | undefined) ?? null,
+    receiptId: (ctx.receiptId as string | undefined) ?? null,
     model: req.model,
     prompt: req.prompt,
     maxOutputTokens: req.maxOutputTokens,

--- a/packages/llm-router/src/errors.ts
+++ b/packages/llm-router/src/errors.ts
@@ -1,0 +1,82 @@
+// Typed errors thrown by the gateway. Every caller-visible failure has
+// a concrete subclass with a stable `code` so the PR C wire layer can
+// map them to HTTP without sniffing message strings.
+
+export type CapKind = "daily" | "wake";
+
+export class CapExceededError extends Error {
+  readonly code = "cap_exceeded";
+  constructor(
+    readonly cap: CapKind,
+    readonly observedMicroUsd: number | null,
+    readonly limitMicroUsd: number | null,
+    readonly retryAfterMs: number,
+  ) {
+    super(
+      `cap_exceeded: ${cap}` +
+        (observedMicroUsd !== null && limitMicroUsd !== null
+          ? ` (observed=${observedMicroUsd}, limit=${limitMicroUsd})`
+          : "") +
+        `, retry_after_ms=${retryAfterMs}`,
+    );
+    this.name = "CapExceededError";
+  }
+}
+
+export class CircuitBreakerOpenError extends Error {
+  readonly code = "breaker_open";
+  constructor(readonly cooldownEndsMs: number) {
+    super(`breaker_open: cooldown_ends_ms=${cooldownEndsMs}`);
+    this.name = "CircuitBreakerOpenError";
+  }
+}
+
+export class IdleModeError extends Error {
+  readonly code = "idle_mode";
+  constructor(readonly idleSinceMs: number) {
+    super(`idle_mode: idle_since_ms=${idleSinceMs}`);
+    this.name = "IdleModeError";
+  }
+}
+
+export class ProviderError extends Error {
+  readonly code = "provider_error";
+  readonly providerKind: string;
+  override readonly cause: unknown;
+  constructor(providerKind: string, cause: unknown) {
+    const causeMsg = cause instanceof Error ? cause.message : String(cause);
+    super(`provider_error: kind=${providerKind} cause=${causeMsg}`);
+    this.name = "ProviderError";
+    this.providerKind = providerKind;
+    this.cause = cause;
+  }
+}
+
+export class UnknownModelError extends Error {
+  readonly code = "unknown_model";
+  constructor(readonly model: string) {
+    super(`unknown_model: ${JSON.stringify(model)}`);
+    this.name = "UnknownModelError";
+  }
+}
+
+/**
+ * Type guard for the gateway's own typed errors. Callers can switch on
+ * `.code` to decide retry behavior without `instanceof` chains.
+ */
+export type GatewayError =
+  | CapExceededError
+  | CircuitBreakerOpenError
+  | IdleModeError
+  | ProviderError
+  | UnknownModelError;
+
+export function isGatewayError(value: unknown): value is GatewayError {
+  return (
+    value instanceof CapExceededError ||
+    value instanceof CircuitBreakerOpenError ||
+    value instanceof IdleModeError ||
+    value instanceof ProviderError ||
+    value instanceof UnknownModelError
+  );
+}

--- a/packages/llm-router/src/gateway.ts
+++ b/packages/llm-router/src/gateway.ts
@@ -29,7 +29,7 @@ import {
 import { Caps, type CapsConfig, DEFAULT_CAPS_CONFIG } from "./caps.ts";
 import { DEFAULT_DEDUPE_CONFIG, DedupeCache, type DedupeConfig } from "./dedupe.ts";
 import { ProviderError, UnknownModelError } from "./errors.ts";
-import { isStubModel, STUB_MODEL_ERROR, STUB_MODEL_FIXED_COST } from "./providers/stub.ts";
+import { isStubModel } from "./providers/stub.ts";
 import type {
   Gateway,
   GatewayCompletionResult,
@@ -66,7 +66,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
     caps.preflightIdle();
     caps.preflightBreaker(ctx.agentSlug);
 
-    const replay = dedupe.lookup(req);
+    const replay = dedupe.lookup(ctx, req);
     if (replay !== null) {
       return replay;
     }
@@ -90,24 +90,32 @@ export function createGateway(deps: GatewayDeps): Gateway {
       throw new ProviderError(provider.kind, err);
     }
 
-    const costMicroUsd: MicroUsd = provider.costEstimator.estimate(
-      req.model,
-      providerResponse.usage,
-    );
+    // Estimator + ledger append are post-provider. A failure here means
+    // we paid the provider but couldn't account for it. Treat that as a
+    // breaker-worthy event so a sustained estimator/ledger fault opens
+    // the circuit instead of letting the gateway keep spending while
+    // every accounting layer reads zero. See triangulation finding H5.
+    let costMicroUsd: MicroUsd;
+    let appended: ReturnType<CostLedger["appendCostEvent"]>;
+    try {
+      costMicroUsd = provider.costEstimator.estimate(req.model, providerResponse.usage);
 
-    // The "row before response" point: appendCostEvent is the only place
-    // an EventLsn for this completion is produced. If this throws, the
-    // response is discarded — we do NOT return a completion without a
-    // matching ledger row. The error is re-thrown so the caller sees
-    // the underlying storage problem and can retry.
-    const payload: CostEventAuditPayload = buildCostEventPayload(
-      ctx,
-      req,
-      providerResponse.usage,
-      costMicroUsd,
-      deps.nowMs(),
-    );
-    const appended = deps.ledger.appendCostEvent(payload);
+      // The "row before response" point: appendCostEvent is the only
+      // place an EventLsn for this completion is produced. If this
+      // throws, the response is discarded — we do NOT return a
+      // completion without a matching ledger row.
+      const payload: CostEventAuditPayload = buildCostEventPayload(
+        ctx,
+        req,
+        providerResponse.usage,
+        costMicroUsd,
+        deps.nowMs(),
+      );
+      appended = deps.ledger.appendCostEvent(payload);
+    } catch (err) {
+      caps.recordError(ctx.agentSlug);
+      throw err;
+    }
 
     // Caps housekeeping AFTER the ledger commit so a crash mid-commit
     // doesn't burn a wake slot that the ledger never saw.
@@ -121,7 +129,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
       costEventLsn: appended.lsn,
       dedupeReplay: false,
     };
-    dedupe.store(req, result);
+    dedupe.store(ctx, req, result);
     return result;
   }
 
@@ -170,19 +178,22 @@ function buildCostEventPayload(
 }
 
 /**
- * Resolve a provider for a model name. For PR B we route by exact-model
- * lookup; PR B.2 (real Anthropic SDK) will route by model prefix
- * (`claude-` → anthropic, `gpt-` → openai, etc.).
+ * Resolve a provider for a model name by exact lookup against each
+ * provider's `models` list. Construction-time collision: if two
+ * providers register the same model, throw immediately so the host
+ * sees the conflict at gateway init rather than at first call.
  */
 function indexProvidersByModel(providers: readonly Provider[]): Map<string, Provider> {
   const out = new Map<string, Provider>();
   for (const provider of providers) {
-    // PR B knows the stub models inline; the real-provider adapters in
-    // PR B.2 / PR B.3 will register their own model lists. Until then,
-    // the stub provider claims both stub-* models.
-    if (provider.kind === "openai-compat") {
-      out.set(STUB_MODEL_FIXED_COST, provider);
-      out.set(STUB_MODEL_ERROR, provider);
+    for (const model of provider.models) {
+      const existing = out.get(model);
+      if (existing !== undefined && existing !== provider) {
+        throw new Error(
+          `provider model collision: ${JSON.stringify(model)} claimed by ${existing.kind} and ${provider.kind}`,
+        );
+      }
+      out.set(model, provider);
     }
   }
   return out;

--- a/packages/llm-router/src/gateway.ts
+++ b/packages/llm-router/src/gateway.ts
@@ -1,0 +1,210 @@
+// Gateway implementation. The order inside `complete()` is the contract:
+//
+//   1. Idle gate (cheap, runs before any state mutation).
+//   2. Breaker gate (cheap; opens reject without consuming budget).
+//   3. Dedupe lookup (cheap; replay short-circuits before wake/daily cost).
+//   4. Daily cap pre-flight (reads ledger).
+//   5. Wake cap pre-flight (in-memory).
+//   6. Provider call.
+//   7. Cost estimate.
+//   8. Ledger write — this is the "row before response" point. On failure,
+//      the response is discarded and the error is re-thrown.
+//   9. Record wake + success in caps.
+//  10. Store result in dedupe cache.
+//  11. Return GatewayCompletionResult with the LSN from step 8.
+//
+// Step 8 is the only place a successful `complete()` can mint a
+// `costEventLsn` to put in the result. No other code path returns a
+// completion. That's the type-system enforcement.
+
+import type { CostLedger } from "@wuphf/broker";
+import {
+  asProviderKind,
+  type CostEventAuditPayload,
+  type CostUnits,
+  type MicroUsd,
+  type ProviderKind,
+} from "@wuphf/protocol";
+
+import { Caps, type CapsConfig, DEFAULT_CAPS_CONFIG } from "./caps.ts";
+import { DEFAULT_DEDUPE_CONFIG, DedupeCache, type DedupeConfig } from "./dedupe.ts";
+import { ProviderError, UnknownModelError } from "./errors.ts";
+import { isStubModel, STUB_MODEL_ERROR, STUB_MODEL_FIXED_COST } from "./providers/stub.ts";
+import type {
+  Gateway,
+  GatewayCompletionResult,
+  GatewayInspection,
+  Provider,
+  ProviderRequest,
+  ProviderResponse,
+  SupervisorContext,
+} from "./types.ts";
+
+export interface GatewayConfig {
+  readonly caps?: Partial<CapsConfig>;
+  readonly dedupe?: Partial<DedupeConfig>;
+}
+
+export interface GatewayDeps {
+  readonly ledger: CostLedger;
+  readonly providers: readonly Provider[];
+  readonly nowMs: () => number;
+  readonly config?: GatewayConfig;
+}
+
+export function createGateway(deps: GatewayDeps): Gateway {
+  const capsConfig: CapsConfig = { ...DEFAULT_CAPS_CONFIG, ...(deps.config?.caps ?? {}) };
+  const dedupeConfig: DedupeConfig = { ...DEFAULT_DEDUPE_CONFIG, ...(deps.config?.dedupe ?? {}) };
+  const caps = new Caps({ ledger: deps.ledger, config: capsConfig, nowMs: deps.nowMs });
+  const dedupe = new DedupeCache({ nowMs: deps.nowMs, config: dedupeConfig });
+  const providers = indexProvidersByModel(deps.providers);
+
+  async function complete(
+    ctx: SupervisorContext,
+    req: ProviderRequest,
+  ): Promise<GatewayCompletionResult> {
+    caps.preflightIdle();
+    caps.preflightBreaker(ctx.agentSlug);
+
+    const replay = dedupe.lookup(req);
+    if (replay !== null) {
+      return replay;
+    }
+
+    caps.preflightDailyCap();
+    caps.preflightWakeCap(ctx.agentSlug);
+
+    const provider = providers.get(req.model);
+    if (provider === undefined) {
+      throw new UnknownModelError(req.model);
+    }
+
+    let providerResponse: ProviderResponse;
+    try {
+      providerResponse = await provider.complete(req);
+    } catch (err) {
+      caps.recordError(ctx.agentSlug);
+      if (err instanceof ProviderError || err instanceof UnknownModelError) {
+        throw err;
+      }
+      throw new ProviderError(provider.kind, err);
+    }
+
+    const costMicroUsd: MicroUsd = provider.costEstimator.estimate(
+      req.model,
+      providerResponse.usage,
+    );
+
+    // The "row before response" point: appendCostEvent is the only place
+    // an EventLsn for this completion is produced. If this throws, the
+    // response is discarded — we do NOT return a completion without a
+    // matching ledger row. The error is re-thrown so the caller sees
+    // the underlying storage problem and can retry.
+    const payload: CostEventAuditPayload = buildCostEventPayload(
+      ctx,
+      req,
+      providerResponse.usage,
+      costMicroUsd,
+      deps.nowMs(),
+    );
+    const appended = deps.ledger.appendCostEvent(payload);
+
+    // Caps housekeeping AFTER the ledger commit so a crash mid-commit
+    // doesn't burn a wake slot that the ledger never saw.
+    caps.recordWake(ctx.agentSlug);
+    caps.recordSuccess(ctx.agentSlug);
+
+    const result: GatewayCompletionResult = {
+      text: providerResponse.text,
+      usage: providerResponse.usage,
+      costMicroUsd,
+      costEventLsn: appended.lsn,
+      dedupeReplay: false,
+    };
+    dedupe.store(req, result);
+    return result;
+  }
+
+  function inspect(): GatewayInspection {
+    dedupe.pruneExpired();
+    return caps.inspect();
+  }
+
+  function noteHumanActivity(): void {
+    caps.noteHumanActivity();
+  }
+
+  return { complete, inspect, noteHumanActivity };
+}
+
+function buildCostEventPayload(
+  ctx: SupervisorContext,
+  req: ProviderRequest,
+  usage: CostUnits,
+  costMicroUsd: MicroUsd,
+  nowMs: number,
+): CostEventAuditPayload {
+  // Pull only the fields cost.ts validates; payload keys not listed in
+  // COST_EVENT_KEYS are rejected by the validator (see protocol cost.ts).
+  const base: CostEventAuditPayload = {
+    agentSlug: ctx.agentSlug,
+    providerKind: providerKindFor(req.model),
+    model: req.model,
+    amountMicroUsd: costMicroUsd,
+    units: usage,
+    occurredAt: new Date(nowMs),
+  };
+  // Omit undefined optionals — the protocol codec preserves absence (not
+  // null), and this matches the canonical-JSON shape the audit chain
+  // hashes against.
+  if (ctx.taskId !== undefined && ctx.receiptId !== undefined) {
+    return { ...base, taskId: ctx.taskId, receiptId: ctx.receiptId };
+  }
+  if (ctx.taskId !== undefined) {
+    return { ...base, taskId: ctx.taskId };
+  }
+  if (ctx.receiptId !== undefined) {
+    return { ...base, receiptId: ctx.receiptId };
+  }
+  return base;
+}
+
+/**
+ * Resolve a provider for a model name. For PR B we route by exact-model
+ * lookup; PR B.2 (real Anthropic SDK) will route by model prefix
+ * (`claude-` → anthropic, `gpt-` → openai, etc.).
+ */
+function indexProvidersByModel(providers: readonly Provider[]): Map<string, Provider> {
+  const out = new Map<string, Provider>();
+  for (const provider of providers) {
+    // PR B knows the stub models inline; the real-provider adapters in
+    // PR B.2 / PR B.3 will register their own model lists. Until then,
+    // the stub provider claims both stub-* models.
+    if (provider.kind === "openai-compat") {
+      out.set(STUB_MODEL_FIXED_COST, provider);
+      out.set(STUB_MODEL_ERROR, provider);
+    }
+  }
+  return out;
+}
+
+/**
+ * Map an internal model name to its `ProviderKind`. The closed enum
+ * lives in `@wuphf/protocol/receipt-types.ts`; adding a new kind is a
+ * wire-shape change.
+ */
+function providerKindFor(model: string): ProviderKind {
+  if (isStubModel(model)) {
+    // Stubs masquerade as openai-compat so the audit payload's
+    // providerKind stays inside the closed enum.
+    return asProviderKind("openai-compat");
+  }
+  // PR B.2 will add prefix routing here; for PR B the stub is the only
+  // working path and we fail loud on unknown models.
+  throw new UnknownModelError(model);
+}
+
+// Re-export for callers that compose their own deps without pulling each
+// helper file individually.
+export { Caps } from "./caps.ts";
+export { DedupeCache } from "./dedupe.ts";

--- a/packages/llm-router/src/index.ts
+++ b/packages/llm-router/src/index.ts
@@ -1,0 +1,35 @@
+export type { CapsConfig } from "./caps.ts";
+export { Caps, DEFAULT_CAPS_CONFIG } from "./caps.ts";
+export type { DedupeConfig } from "./dedupe.ts";
+export { DEFAULT_DEDUPE_CONFIG, DedupeCache, hashRequest } from "./dedupe.ts";
+export type { GatewayError } from "./errors.ts";
+export {
+  CapExceededError,
+  CircuitBreakerOpenError,
+  IdleModeError,
+  isGatewayError,
+  ProviderError,
+  UnknownModelError,
+} from "./errors.ts";
+export type { GatewayConfig, GatewayDeps } from "./gateway.ts";
+export { createGateway } from "./gateway.ts";
+export {
+  createStubProvider,
+  isStubModel,
+  STUB_FIXED_COST_MICRO_USD,
+  STUB_MODEL_ERROR,
+  STUB_MODEL_FIXED_COST,
+  StubProvider,
+} from "./providers/stub.ts";
+export type {
+  AgentInspection,
+  BreakerState,
+  CostEstimator,
+  Gateway,
+  GatewayCompletionResult,
+  GatewayInspection,
+  Provider,
+  ProviderRequest,
+  ProviderResponse,
+  SupervisorContext,
+} from "./types.ts";

--- a/packages/llm-router/src/providers/stub.ts
+++ b/packages/llm-router/src/providers/stub.ts
@@ -1,0 +1,101 @@
+// Stub provider for the §10.4 burn-down (`ci:burn:nightly`).
+//
+// Determinism is the contract: every call costs exactly
+// STUB_FIXED_COST_MICRO_USD with zero variance, returns canned text, and
+// reports fixed token usage. The burn-down asserts the per-office daily
+// cap (default $5 = 5_000_000 micro-USD) holds at $5.00 ± $0.05 across 60
+// minutes of throttled calls; that contract requires exact-amount
+// predictability.
+//
+// Two model names are exposed:
+//
+//   stub-fixed-cost   — the §10.4 target. 10000 micro-USD/call.
+//   stub-error        — always throws. Used for breaker tests.
+//
+// Adding a third "random cost" variant is tempting for testing daily-cap
+// edge cases but would break §10.4's invariance — keep them in test files
+// with their own provider.
+
+import {
+  asMicroUsd,
+  asProviderKind,
+  type CostUnits,
+  type MicroUsd,
+  type ProviderKind,
+} from "@wuphf/protocol";
+
+import { ProviderError, UnknownModelError } from "../errors.ts";
+import type { CostEstimator, Provider, ProviderRequest, ProviderResponse } from "../types.ts";
+
+const STUB_PROVIDER_KIND: ProviderKind = asProviderKind("openai-compat");
+
+/**
+ * $0.01 per call. Picked so the §10.4 burn-down can run 500 calls
+ * inside the $5 cap and have ~$0 headroom — a tighter cap surface for
+ * the test, while still cheap enough that the wake cap throttles before
+ * the daily cap (12/hr × 60min = 720 wakes; daily cap stops at 500).
+ */
+export const STUB_FIXED_COST_MICRO_USD = 10_000;
+
+const STUB_FIXED_RESPONSE_TEXT = "ack";
+
+// Identical usage for every call; cache fields are zero (stub does not
+// model prompt caching). Holding usage constant makes the §10.4 ledger
+// math byte-for-byte reproducible.
+const STUB_FIXED_USAGE: CostUnits = Object.freeze({
+  inputTokens: 100,
+  outputTokens: 50,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+});
+
+export const STUB_MODEL_FIXED_COST = "stub-fixed-cost";
+export const STUB_MODEL_ERROR = "stub-error";
+
+class StubCostEstimator implements CostEstimator {
+  estimate(model: string, _usage: CostUnits): MicroUsd {
+    if (model === STUB_MODEL_FIXED_COST) {
+      return asMicroUsd(STUB_FIXED_COST_MICRO_USD);
+    }
+    if (model === STUB_MODEL_ERROR) {
+      // stub-error never produces a successful response, so this branch is
+      // unreachable in practice; the throw makes the dead branch loud if a
+      // future refactor accidentally takes it.
+      throw new UnknownModelError(model);
+    }
+    throw new UnknownModelError(model);
+  }
+}
+
+/**
+ * `Provider` implementation for the stub models. Constructed once and
+ * registered alongside real providers on `Gateway` startup; the gateway
+ * routes requests to a provider by model-name prefix matching.
+ */
+export class StubProvider implements Provider {
+  // ProviderKind doesn't have "stub"; "openai-compat" is the catch-all
+  // (see protocol PROVIDER_KIND_VALUES).
+  readonly kind: ProviderKind = STUB_PROVIDER_KIND;
+  readonly costEstimator: CostEstimator = new StubCostEstimator();
+
+  async complete(req: ProviderRequest): Promise<ProviderResponse> {
+    if (req.model === STUB_MODEL_FIXED_COST) {
+      return Promise.resolve({
+        text: STUB_FIXED_RESPONSE_TEXT,
+        usage: STUB_FIXED_USAGE,
+      });
+    }
+    if (req.model === STUB_MODEL_ERROR) {
+      throw new ProviderError("openai-compat", new Error("stub-error: forced failure"));
+    }
+    throw new UnknownModelError(req.model);
+  }
+}
+
+export function createStubProvider(): StubProvider {
+  return new StubProvider();
+}
+
+export function isStubModel(model: string): boolean {
+  return model === STUB_MODEL_FIXED_COST || model === STUB_MODEL_ERROR;
+}

--- a/packages/llm-router/src/providers/stub.ts
+++ b/packages/llm-router/src/providers/stub.ts
@@ -74,8 +74,12 @@ class StubCostEstimator implements CostEstimator {
  */
 export class StubProvider implements Provider {
   // ProviderKind doesn't have "stub"; "openai-compat" is the catch-all
-  // (see protocol PROVIDER_KIND_VALUES).
+  // for audit-event attribution (see protocol PROVIDER_KIND_VALUES).
+  // The gateway routes by `models`, NOT by `kind`, so this stub can
+  // share `kind` with a future real openai-compat provider without
+  // colliding on model registration.
   readonly kind: ProviderKind = STUB_PROVIDER_KIND;
+  readonly models: readonly string[] = [STUB_MODEL_FIXED_COST, STUB_MODEL_ERROR];
   readonly costEstimator: CostEstimator = new StubCostEstimator();
 
   async complete(req: ProviderRequest): Promise<ProviderResponse> {

--- a/packages/llm-router/src/types.ts
+++ b/packages/llm-router/src/types.ts
@@ -61,6 +61,15 @@ export interface CostEstimator {
 
 export interface Provider {
   readonly kind: ProviderKind;
+  /**
+   * Exact model IDs this provider handles. The gateway routes by exact
+   * match of `ProviderRequest.model` against this list — NOT by `kind`.
+   * Two providers can share a `kind` (e.g. real openai-compat + stub
+   * both report `"openai-compat"` for audit purposes) without colliding
+   * because each owns a disjoint set of model strings. See
+   * triangulation finding H4.
+   */
+  readonly models: readonly string[];
   readonly costEstimator: CostEstimator;
   complete(req: ProviderRequest): Promise<ProviderResponse>;
 }

--- a/packages/llm-router/src/types.ts
+++ b/packages/llm-router/src/types.ts
@@ -1,0 +1,115 @@
+// Gateway types — public surface.
+//
+// The "type-system enforced row-before-response" contract works like this:
+// `Gateway.complete()` returns a `GatewayCompletionResult` that carries the
+// `cost_event` LSN. Inside the gateway implementation, the only way to fill
+// that LSN is to call `ledger.appendCostEvent()` first; a developer who
+// short-circuits the ledger write has no LSN to return. The unit tests
+// verify the LSN matches an actual row in `event_log`.
+
+import type {
+  AgentSlug,
+  CostUnits,
+  EventLsn,
+  MicroUsd,
+  ProviderKind,
+  ReceiptId,
+  TaskId,
+} from "@wuphf/protocol";
+
+/**
+ * Caller context for every `Gateway.complete()` call. Identifies the agent
+ * (drives wake-cap and per-agent budget routing), and optionally the task
+ * and receipt the call is being made on behalf of (so the cost_event
+ * payload can attribute spend).
+ */
+export interface SupervisorContext {
+  readonly agentSlug: AgentSlug;
+  readonly taskId?: TaskId;
+  readonly receiptId?: ReceiptId;
+}
+
+/**
+ * Wire-shape-agnostic request. Real provider SDKs receive a translated
+ * subset of this in their own request types; the gateway only needs the
+ * fields it must hash for dedupe and pass to the cost estimator.
+ */
+export interface ProviderRequest {
+  readonly model: string;
+  readonly prompt: string;
+  readonly maxOutputTokens: number;
+}
+
+/**
+ * What providers return. `usage` populates the cost_event's `units`
+ * field directly so cache accounting (Anthropic-style) survives intact.
+ */
+export interface ProviderResponse {
+  readonly text: string;
+  readonly usage: CostUnits;
+}
+
+export interface CostEstimator {
+  /**
+   * Given a model name and post-call usage counters, return the
+   * integer-micro-USD cost. Pure function; per-model pricing tables
+   * live here. The estimator MUST NOT do I/O — it runs inside the
+   * gateway's hot path and on the §10.4 burn-down.
+   */
+  estimate(model: string, usage: CostUnits): MicroUsd;
+}
+
+export interface Provider {
+  readonly kind: ProviderKind;
+  readonly costEstimator: CostEstimator;
+  complete(req: ProviderRequest): Promise<ProviderResponse>;
+}
+
+/**
+ * Result returned by `Gateway.complete()`. The presence of `costEventLsn`
+ * is the public proof that the cost ledger row was written. Callers
+ * should never have to handle a "completion without a cost row" case;
+ * either the gateway returned a result with the LSN, or it threw.
+ */
+export interface GatewayCompletionResult {
+  readonly text: string;
+  readonly usage: CostUnits;
+  readonly costMicroUsd: MicroUsd;
+  readonly costEventLsn: EventLsn;
+  /** True iff this response was served from the 60s dedupe cache. */
+  readonly dedupeReplay: boolean;
+}
+
+export interface Gateway {
+  complete(ctx: SupervisorContext, req: ProviderRequest): Promise<GatewayCompletionResult>;
+
+  /**
+   * Mark "human / scheduler activity just happened" so the idle clock
+   * resets. The supervisor calls this on every inbound human action;
+   * agent-initiated activity does NOT reset the clock (otherwise an
+   * agent loop would keep itself awake indefinitely).
+   */
+  noteHumanActivity(): void;
+
+  /**
+   * Diagnostic snapshot of the gateway's process-local state (wake-cap
+   * window, breaker state, idle window). Used by the §10.4 burn-down
+   * and the cost-tile API. Not a fresh transaction with the ledger.
+   */
+  inspect(): GatewayInspection;
+}
+
+export interface GatewayInspection {
+  readonly idleSinceMs: number | null;
+  readonly idle: boolean;
+  readonly perAgent: ReadonlyMap<string, AgentInspection>;
+}
+
+export interface AgentInspection {
+  readonly recentWakeCount: number;
+  readonly breaker: BreakerState;
+}
+
+export type BreakerState =
+  | { readonly status: "closed"; readonly recentErrors: number }
+  | { readonly status: "open"; readonly openedAtMs: number; readonly cooldownEndsMs: number };

--- a/packages/llm-router/tests/gateway.spec.ts
+++ b/packages/llm-router/tests/gateway.spec.ts
@@ -1,0 +1,303 @@
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { asAgentSlug, asReceiptId, asTaskId } from "@wuphf/protocol";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CapExceededError,
+  CircuitBreakerOpenError,
+  createGateway,
+  createStubProvider,
+  type Gateway,
+  IdleModeError,
+  type ProviderRequest,
+  STUB_FIXED_COST_MICRO_USD,
+  STUB_MODEL_ERROR,
+  STUB_MODEL_FIXED_COST,
+  type SupervisorContext,
+} from "../src/index.ts";
+
+interface Clock {
+  now: number;
+}
+
+function setup(opts: { dailyMicroUsd?: number; wakeCapPerHour?: number } = {}): {
+  gateway: Gateway;
+  clock: Clock;
+  ledger: ReturnType<typeof createCostLedger>;
+  db: ReturnType<typeof openDatabase>;
+} {
+  const db = openDatabase({ path: ":memory:" });
+  runMigrations(db);
+  const eventLog = createEventLog(db);
+  const ledger = createCostLedger(db, eventLog);
+  const clock: Clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+  const gateway = createGateway({
+    ledger,
+    providers: [createStubProvider()],
+    nowMs: () => clock.now,
+    config: {
+      caps: {
+        ...(opts.dailyMicroUsd !== undefined ? { dailyMicroUsd: opts.dailyMicroUsd } : {}),
+        ...(opts.wakeCapPerHour !== undefined ? { wakeCapPerHour: opts.wakeCapPerHour } : {}),
+      },
+    },
+  });
+  return { gateway, clock, ledger, db };
+}
+
+const CTX: SupervisorContext = {
+  agentSlug: asAgentSlug("primary"),
+  taskId: asTaskId("01BRZ3NDEKTSV4RRFFQ69G5FA0"),
+  receiptId: asReceiptId("01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+};
+
+const REQ: ProviderRequest = {
+  model: STUB_MODEL_FIXED_COST,
+  prompt: "hello",
+  maxOutputTokens: 64,
+};
+
+describe("gateway happy path", () => {
+  let fix: ReturnType<typeof setup>;
+  beforeEach(() => {
+    fix = setup();
+  });
+  afterEach(() => {
+    fix.db.close();
+  });
+
+  it("writes a cost_event before returning, and the LSN matches event_log", async () => {
+    const result = await fix.gateway.complete(CTX, REQ);
+    expect(result.text).toBe("ack");
+    expect(result.costMicroUsd as number).toBe(STUB_FIXED_COST_MICRO_USD);
+    expect(result.dedupeReplay).toBe(false);
+    expect(result.costEventLsn).toBe("v1:1");
+
+    // The §15.A invariant: event_log holds exactly one cost.event row at
+    // the LSN we returned.
+    const row = fix.db
+      .prepare<[number], { readonly lsn: number; readonly type: string }>(
+        "SELECT lsn, type FROM event_log WHERE lsn = ?",
+      )
+      .get(1);
+    expect(row?.type).toBe("cost.event");
+    expect(row?.lsn).toBe(1);
+  });
+
+  it("agent + task projections reflect the call atomically", async () => {
+    await fix.gateway.complete(CTX, REQ);
+    const agentRow = fix.ledger.getAgentSpend("primary", "2026-05-12");
+    expect(agentRow?.totalMicroUsd as number).toBe(STUB_FIXED_COST_MICRO_USD);
+    const taskRow = fix.ledger.getTaskSpend("01BRZ3NDEKTSV4RRFFQ69G5FA0");
+    expect(taskRow?.totalMicroUsd as number).toBe(STUB_FIXED_COST_MICRO_USD);
+  });
+});
+
+describe("dedupe", () => {
+  it("identical payload within 60s returns the cached result without a new ledger row", async () => {
+    const fix = setup();
+    try {
+      const r1 = await fix.gateway.complete(CTX, REQ);
+      expect(r1.dedupeReplay).toBe(false);
+
+      fix.clock.now += 30_000; // 30s later
+
+      const r2 = await fix.gateway.complete(CTX, REQ);
+      expect(r2.dedupeReplay).toBe(true);
+      expect(r2.costEventLsn).toBe(r1.costEventLsn);
+      expect(r2.costMicroUsd).toBe(r1.costMicroUsd);
+
+      const eventCount = fix.db
+        .prepare<[], { readonly n: number }>(
+          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
+        )
+        .get();
+      expect(eventCount?.n).toBe(1);
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("after the 60s window expires, the same payload triggers a fresh ledger write", async () => {
+    const fix = setup();
+    try {
+      const r1 = await fix.gateway.complete(CTX, REQ);
+      fix.clock.now += 61_000; // past the dedupe window
+      const r2 = await fix.gateway.complete(CTX, REQ);
+      expect(r2.dedupeReplay).toBe(false);
+      expect(r2.costEventLsn).not.toBe(r1.costEventLsn);
+    } finally {
+      fix.db.close();
+    }
+  });
+});
+
+describe("daily cap", () => {
+  it("blocks once today's office spend reaches the cap", async () => {
+    // Cap of one stub call. After call #1 the projection is at the cap,
+    // and call #2 must reject before reaching the provider.
+    const fix = setup({ dailyMicroUsd: STUB_FIXED_COST_MICRO_USD });
+    try {
+      await fix.gateway.complete(CTX, REQ);
+      // Bypass dedupe by changing the prompt.
+      const second: ProviderRequest = { ...REQ, prompt: "different" };
+      await expect(fix.gateway.complete(CTX, second)).rejects.toBeInstanceOf(CapExceededError);
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("counts spend across all agents (per-office cap, not per-agent)", async () => {
+    const fix = setup({ dailyMicroUsd: STUB_FIXED_COST_MICRO_USD });
+    try {
+      const ctxA: SupervisorContext = { agentSlug: asAgentSlug("agent_a") };
+      const ctxB: SupervisorContext = { agentSlug: asAgentSlug("agent_b") };
+      await fix.gateway.complete(ctxA, { ...REQ, prompt: "a" });
+      await expect(fix.gateway.complete(ctxB, { ...REQ, prompt: "b" })).rejects.toBeInstanceOf(
+        CapExceededError,
+      );
+    } finally {
+      fix.db.close();
+    }
+  });
+});
+
+describe("wake cap", () => {
+  it("blocks the 13th wake within an hour for the same agent", async () => {
+    const fix = setup({ wakeCapPerHour: 3 });
+    try {
+      // 3 successful wakes fit; the 4th is rejected.
+      for (let i = 0; i < 3; i += 1) {
+        await fix.gateway.complete(CTX, { ...REQ, prompt: `unique-${i}` });
+      }
+      await expect(
+        fix.gateway.complete(CTX, { ...REQ, prompt: "overflow" }),
+      ).rejects.toBeInstanceOf(CapExceededError);
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("wake-cap window slides — old wakes drop out after wakeWindowMs", async () => {
+    const fix = setup({ wakeCapPerHour: 2 });
+    try {
+      await fix.gateway.complete(CTX, { ...REQ, prompt: "a" });
+      await fix.gateway.complete(CTX, { ...REQ, prompt: "b" });
+      // 3rd within an hour: rejected
+      await expect(fix.gateway.complete(CTX, { ...REQ, prompt: "c" })).rejects.toBeInstanceOf(
+        CapExceededError,
+      );
+      // Advance past the wake window; old wakes drop out. Also note
+      // human activity so we don't trip the idle gate (which has the
+      // same 60min+ horizon as our advance).
+      fix.clock.now += 60 * 60 * 1000 + 1;
+      fix.gateway.noteHumanActivity();
+      const r = await fix.gateway.complete(CTX, { ...REQ, prompt: "c" });
+      expect(r.dedupeReplay).toBe(false);
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("wake cap is per-agent (one agent's saturation doesn't block another)", async () => {
+    const fix = setup({ wakeCapPerHour: 1 });
+    try {
+      const ctxA: SupervisorContext = { agentSlug: asAgentSlug("agent_a") };
+      const ctxB: SupervisorContext = { agentSlug: asAgentSlug("agent_b") };
+      await fix.gateway.complete(ctxA, { ...REQ, prompt: "a" });
+      await expect(fix.gateway.complete(ctxA, { ...REQ, prompt: "a2" })).rejects.toBeInstanceOf(
+        CapExceededError,
+      );
+      // Different agent still works.
+      const r = await fix.gateway.complete(ctxB, { ...REQ, prompt: "b" });
+      expect(r.dedupeReplay).toBe(false);
+    } finally {
+      fix.db.close();
+    }
+  });
+});
+
+describe("circuit breaker", () => {
+  it("opens after 2 errors in the window and rejects further calls until cooldown", async () => {
+    const fix = setup();
+    try {
+      const errReq: ProviderRequest = { ...REQ, model: STUB_MODEL_ERROR };
+      // First error: breaker stays closed.
+      await expect(fix.gateway.complete(CTX, errReq)).rejects.toBeTruthy();
+      // Second error: breaker opens.
+      await expect(fix.gateway.complete(CTX, { ...errReq, prompt: "err2" })).rejects.toBeTruthy();
+      // Third call (even with success-able model): breaker open.
+      await expect(
+        fix.gateway.complete(CTX, { ...REQ, prompt: "after-open" }),
+      ).rejects.toBeInstanceOf(CircuitBreakerOpenError);
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("cooldown elapses → breaker half-opens → next call closes it on success", async () => {
+    const fix = setup();
+    try {
+      const errReq: ProviderRequest = { ...REQ, model: STUB_MODEL_ERROR };
+      await expect(fix.gateway.complete(CTX, errReq)).rejects.toBeTruthy();
+      await expect(fix.gateway.complete(CTX, { ...errReq, prompt: "err2" })).rejects.toBeTruthy();
+      // Advance past cooldown. Same horizon as idle threshold (5min), so
+      // note human activity so the idle gate doesn't reject the retry.
+      fix.clock.now += 5 * 60 * 1000 + 1;
+      fix.gateway.noteHumanActivity();
+      const r = await fix.gateway.complete(CTX, { ...REQ, prompt: "after-cooldown" });
+      expect(r.dedupeReplay).toBe(false);
+    } finally {
+      fix.db.close();
+    }
+  });
+});
+
+describe("idle mode", () => {
+  it("rejects after 5min of inactivity", async () => {
+    const fix = setup();
+    try {
+      // Start active.
+      await fix.gateway.complete(CTX, REQ);
+      // Advance past idle threshold. noteHumanActivity is the only reset.
+      fix.clock.now += 5 * 60 * 1000 + 1;
+      await expect(
+        fix.gateway.complete(CTX, { ...REQ, prompt: "after-idle" }),
+      ).rejects.toBeInstanceOf(IdleModeError);
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("noteHumanActivity resets the idle clock", async () => {
+    const fix = setup();
+    try {
+      fix.clock.now += 5 * 60 * 1000 + 1;
+      // Without note: rejected.
+      await expect(fix.gateway.complete(CTX, { ...REQ, prompt: "p" })).rejects.toBeInstanceOf(
+        IdleModeError,
+      );
+      fix.gateway.noteHumanActivity();
+      const r = await fix.gateway.complete(CTX, { ...REQ, prompt: "p2" });
+      expect(r.dedupeReplay).toBe(false);
+    } finally {
+      fix.db.close();
+    }
+  });
+});
+
+describe("inspect()", () => {
+  it("returns wake counts and breaker state per agent", async () => {
+    const fix = setup({ wakeCapPerHour: 5 });
+    try {
+      await fix.gateway.complete(CTX, { ...REQ, prompt: "a" });
+      await fix.gateway.complete(CTX, { ...REQ, prompt: "b" });
+      const inspection = fix.gateway.inspect();
+      const agent = inspection.perAgent.get("primary");
+      expect(agent?.recentWakeCount).toBe(2);
+      expect(agent?.breaker.status).toBe("closed");
+    } finally {
+      fix.db.close();
+    }
+  });
+});

--- a/packages/llm-router/tests/gateway.spec.ts
+++ b/packages/llm-router/tests/gateway.spec.ts
@@ -1,14 +1,16 @@
 import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
-import { asAgentSlug, asReceiptId, asTaskId } from "@wuphf/protocol";
+import { asAgentSlug, asProviderKind, asReceiptId, asTaskId } from "@wuphf/protocol";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   CapExceededError,
   CircuitBreakerOpenError,
+  type CostEstimator,
   createGateway,
   createStubProvider,
   type Gateway,
   IdleModeError,
+  type Provider,
   type ProviderRequest,
   STUB_FIXED_COST_MICRO_USD,
   STUB_MODEL_ERROR,
@@ -130,6 +132,50 @@ describe("dedupe", () => {
       fix.db.close();
     }
   });
+
+  it("dedupe does NOT replay across agents — context is part of the key (B3)", async () => {
+    const fix = setup();
+    try {
+      const ctxA: SupervisorContext = { agentSlug: asAgentSlug("agent_a") };
+      const ctxB: SupervisorContext = { agentSlug: asAgentSlug("agent_b") };
+      // Same prompt, different agents. Each must produce a fresh
+      // cost_event LSN; the second call must NOT replay the first.
+      const r1 = await fix.gateway.complete(ctxA, REQ);
+      const r2 = await fix.gateway.complete(ctxB, REQ);
+      expect(r1.dedupeReplay).toBe(false);
+      expect(r2.dedupeReplay).toBe(false);
+      expect(r2.costEventLsn).not.toBe(r1.costEventLsn);
+      // Both agents have a row in cost_by_agent.
+      expect(fix.ledger.getAgentSpend("agent_a", "2026-05-12")?.totalMicroUsd as number).toBe(
+        STUB_FIXED_COST_MICRO_USD,
+      );
+      expect(fix.ledger.getAgentSpend("agent_b", "2026-05-12")?.totalMicroUsd as number).toBe(
+        STUB_FIXED_COST_MICRO_USD,
+      );
+    } finally {
+      fix.db.close();
+    }
+  });
+
+  it("dedupe does NOT replay across tasks — taskId is part of the key (B3)", async () => {
+    const fix = setup();
+    try {
+      const ctxTask1: SupervisorContext = {
+        agentSlug: asAgentSlug("primary"),
+        taskId: asTaskId("01BRZ3NDEKTSV4RRFFQ69G5FA0"),
+      };
+      const ctxTask2: SupervisorContext = {
+        agentSlug: asAgentSlug("primary"),
+        taskId: asTaskId("01BRZ3NDEKTSV4RRFFQ69G5FA1"),
+      };
+      const r1 = await fix.gateway.complete(ctxTask1, REQ);
+      const r2 = await fix.gateway.complete(ctxTask2, REQ);
+      expect(r2.dedupeReplay).toBe(false);
+      expect(r2.costEventLsn).not.toBe(r1.costEventLsn);
+    } finally {
+      fix.db.close();
+    }
+  });
 });
 
 describe("daily cap", () => {
@@ -218,6 +264,66 @@ describe("wake cap", () => {
 });
 
 describe("circuit breaker", () => {
+  it("post-provider failures also record breaker errors (H5)", async () => {
+    // Custom provider whose .complete() succeeds (so the
+    // pre-existing provider-error catch does NOT fire), but whose
+    // estimator throws — exercising the new post-provider catch
+    // around estimate + appendCostEvent. Two failures must open the
+    // breaker.
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const clock: Clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+    const throwingEstimator: CostEstimator = {
+      estimate() {
+        throw new Error("estimator_unavailable");
+      },
+    };
+    const failingProvider: Provider = {
+      kind: asProviderKind("openai-compat"),
+      models: ["test-throwing-model"],
+      costEstimator: throwingEstimator,
+      async complete() {
+        return Promise.resolve({
+          text: "ok",
+          usage: {
+            inputTokens: 1,
+            outputTokens: 1,
+            cacheReadTokens: 0,
+            cacheCreationTokens: 0,
+          },
+        });
+      },
+    };
+    const gateway = createGateway({
+      ledger,
+      providers: [failingProvider],
+      nowMs: () => clock.now,
+    });
+    try {
+      await expect(
+        gateway.complete(CTX, {
+          model: "test-throwing-model",
+          prompt: "p1",
+          maxOutputTokens: 8,
+        }),
+      ).rejects.toThrow(/estimator_unavailable/);
+      await expect(
+        gateway.complete(CTX, {
+          model: "test-throwing-model",
+          prompt: "p2",
+          maxOutputTokens: 8,
+        }),
+      ).rejects.toThrow(/estimator_unavailable/);
+      const inspection = gateway.inspect();
+      const agent = inspection.perAgent.get("primary");
+      expect(agent?.breaker.status).toBe("open");
+    } finally {
+      db.close();
+    }
+  });
+
   it("opens after 2 errors in the window and rejects further calls until cooldown", async () => {
     const fix = setup();
     try {

--- a/packages/llm-router/tests/threshold-integration.spec.ts
+++ b/packages/llm-router/tests/threshold-integration.spec.ts
@@ -1,0 +1,205 @@
+// End-to-end test that exercises the cost ledger's threshold reactor
+// through the gateway. This is what validates that PR A's storage path
+// composes with PR B's gateway: each Gateway.complete() writes a
+// cost_event, which the in-transaction reactor scans against active
+// budgets, which emits cost.budget.threshold.crossed events.
+//
+// Per the §15.A architecture-proof contract:
+//   sum(cost_events) == sum(cost_by_agent) == sum(cost_by_task)
+// must hold after every commit. We assert this at the end of the run.
+
+import {
+  createCostLedger,
+  createEventLog,
+  openDatabase,
+  runMigrations,
+  runReplayCheck,
+} from "@wuphf/broker";
+import {
+  asAgentSlug,
+  asBudgetId,
+  asMicroUsd,
+  asSignerIdentity,
+  asTaskId,
+  type BudgetSetAuditPayload,
+} from "@wuphf/protocol";
+import { describe, expect, it } from "vitest";
+
+import {
+  createGateway,
+  createStubProvider,
+  STUB_FIXED_COST_MICRO_USD,
+  STUB_MODEL_FIXED_COST,
+  type SupervisorContext,
+} from "../src/index.ts";
+
+describe("gateway → ledger → threshold reactor integration", () => {
+  it("threshold crossings fire from gateway calls, replay-check passes after the run", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+    const gateway = createGateway({
+      ledger,
+      providers: [createStubProvider()],
+      nowMs: () => clock.now,
+      // High caps so this test isn't throttled by caps; we're measuring
+      // threshold reactor behavior, not cap enforcement.
+      config: {
+        caps: {
+          dailyMicroUsd: 10_000_000,
+          wakeCapPerHour: 1_000,
+          idleThresholdMs: 24 * 60 * 60 * 1000,
+        },
+      },
+    });
+
+    // Set a budget targeting one agent so we can see the threshold fire.
+    const budget: BudgetSetAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      scope: "agent",
+      subjectId: "primary",
+      limitMicroUsd: asMicroUsd(50_000), // $0.05 = 5 stub calls
+      thresholdsBps: [5_000, 10_000], // 50% and 100%
+      setBy: asSignerIdentity("operator@example.com"),
+      setAt: new Date(clock.now),
+    };
+    ledger.appendBudgetSet(budget);
+
+    const ctx: SupervisorContext = {
+      agentSlug: asAgentSlug("primary"),
+      taskId: asTaskId("01BRZ3NDEKTSV4RRFFQ69G5FA0"),
+    };
+
+    // 6 calls × $0.01 = $0.06. Should fire 50% (after call 3) and 100%
+    // (after call 5).
+    let firstCrossingLsn: string | null = null;
+    let secondCrossingLsn: string | null = null;
+    for (let i = 0; i < 6; i += 1) {
+      await gateway.complete(ctx, {
+        model: STUB_MODEL_FIXED_COST,
+        prompt: `call-${i}`,
+        maxOutputTokens: 8,
+      });
+      const crossingsNow = ledger.listThresholdCrossings();
+      if (firstCrossingLsn === null && crossingsNow.length === 1) {
+        firstCrossingLsn = crossingsNow[0]?.crossedAtLsn ?? null;
+        expect(crossingsNow[0]?.thresholdBps).toBe(5_000);
+        // First crossing should fire after cumulative spend ≥ 25_000 μUSD.
+        // 3 × 10_000 = 30_000, so this fires on call 3 (index 2).
+        expect(i).toBe(2);
+      }
+      if (secondCrossingLsn === null && crossingsNow.length === 2) {
+        secondCrossingLsn = crossingsNow[1]?.crossedAtLsn ?? null;
+        expect(crossingsNow[1]?.thresholdBps).toBe(10_000);
+        // Second crossing fires once cumulative ≥ 50_000 μUSD, i.e. call 5.
+        expect(i).toBe(4);
+      }
+      clock.now += 1;
+    }
+
+    expect(firstCrossingLsn).not.toBeNull();
+    expect(secondCrossingLsn).not.toBeNull();
+
+    // §15.A sum invariant: replay-check must pass after a healthy run.
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+    expect(report.discrepancies).toEqual([]);
+
+    // The event_log must contain: 1 budget_set + 6 cost_event + 2
+    // threshold-crossed = 9 cost.* events.
+    const counts = db
+      .prepare<[], { readonly type: string; readonly n: number }>(
+        "SELECT type, COUNT(*) AS n FROM event_log GROUP BY type ORDER BY type",
+      )
+      .all();
+    const byType = new Map(counts.map((row) => [row.type, row.n]));
+    expect(byType.get("cost.event")).toBe(6);
+    expect(byType.get("cost.budget.set")).toBe(1);
+    expect(byType.get("cost.budget.threshold.crossed")).toBe(2);
+
+    db.close();
+  });
+
+  it("raising a budget mid-run re-arms thresholds (PR A composite-PK contract)", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+    const gateway = createGateway({
+      ledger,
+      providers: [createStubProvider()],
+      nowMs: () => clock.now,
+      config: {
+        caps: {
+          dailyMicroUsd: 10_000_000,
+          wakeCapPerHour: 1_000,
+          idleThresholdMs: 24 * 60 * 60 * 1000,
+        },
+      },
+    });
+
+    const budgetId = asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ");
+    const setBy = asSignerIdentity("operator@example.com");
+    const ctx: SupervisorContext = { agentSlug: asAgentSlug("primary") };
+
+    // Budget 1: $0.02 (2 calls at 50% triggers after 1 call).
+    ledger.appendBudgetSet({
+      budgetId,
+      scope: "agent",
+      subjectId: "primary",
+      limitMicroUsd: asMicroUsd(20_000),
+      thresholdsBps: [5_000],
+      setBy,
+      setAt: new Date(clock.now),
+    });
+
+    await gateway.complete(ctx, {
+      model: STUB_MODEL_FIXED_COST,
+      prompt: "p1",
+      maxOutputTokens: 8,
+    });
+    clock.now += 1;
+    let crossings = ledger.listThresholdCrossings();
+    expect(crossings.length).toBe(1);
+    const firstBudgetSetLsn = crossings[0]?.budgetSetLsn;
+
+    // Raise the budget to $0.10. New budget_set LSN is minted.
+    ledger.appendBudgetSet({
+      budgetId,
+      scope: "agent",
+      subjectId: "primary",
+      limitMicroUsd: asMicroUsd(100_000),
+      thresholdsBps: [5_000],
+      setBy,
+      setAt: new Date(clock.now),
+    });
+
+    // We need 5 more calls to cross 50% of $0.10 = $0.05 (cumulative $0.06).
+    // After 4 more calls cumulative is $0.05; after 5 it's $0.06 > $0.05.
+    for (let i = 0; i < 5; i += 1) {
+      await gateway.complete(ctx, {
+        model: STUB_MODEL_FIXED_COST,
+        prompt: `re-arm-${i}`,
+        maxOutputTokens: 8,
+      });
+      clock.now += 1;
+    }
+    crossings = ledger.listThresholdCrossings();
+    // Two rows now: one under the first budget_set epoch, one under the
+    // second. Same threshold (5_000), different budget_set_lsn — exactly
+    // the PR A composite-PK contract.
+    expect(crossings.length).toBe(2);
+    expect(crossings[0]?.budgetSetLsn).toBe(firstBudgetSetLsn);
+    expect(crossings[1]?.budgetSetLsn).not.toBe(firstBudgetSetLsn);
+    expect(crossings[1]?.thresholdBps).toBe(5_000);
+
+    // Replay-check still passes.
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+
+    db.close();
+  });
+});

--- a/packages/llm-router/tsconfig.json
+++ b/packages/llm-router/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": true,
+    "useUnknownInCatchVariables": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*", "vitest.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/llm-router/vitest.config.ts
+++ b/packages/llm-router/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+// Coverage thresholds intentionally start unset — the gateway will grow new
+// surface (real Anthropic adapter, Ollama, etc.) and coverage numbers should
+// settle once the post-§15.A surface is locked. Bring them in via a follow-up
+// once the burn-down (§10.4) and the supervisor wire are both stable.
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.spec.ts"],
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      reporter: process.env["CI"] ? ["text", "json-summary"] : ["text"],
+      reportsDirectory: "coverage",
+    },
+  },
+});


### PR DESCRIPTION
## Summary

PR B of WUPHF v1 branch 7, **stacked on #816** (`feat/cost-ledger-proof`).
Implements the in-process AI gateway per RFC §7.5. Every agent runner
proxies through one `Gateway.complete()` call that writes a `cost_event`
into the PR A ledger **before** the response returns — the chokepoint
contract that makes daily caps enforceable.

This PR validates PR A end to end: the gateway's integration test runs
real ledger writes, triggers the threshold reactor, and asserts
`runReplayCheck()` passes after the run.

```mermaid
flowchart LR
  A[agent runner] -->|complete ctx,req| G[Gateway]
  G --> Idle{idle?}
  Idle -->|yes| RE1[IdleModeError]
  Idle -->|no| Br{breaker open?}
  Br -->|yes| RE2[CircuitBreakerOpenError]
  Br -->|no| D{dedupe hit?}
  D -->|yes| Replay[cached result]
  D -->|no| Daily{daily cap?}
  Daily -->|over| RE3[CapExceededError daily]
  Daily -->|under| Wake{wake cap?}
  Wake -->|over| RE4[CapExceededError wake]
  Wake -->|under| P[provider.complete]
  P -->|error| BrErr[caps.recordError → breaker]
  P -->|ok| Est[costEstimator]
  Est --> L[ledger.appendCostEvent]
  L --> Result[GatewayCompletionResult<br/>with costEventLsn]
```

### What's in this PR

New package `@wuphf/llm-router`:

| File | Purpose |
|--|--|
| `src/types.ts` | `Gateway`, `GatewayCompletionResult` (carries `costEventLsn` — the type-system proof of the ledger write), `Provider`, `CostEstimator`, `SupervisorContext` |
| `src/errors.ts` | `CapExceededError`, `CircuitBreakerOpenError`, `IdleModeError`, `ProviderError`, `UnknownModelError`, each with a stable `code` for PR C wire mapping |
| `src/caps.ts` | Per-office daily cap (reads `cost_by_agent`), per-agent wake cap (in-memory sliding window), circuit breaker, idle mode |
| `src/dedupe.ts` | SHA-256 content-hash dedupe with 60s sliding window per §7.5 |
| `src/providers/stub.ts` | Deterministic `stub-fixed-cost` provider + `stub-error` for breaker tests |
| `src/gateway.ts` | Orchestration; the order inside `complete()` is the contract |
| `scripts/ci-burn-nightly.ts` | §10.4 implementation — 10 wakes/min × 60min on stub-fixed-cost |
| `tests/gateway.spec.ts` | Unit tests for every cap class, dedupe, breaker, idle |
| `tests/threshold-integration.spec.ts` | End-to-end validation that gateway calls trigger the PR A threshold reactor and `runReplayCheck` passes |

Broker surface change (one file):

- `packages/broker/src/index.ts` exports `openDatabase`, `createEventLog`,
  `runMigrations`, `CURRENT_SCHEMA_VERSION` so hosts wiring a cost ledger
  can construct the dependencies cleanly.

### Design decisions baked in

1. **The cost row is written before the response is returned.** The
   gateway returns `GatewayCompletionResult` which carries
   `costEventLsn: EventLsn`. The only code path that mints that LSN is
   `ledger.appendCostEvent`. If the ledger write throws, the response
   is discarded.
2. **Daily cap reads from the projection, not in-memory counters.**
   Projection is the source of truth and survives broker restarts.
3. **Wake cap, breaker, and idle mode are process-local on purpose.**
   They reset on restart; the consequences of a one-minute amnesia
   are bounded and not worth the I/O.
4. **`noteHumanActivity()` is the only idle-reset path.** Agent-driven
   activity does NOT keep the broker awake; otherwise an agent loop
   would prevent dormancy.
5. **Identical-payload dedupe uses content hash (not idempotency key).**
   Internal agent runners that re-issue a payload without minting a
   key still get dedup protection.
6. **Stub provider is exact-deterministic** (10000 μUSD/call, zero
   variance) so §10.4's $5.00 ± $0.05 assertion has byte-stable input.

### §10.4 burn-down

```
$ bun run burn:nightly
@wuphf/llm-router — §10.4 burn-down
--wakes-per-minute 10 --minutes 60 --model stub-fixed-cost

PASS read-only at $5.00 ± $0.05
     observed: total_spend=5000000 μUSD, capped_count=100
PASS per-agent wake cap throttles before daily cap
     observed: successes=12, wake_cap_hit_at=12
PASS circuit breaker fires within 3 consecutive failures
     observed: breaker_tripped_at_failure=2

3/3 assertions passed
```

### PR A validation (the original goal of this PR)

The `threshold-integration.spec.ts` test takes the most ambitious
PR-A claim — "the §15.A sum invariant holds at every commit" —
and exercises it through the gateway:

1. Set a budget on `agent="primary"` for $0.05, thresholds 50% + 100%.
2. Issue 6 gateway calls. Each writes a `cost_event` and the
   threshold reactor runs inside the same transaction.
3. Assert: first crossing fires at call 3 (cumulative ≥ $0.025);
   second crossing fires at call 5 (cumulative ≥ $0.05).
4. Run `runReplayCheck(db)`. Must be `ok: true` with zero
   discrepancies.
5. Count event_log rows: 1 `budget_set` + 6 `cost_event` + 2
   `threshold_crossed` = 9 cost.* events.

A second integration test asserts the **composite-PK re-arm contract**:
raising a budget mid-run mints fresh crossings under the new
`budget_set` LSN. Same `(budget_id, threshold_bps)` pair fires twice
because the third PK component (`budget_set_lsn`) differs.

Both pass byte-for-byte deterministically.

## Test plan

- [x] `@wuphf/protocol`: `bunx vitest run` → 547 passed (unchanged)
- [x] `@wuphf/broker`: `bunx vitest run tests` → 184 passed (unchanged)
- [x] `@wuphf/llm-router`: `bunx vitest run` → 16 passed
- [x] `@wuphf/llm-router`: `bun run burn:nightly` → 3/3 §10.4 assertions
- [x] `bunx tsc --noEmit` across all three packages → clean
- [x] `bunx biome check` across all three packages → clean
- [x] Pre-push lefthook (protocol-demo + protocol-invariants +
      protocol-wire-contract) → all pass

## Out of scope (follow-on PRs)

- **PR B.2** — `@anthropic-ai/sdk` adapter (real-provider validation
  of the cost estimator pricing table)
- **PR B.3** — `openai` + `ollama` adapters
- **PR C** — cost-tile UI, SSE updates, throttle banners, first-run
  cost-gate flow

## Review notes

- This PR is **stacked on #816**. GitHub diff is from
  `feat/cost-ledger-proof`, not `main`. To review just this slice,
  look at the `packages/llm-router/` tree and the small
  `packages/broker/src/index.ts` export addition.
- Once #816 merges, this PR's base will move to `main` and the
  diff will collapse to the union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)