### PR TITLE
feat(llm-router): Anthropic SDK adapter with per-model pricing (branch 7 PR B.2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
       "name": "@wuphf/llm-router",
       "version": "0.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "0.71.0",
         "@wuphf/broker": "workspace:*",
         "@wuphf/protocol": "workspace:*",
         "better-sqlite3": "12.9.0",
@@ -107,6 +108,8 @@
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-go1XeWXmpxuiTkosSXpb8tokLk2ZLkIRcXpbWVwJM6gH5OBtHOVsfPfGuqI1oW7RRt4qc59EmYbrXRZ0Ng06Jw=="],
+
     "@azu/format-text": ["@azu/format-text@1.0.2", "", {}, "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg=="],
 
     "@azu/style-format": ["@azu/style-format@1.0.1", "", { "dependencies": { "@azu/format-text": "^1.0.1" } }, "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g=="],
@@ -140,6 +143,8 @@
     "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
     "@babel/plugin-transform-arrow-functions": ["@babel/plugin-transform-arrow-functions@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
@@ -953,6 +958,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
@@ -1334,6 +1341,8 @@
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "truncate-utf8-bytes": ["truncate-utf8-bytes@1.0.2", "", { "dependencies": { "utf8-byte-length": "^1.0.1" } }, "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -68,12 +68,12 @@
       "name": "@wuphf/llm-router",
       "version": "0.0.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.71.0",
         "@wuphf/broker": "workspace:*",
         "@wuphf/protocol": "workspace:*",
         "better-sqlite3": "12.9.0",
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "0.71.0",
         "@biomejs/biome": "2.4.15",
         "@types/better-sqlite3": "7.6.13",
         "@types/node": "^22.10.0",
@@ -82,6 +82,12 @@
         "typescript": "^5.6.0",
         "vitest": "^2.1.0",
       },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": "^0.71.0",
+      },
+      "optionalPeers": [
+        "@anthropic-ai/sdk",
+      ],
     },
     "packages/protocol": {
       "name": "@wuphf/protocol",

--- a/packages/llm-router/README.md
+++ b/packages/llm-router/README.md
@@ -20,37 +20,74 @@ runners — there is no parallel call path to an LLM in this codebase.
 
 ## Providers
 
-- `stub-fixed-cost` — deterministic test target for the §10.4 nightly
-  burn-down. Every call costs 10000 micro-USD (= $0.01) and returns a
-  canned response.
-- `anthropic` (PR B.2 follow-up) — `@anthropic-ai/sdk` adapter.
-- `openai` (PR B.3 follow-up) — `openai` SDK adapter.
-- `ollama` (PR B.3 follow-up) — local model adapter.
+- `stub-fixed-cost` / `stub-error` — deterministic test targets for the
+  §10.4 nightly burn-down. Every call costs 10000 micro-USD (= $0.01)
+  and returns a canned response (or throws, for `stub-error`).
+- **`anthropic` — `@anthropic-ai/sdk` adapter (PR B.2).** Subpath import:
+  `import { createAnthropicProvider } from "@wuphf/llm-router/anthropic"`.
+  Covers `claude-opus-4-*`, `claude-sonnet-4-*`, `claude-haiku-4-*` with
+  built-in integer-μUSD pricing; hosts may override the pricing table
+  for negotiated rates.
+- `openai` / `ollama` — future PRs.
 
 ## Usage
 
+### Stub (tests, §10.4 burn-down)
+
 ```ts
-import { createGateway } from "@wuphf/llm-router";
-import { createCostLedger, createCommandIdempotencyStore } from "@wuphf/broker";
+import { createGateway, createStubProvider } from "@wuphf/llm-router";
+import { createCostLedger } from "@wuphf/broker";
 
 const gateway = createGateway({
   ledger,                             // from @wuphf/broker
   providers: [createStubProvider()],
-  caps: {
-    dailyMicroUsd: 5_000_000,         // $5/day per RFC §8
-    wakeCapPerHour: 12,
-    breakerErrorThreshold: 2,
-    breakerWindowMs: 10 * 60 * 1000,
-    breakerCooldownMs: 5 * 60 * 1000,
-    idleThresholdMs: 5 * 60 * 1000,
-    dedupeWindowMs: 60 * 1000,
-  },
   nowMs: () => Date.now(),
 });
 
 const result = await gateway.complete(ctx, request);
 // result.costEventLsn is the proof the cost row was written.
 ```
+
+### Anthropic (production)
+
+```ts
+import { createGateway } from "@wuphf/llm-router";
+import { createAnthropicProviderWithKey } from "@wuphf/llm-router/anthropic";
+
+const gateway = createGateway({
+  ledger,
+  providers: [
+    createAnthropicProviderWithKey({
+      apiKey: process.env.ANTHROPIC_API_KEY!,
+      // Optional: override pricing for negotiated rates.
+      // pricing: { ... }
+    }),
+  ],
+  nowMs: () => Date.now(),
+});
+
+const result = await gateway.complete(
+  { agentSlug: asAgentSlug("primary") },
+  { model: "claude-opus-4-7", prompt: "go", maxOutputTokens: 1024 },
+);
+```
+
+For tests, inject a fake client matching the `AnthropicClient` interface:
+
+```ts
+import { createAnthropicProvider } from "@wuphf/llm-router/anthropic";
+
+const provider = createAnthropicProvider({
+  client: {
+    messages: {
+      create: async (params) => ({ content: [...], usage: { ... } }),
+    },
+  },
+});
+```
+
+The subpath import keeps the `@anthropic-ai/sdk` install cost off any
+host that only uses the stub.
 
 ## §10.4 nightly burn-down
 

--- a/packages/llm-router/README.md
+++ b/packages/llm-router/README.md
@@ -25,9 +25,11 @@ runners — there is no parallel call path to an LLM in this codebase.
   and returns a canned response (or throws, for `stub-error`).
 - **`anthropic` — `@anthropic-ai/sdk` adapter (PR B.2).** Subpath import:
   `import { createAnthropicProvider } from "@wuphf/llm-router/anthropic"`.
-  Covers `claude-opus-4-*`, `claude-sonnet-4-*`, `claude-haiku-4-*` with
-  built-in integer-μUSD pricing; hosts may override the pricing table
-  for negotiated rates.
+  Covers `claude-opus-4-1`, `claude-opus-4-{5,6,7}`, `claude-sonnet-4-{5,6}`,
+  `claude-haiku-4-5` with built-in integer-μUSD pricing; hosts may
+  override the pricing table for negotiated rates. The SDK is an
+  **optional peer dependency** — hosts using only the stub do not
+  install it.
 - `openai` / `ollama` — future PRs.
 
 ## Usage
@@ -50,15 +52,31 @@ const result = await gateway.complete(ctx, request);
 
 ### Anthropic (production)
 
+First install the SDK alongside the router (it's an optional peer dep):
+
+```bash
+bun add @anthropic-ai/sdk @wuphf/llm-router
+```
+
+Then wire it:
+
 ```ts
 import { createGateway } from "@wuphf/llm-router";
 import { createAnthropicProviderWithKey } from "@wuphf/llm-router/anthropic";
 
+// Read the key from your secret store. The constructor rejects an
+// empty/non-string value; do NOT rely on `!` non-null assertions —
+// they don't run at runtime.
+const apiKey = process.env.ANTHROPIC_API_KEY;
+if (typeof apiKey !== "string" || apiKey.length === 0) {
+  throw new Error("ANTHROPIC_API_KEY is required");
+}
+
 const gateway = createGateway({
   ledger,
   providers: [
-    createAnthropicProviderWithKey({
-      apiKey: process.env.ANTHROPIC_API_KEY!,
+    await createAnthropicProviderWithKey({
+      apiKey,
       // Optional: override pricing for negotiated rates.
       // pricing: { ... }
     }),
@@ -72,7 +90,12 @@ const result = await gateway.complete(
 );
 ```
 
-For tests, inject a fake client matching the `AnthropicClient` interface:
+`createAnthropicProviderWithKey` is `async` because the SDK module is
+loaded lazily via dynamic import — hosts that never call this function
+never pay the SDK's parse/load cost.
+
+For tests, inject a fake client matching the `AnthropicClient`
+interface (no SDK install needed):
 
 ```ts
 import { createAnthropicProvider } from "@wuphf/llm-router/anthropic";
@@ -80,14 +103,11 @@ import { createAnthropicProvider } from "@wuphf/llm-router/anthropic";
 const provider = createAnthropicProvider({
   client: {
     messages: {
-      create: async (params) => ({ content: [...], usage: { ... } }),
+      create: async (params, options) => ({ content: [...], usage: { ... } }),
     },
   },
 });
 ```
-
-The subpath import keeps the `@anthropic-ai/sdk` install cost off any
-host that only uses the stub.
 
 ## §10.4 nightly burn-down
 

--- a/packages/llm-router/package.json
+++ b/packages/llm-router/package.json
@@ -21,12 +21,18 @@
     "burn:nightly": "tsx scripts/ci-burn-nightly.ts"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "0.71.0",
     "@wuphf/broker": "workspace:*",
     "@wuphf/protocol": "workspace:*",
     "better-sqlite3": "12.9.0"
   },
+  "peerDependencies": {
+    "@anthropic-ai/sdk": "^0.71.0"
+  },
+  "peerDependenciesMeta": {
+    "@anthropic-ai/sdk": { "optional": true }
+  },
   "devDependencies": {
+    "@anthropic-ai/sdk": "0.71.0",
     "@biomejs/biome": "2.4.15",
     "@types/better-sqlite3": "7.6.13",
     "@types/node": "^22.10.0",

--- a/packages/llm-router/package.json
+++ b/packages/llm-router/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./anthropic": "./src/providers/anthropic.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -20,6 +21,7 @@
     "burn:nightly": "tsx scripts/ci-burn-nightly.ts"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "0.71.0",
     "@wuphf/broker": "workspace:*",
     "@wuphf/protocol": "workspace:*",
     "better-sqlite3": "12.9.0"

--- a/packages/llm-router/src/errors.ts
+++ b/packages/llm-router/src/errors.ts
@@ -39,16 +39,67 @@ export class IdleModeError extends Error {
   }
 }
 
+/**
+ * Optional structured metadata an adapter can attach when wrapping a
+ * provider-side error. None are required — older adapters that don't
+ * surface these stay backwards-compatible — but a real provider (e.g.
+ * Anthropic) SHOULD populate them so on-call has parseable failure
+ * info. See triangulation #2 finding B2-5.
+ */
+export interface ProviderErrorMetadata {
+  /** HTTP status (or other transport status) when applicable. */
+  readonly status?: number;
+  /** Provider's request id, when the SDK exposes it. */
+  readonly requestId?: string;
+  /** Provider-specific error-type discriminator (e.g. "rate_limit_error"). */
+  readonly errorType?: string;
+  /** Milliseconds the caller should wait before retrying (e.g. 429 retry-after). */
+  readonly retryAfterMs?: number;
+}
+
 export class ProviderError extends Error {
   readonly code = "provider_error";
   readonly providerKind: string;
   override readonly cause: unknown;
-  constructor(providerKind: string, cause: unknown) {
+  readonly status?: number;
+  readonly requestId?: string;
+  readonly errorType?: string;
+  readonly retryAfterMs?: number;
+  constructor(providerKind: string, cause: unknown, metadata: ProviderErrorMetadata = {}) {
     const causeMsg = cause instanceof Error ? cause.message : String(cause);
     super(`provider_error: kind=${providerKind} cause=${causeMsg}`);
     this.name = "ProviderError";
     this.providerKind = providerKind;
     this.cause = cause;
+    if (metadata.status !== undefined) this.status = metadata.status;
+    if (metadata.requestId !== undefined) this.requestId = metadata.requestId;
+    if (metadata.errorType !== undefined) this.errorType = metadata.errorType;
+    if (metadata.retryAfterMs !== undefined) this.retryAfterMs = metadata.retryAfterMs;
+  }
+}
+
+/**
+ * Caller-input error: the provider rejected the request as malformed
+ * (400, 413, 422 in HTTP terms). The gateway does NOT count this as a
+ * breaker strike — bad input from one caller shouldn't open the
+ * breaker for the whole agent. See triangulation #2 finding B2-7.
+ */
+export class BadRequestError extends Error {
+  readonly code = "bad_request";
+  readonly providerKind: string;
+  override readonly cause: unknown;
+  readonly status?: number;
+  readonly requestId?: string;
+  readonly errorType?: string;
+  constructor(providerKind: string, cause: unknown, metadata: ProviderErrorMetadata = {}) {
+    const causeMsg = cause instanceof Error ? cause.message : String(cause);
+    super(`bad_request: kind=${providerKind} cause=${causeMsg}`);
+    this.name = "BadRequestError";
+    this.providerKind = providerKind;
+    this.cause = cause;
+    if (metadata.status !== undefined) this.status = metadata.status;
+    if (metadata.requestId !== undefined) this.requestId = metadata.requestId;
+    if (metadata.errorType !== undefined) this.errorType = metadata.errorType;
   }
 }
 
@@ -65,6 +116,7 @@ export class UnknownModelError extends Error {
  * `.code` to decide retry behavior without `instanceof` chains.
  */
 export type GatewayError =
+  | BadRequestError
   | CapExceededError
   | CircuitBreakerOpenError
   | IdleModeError
@@ -73,6 +125,7 @@ export type GatewayError =
 
 export function isGatewayError(value: unknown): value is GatewayError {
   return (
+    value instanceof BadRequestError ||
     value instanceof CapExceededError ||
     value instanceof CircuitBreakerOpenError ||
     value instanceof IdleModeError ||

--- a/packages/llm-router/src/gateway.ts
+++ b/packages/llm-router/src/gateway.ts
@@ -22,7 +22,7 @@ import type { CostEventAuditPayload, CostUnits, MicroUsd, ProviderKind } from "@
 
 import { Caps, type CapsConfig, DEFAULT_CAPS_CONFIG } from "./caps.ts";
 import { DEFAULT_DEDUPE_CONFIG, DedupeCache, type DedupeConfig } from "./dedupe.ts";
-import { ProviderError, UnknownModelError } from "./errors.ts";
+import { BadRequestError, ProviderError, UnknownModelError } from "./errors.ts";
 import type {
   Gateway,
   GatewayCompletionResult,
@@ -76,6 +76,12 @@ export function createGateway(deps: GatewayDeps): Gateway {
     try {
       providerResponse = await provider.complete(req);
     } catch (err) {
+      // Caller-input errors (400/413/422) do NOT count as breaker
+      // strikes — bad input from one caller shouldn't open the breaker
+      // for the whole agent. See triangulation #2 finding B2-7.
+      if (err instanceof BadRequestError) {
+        throw err;
+      }
       caps.recordError(ctx.agentSlug);
       if (err instanceof ProviderError || err instanceof UnknownModelError) {
         throw err;

--- a/packages/llm-router/src/gateway.ts
+++ b/packages/llm-router/src/gateway.ts
@@ -18,18 +18,11 @@
 // completion. That's the type-system enforcement.
 
 import type { CostLedger } from "@wuphf/broker";
-import {
-  asProviderKind,
-  type CostEventAuditPayload,
-  type CostUnits,
-  type MicroUsd,
-  type ProviderKind,
-} from "@wuphf/protocol";
+import type { CostEventAuditPayload, CostUnits, MicroUsd, ProviderKind } from "@wuphf/protocol";
 
 import { Caps, type CapsConfig, DEFAULT_CAPS_CONFIG } from "./caps.ts";
 import { DEFAULT_DEDUPE_CONFIG, DedupeCache, type DedupeConfig } from "./dedupe.ts";
 import { ProviderError, UnknownModelError } from "./errors.ts";
-import { isStubModel } from "./providers/stub.ts";
 import type {
   Gateway,
   GatewayCompletionResult,
@@ -107,6 +100,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
       const payload: CostEventAuditPayload = buildCostEventPayload(
         ctx,
         req,
+        provider.kind,
         providerResponse.usage,
         costMicroUsd,
         deps.nowMs(),
@@ -148,15 +142,18 @@ export function createGateway(deps: GatewayDeps): Gateway {
 function buildCostEventPayload(
   ctx: SupervisorContext,
   req: ProviderRequest,
+  providerKind: ProviderKind,
   usage: CostUnits,
   costMicroUsd: MicroUsd,
   nowMs: number,
 ): CostEventAuditPayload {
   // Pull only the fields cost.ts validates; payload keys not listed in
   // COST_EVENT_KEYS are rejected by the validator (see protocol cost.ts).
+  // `providerKind` comes from the resolved provider so the audit row
+  // records who actually fulfilled the request — no hard-coded mapping.
   const base: CostEventAuditPayload = {
     agentSlug: ctx.agentSlug,
-    providerKind: providerKindFor(req.model),
+    providerKind,
     model: req.model,
     amountMicroUsd: costMicroUsd,
     units: usage,
@@ -197,22 +194,6 @@ function indexProvidersByModel(providers: readonly Provider[]): Map<string, Prov
     }
   }
   return out;
-}
-
-/**
- * Map an internal model name to its `ProviderKind`. The closed enum
- * lives in `@wuphf/protocol/receipt-types.ts`; adding a new kind is a
- * wire-shape change.
- */
-function providerKindFor(model: string): ProviderKind {
-  if (isStubModel(model)) {
-    // Stubs masquerade as openai-compat so the audit payload's
-    // providerKind stays inside the closed enum.
-    return asProviderKind("openai-compat");
-  }
-  // PR B.2 will add prefix routing here; for PR B the stub is the only
-  // working path and we fail loud on unknown models.
-  throw new UnknownModelError(model);
 }
 
 // Re-export for callers that compose their own deps without pulling each

--- a/packages/llm-router/src/index.ts
+++ b/packages/llm-router/src/index.ts
@@ -2,8 +2,9 @@ export type { CapsConfig } from "./caps.ts";
 export { Caps, DEFAULT_CAPS_CONFIG } from "./caps.ts";
 export type { DedupeConfig } from "./dedupe.ts";
 export { DEFAULT_DEDUPE_CONFIG, DedupeCache, hashRequest } from "./dedupe.ts";
-export type { GatewayError } from "./errors.ts";
+export type { GatewayError, ProviderErrorMetadata } from "./errors.ts";
 export {
+  BadRequestError,
   CapExceededError,
   CircuitBreakerOpenError,
   IdleModeError,

--- a/packages/llm-router/src/providers/anthropic-pricing.ts
+++ b/packages/llm-router/src/providers/anthropic-pricing.ts
@@ -1,0 +1,189 @@
+// Anthropic per-model pricing, expressed as integer micro-USD per token.
+//
+// Why integer-per-token (not the public-facing $/MTok rate):
+//   - The cost ledger is integer micro-USD throughout (see §15.A I1/I2 in
+//     `@wuphf/broker` cost-ledger). Storing the rate the same way means
+//     `tokens * rate` produces an integer micro-USD value directly, with no
+//     intermediate float and no rounding ambiguity.
+//   - Public rates are quoted in $/million-tokens; we just divide by 1 (mtok)
+//     and multiply by 1_000_000 (μUSD/USD): rate_per_token_micro_usd =
+//     public_rate_per_mtok_usd. A $3/MTok rate becomes exactly 3 μUSD/tok.
+//
+// Source: https://www.anthropic.com/pricing (verified against the published
+// table as of 2026-01). Hosts may override any field via the
+// `AnthropicPricingTable` config injected at construction time, so a price
+// change does not require a code release.
+//
+// What's covered:
+//   - input_tokens                → `inputMicroUsdPerToken`
+//   - output_tokens               → `outputMicroUsdPerToken`
+//   - cache_read_input_tokens     → `cacheReadMicroUsdPerToken`
+//   - cache_creation_input_tokens → `cacheCreationMicroUsdPerToken`
+//
+// Out of scope (deferred):
+//   - 1h extended TTL cache pricing (`ephemeral_1h_input_tokens`) — premium
+//     tier with separate rate; PR B.2 only covers the 5m default tier.
+//   - Server-tool-use pricing (web search, code execution) — separate billable
+//     line items, not part of message-level usage.
+
+import { asMicroUsd, type CostUnits, type MicroUsd } from "@wuphf/protocol";
+
+import { UnknownModelError } from "../errors.ts";
+import type { CostEstimator } from "../types.ts";
+
+/**
+ * Per-token integer micro-USD rates for one model. Cache fields are the
+ * 5-minute-TTL ephemeral cache; 1h extended TTL is out of scope for PR B.2.
+ */
+export interface AnthropicModelPricing {
+  readonly inputMicroUsdPerToken: number;
+  readonly outputMicroUsdPerToken: number;
+  readonly cacheReadMicroUsdPerToken: number;
+  readonly cacheCreationMicroUsdPerToken: number;
+}
+
+export type AnthropicPricingTable = Readonly<Record<string, AnthropicModelPricing>>;
+
+/**
+ * Built-in pricing for the Claude 4.x family as of 2026-01. Each rate is
+ * the public $/MTok price expressed as integer μUSD/tok.
+ *
+ *   Opus 4.x:    $15 input / $75 output / $1.50 cache-read / $18.75 cache-write
+ *   Sonnet 4.x:  $3  input / $15 output / $0.30 cache-read / $3.75  cache-write
+ *   Haiku 4.x:   $1  input / $5  output / $0.10 cache-read / $1.25  cache-write
+ *
+ * Cache-read is 10% of input cost; cache-creation is 1.25x input cost. This
+ * is Anthropic's standard ratio across the family — if a future model
+ * publishes a different ratio, override via the config.
+ *
+ * The fractional cache rates ($1.50, $18.75, $3.75) round to non-integer
+ * μUSD/tok — we use the precise published rate, not a rounded approximation.
+ * To keep integer arithmetic exact, rates are micro-USD per 100 tokens
+ * (i.e. centi-micro-USD per token, or 10⁻⁸ USD/tok). At runtime the cost
+ * estimator divides by 100 with floor — exact for the published rate steps.
+ *
+ * No: the simpler design is to keep rates as μUSD per million-tokens
+ * (effectively, since $1/MTok = 1 μUSD/tok), and use `Math.round(tokens *
+ * rateNumerator / rateDenominator)` to handle fractional cents. Let's do
+ * that:
+ *
+ *   Each pricing entry stores a per-token rate in fixed-point with implicit
+ *   scale 1 (i.e. integer μUSD/tok), and we use Math.round for cache rates
+ *   that have a fractional cent component. We accept a 1 μUSD/MTok rounding
+ *   "error" on cache lines; for the §15.A invariant this is acceptable
+ *   because the rounding is deterministic and the rate ranges are clamped.
+ *
+ * Actually, the cleanest approach: store cache rates as
+ * "micro-USD per 1000 tokens" so the integer arithmetic is exact at the
+ * granularity Anthropic actually charges:
+ *
+ *   $1.50/MTok = 1500 μUSD/MTok = 1.5 μUSD/Ktok = 1500 nanoUSD/tok.
+ *
+ * Since our ledger is μUSD-integer, we use μUSD-per-1000-tokens and divide
+ * by 1000 at billing time. This is exactly how the broker projection-side
+ * pricing works for receipt cost displays.
+ *
+ * For PR B.2 simplicity: store all rates in `microUsdPer1000Tokens` units
+ * and divide at estimation time. Documented precisely in
+ * `estimateAnthropicCostMicroUsd` below.
+ */
+export const DEFAULT_ANTHROPIC_PRICING: AnthropicPricingTable = Object.freeze({
+  // Claude Opus 4.x family ($15 / $75 / $1.50 / $18.75 per MTok)
+  "claude-opus-4-5": {
+    inputMicroUsdPerToken: 15,
+    outputMicroUsdPerToken: 75,
+    cacheReadMicroUsdPerToken: 1, // 1.5 rounded down — see "rounding policy" below
+    cacheCreationMicroUsdPerToken: 19, // 18.75 rounded up
+  },
+  "claude-opus-4-1": {
+    inputMicroUsdPerToken: 15,
+    outputMicroUsdPerToken: 75,
+    cacheReadMicroUsdPerToken: 1,
+    cacheCreationMicroUsdPerToken: 19,
+  },
+  "claude-opus-4-7": {
+    inputMicroUsdPerToken: 15,
+    outputMicroUsdPerToken: 75,
+    cacheReadMicroUsdPerToken: 1,
+    cacheCreationMicroUsdPerToken: 19,
+  },
+  // Claude Sonnet 4.x family ($3 / $15 / $0.30 / $3.75 per MTok)
+  "claude-sonnet-4-5": {
+    inputMicroUsdPerToken: 3,
+    outputMicroUsdPerToken: 15,
+    cacheReadMicroUsdPerToken: 0, // 0.30 rounds to 0 at integer-per-tok granularity
+    cacheCreationMicroUsdPerToken: 4, // 3.75 rounded up
+  },
+  "claude-sonnet-4-6": {
+    inputMicroUsdPerToken: 3,
+    outputMicroUsdPerToken: 15,
+    cacheReadMicroUsdPerToken: 0,
+    cacheCreationMicroUsdPerToken: 4,
+  },
+  // Claude Haiku 4.x family ($1 / $5 / $0.10 / $1.25 per MTok)
+  "claude-haiku-4-5": {
+    inputMicroUsdPerToken: 1,
+    outputMicroUsdPerToken: 5,
+    cacheReadMicroUsdPerToken: 0, // 0.10 rounds to 0
+    cacheCreationMicroUsdPerToken: 1, // 1.25 rounded down
+  },
+});
+
+/**
+ * Rounding policy (PR B.2): per-token rates are stored as integer μUSD/tok.
+ * Rates with sub-μUSD/tok precision (e.g. $0.30/MTok cache-read on Sonnet =
+ * 0.3 μUSD/tok) round to the nearest integer. The §15.A invariant is
+ * preserved because the rounding is deterministic, and the ledger still
+ * holds the rounded integer.
+ *
+ * Trade-off: a cache-read-heavy run on Sonnet under-bills slightly (0.30
+ * rounds down to 0). Hosts that need exact sub-μUSD precision should
+ * override the pricing table with their own fixed-point representation, OR
+ * wait for a PR that switches to fractional rates. PR B.2 keeps the
+ * floor-to-integer behavior because:
+ *   - It matches what the broker's `cost_event.amountMicroUsd` field can
+ *     hold (integer μUSD).
+ *   - Under-billing the cache line is the safe-by-default direction; the
+ *     observed total still respects the §10.4 ±$0.05 burn-down tolerance.
+ *   - The cap-enforcement story (per-office daily) sees the same integer
+ *     amount that's written to the ledger, so the cap behavior tracks the
+ *     stored value.
+ */
+
+export function estimateAnthropicCostMicroUsd(
+  pricing: AnthropicPricingTable,
+  model: string,
+  units: CostUnits,
+): MicroUsd {
+  const rate = pricing[model];
+  if (rate === undefined) {
+    throw new UnknownModelError(model);
+  }
+  const total =
+    rate.inputMicroUsdPerToken * units.inputTokens +
+    rate.outputMicroUsdPerToken * units.outputTokens +
+    rate.cacheReadMicroUsdPerToken * units.cacheReadTokens +
+    rate.cacheCreationMicroUsdPerToken * units.cacheCreationTokens;
+  return asMicroUsd(total);
+}
+
+/**
+ * Build a `CostEstimator` bound to a specific pricing table. Used by
+ * `AnthropicProvider` and overridable by hosts that need a different
+ * price book (alternate negotiated rates, currency conversion, etc.).
+ */
+export function createAnthropicCostEstimator(pricing: AnthropicPricingTable): CostEstimator {
+  return {
+    estimate(model: string, units: CostUnits): MicroUsd {
+      return estimateAnthropicCostMicroUsd(pricing, model, units);
+    },
+  };
+}
+
+/**
+ * The set of model IDs the default pricing table knows about. Used by the
+ * provider to declare its `models[]` for gateway routing.
+ */
+export const DEFAULT_ANTHROPIC_MODELS: readonly string[] = Object.freeze(
+  Object.keys(DEFAULT_ANTHROPIC_PRICING),
+);

--- a/packages/llm-router/src/providers/anthropic-pricing.ts
+++ b/packages/llm-router/src/providers/anthropic-pricing.ts
@@ -1,30 +1,52 @@
-// Anthropic per-model pricing, expressed as integer micro-USD per token.
+// Anthropic per-model pricing, stored as integer micro-USD per million
+// tokens (μUSD/MTok).
 //
-// Why integer-per-token (not the public-facing $/MTok rate):
-//   - The cost ledger is integer micro-USD throughout (see §15.A I1/I2 in
-//     `@wuphf/broker` cost-ledger). Storing the rate the same way means
-//     `tokens * rate` produces an integer micro-USD value directly, with no
-//     intermediate float and no rounding ambiguity.
-//   - Public rates are quoted in $/million-tokens; we just divide by 1 (mtok)
-//     and multiply by 1_000_000 (μUSD/USD): rate_per_token_micro_usd =
-//     public_rate_per_mtok_usd. A $3/MTok rate becomes exactly 3 μUSD/tok.
+// Why this unit and not μUSD/tok?
 //
-// Source: https://www.anthropic.com/pricing (verified against the published
-// table as of 2026-01). Hosts may override any field via the
-// `AnthropicPricingTable` config injected at construction time, so a price
-// change does not require a code release.
+//   Anthropic publishes rates in $/MTok (e.g. "$3/MTok input"). Storing
+//   the rate at the same scale Anthropic publishes lets us copy public
+//   prices in exact, then accumulate per call in μUSD-million-tokens
+//   space and divide once at the end. That preserves sub-μUSD/tok
+//   precision (cache reads at $0.30/MTok = 300 μUSD/MTok) instead of
+//   floor-rounding to zero per token.
 //
-// What's covered:
-//   - input_tokens                → `inputMicroUsdPerToken`
-//   - output_tokens               → `outputMicroUsdPerToken`
-//   - cache_read_input_tokens     → `cacheReadMicroUsdPerToken`
-//   - cache_creation_input_tokens → `cacheCreationMicroUsdPerToken`
+//   Earlier draft (PR B.2 round 1, commit 0e5c8c4b) stored rates as
+//   μUSD/tok. Sonnet/Haiku cache-read rates at $0.30/$0.10 per MTok
+//   rounded to 0 μUSD/tok, so a cache-heavy workload could spend
+//   real money while `cost_event.amountMicroUsd` recorded 0 — bypassing
+//   the daily cap. See triangulation #2 finding B2-2 (security BLOCK,
+//   api/sre HIGH).
+//
+// All rates are integer μUSD per million tokens:
+//
+//   public price → integer rate
+//   ─────────────────────────────
+//   $15.00/MTok  → 15_000_000
+//   $3.00/MTok   →  3_000_000
+//   $1.00/MTok   →  1_000_000
+//   $0.30/MTok   →    300_000
+//   $0.10/MTok   →    100_000
+//   $0.50/MTok   →    500_000
+//   $6.25/MTok   →  6_250_000
+//   $18.75/MTok  → 18_750_000
+//
+// Per-call cost is:
+//
+//   sum_micro_million = sum(tokens_i * rate_i)
+//   amountMicroUsd    = (sum_micro_million + 500_000) / 1_000_000  (integer)
+//
+// The +500_000 / 1_000_000 is round-half-up; deterministic, matches
+// the §15.A integer-math invariant, and never produces a sub-μUSD
+// rounding loss greater than 0.5 μUSD per total call.
+//
+// Pricing source: https://www.anthropic.com/pricing (verified 2026-05-12
+// against the public table). Hosts override any rate via the
+// `AnthropicPricingTable` config injected at construction time — price
+// changes never require a code release.
 //
 // Out of scope (deferred):
-//   - 1h extended TTL cache pricing (`ephemeral_1h_input_tokens`) — premium
-//     tier with separate rate; PR B.2 only covers the 5m default tier.
-//   - Server-tool-use pricing (web search, code execution) — separate billable
-//     line items, not part of message-level usage.
+//   - 1h extended TTL cache pricing (`ephemeral_1h_input_tokens`)
+//   - Server-tool-use pricing (web search, code execution)
 
 import { asMicroUsd, type CostUnits, type MicroUsd } from "@wuphf/protocol";
 
@@ -32,124 +54,104 @@ import { UnknownModelError } from "../errors.ts";
 import type { CostEstimator } from "../types.ts";
 
 /**
- * Per-token integer micro-USD rates for one model. Cache fields are the
- * 5-minute-TTL ephemeral cache; 1h extended TTL is out of scope for PR B.2.
+ * Per-model rates in integer micro-USD per million tokens (μUSD/MTok).
+ * All four fields MUST be non-negative safe integers; validation is
+ * enforced at provider construction (`createAnthropicProvider`).
+ *
+ * Cache fields are the 5-minute-TTL ephemeral cache. 1h extended TTL
+ * is out of scope.
  */
 export interface AnthropicModelPricing {
-  readonly inputMicroUsdPerToken: number;
-  readonly outputMicroUsdPerToken: number;
-  readonly cacheReadMicroUsdPerToken: number;
-  readonly cacheCreationMicroUsdPerToken: number;
+  readonly inputMicroUsdPerMTok: number;
+  readonly outputMicroUsdPerMTok: number;
+  readonly cacheReadMicroUsdPerMTok: number;
+  readonly cacheCreationMicroUsdPerMTok: number;
 }
 
 export type AnthropicPricingTable = Readonly<Record<string, AnthropicModelPricing>>;
 
 /**
- * Built-in pricing for the Claude 4.x family as of 2026-01. Each rate is
- * the public $/MTok price expressed as integer μUSD/tok.
+ * Built-in pricing for the Claude 4.x family, current as of 2026-05.
  *
- *   Opus 4.x:    $15 input / $75 output / $1.50 cache-read / $18.75 cache-write
- *   Sonnet 4.x:  $3  input / $15 output / $0.30 cache-read / $3.75  cache-write
- *   Haiku 4.x:   $1  input / $5  output / $0.10 cache-read / $1.25  cache-write
+ *   Opus 4.5 / 4.6 / 4.7:  $5  / $25 / $0.50 / $6.25  per MTok
+ *   Opus 4.1 (legacy):     $15 / $75 / $1.50 / $18.75 per MTok
+ *   Sonnet 4.5 / 4.6:      $3  / $15 / $0.30 / $3.75  per MTok
+ *   Haiku 4.5:             $1  / $5  / $0.10 / $1.25  per MTok
  *
- * Cache-read is 10% of input cost; cache-creation is 1.25x input cost. This
- * is Anthropic's standard ratio across the family — if a future model
- * publishes a different ratio, override via the config.
+ * Opus 4.5+ dropped 3x from the 4.1 generation per Anthropic's
+ * 2025-11 announcement. The previous draft of this table used 4.1
+ * rates for 4.5/4.7, which over-billed by 3x and would have caused
+ * false daily-cap trips — see triangulation #2 finding B2-1.
  *
- * The fractional cache rates ($1.50, $18.75, $3.75) round to non-integer
- * μUSD/tok — we use the precise published rate, not a rounded approximation.
- * To keep integer arithmetic exact, rates are micro-USD per 100 tokens
- * (i.e. centi-micro-USD per token, or 10⁻⁸ USD/tok). At runtime the cost
- * estimator divides by 100 with floor — exact for the published rate steps.
- *
- * No: the simpler design is to keep rates as μUSD per million-tokens
- * (effectively, since $1/MTok = 1 μUSD/tok), and use `Math.round(tokens *
- * rateNumerator / rateDenominator)` to handle fractional cents. Let's do
- * that:
- *
- *   Each pricing entry stores a per-token rate in fixed-point with implicit
- *   scale 1 (i.e. integer μUSD/tok), and we use Math.round for cache rates
- *   that have a fractional cent component. We accept a 1 μUSD/MTok rounding
- *   "error" on cache lines; for the §15.A invariant this is acceptable
- *   because the rounding is deterministic and the rate ranges are clamped.
- *
- * Actually, the cleanest approach: store cache rates as
- * "micro-USD per 1000 tokens" so the integer arithmetic is exact at the
- * granularity Anthropic actually charges:
- *
- *   $1.50/MTok = 1500 μUSD/MTok = 1.5 μUSD/Ktok = 1500 nanoUSD/tok.
- *
- * Since our ledger is μUSD-integer, we use μUSD-per-1000-tokens and divide
- * by 1000 at billing time. This is exactly how the broker projection-side
- * pricing works for receipt cost displays.
- *
- * For PR B.2 simplicity: store all rates in `microUsdPer1000Tokens` units
- * and divide at estimation time. Documented precisely in
- * `estimateAnthropicCostMicroUsd` below.
+ * Hosts that want negotiated rates pass a full `AnthropicPricingTable`
+ * to `createAnthropicProvider`. The model registry derives from the
+ * passed table's keys, so adding a model is one config change.
  */
 export const DEFAULT_ANTHROPIC_PRICING: AnthropicPricingTable = Object.freeze({
-  // Claude Opus 4.x family ($15 / $75 / $1.50 / $18.75 per MTok)
-  "claude-opus-4-5": {
-    inputMicroUsdPerToken: 15,
-    outputMicroUsdPerToken: 75,
-    cacheReadMicroUsdPerToken: 1, // 1.5 rounded down — see "rounding policy" below
-    cacheCreationMicroUsdPerToken: 19, // 18.75 rounded up
-  },
+  // Opus 4.1 (legacy generation): $15 / $75 / $1.50 / $18.75 per MTok
   "claude-opus-4-1": {
-    inputMicroUsdPerToken: 15,
-    outputMicroUsdPerToken: 75,
-    cacheReadMicroUsdPerToken: 1,
-    cacheCreationMicroUsdPerToken: 19,
+    inputMicroUsdPerMTok: 15_000_000,
+    outputMicroUsdPerMTok: 75_000_000,
+    cacheReadMicroUsdPerMTok: 1_500_000,
+    cacheCreationMicroUsdPerMTok: 18_750_000,
+  },
+  // Opus 4.5 / 4.6 / 4.7 generation: $5 / $25 / $0.50 / $6.25 per MTok
+  "claude-opus-4-5": {
+    inputMicroUsdPerMTok: 5_000_000,
+    outputMicroUsdPerMTok: 25_000_000,
+    cacheReadMicroUsdPerMTok: 500_000,
+    cacheCreationMicroUsdPerMTok: 6_250_000,
+  },
+  "claude-opus-4-6": {
+    inputMicroUsdPerMTok: 5_000_000,
+    outputMicroUsdPerMTok: 25_000_000,
+    cacheReadMicroUsdPerMTok: 500_000,
+    cacheCreationMicroUsdPerMTok: 6_250_000,
   },
   "claude-opus-4-7": {
-    inputMicroUsdPerToken: 15,
-    outputMicroUsdPerToken: 75,
-    cacheReadMicroUsdPerToken: 1,
-    cacheCreationMicroUsdPerToken: 19,
+    inputMicroUsdPerMTok: 5_000_000,
+    outputMicroUsdPerMTok: 25_000_000,
+    cacheReadMicroUsdPerMTok: 500_000,
+    cacheCreationMicroUsdPerMTok: 6_250_000,
   },
-  // Claude Sonnet 4.x family ($3 / $15 / $0.30 / $3.75 per MTok)
+  // Sonnet 4.x family ($3 / $15 / $0.30 / $3.75 per MTok)
   "claude-sonnet-4-5": {
-    inputMicroUsdPerToken: 3,
-    outputMicroUsdPerToken: 15,
-    cacheReadMicroUsdPerToken: 0, // 0.30 rounds to 0 at integer-per-tok granularity
-    cacheCreationMicroUsdPerToken: 4, // 3.75 rounded up
+    inputMicroUsdPerMTok: 3_000_000,
+    outputMicroUsdPerMTok: 15_000_000,
+    cacheReadMicroUsdPerMTok: 300_000,
+    cacheCreationMicroUsdPerMTok: 3_750_000,
   },
   "claude-sonnet-4-6": {
-    inputMicroUsdPerToken: 3,
-    outputMicroUsdPerToken: 15,
-    cacheReadMicroUsdPerToken: 0,
-    cacheCreationMicroUsdPerToken: 4,
+    inputMicroUsdPerMTok: 3_000_000,
+    outputMicroUsdPerMTok: 15_000_000,
+    cacheReadMicroUsdPerMTok: 300_000,
+    cacheCreationMicroUsdPerMTok: 3_750_000,
   },
-  // Claude Haiku 4.x family ($1 / $5 / $0.10 / $1.25 per MTok)
+  // Haiku 4.5 ($1 / $5 / $0.10 / $1.25 per MTok)
   "claude-haiku-4-5": {
-    inputMicroUsdPerToken: 1,
-    outputMicroUsdPerToken: 5,
-    cacheReadMicroUsdPerToken: 0, // 0.10 rounds to 0
-    cacheCreationMicroUsdPerToken: 1, // 1.25 rounded down
+    inputMicroUsdPerMTok: 1_000_000,
+    outputMicroUsdPerMTok: 5_000_000,
+    cacheReadMicroUsdPerMTok: 100_000,
+    cacheCreationMicroUsdPerMTok: 1_250_000,
   },
 });
 
-/**
- * Rounding policy (PR B.2): per-token rates are stored as integer μUSD/tok.
- * Rates with sub-μUSD/tok precision (e.g. $0.30/MTok cache-read on Sonnet =
- * 0.3 μUSD/tok) round to the nearest integer. The §15.A invariant is
- * preserved because the rounding is deterministic, and the ledger still
- * holds the rounded integer.
- *
- * Trade-off: a cache-read-heavy run on Sonnet under-bills slightly (0.30
- * rounds down to 0). Hosts that need exact sub-μUSD precision should
- * override the pricing table with their own fixed-point representation, OR
- * wait for a PR that switches to fractional rates. PR B.2 keeps the
- * floor-to-integer behavior because:
- *   - It matches what the broker's `cost_event.amountMicroUsd` field can
- *     hold (integer μUSD).
- *   - Under-billing the cache line is the safe-by-default direction; the
- *     observed total still respects the §10.4 ±$0.05 burn-down tolerance.
- *   - The cap-enforcement story (per-office daily) sees the same integer
- *     amount that's written to the ledger, so the cap behavior tracks the
- *     stored value.
- */
+const ONE_MILLION = 1_000_000;
+const ROUND_HALF_UP = ONE_MILLION / 2;
 
+/**
+ * Compute the integer μUSD cost of one Anthropic call. Accumulates in
+ * μUSD-million-tokens space (no precision loss for sub-μUSD/tok rates
+ * like $0.30/MTok cache-reads), then round-half-up to integer μUSD.
+ *
+ * The §15.A invariant holds because the final value is a non-negative
+ * safe integer; intermediate fixed-point accumulation never leaves
+ * integer arithmetic.
+ *
+ * Overflow safety: max plausible per-call sum is
+ *   input_tokens (1e6) * input_rate (15e6 μUSD/MTok)
+ *   = 1.5e13, well inside Number.MAX_SAFE_INTEGER (~9e15).
+ */
 export function estimateAnthropicCostMicroUsd(
   pricing: AnthropicPricingTable,
   model: string,
@@ -159,12 +161,13 @@ export function estimateAnthropicCostMicroUsd(
   if (rate === undefined) {
     throw new UnknownModelError(model);
   }
-  const total =
-    rate.inputMicroUsdPerToken * units.inputTokens +
-    rate.outputMicroUsdPerToken * units.outputTokens +
-    rate.cacheReadMicroUsdPerToken * units.cacheReadTokens +
-    rate.cacheCreationMicroUsdPerToken * units.cacheCreationTokens;
-  return asMicroUsd(total);
+  const accum =
+    rate.inputMicroUsdPerMTok * units.inputTokens +
+    rate.outputMicroUsdPerMTok * units.outputTokens +
+    rate.cacheReadMicroUsdPerMTok * units.cacheReadTokens +
+    rate.cacheCreationMicroUsdPerMTok * units.cacheCreationTokens;
+  const rounded = Math.floor((accum + ROUND_HALF_UP) / ONE_MILLION);
+  return asMicroUsd(rounded);
 }
 
 /**
@@ -181,8 +184,44 @@ export function createAnthropicCostEstimator(pricing: AnthropicPricingTable): Co
 }
 
 /**
- * The set of model IDs the default pricing table knows about. Used by the
- * provider to declare its `models[]` for gateway routing.
+ * Validate a pricing table at provider construction. Throws on any
+ * invalid entry so the gateway never tries to bill a malformed rate.
+ * See triangulation #2 finding B2-6.
+ */
+export function validateAnthropicPricingTable(table: AnthropicPricingTable): void {
+  const models = Object.keys(table);
+  if (models.length === 0) {
+    throw new Error("AnthropicPricingTable must register at least one model");
+  }
+  for (const model of models) {
+    if (model.length === 0) {
+      throw new Error("AnthropicPricingTable model id must be a non-empty string");
+    }
+    const rate = table[model];
+    if (rate === undefined) {
+      // Shouldn't happen given Object.keys, but the guard keeps the
+      // type narrowing honest for the loop body.
+      throw new Error(`AnthropicPricingTable: missing rate for model ${JSON.stringify(model)}`);
+    }
+    const fields: Array<[string, number]> = [
+      ["inputMicroUsdPerMTok", rate.inputMicroUsdPerMTok],
+      ["outputMicroUsdPerMTok", rate.outputMicroUsdPerMTok],
+      ["cacheReadMicroUsdPerMTok", rate.cacheReadMicroUsdPerMTok],
+      ["cacheCreationMicroUsdPerMTok", rate.cacheCreationMicroUsdPerMTok],
+    ];
+    for (const [field, value] of fields) {
+      if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+        throw new Error(
+          `AnthropicPricingTable[${JSON.stringify(model)}].${field} must be a non-negative safe integer, got ${String(value)}`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * The set of model IDs the default pricing table knows about. Used by
+ * the provider to declare its `models[]` for gateway routing.
  */
 export const DEFAULT_ANTHROPIC_MODELS: readonly string[] = Object.freeze(
   Object.keys(DEFAULT_ANTHROPIC_PRICING),

--- a/packages/llm-router/src/providers/anthropic.ts
+++ b/packages/llm-router/src/providers/anthropic.ts
@@ -1,56 +1,88 @@
 // Anthropic SDK adapter for `Gateway.complete()`.
 //
 // Subpath import: hosts use `import { createAnthropicProvider } from
-// "@wuphf/llm-router/anthropic"`. The root `@wuphf/llm-router` does NOT
-// pull `@anthropic-ai/sdk` into the import graph, mirroring the
-// `@wuphf/broker/sqlite` precedent. Hosts that only use the stub
-// (e.g. tests, §10.4 burn-down) pay zero install cost for the SDK.
+// "@wuphf/llm-router/anthropic"`. `@anthropic-ai/sdk` is a peer
+// dependency — hosts that only use the stub do not install it. The
+// convenience constructor `createAnthropicProviderWithKey` uses a
+// dynamic import so the SDK module is loaded only when the host
+// explicitly asks for it; the structural-client path
+// (`createAnthropicProvider`) never touches the SDK.
 //
-// The adapter wires four things:
+// The adapter wires five things:
 //
 //   1. Provider routing: `models[]` is bound to the pricing-table model
 //      IDs, so the gateway's exact-match registration (post-H4 fix) puts
 //      `claude-*` requests on this provider. A host that adds a new
-//      pricing entry MUST also expand `models[]` — `createAnthropicProvider`
-//      handles this automatically when given the pricing table.
+//      pricing entry MUST also expand `models[]` —
+//      `createAnthropicProvider` handles this automatically when given
+//      the pricing table.
 //
-//   2. Cost estimation: integer-μUSD pricing (`anthropic-pricing.ts`). The
-//      §15.A invariant is preserved because we never leave integer math
-//      between provider response and `appendCostEvent`.
+//   2. Cost estimation: integer-μUSD pricing (`anthropic-pricing.ts`).
+//      The §15.A invariant is preserved because we never leave integer
+//      math between provider response and `appendCostEvent`.
 //
 //   3. Request translation: `ProviderRequest` carries a single string
 //      prompt today (the simplest shape the gateway needs); we translate
 //      to a single user message and lift `maxOutputTokens` directly into
 //      Anthropic's `max_tokens` field.
 //
-//   4. Error mapping: every SDK error class collapses to `ProviderError`
-//      with the original error attached as `cause`. The breaker sees one
-//      consistent failure surface regardless of HTTP status. We do NOT
-//      try to distinguish 429 / 5xx here — the breaker treats every
-//      failure as a strike, and the in-flight reservation issue (#819)
-//      is where rate-limit-specific behavior belongs.
+//   4. Error mapping: structured triage of SDK errors. 400/413/422
+//      (caller-input errors) → `BadRequestError`, which the gateway does
+//      NOT count as a breaker strike (triangulation B2-7). 401/403/429/
+//      5xx/network → `ProviderError` with structured metadata (status,
+//      requestId, errorType, retryAfterMs) preserved for on-call
+//      (triangulation B2-5).
+//
+//   5. Idempotency-key threading: every call mints a deterministic key
+//      from the request bytes and passes it to `messages.create` so SDK
+//      retries (which are on by default) don't double-charge after a
+//      lost response (triangulation B2-4). The key is content-derived,
+//      so a logical retry from the same caller reuses it.
 
-import Anthropic from "@anthropic-ai/sdk";
-import { asProviderKind, type CostUnits, type ProviderKind } from "@wuphf/protocol";
+import {
+  asProviderKind,
+  type CostUnits,
+  canonicalJSON,
+  type ProviderKind,
+  sha256Hex,
+} from "@wuphf/protocol";
 
-import { ProviderError, UnknownModelError } from "../errors.ts";
+import { BadRequestError, ProviderError, UnknownModelError } from "../errors.ts";
 import type { CostEstimator, Provider, ProviderRequest, ProviderResponse } from "../types.ts";
 import {
   type AnthropicPricingTable,
   createAnthropicCostEstimator,
   DEFAULT_ANTHROPIC_MODELS,
   DEFAULT_ANTHROPIC_PRICING,
+  validateAnthropicPricingTable,
 } from "./anthropic-pricing.ts";
 
 const ANTHROPIC_PROVIDER_KIND: ProviderKind = asProviderKind("anthropic");
 
+// HTTP status set the gateway treats as caller-input (NOT breaker strikes).
+// 400 = bad request, 413 = payload too large, 422 = unprocessable entity.
+// 401 (auth), 403 (permission), 429 (rate limit), and 5xx stay as
+// ProviderError so the breaker can react to real provider failures.
+const CALLER_INPUT_STATUSES = new Set<number>([400, 413, 422]);
+
+// Loose-typed accessor for SDK error metadata. The SDK's `APIError`
+// class declares `status`, `headers`, and `error`; we read defensively
+// so a future SDK version that renames a field degrades gracefully
+// rather than throwing inside the catch handler.
+interface SdkErrorLike {
+  readonly status?: unknown;
+  readonly headers?: unknown;
+  readonly error?: unknown;
+  readonly requestID?: unknown;
+}
+
 /**
- * Minimal slice of the Anthropic SDK surface we depend on, so tests can
- * inject a fake client without pulling the whole SDK type tree.
+ * Minimal slice of the Anthropic SDK surface we depend on. Tests inject
+ * a fake; the real `Anthropic` client matches.
  *
- * The shape mirrors `client.messages.create(MessageCreateParamsNonStreaming,
- * options) → APIPromise<Message>`. Streaming is out of scope for PR B.2 —
- * see "out of scope" in the package README.
+ * The signature mirrors `client.messages.create(params, options)`. We
+ * only use `options.idempotencyKey` — the SDK accepts arbitrary
+ * RequestOptions but we don't depend on the rest.
  */
 export interface AnthropicMessageCreateParams {
   readonly model: string;
@@ -59,6 +91,16 @@ export interface AnthropicMessageCreateParams {
     readonly role: "user" | "assistant";
     readonly content: string;
   }>;
+}
+
+export interface AnthropicRequestOptions {
+  /**
+   * Stable string the SDK forwards as the `idempotency-key` header.
+   * Anthropic's server deduplicates same-key requests within a window,
+   * which prevents double-charges after lost responses and during SDK
+   * internal retries.
+   */
+  readonly idempotencyKey?: string;
 }
 
 export interface AnthropicMessageUsage {
@@ -73,38 +115,37 @@ export interface AnthropicMessage {
   readonly usage: AnthropicMessageUsage;
 }
 
-/**
- * Anything that exposes `messages.create(params) → Promise<AnthropicMessage>`
- * satisfies this. The real `Anthropic` client matches; tests pass a fake.
- */
 export interface AnthropicClient {
   readonly messages: {
-    create(params: AnthropicMessageCreateParams): Promise<AnthropicMessage>;
+    create(
+      params: AnthropicMessageCreateParams,
+      options?: AnthropicRequestOptions,
+    ): Promise<AnthropicMessage>;
   };
 }
 
 export interface CreateAnthropicProviderArgs {
   /**
-   * Anthropic SDK client. Production: `new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })`.
-   * Tests: inject a fake matching `AnthropicClient`.
-   *
-   * Optional in this signature so a host that only wants pricing/model
-   * registration (e.g. a smoke test that doesn't actually call the API)
-   * can pass `undefined` — but `complete()` will throw if called.
+   * Anthropic SDK client (production) or a fake matching `AnthropicClient`
+   * (tests). The structural-client path does NOT pull in `@anthropic-ai/sdk`.
    */
   readonly client: AnthropicClient;
   /**
    * Pricing table override. Defaults to `DEFAULT_ANTHROPIC_PRICING`.
-   * The provider's `models[]` is derived from the table's keys, so
-   * overriding extends model registration in one place.
+   * Validated at construction; throws on missing/invalid entries.
    */
   readonly pricing?: AnthropicPricingTable;
 }
 
 export function createAnthropicProvider(args: CreateAnthropicProviderArgs): Provider {
   const pricing = args.pricing ?? DEFAULT_ANTHROPIC_PRICING;
+  // B2-6: validate pricing at construction so a bad config never reaches
+  // a billable call. The default table is also validated — cheap and
+  // catches future drift if someone edits a rate to NaN.
+  validateAnthropicPricingTable(pricing);
   const models: readonly string[] =
     args.pricing === undefined ? DEFAULT_ANTHROPIC_MODELS : Object.keys(pricing);
+  const modelSet = new Set<string>(models);
   const costEstimator: CostEstimator = createAnthropicCostEstimator(pricing);
 
   return {
@@ -112,7 +153,7 @@ export function createAnthropicProvider(args: CreateAnthropicProviderArgs): Prov
     models,
     costEstimator,
     async complete(req: ProviderRequest): Promise<ProviderResponse> {
-      if (!models.includes(req.model)) {
+      if (!modelSet.has(req.model)) {
         // Defensive: the gateway already routed by exact-match, so this
         // shouldn't fire in practice. If it does, the host built two
         // providers claiming overlapping models and the gateway delivered
@@ -120,19 +161,26 @@ export function createAnthropicProvider(args: CreateAnthropicProviderArgs): Prov
         // gets a stable error type instead of an SDK-level 4xx.
         throw new UnknownModelError(req.model);
       }
+      // B2-7: pre-validate caller input. max_tokens must be > 0; the
+      // server rejects 0 with 400 anyway, but pre-rejecting locally
+      // means we don't burn a network round-trip OR send an idempotency
+      // key that the server would reuse for a real retry.
+      if (!Number.isSafeInteger(req.maxOutputTokens) || req.maxOutputTokens <= 0) {
+        throw new BadRequestError(ANTHROPIC_PROVIDER_KIND, new Error("maxOutputTokens_invalid"));
+      }
+      const params: AnthropicMessageCreateParams = {
+        model: req.model,
+        max_tokens: req.maxOutputTokens,
+        messages: [{ role: "user", content: req.prompt }],
+      };
+      const options: AnthropicRequestOptions = {
+        idempotencyKey: deriveIdempotencyKey(req),
+      };
       let raw: AnthropicMessage;
       try {
-        raw = await args.client.messages.create({
-          model: req.model,
-          max_tokens: req.maxOutputTokens,
-          messages: [{ role: "user", content: req.prompt }],
-        });
+        raw = await args.client.messages.create(params, options);
       } catch (err) {
-        // Every SDK error (auth, rate-limit, 5xx, network, abort) collapses
-        // to ProviderError. The breaker treats them all as strikes; the
-        // in-flight reservation work (issue #819) is where rate-limit-
-        // specific retry / cool-down semantics belong.
-        throw new ProviderError(ANTHROPIC_PROVIDER_KIND, err);
+        throw classifySdkError(err);
       }
       return {
         text: extractText(raw.content),
@@ -143,21 +191,127 @@ export function createAnthropicProvider(args: CreateAnthropicProviderArgs): Prov
 }
 
 /**
+ * Derive a stable idempotency key from the request payload. Same logical
+ * request → same key → Anthropic dedupes server-side. Different agents
+ * issuing the same prompt get DIFFERENT keys upstream, because the
+ * gateway's dedupe already short-circuits same-(ctx, request) repeats
+ * before they reach the provider. (See B3 fix in PR B; dedupe key is
+ * (agentSlug, taskId, receiptId, request).)
+ *
+ * The key prefix `wuphf-` makes it identifiable in Anthropic-side logs
+ * if support needs to trace one.
+ */
+function deriveIdempotencyKey(req: ProviderRequest): string {
+  const projection = canonicalJSON({
+    model: req.model,
+    prompt: req.prompt,
+    maxOutputTokens: req.maxOutputTokens,
+  });
+  // Idempotency keys are documented as ≤ 256 chars; SHA-256 hex is 64,
+  // well inside the budget, and deterministic across processes.
+  return `wuphf-${sha256Hex(projection)}`;
+}
+
+/**
+ * Map an SDK error to the right typed gateway error. Caller-input
+ * statuses (400/413/422) → `BadRequestError` (NOT a breaker strike);
+ * everything else → `ProviderError` with structured metadata so on-call
+ * sees status/requestId/retry-after instead of opaque "provider_error".
+ */
+function classifySdkError(err: unknown): BadRequestError | ProviderError {
+  const meta = extractSdkErrorMetadata(err);
+  if (meta.status !== undefined && CALLER_INPUT_STATUSES.has(meta.status)) {
+    return new BadRequestError(ANTHROPIC_PROVIDER_KIND, err, {
+      ...(meta.status !== undefined ? { status: meta.status } : {}),
+      ...(meta.requestId !== undefined ? { requestId: meta.requestId } : {}),
+      ...(meta.errorType !== undefined ? { errorType: meta.errorType } : {}),
+    });
+  }
+  return new ProviderError(ANTHROPIC_PROVIDER_KIND, err, {
+    ...(meta.status !== undefined ? { status: meta.status } : {}),
+    ...(meta.requestId !== undefined ? { requestId: meta.requestId } : {}),
+    ...(meta.errorType !== undefined ? { errorType: meta.errorType } : {}),
+    ...(meta.retryAfterMs !== undefined ? { retryAfterMs: meta.retryAfterMs } : {}),
+  });
+}
+
+interface ExtractedSdkMetadata {
+  readonly status?: number;
+  readonly requestId?: string;
+  readonly errorType?: string;
+  readonly retryAfterMs?: number;
+}
+
+function extractSdkErrorMetadata(err: unknown): ExtractedSdkMetadata {
+  if (typeof err !== "object" || err === null) return {};
+  const e = err as SdkErrorLike;
+  const out: { -readonly [K in keyof ExtractedSdkMetadata]: ExtractedSdkMetadata[K] } = {};
+  if (typeof e.status === "number") {
+    out.status = e.status;
+  }
+  if (typeof e.requestID === "string") {
+    out.requestId = e.requestID;
+  }
+  if (typeof e.error === "object" && e.error !== null) {
+    const errBody = e.error as { readonly error?: { readonly type?: unknown } };
+    if (typeof errBody.error?.type === "string") {
+      out.errorType = errBody.error.type;
+    }
+  }
+  if (typeof e.headers === "object" && e.headers !== null) {
+    // SDK's `headers` is a Headers-like; try both .get() (Headers
+    // instance) and indexer (plain object).
+    const retryAfter = readHeader(e.headers, "retry-after");
+    if (retryAfter !== undefined) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds) && seconds >= 0) {
+        out.retryAfterMs = Math.round(seconds * 1000);
+      }
+    }
+  }
+  return out;
+}
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  // Headers instance
+  if (typeof headers === "object" && headers !== null && "get" in headers) {
+    const getter = (headers as { readonly get?: (n: string) => string | null }).get;
+    if (typeof getter === "function") {
+      const v = getter.call(headers, name);
+      if (typeof v === "string") return v;
+    }
+  }
+  // Plain object indexer
+  if (typeof headers === "object" && headers !== null) {
+    const lower = name.toLowerCase();
+    for (const [k, v] of Object.entries(headers as Record<string, unknown>)) {
+      if (k.toLowerCase() === lower && typeof v === "string") {
+        return v;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
  * Flatten Anthropic's content-block array to a single text response.
  * For PR B.2 we only handle `type === "text"` blocks (the standard
  * non-streaming, non-tool-use path). Tool-use blocks and thinking blocks
  * are ignored on text extraction; their token usage is still in `usage`
  * so the cost line is correct. PR B.3+ will plumb tool_use through to
  * the gateway response shape.
+ *
+ * Uses array-join instead of `+=` so allocation is O(total text) rather
+ * than O(blocks²) for large multi-block responses.
  */
 function extractText(content: AnthropicMessage["content"]): string {
-  let out = "";
+  const parts: string[] = [];
   for (const block of content) {
     if (block.type === "text" && typeof block.text === "string") {
-      out += block.text;
+      parts.push(block.text);
     }
   }
-  return out;
+  return parts.join("");
 }
 
 /**
@@ -187,21 +341,38 @@ export {
   DEFAULT_ANTHROPIC_MODELS,
   DEFAULT_ANTHROPIC_PRICING,
   estimateAnthropicCostMicroUsd,
+  validateAnthropicPricingTable,
 } from "./anthropic-pricing.ts";
 
-// Convenience constructor for the real SDK client. Hosts that don't want
-// to import `@anthropic-ai/sdk` directly can call this with their API key
-// and get a ready-to-use Provider.
-//
-// Reads the key from the argument, NOT from process.env, so the secret
-// boundary stays at the host — per protocol AGENTS.md, "Always source
-// credentials from .env files. Never pass API tokens inline on the
-// command line."
-export function createAnthropicProviderWithKey(args: {
+/**
+ * Convenience constructor for the real SDK client. The SDK is a peer
+ * dependency; this function uses a dynamic import so a host that only
+ * uses the structural-client path (e.g. tests) never loads the SDK
+ * module. Triangulation #2 finding perf-1 / B2-3.
+ *
+ * Reads the key from the argument, NOT from process.env, so the secret
+ * boundary stays at the host — per protocol AGENTS.md, "Always source
+ * credentials from .env files. Never pass API tokens inline on the
+ * command line."
+ *
+ * Runtime validation: `apiKey` must be a non-empty string. The README's
+ * `process.env.ANTHROPIC_API_KEY!` non-null assertion can forge "key
+ * exists" from JS or misconfigured TS; this rejects it explicitly.
+ */
+export async function createAnthropicProviderWithKey(args: {
   readonly apiKey: string;
   readonly pricing?: AnthropicPricingTable;
-}): Provider {
-  const client = new Anthropic({ apiKey: args.apiKey });
+}): Promise<Provider> {
+  if (typeof args.apiKey !== "string" || args.apiKey.length === 0) {
+    throw new Error(
+      "createAnthropicProviderWithKey: apiKey must be a non-empty string (got " +
+        typeof args.apiKey +
+        ")",
+    );
+  }
+  const sdk = await import("@anthropic-ai/sdk");
+  const AnthropicCtor = sdk.default;
+  const client = new AnthropicCtor({ apiKey: args.apiKey });
   return createAnthropicProvider({
     client: client as unknown as AnthropicClient,
     ...(args.pricing !== undefined ? { pricing: args.pricing } : {}),

--- a/packages/llm-router/src/providers/anthropic.ts
+++ b/packages/llm-router/src/providers/anthropic.ts
@@ -1,0 +1,209 @@
+// Anthropic SDK adapter for `Gateway.complete()`.
+//
+// Subpath import: hosts use `import { createAnthropicProvider } from
+// "@wuphf/llm-router/anthropic"`. The root `@wuphf/llm-router` does NOT
+// pull `@anthropic-ai/sdk` into the import graph, mirroring the
+// `@wuphf/broker/sqlite` precedent. Hosts that only use the stub
+// (e.g. tests, §10.4 burn-down) pay zero install cost for the SDK.
+//
+// The adapter wires four things:
+//
+//   1. Provider routing: `models[]` is bound to the pricing-table model
+//      IDs, so the gateway's exact-match registration (post-H4 fix) puts
+//      `claude-*` requests on this provider. A host that adds a new
+//      pricing entry MUST also expand `models[]` — `createAnthropicProvider`
+//      handles this automatically when given the pricing table.
+//
+//   2. Cost estimation: integer-μUSD pricing (`anthropic-pricing.ts`). The
+//      §15.A invariant is preserved because we never leave integer math
+//      between provider response and `appendCostEvent`.
+//
+//   3. Request translation: `ProviderRequest` carries a single string
+//      prompt today (the simplest shape the gateway needs); we translate
+//      to a single user message and lift `maxOutputTokens` directly into
+//      Anthropic's `max_tokens` field.
+//
+//   4. Error mapping: every SDK error class collapses to `ProviderError`
+//      with the original error attached as `cause`. The breaker sees one
+//      consistent failure surface regardless of HTTP status. We do NOT
+//      try to distinguish 429 / 5xx here — the breaker treats every
+//      failure as a strike, and the in-flight reservation issue (#819)
+//      is where rate-limit-specific behavior belongs.
+
+import Anthropic from "@anthropic-ai/sdk";
+import { asProviderKind, type CostUnits, type ProviderKind } from "@wuphf/protocol";
+
+import { ProviderError, UnknownModelError } from "../errors.ts";
+import type { CostEstimator, Provider, ProviderRequest, ProviderResponse } from "../types.ts";
+import {
+  type AnthropicPricingTable,
+  createAnthropicCostEstimator,
+  DEFAULT_ANTHROPIC_MODELS,
+  DEFAULT_ANTHROPIC_PRICING,
+} from "./anthropic-pricing.ts";
+
+const ANTHROPIC_PROVIDER_KIND: ProviderKind = asProviderKind("anthropic");
+
+/**
+ * Minimal slice of the Anthropic SDK surface we depend on, so tests can
+ * inject a fake client without pulling the whole SDK type tree.
+ *
+ * The shape mirrors `client.messages.create(MessageCreateParamsNonStreaming,
+ * options) → APIPromise<Message>`. Streaming is out of scope for PR B.2 —
+ * see "out of scope" in the package README.
+ */
+export interface AnthropicMessageCreateParams {
+  readonly model: string;
+  readonly max_tokens: number;
+  readonly messages: ReadonlyArray<{
+    readonly role: "user" | "assistant";
+    readonly content: string;
+  }>;
+}
+
+export interface AnthropicMessageUsage {
+  readonly input_tokens: number;
+  readonly output_tokens: number;
+  readonly cache_read_input_tokens: number | null;
+  readonly cache_creation_input_tokens: number | null;
+}
+
+export interface AnthropicMessage {
+  readonly content: ReadonlyArray<{ readonly type: string; readonly text?: string }>;
+  readonly usage: AnthropicMessageUsage;
+}
+
+/**
+ * Anything that exposes `messages.create(params) → Promise<AnthropicMessage>`
+ * satisfies this. The real `Anthropic` client matches; tests pass a fake.
+ */
+export interface AnthropicClient {
+  readonly messages: {
+    create(params: AnthropicMessageCreateParams): Promise<AnthropicMessage>;
+  };
+}
+
+export interface CreateAnthropicProviderArgs {
+  /**
+   * Anthropic SDK client. Production: `new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })`.
+   * Tests: inject a fake matching `AnthropicClient`.
+   *
+   * Optional in this signature so a host that only wants pricing/model
+   * registration (e.g. a smoke test that doesn't actually call the API)
+   * can pass `undefined` — but `complete()` will throw if called.
+   */
+  readonly client: AnthropicClient;
+  /**
+   * Pricing table override. Defaults to `DEFAULT_ANTHROPIC_PRICING`.
+   * The provider's `models[]` is derived from the table's keys, so
+   * overriding extends model registration in one place.
+   */
+  readonly pricing?: AnthropicPricingTable;
+}
+
+export function createAnthropicProvider(args: CreateAnthropicProviderArgs): Provider {
+  const pricing = args.pricing ?? DEFAULT_ANTHROPIC_PRICING;
+  const models: readonly string[] =
+    args.pricing === undefined ? DEFAULT_ANTHROPIC_MODELS : Object.keys(pricing);
+  const costEstimator: CostEstimator = createAnthropicCostEstimator(pricing);
+
+  return {
+    kind: ANTHROPIC_PROVIDER_KIND,
+    models,
+    costEstimator,
+    async complete(req: ProviderRequest): Promise<ProviderResponse> {
+      if (!models.includes(req.model)) {
+        // Defensive: the gateway already routed by exact-match, so this
+        // shouldn't fire in practice. If it does, the host built two
+        // providers claiming overlapping models and the gateway delivered
+        // to the wrong one — surface as UnknownModelError so the caller
+        // gets a stable error type instead of an SDK-level 4xx.
+        throw new UnknownModelError(req.model);
+      }
+      let raw: AnthropicMessage;
+      try {
+        raw = await args.client.messages.create({
+          model: req.model,
+          max_tokens: req.maxOutputTokens,
+          messages: [{ role: "user", content: req.prompt }],
+        });
+      } catch (err) {
+        // Every SDK error (auth, rate-limit, 5xx, network, abort) collapses
+        // to ProviderError. The breaker treats them all as strikes; the
+        // in-flight reservation work (issue #819) is where rate-limit-
+        // specific retry / cool-down semantics belong.
+        throw new ProviderError(ANTHROPIC_PROVIDER_KIND, err);
+      }
+      return {
+        text: extractText(raw.content),
+        usage: usageToCostUnits(raw.usage),
+      };
+    },
+  };
+}
+
+/**
+ * Flatten Anthropic's content-block array to a single text response.
+ * For PR B.2 we only handle `type === "text"` blocks (the standard
+ * non-streaming, non-tool-use path). Tool-use blocks and thinking blocks
+ * are ignored on text extraction; their token usage is still in `usage`
+ * so the cost line is correct. PR B.3+ will plumb tool_use through to
+ * the gateway response shape.
+ */
+function extractText(content: AnthropicMessage["content"]): string {
+  let out = "";
+  for (const block of content) {
+    if (block.type === "text" && typeof block.text === "string") {
+      out += block.text;
+    }
+  }
+  return out;
+}
+
+/**
+ * Translate Anthropic's Usage to our CostUnits shape. SDK can return
+ * `null` for cache fields (when the request didn't use prompt caching) —
+ * coerce to 0 so the protocol CostUnits invariant (non-negative integer)
+ * holds.
+ */
+function usageToCostUnits(usage: AnthropicMessageUsage): CostUnits {
+  return {
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    cacheReadTokens: usage.cache_read_input_tokens ?? 0,
+    cacheCreationTokens: usage.cache_creation_input_tokens ?? 0,
+  };
+}
+
+// Re-export pricing surface so hosts using the subpath get one import line:
+//   import {
+//     createAnthropicProvider,
+//     DEFAULT_ANTHROPIC_PRICING,
+//     type AnthropicPricingTable,
+//   } from "@wuphf/llm-router/anthropic";
+export type { AnthropicModelPricing, AnthropicPricingTable } from "./anthropic-pricing.ts";
+export {
+  createAnthropicCostEstimator,
+  DEFAULT_ANTHROPIC_MODELS,
+  DEFAULT_ANTHROPIC_PRICING,
+  estimateAnthropicCostMicroUsd,
+} from "./anthropic-pricing.ts";
+
+// Convenience constructor for the real SDK client. Hosts that don't want
+// to import `@anthropic-ai/sdk` directly can call this with their API key
+// and get a ready-to-use Provider.
+//
+// Reads the key from the argument, NOT from process.env, so the secret
+// boundary stays at the host — per protocol AGENTS.md, "Always source
+// credentials from .env files. Never pass API tokens inline on the
+// command line."
+export function createAnthropicProviderWithKey(args: {
+  readonly apiKey: string;
+  readonly pricing?: AnthropicPricingTable;
+}): Provider {
+  const client = new Anthropic({ apiKey: args.apiKey });
+  return createAnthropicProvider({
+    client: client as unknown as AnthropicClient,
+    ...(args.pricing !== undefined ? { pricing: args.pricing } : {}),
+  });
+}

--- a/packages/llm-router/tests/providers/anthropic.spec.ts
+++ b/packages/llm-router/tests/providers/anthropic.spec.ts
@@ -1,0 +1,244 @@
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { asAgentSlug, asMicroUsd } from "@wuphf/protocol";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGateway,
+  ProviderError,
+  type SupervisorContext,
+  UnknownModelError,
+} from "../../src/index.ts";
+import {
+  type AnthropicClient,
+  type AnthropicMessage,
+  type AnthropicMessageCreateParams,
+  createAnthropicProvider,
+  DEFAULT_ANTHROPIC_PRICING,
+  estimateAnthropicCostMicroUsd,
+} from "../../src/providers/anthropic.ts";
+
+function fakeClient(stub: (params: AnthropicMessageCreateParams) => AnthropicMessage): {
+  readonly client: AnthropicClient;
+  readonly create: ReturnType<typeof vi.fn>;
+} {
+  const create = vi.fn(async (params: AnthropicMessageCreateParams) =>
+    Promise.resolve(stub(params)),
+  );
+  return { client: { messages: { create } }, create };
+}
+
+describe("Anthropic pricing", () => {
+  it("computes cost as integer μUSD from token counts", () => {
+    // Sonnet 4.6 = $3 / $15 input/output per MTok = 3 / 15 μUSD/tok.
+    const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-sonnet-4-6", {
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    // 1000 * 3 + 500 * 15 = 3000 + 7500 = 10500 μUSD = $0.0105
+    expect(cost as number).toBe(10_500);
+  });
+
+  it("accounts for cache read + creation lines", () => {
+    // Opus rates: input 15, output 75, cache_read 1 (1.5 rounded down),
+    // cache_creation 19 (18.75 rounded up).
+    const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-opus-4-7", {
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 1_000,
+      cacheCreationTokens: 100,
+    });
+    // 100*15 + 50*75 + 1000*1 + 100*19 = 1500 + 3750 + 1000 + 1900 = 8150
+    expect(cost as number).toBe(8_150);
+  });
+
+  it("throws UnknownModelError for unrecognized models", () => {
+    expect(() =>
+      estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-mystery-99", {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    ).toThrow(UnknownModelError);
+  });
+
+  it("respects a host-supplied pricing-table override", () => {
+    const cost = estimateAnthropicCostMicroUsd(
+      {
+        "negotiated-opus": {
+          inputMicroUsdPerToken: 8, // 8 μUSD/tok = $8/MTok negotiated rate
+          outputMicroUsdPerToken: 40,
+          cacheReadMicroUsdPerToken: 1,
+          cacheCreationMicroUsdPerToken: 10,
+        },
+      },
+      "negotiated-opus",
+      { inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    );
+    expect(cost as number).toBe(100 * 8 + 50 * 40);
+  });
+});
+
+describe("AnthropicProvider", () => {
+  it("translates ProviderRequest → Anthropic Messages.create params", async () => {
+    const { client, create } = fakeClient(() => ({
+      content: [{ type: "text", text: "hello world" }],
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    }));
+    const provider = createAnthropicProvider({ client });
+
+    const res = await provider.complete({
+      model: "claude-sonnet-4-6",
+      prompt: "say hi",
+      maxOutputTokens: 64,
+    });
+
+    expect(create).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith({
+      model: "claude-sonnet-4-6",
+      max_tokens: 64,
+      messages: [{ role: "user", content: "say hi" }],
+    });
+    expect(res.text).toBe("hello world");
+    expect(res.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+  });
+
+  it("declares models = pricing table keys for gateway routing", () => {
+    const provider = createAnthropicProvider({ client: fakeClient(() => emptyMessage()).client });
+    expect(provider.models).toEqual(Object.keys(DEFAULT_ANTHROPIC_PRICING));
+    expect(provider.models).toContain("claude-opus-4-7");
+    expect(provider.models).toContain("claude-sonnet-4-6");
+    expect(provider.models).toContain("claude-haiku-4-5");
+  });
+
+  it("uses pricing-override model list when provided", () => {
+    const provider = createAnthropicProvider({
+      client: fakeClient(() => emptyMessage()).client,
+      pricing: {
+        "negotiated-x": {
+          inputMicroUsdPerToken: 1,
+          outputMicroUsdPerToken: 1,
+          cacheReadMicroUsdPerToken: 0,
+          cacheCreationMicroUsdPerToken: 0,
+        },
+      },
+    });
+    expect(provider.models).toEqual(["negotiated-x"]);
+  });
+
+  it("flattens multi-block content into one string", async () => {
+    const { client } = fakeClient(() => ({
+      content: [
+        { type: "text", text: "first " },
+        { type: "thinking" }, // ignored: not text
+        { type: "text", text: "second" },
+      ],
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: null,
+        cache_creation_input_tokens: null,
+      },
+    }));
+    const provider = createAnthropicProvider({ client });
+    const res = await provider.complete({
+      model: "claude-sonnet-4-6",
+      prompt: "p",
+      maxOutputTokens: 8,
+    });
+    expect(res.text).toBe("first second");
+    // null cache fields coerce to 0.
+    expect(res.usage.cacheReadTokens).toBe(0);
+    expect(res.usage.cacheCreationTokens).toBe(0);
+  });
+
+  it("wraps SDK errors as ProviderError", async () => {
+    const sdkErr = new Error("rate_limited");
+    const provider = createAnthropicProvider({
+      client: {
+        messages: {
+          create: async () => {
+            throw sdkErr;
+          },
+        },
+      },
+    });
+    await expect(
+      provider.complete({ model: "claude-opus-4-7", prompt: "p", maxOutputTokens: 8 }),
+    ).rejects.toBeInstanceOf(ProviderError);
+  });
+
+  it("rejects models not in the pricing table with UnknownModelError", async () => {
+    const provider = createAnthropicProvider({ client: fakeClient(() => emptyMessage()).client });
+    await expect(
+      provider.complete({ model: "claude-not-real", prompt: "p", maxOutputTokens: 8 }),
+    ).rejects.toBeInstanceOf(UnknownModelError);
+  });
+});
+
+describe("AnthropicProvider → Gateway → CostLedger end-to-end (mocked SDK)", () => {
+  it("a full Gateway.complete() call writes the right amount to cost_by_agent", async () => {
+    const { client } = fakeClient(() => ({
+      content: [{ type: "text", text: "ok" }],
+      usage: {
+        input_tokens: 1_000,
+        output_tokens: 500,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+    }));
+    const provider = createAnthropicProvider({ client });
+
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+    const gateway = createGateway({
+      ledger,
+      providers: [provider],
+      nowMs: () => clock.now,
+    });
+    try {
+      const ctx: SupervisorContext = { agentSlug: asAgentSlug("primary") };
+      const result = await gateway.complete(ctx, {
+        model: "claude-sonnet-4-6",
+        prompt: "go",
+        maxOutputTokens: 1_024,
+      });
+      // Sonnet rate: 1000*3 + 500*15 = 10500 μUSD = $0.0105.
+      expect(result.costMicroUsd as number).toBe(10_500);
+      const agentRow = ledger.getAgentSpend("primary", "2026-05-12");
+      expect(agentRow?.totalMicroUsd as number).toBe(10_500);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+function emptyMessage(): AnthropicMessage {
+  return {
+    content: [],
+    usage: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: null,
+      cache_creation_input_tokens: null,
+    },
+  };
+}
+
+// Keep this around so the `vi` import isn't flagged when the file is
+// trimmed in future refactors.
+void asMicroUsd;

--- a/packages/llm-router/tests/providers/anthropic.spec.ts
+++ b/packages/llm-router/tests/providers/anthropic.spec.ts
@@ -2,8 +2,10 @@ import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@
 import { asAgentSlug, asMicroUsd } from "@wuphf/protocol";
 import { describe, expect, it, vi } from "vitest";
 import {
+  BadRequestError,
   createGateway,
   ProviderError,
+  type ProviderRequest,
   type SupervisorContext,
   UnknownModelError,
 } from "../../src/index.ts";
@@ -20,36 +22,71 @@ function fakeClient(stub: (params: AnthropicMessageCreateParams) => AnthropicMes
   readonly client: AnthropicClient;
   readonly create: ReturnType<typeof vi.fn>;
 } {
-  const create = vi.fn(async (params: AnthropicMessageCreateParams) =>
-    Promise.resolve(stub(params)),
+  const create = vi.fn(
+    async (params: AnthropicMessageCreateParams, _options?: { readonly idempotencyKey?: string }) =>
+      Promise.resolve(stub(params)),
   );
   return { client: { messages: { create } }, create };
 }
 
 describe("Anthropic pricing", () => {
-  it("computes cost as integer μUSD from token counts", () => {
-    // Sonnet 4.6 = $3 / $15 input/output per MTok = 3 / 15 μUSD/tok.
+  it("computes cost as integer μUSD from token counts (per-MTok fixed-point)", () => {
+    // Sonnet 4.6 = $3/$15 per MTok = 3_000_000 / 15_000_000 μUSD/MTok.
     const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-sonnet-4-6", {
       inputTokens: 1_000,
       outputTokens: 500,
       cacheReadTokens: 0,
       cacheCreationTokens: 0,
     });
-    // 1000 * 3 + 500 * 15 = 3000 + 7500 = 10500 μUSD = $0.0105
+    // (1000*3_000_000 + 500*15_000_000) / 1_000_000 = (3e9 + 7.5e9) / 1e6 = 10_500
     expect(cost as number).toBe(10_500);
   });
 
-  it("accounts for cache read + creation lines", () => {
-    // Opus rates: input 15, output 75, cache_read 1 (1.5 rounded down),
-    // cache_creation 19 (18.75 rounded up).
+  it("accounts for cache read + creation lines (Opus 4.7 = $5/$25/$0.50/$6.25)", () => {
     const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-opus-4-7", {
       inputTokens: 100,
       outputTokens: 50,
       cacheReadTokens: 1_000,
       cacheCreationTokens: 100,
     });
-    // 100*15 + 50*75 + 1000*1 + 100*19 = 1500 + 3750 + 1000 + 1900 = 8150
-    expect(cost as number).toBe(8_150);
+    // 100*5e6 + 50*25e6 + 1000*5e5 + 100*6.25e6 = 5e8 + 1.25e9 + 5e8 + 6.25e8
+    //   = 2.875e9, /1e6 = 2875.
+    expect(cost as number).toBe(2_875);
+  });
+
+  it("preserves sub-μUSD/tok precision (Sonnet $0.30/MTok cache reads — B2-2 fix)", () => {
+    // 1_000_000 Sonnet cache-read tokens at $0.30/MTok = exactly $0.30 = 300_000 μUSD.
+    // The earlier per-tok-rounded design would have stored 0 μUSD.
+    const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-sonnet-4-6", {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 1_000_000,
+      cacheCreationTokens: 0,
+    });
+    expect(cost as number).toBe(300_000);
+  });
+
+  it("Opus 4.5/4.6/4.7 use the post-2025-11 reduced pricing (B2-1 fix)", () => {
+    for (const model of ["claude-opus-4-5", "claude-opus-4-6", "claude-opus-4-7"]) {
+      // 1M input tokens at the Opus 4.5+ rate ($5/MTok) = $5 = 5_000_000 μUSD.
+      const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, model, {
+        inputTokens: 1_000_000,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      });
+      expect(cost as number).toBe(5_000_000);
+    }
+  });
+
+  it("Opus 4.1 retains the legacy $15/MTok rate", () => {
+    const cost = estimateAnthropicCostMicroUsd(DEFAULT_ANTHROPIC_PRICING, "claude-opus-4-1", {
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    expect(cost as number).toBe(15_000_000);
   });
 
   it("throws UnknownModelError for unrecognized models", () => {
@@ -67,16 +104,17 @@ describe("Anthropic pricing", () => {
     const cost = estimateAnthropicCostMicroUsd(
       {
         "negotiated-opus": {
-          inputMicroUsdPerToken: 8, // 8 μUSD/tok = $8/MTok negotiated rate
-          outputMicroUsdPerToken: 40,
-          cacheReadMicroUsdPerToken: 1,
-          cacheCreationMicroUsdPerToken: 10,
+          inputMicroUsdPerMTok: 8_000_000,
+          outputMicroUsdPerMTok: 40_000_000,
+          cacheReadMicroUsdPerMTok: 1_000_000,
+          cacheCreationMicroUsdPerMTok: 10_000_000,
         },
       },
       "negotiated-opus",
       { inputTokens: 100, outputTokens: 50, cacheReadTokens: 0, cacheCreationTokens: 0 },
     );
-    expect(cost as number).toBe(100 * 8 + 50 * 40);
+    // (100*8e6 + 50*40e6) / 1e6 = 2.8e9 / 1e6 = 2_800.
+    expect(cost as number).toBe(2_800);
   });
 });
 
@@ -100,11 +138,17 @@ describe("AnthropicProvider", () => {
     });
 
     expect(create).toHaveBeenCalledOnce();
-    expect(create).toHaveBeenCalledWith({
-      model: "claude-sonnet-4-6",
-      max_tokens: 64,
-      messages: [{ role: "user", content: "say hi" }],
-    });
+    expect(create).toHaveBeenCalledWith(
+      {
+        model: "claude-sonnet-4-6",
+        max_tokens: 64,
+        messages: [{ role: "user", content: "say hi" }],
+      },
+      // Second arg is the options bag; idempotencyKey is content-derived.
+      expect.objectContaining({
+        idempotencyKey: expect.stringMatching(/^wuphf-[0-9a-f]{64}$/),
+      }),
+    );
     expect(res.text).toBe("hello world");
     expect(res.usage).toEqual({
       inputTokens: 100,
@@ -127,10 +171,10 @@ describe("AnthropicProvider", () => {
       client: fakeClient(() => emptyMessage()).client,
       pricing: {
         "negotiated-x": {
-          inputMicroUsdPerToken: 1,
-          outputMicroUsdPerToken: 1,
-          cacheReadMicroUsdPerToken: 0,
-          cacheCreationMicroUsdPerToken: 0,
+          inputMicroUsdPerMTok: 1_000_000,
+          outputMicroUsdPerMTok: 1_000_000,
+          cacheReadMicroUsdPerMTok: 0,
+          cacheCreationMicroUsdPerMTok: 0,
         },
       },
     });
@@ -184,6 +228,144 @@ describe("AnthropicProvider", () => {
     await expect(
       provider.complete({ model: "claude-not-real", prompt: "p", maxOutputTokens: 8 }),
     ).rejects.toBeInstanceOf(UnknownModelError);
+  });
+
+  it("threads a deterministic idempotency key to messages.create (B2-4)", async () => {
+    const { client, create } = fakeClient(() => emptyMessage());
+    const provider = createAnthropicProvider({ client });
+    const req: ProviderRequest = {
+      model: "claude-sonnet-4-6",
+      prompt: "same-payload",
+      maxOutputTokens: 32,
+    };
+    await provider.complete(req);
+    await provider.complete(req);
+    // Same request → same idempotency key on both SDK calls.
+    const firstCall = create.mock.calls[0] as unknown as readonly [
+      unknown,
+      { readonly idempotencyKey: string },
+    ];
+    const secondCall = create.mock.calls[1] as unknown as readonly [
+      unknown,
+      { readonly idempotencyKey: string },
+    ];
+    const firstKey = firstCall[1]?.idempotencyKey;
+    const secondKey = secondCall[1]?.idempotencyKey;
+    expect(firstKey).toBe(secondKey);
+    expect(firstKey).toMatch(/^wuphf-[0-9a-f]{64}$/);
+  });
+
+  it("maps SDK 4xx to BadRequestError (NOT breaker-worthy) — B2-7", async () => {
+    const sdkErr = {
+      status: 400,
+      headers: {},
+      error: { error: { type: "invalid_request_error" } },
+      requestID: "req_abc123",
+      message: "max_tokens must be ≥ 1",
+    };
+    const provider = createAnthropicProvider({
+      client: {
+        messages: {
+          create: async () => {
+            throw sdkErr;
+          },
+        },
+      },
+    });
+    const promise = provider.complete({
+      model: "claude-sonnet-4-6",
+      prompt: "p",
+      maxOutputTokens: 8,
+    });
+    await expect(promise).rejects.toBeInstanceOf(BadRequestError);
+    await expect(promise).rejects.toMatchObject({
+      status: 400,
+      requestId: "req_abc123",
+      errorType: "invalid_request_error",
+    });
+  });
+
+  it("maps SDK 429 to ProviderError with retryAfterMs extracted (B2-5)", async () => {
+    const sdkErr = {
+      status: 429,
+      headers: { "retry-after": "12" },
+      error: { error: { type: "rate_limit_error" } },
+      requestID: "req_rate_1",
+      message: "rate limited",
+    };
+    const provider = createAnthropicProvider({
+      client: {
+        messages: {
+          create: async () => {
+            throw sdkErr;
+          },
+        },
+      },
+    });
+    const promise = provider.complete({
+      model: "claude-sonnet-4-6",
+      prompt: "p",
+      maxOutputTokens: 8,
+    });
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      status: 429,
+      requestId: "req_rate_1",
+      errorType: "rate_limit_error",
+      retryAfterMs: 12_000,
+    });
+  });
+
+  it("pre-rejects maxOutputTokens <= 0 without an SDK call (B2-7)", async () => {
+    const { client, create } = fakeClient(() => emptyMessage());
+    const provider = createAnthropicProvider({ client });
+    await expect(
+      provider.complete({ model: "claude-sonnet-4-6", prompt: "p", maxOutputTokens: 0 }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(create).not.toHaveBeenCalled();
+  });
+});
+
+describe("pricing-table validation (B2-6)", () => {
+  it("rejects an empty pricing table at construction", () => {
+    expect(() =>
+      createAnthropicProvider({
+        client: fakeClient(() => emptyMessage()).client,
+        pricing: {},
+      }),
+    ).toThrow(/at least one model/);
+  });
+
+  it("rejects a non-integer rate at construction", () => {
+    expect(() =>
+      createAnthropicProvider({
+        client: fakeClient(() => emptyMessage()).client,
+        pricing: {
+          "bad-model": {
+            inputMicroUsdPerMTok: 1.5,
+            outputMicroUsdPerMTok: 1,
+            cacheReadMicroUsdPerMTok: 0,
+            cacheCreationMicroUsdPerMTok: 0,
+          },
+        },
+      }),
+    ).toThrow(/non-negative safe integer/);
+  });
+
+  it("rejects a negative rate at construction", () => {
+    expect(() =>
+      createAnthropicProvider({
+        client: fakeClient(() => emptyMessage()).client,
+        pricing: {
+          "bad-model": {
+            inputMicroUsdPerMTok: -1,
+            outputMicroUsdPerMTok: 1,
+            cacheReadMicroUsdPerMTok: 0,
+            cacheCreationMicroUsdPerMTok: 0,
+          },
+        },
+      }),
+    ).toThrow(/non-negative safe integer/);
   });
 });
 


### PR DESCRIPTION
## Summary

PR B.2 of WUPHF v1 branch 7, **stacked on #818** (`feat/cost-ceiling-supervisor-core`). Plugs the real `@anthropic-ai/sdk` into the gateway via a clean `Provider` adapter. Exposed at the subpath `@wuphf/llm-router/anthropic` so hosts that only use the stub pay zero install cost for the SDK — same precedent as `@wuphf/broker/sqlite`.

This is the first PR that flows real-provider traffic through the cost-ledger end to end (test-side, with a mocked SDK client). It validates the routing-by-model fix (H4) and the type-system "row before response" contract under a non-trivial provider.

```mermaid
flowchart LR
  A[agent runner] -->|complete ctx,req| G[Gateway]
  G -->|model = claude-*| Anthropic[AnthropicProvider]
  Anthropic -->|messages.create| SDK[@anthropic-ai/sdk]
  SDK --> API[(api.anthropic.com)]
  API --> SDK
  SDK --> Anthropic
  Anthropic -->|text + usage| G
  G --> Est[anthropic-pricing estimate]
  Est --> L[ledger.appendCostEvent]
  L --> Result[GatewayCompletionResult<br/>with costEventLsn]
```

## What's in this PR

### Pricing table

`src/providers/anthropic-pricing.ts` — integer-μUSD-per-token pricing for Claude 4.x family:

| Model family | input | output | cache-read | cache-creation |
|---|---|---|---|---|
| Opus 4.x | 15 μUSD/tok | 75 μUSD/tok | 1 (1.5↓) | 19 (18.75↑) |
| Sonnet 4.x | 3 | 15 | 0 (0.3↓) | 4 (3.75↑) |
| Haiku 4.x | 1 | 5 | 0 (0.1↓) | 1 (1.25↓) |

Public $/MTok → integer μUSD/tok is exact for whole-dollar rates ($3/MTok = 3 μUSD/tok). Cache rates with sub-μUSD/tok precision round to integer — documented trade-off; preserves the §15.A integer-math invariant. Hosts override the table for negotiated rates.

### Adapter

`src/providers/anthropic.ts`:

- `createAnthropicProvider({ client, pricing? })` — accepts an injected client; used in tests.
- `createAnthropicProviderWithKey({ apiKey, pricing? })` — convenience constructor that builds the real SDK client.
- `AnthropicClient` interface — minimal structural slice so test code doesn't need the whole SDK type tree.
- Translates `ProviderRequest` → `Messages.create` params (model, max_tokens, single user message).
- Flattens multi-block content to text; ignores tool-use / thinking blocks (deferred to a future PR).
- Coerces null cache fields to 0 (SDK returns null when caching wasn't requested).
- Wraps every SDK error as `ProviderError` so the breaker treats them uniformly.

### Gateway cleanup

The pre-existing `providerKindFor(model)` helper hardcoded a stub-only mapping (a leftover from PR B). Replaced with `provider.kind` from the resolved provider so audit rows record who actually fulfilled the request — no per-model routing logic in two places.

### Tests

11 new tests in `tests/providers/anthropic.spec.ts`:

- Pricing math: input + output, cache lines, unknown model rejection, host-supplied table override.
- Adapter: request translation (params shape), model-list registration (default + override), multi-block content flattening, null cache coercion, SDK error → `ProviderError`, unrecognized model → `UnknownModelError`.
- **End-to-end**: `Gateway.complete()` with the Anthropic adapter (mocked SDK) writes `cost_by_agent` with the correct integer amount.

### Subpath export

```ts
import { createAnthropicProvider } from "@wuphf/llm-router/anthropic";
```

vs. the root which stays SDK-free:

```ts
import { createGateway, createStubProvider } from "@wuphf/llm-router";
```

## Design decisions

1. **Integer μUSD/tok storage**, not float $/MTok. Same reason as the ledger: §15.A invariants need decidable integer math.
2. **Cache-rate rounding** is floor-to-integer. Under-bills cache lines slightly; safe-by-default direction, deterministic. Documented in pricing file.
3. **Subpath import** to keep SDK install cost off stub-only hosts.
4. **Host-overridable pricing** so price changes don't require a code release.
5. **Models[] = pricing-table keys** — extending the pricing extends model registration in one place.
6. **Inject client for tests** via the structural `AnthropicClient` interface — no need to import the whole SDK type tree.
7. **No streaming** — `Messages.create(..., stream: true)` is a separate API contract and a future PR.
8. **No tool-use plumbing** — tool_use blocks are detected (token usage still recorded correctly) but their structured form isn't surfaced through the gateway response shape yet. PR B.3+.

## Test plan

- [x] `bunx tsc --noEmit` in `packages/llm-router/` → clean
- [x] `bunx biome check` in `packages/llm-router/` → clean
- [x] `bunx vitest run` (llm-router) → **30 passed** (was 19; +11 Anthropic suite)
- [x] `bunx vitest run tests` (broker) → 188 passed (unchanged)
- [x] `bunx vitest run` (protocol) → 547 passed (unchanged)
- [x] `bun run burn:nightly` → 3/3 §10.4 assertions still pass
- [x] Pre-push lefthook → broker-invariants, broker-test, broker-typecheck, complexity-baseline, file-size, desktop-* all green

## Out of scope (follow-on PRs)

- **Streaming** — `stream: true` with SSE event handling
- **Tool-use** — surface `tool_use` content blocks through the gateway response shape
- **OpenAI / Ollama adapters** — same Provider interface, different SDKs (PR B.3)
- **1h extended TTL cache pricing** — separate rate tier
- **Rate-limit-specific retry/cool-down** — covered by #819 (in-flight reservation system)

## Review notes

- This PR is **stacked on #818**. GitHub diff is from `feat/cost-ceiling-supervisor-core`, not `main`.
- To review just this slice: `packages/llm-router/src/providers/anthropic*.ts`, `tests/providers/anthropic.spec.ts`, and the small gateway.ts cleanup.
- Once #816 and #818 merge, this PR's base will collapse to `main` and the diff will be just the Anthropic surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)