### PR TITLE
feat(llm-router): ollama adapter for local model execution (branch 7 PR B.4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -78,6 +78,7 @@
         "@types/better-sqlite3": "7.6.13",
         "@types/node": "^22.10.0",
         "@vitest/coverage-v8": "2.1.9",
+        "ollama": "0.5.18",
         "openai": "6.7.0",
         "tsx": "^4.19.0",
         "typescript": "^5.6.0",
@@ -85,10 +86,12 @@
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.71.0",
+        "ollama": "^0.5.0",
         "openai": "^6.7.0",
       },
       "optionalPeers": [
         "@anthropic-ai/sdk",
+        "ollama",
         "openai",
       ],
     },
@@ -1121,6 +1124,8 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "ollama": ["ollama@0.5.18", "", { "dependencies": { "whatwg-fetch": "^3.6.20" } }, "sha512-lTFqTf9bo7Cd3hpF6CviBe/DEhewjoZYd9N/uCe7O20qYTvGqrNOFOBDj3lbZgFWHUgDv5EeyusYxsZSLS8nvg=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
@@ -1398,6 +1403,8 @@
     "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
+
+    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 

--- a/packages/llm-router/README.md
+++ b/packages/llm-router/README.md
@@ -37,7 +37,15 @@ runners — there is no parallel call path to an LLM in this codebase.
   `prompt_tokens` so the discounted cached-input rate applies correctly.
   SDK is an **optional peer dependency** — only installed if the host
   wants it.
-- `ollama` — future PR.
+- **`ollama` — `ollama` SDK adapter (PR B.4).** Subpath import:
+  `import { createOllamaProvider } from "@wuphf/llm-router/ollama"`.
+  Covers `llama3.3`, `llama3.2`, `llama3.1`, `qwen2.5`, `gemma2`,
+  `mistral-small3.1`. **All default pricing is zero** — Ollama runs
+  locally on the host's hardware, so there is no per-token provider
+  charge. The `cost_event` row is still written for accounting
+  uniformity (Hard rule #1). Hosts that want to model GPU/electricity
+  cost override the pricing table with non-zero rates. SDK is an
+  **optional peer dependency**.
 
 ## Usage
 
@@ -150,6 +158,92 @@ const result = await gateway.complete(
 The adapter splits OpenAI's `prompt_tokens_details.cached_tokens` out
 of `prompt_tokens` so the discounted cached-input rate applies to the
 cached subset (typically 10% of input cost on GPT-5 family).
+
+### Ollama (local execution)
+
+Ollama runs models on the host's own hardware. There is no API key, no
+remote endpoint, and **no per-token provider charge** — default
+pricing is zero across the board. The gateway still writes one
+`cost_event` per call (amount 0) so `cost_by_agent` and the §10.4
+projection stay uniform across providers.
+
+Install the SDK alongside the router (optional peer dep):
+
+```bash
+bun add ollama @wuphf/llm-router
+```
+
+```ts
+import { createGateway } from "@wuphf/llm-router";
+import { createOllamaProviderWithUrl } from "@wuphf/llm-router/ollama";
+
+const gateway = createGateway({
+  ledger,
+  providers: [
+    // baseUrl defaults to http://localhost:11434.
+    await createOllamaProviderWithUrl(),
+  ],
+  nowMs: () => Date.now(),
+});
+
+const result = await gateway.complete(
+  { agentSlug: asAgentSlug("primary") },
+  { model: "llama3.3", prompt: "go", maxOutputTokens: 1024 },
+);
+// result.costMicroUsd === 0 (local execution), but the cost_event row
+// was written and `result.costEventLsn` is its LSN.
+```
+
+For a remote Ollama (LAN, SSH tunnel) pass an explicit URL:
+
+```ts
+await createOllamaProviderWithUrl({ baseUrl: "http://10.0.0.5:11434" });
+```
+
+Hosts that want to model local GPU / electricity cost can override the
+pricing table; the integer-μUSD/MTok shape is identical to the other
+adapters:
+
+```ts
+import { createOllamaProviderWithUrl } from "@wuphf/llm-router/ollama";
+
+await createOllamaProviderWithUrl({
+  pricing: {
+    "llama3.3": {
+      inputMicroUsdPerMTok: 100_000,  // $0.10/MTok GPU cost
+      outputMicroUsdPerMTok: 200_000, // $0.20/MTok
+      cacheReadMicroUsdPerMTok: 0,
+      cacheCreationMicroUsdPerMTok: 0,
+    },
+  },
+});
+```
+
+For tests, inject a fake client matching the `OllamaClient` interface
+(no SDK install needed):
+
+```ts
+import { createOllamaProvider } from "@wuphf/llm-router/ollama";
+
+const provider = createOllamaProvider({
+  client: {
+    chat: async (request) => ({
+      model: "llama3.3",
+      message: { role: "assistant", content: "ok" },
+      done: true,
+      prompt_eval_count: 100,
+      eval_count: 50,
+    }),
+  },
+});
+```
+
+Unlike the Anthropic/OpenAI adapters, the Ollama adapter does **not**
+mint an idempotency key. Ollama is a local HTTP server with no
+documented server-side dedupe contract, and a "retry against the same
+local process" doesn't incur double billing because billing is $0.
+The gateway's content-hash dedupe (60s sliding window) still applies
+upstream.
 
 ## §10.4 nightly burn-down
 

--- a/packages/llm-router/package.json
+++ b/packages/llm-router/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./anthropic": "./src/providers/anthropic.ts",
-    "./openai": "./src/providers/openai.ts"
+    "./openai": "./src/providers/openai.ts",
+    "./ollama": "./src/providers/ollama.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",
@@ -28,15 +29,18 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.71.0",
+    "ollama": "^0.5.0",
     "openai": "^6.7.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": { "optional": true },
+    "ollama": { "optional": true },
     "openai": { "optional": true }
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "0.71.0",
     "@biomejs/biome": "2.4.15",
+    "ollama": "0.5.18",
     "openai": "6.7.0",
     "@types/better-sqlite3": "7.6.13",
     "@types/node": "^22.10.0",

--- a/packages/llm-router/src/providers/ollama-pricing.ts
+++ b/packages/llm-router/src/providers/ollama-pricing.ts
@@ -1,0 +1,164 @@
+// Ollama per-model pricing — zero across the board.
+//
+// Ollama runs locally on the host's hardware; there is no provider-side
+// charge per token. The pricing table is still wired so the gateway's
+// `Gateway.complete()` writes a `cost_event` for every successful call
+// (Hard rule #1: no row, no response). The amount is just `0 μUSD`.
+//
+// Why keep the table at all then?
+//
+//   1. Accounting consistency: every Gateway.complete() emits exactly
+//      one cost_event row, regardless of provider. Downstream consumers
+//      (cost tile, §10.4 burn-down projection, cost_by_agent) get a
+//      uniform shape.
+//   2. Host overridability: a host that wants to model GPU/electricity
+//      cost can pass a custom `OllamaPricingTable` with non-zero rates.
+//      The integer-μUSD/MTok shape is preserved so the §15.A sum
+//      invariant continues to hold under host overrides.
+//   3. Discoverability: the table acts as the registered model list,
+//      mirroring the Anthropic/OpenAI adapter pattern (`models[]`
+//      derives from the pricing keys).
+//
+// The model set mirrors what the public `ollama` SDK type defs
+// reference and what `ollama.com/library` ships as common defaults:
+// llama 3.1 / 3.2 / 3.3, qwen2.5, gemma2, and mistral-small3.1.
+// Adding a model is one config entry — the host passes
+// `{ "model-name": { ... } }` to `createOllamaProvider`.
+
+import { asMicroUsd, type CostUnits, type MicroUsd } from "@wuphf/protocol";
+
+import { UnknownModelError } from "../errors.ts";
+import type { CostEstimator } from "../types.ts";
+
+/**
+ * Per-model rates in integer micro-USD per million tokens (μUSD/MTok).
+ * Same shape and unit as Anthropic's table so a host that wants to
+ * model GPU cost can populate the fields with non-zero rates and the
+ * estimator math works unchanged.
+ *
+ * Cache fields exist for shape uniformity. Ollama itself does not
+ * surface a cache-read/cache-creation accounting split in its
+ * ChatResponse, so the adapter zeroes them when translating usage.
+ */
+export interface OllamaModelPricing {
+  readonly inputMicroUsdPerMTok: number;
+  readonly outputMicroUsdPerMTok: number;
+  readonly cacheReadMicroUsdPerMTok: number;
+  readonly cacheCreationMicroUsdPerMTok: number;
+}
+
+export type OllamaPricingTable = Readonly<Record<string, OllamaModelPricing>>;
+
+const ZERO_RATES: OllamaModelPricing = Object.freeze({
+  inputMicroUsdPerMTok: 0,
+  outputMicroUsdPerMTok: 0,
+  cacheReadMicroUsdPerMTok: 0,
+  cacheCreationMicroUsdPerMTok: 0,
+});
+
+/**
+ * Built-in pricing for common Ollama models. All rates are zero because
+ * Ollama is a local model runner — the host pays no per-token cost.
+ *
+ * Hosts that want to track GPU/electricity cost pass a custom table to
+ * `createOllamaProvider`. The model registry derives from the passed
+ * table's keys, so adding a model is one config change.
+ */
+export const DEFAULT_OLLAMA_PRICING: OllamaPricingTable = Object.freeze({
+  "llama3.3": ZERO_RATES,
+  "llama3.2": ZERO_RATES,
+  "llama3.1": ZERO_RATES,
+  "qwen2.5": ZERO_RATES,
+  gemma2: ZERO_RATES,
+  "mistral-small3.1": ZERO_RATES,
+});
+
+const ONE_MILLION = 1_000_000;
+const ROUND_HALF_UP = ONE_MILLION / 2;
+
+/**
+ * Compute the integer μUSD cost of one Ollama call. Same fixed-point
+ * shape as the Anthropic/OpenAI estimators so a host that overrides
+ * the table with non-zero GPU rates gets identical math behavior.
+ *
+ * With the default table (all zeros), the result is always 0 — but the
+ * function still goes through the same arithmetic so the §15.A integer
+ * invariant holds uniformly.
+ *
+ * Overflow safety: max plausible per-call sum is identical to the other
+ * estimators (1e6 tokens × 1e7 μUSD/MTok = 1e13), well inside
+ * `Number.MAX_SAFE_INTEGER`.
+ */
+export function estimateOllamaCostMicroUsd(
+  pricing: OllamaPricingTable,
+  model: string,
+  units: CostUnits,
+): MicroUsd {
+  const rate = pricing[model];
+  if (rate === undefined) {
+    throw new UnknownModelError(model);
+  }
+  const accum =
+    rate.inputMicroUsdPerMTok * units.inputTokens +
+    rate.outputMicroUsdPerMTok * units.outputTokens +
+    rate.cacheReadMicroUsdPerMTok * units.cacheReadTokens +
+    rate.cacheCreationMicroUsdPerMTok * units.cacheCreationTokens;
+  const rounded = Math.floor((accum + ROUND_HALF_UP) / ONE_MILLION);
+  return asMicroUsd(rounded);
+}
+
+/**
+ * Build a `CostEstimator` bound to a specific pricing table. Used by
+ * `OllamaProvider` and overridable by hosts that need a different
+ * price book (e.g. to model local GPU cost or to add a new model).
+ */
+export function createOllamaCostEstimator(pricing: OllamaPricingTable): CostEstimator {
+  return {
+    estimate(model: string, units: CostUnits): MicroUsd {
+      return estimateOllamaCostMicroUsd(pricing, model, units);
+    },
+  };
+}
+
+/**
+ * Validate a pricing table at provider construction. Same contract as
+ * `validateAnthropicPricingTable` / `validateOpenAIPricingTable`: all
+ * rates MUST be non-negative safe integers. Zero is explicitly allowed
+ * — that's the default — but `NaN`, negatives, and floats throw.
+ */
+export function validateOllamaPricingTable(table: OllamaPricingTable): void {
+  const models = Object.keys(table);
+  if (models.length === 0) {
+    throw new Error("OllamaPricingTable must register at least one model");
+  }
+  for (const model of models) {
+    if (model.length === 0) {
+      throw new Error("OllamaPricingTable model id must be a non-empty string");
+    }
+    const rate = table[model];
+    if (rate === undefined) {
+      throw new Error(`OllamaPricingTable: missing rate for model ${JSON.stringify(model)}`);
+    }
+    const fields: Array<[string, number]> = [
+      ["inputMicroUsdPerMTok", rate.inputMicroUsdPerMTok],
+      ["outputMicroUsdPerMTok", rate.outputMicroUsdPerMTok],
+      ["cacheReadMicroUsdPerMTok", rate.cacheReadMicroUsdPerMTok],
+      ["cacheCreationMicroUsdPerMTok", rate.cacheCreationMicroUsdPerMTok],
+    ];
+    for (const [field, value] of fields) {
+      if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+        throw new Error(
+          `OllamaPricingTable[${JSON.stringify(model)}].${field} must be a non-negative safe integer, got ${String(value)}`,
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Model IDs the default table knows about. Used by the provider to
+ * declare its `models[]` for gateway routing.
+ */
+export const DEFAULT_OLLAMA_MODELS: readonly string[] = Object.freeze(
+  Object.keys(DEFAULT_OLLAMA_PRICING),
+);

--- a/packages/llm-router/src/providers/ollama.ts
+++ b/packages/llm-router/src/providers/ollama.ts
@@ -1,0 +1,259 @@
+// Ollama SDK adapter for `Gateway.complete()`.
+//
+// Subpath import: hosts use `import { createOllamaProvider } from
+// "@wuphf/llm-router/ollama"`. `ollama` is an optional peer
+// dependency — hosts that only use the stub or another provider do
+// not install it. The convenience constructor
+// `createOllamaProviderWithUrl` uses a dynamic import so the SDK
+// module loads only when the host explicitly asks for it.
+//
+// Differences from the Anthropic / OpenAI adapters:
+//
+//   - **Zero-cost pricing by default.** Ollama runs locally on the
+//     host's hardware — there is no per-token provider charge. The
+//     pricing table holds all-zero rates so `cost_event.amountMicroUsd`
+//     is 0. The `cost_event` row is still written (Hard rule #1: no row,
+//     no response) for accounting uniformity. Hosts that want to model
+//     GPU/electricity cost override the pricing table.
+//
+//   - **No idempotency-key.** Ollama is a local HTTP server with no
+//     documented server-side request dedupe contract. There's no header
+//     to forward, and a "retry against the same local process" doesn't
+//     incur double-billing because billing is $0 to start with. The
+//     gateway's content-hash dedupe (60s sliding window) still applies
+//     upstream of this adapter.
+//
+//   - **No API-key constructor.** Local execution; no auth. We expose
+//     `createOllamaProvider({ client, pricing? })` for full DI and
+//     `createOllamaProviderWithUrl({ baseUrl?, pricing? })` as a
+//     convenience that lazy-loads the SDK and constructs the client
+//     with a base URL (default `http://localhost:11434`).
+//
+// Otherwise the wiring mirrors the existing adapters:
+//
+//   1. Provider routing: `models[]` is bound to the pricing-table keys
+//      so the gateway's exact-match registration delivers e.g.
+//      `llama3.3` requests here.
+//
+//   2. Cost estimation: integer-μUSD pricing (`ollama-pricing.ts`),
+//      same fixed-point shape as the other adapters — preserves §15.A
+//      integer invariant under host overrides.
+//
+//   3. Request translation: `ProviderRequest` carries one string
+//      prompt → one user message; `maxOutputTokens` → `options.num_predict`
+//      (Ollama's name for the generation cap). Streaming is disabled
+//      (`stream: false`) so the SDK returns a single `ChatResponse`.
+//
+//   4. Error mapping: Ollama errors are typically network/connection
+//      failures (server not running, model not pulled). We map all
+//      thrown errors to `ProviderError`. There's no HTTP-status-based
+//      caller-input class to peel off the way Anthropic/OpenAI do —
+//      Ollama's local HTTP errors don't follow the 4xx-vs-5xx
+//      convention reliably. We DO pre-validate `maxOutputTokens > 0`
+//      locally as `BadRequestError`, same as the other adapters.
+
+import { asProviderKind, type CostUnits, type ProviderKind } from "@wuphf/protocol";
+
+import { BadRequestError, ProviderError, UnknownModelError } from "../errors.ts";
+import type { CostEstimator, Provider, ProviderRequest, ProviderResponse } from "../types.ts";
+import {
+  createOllamaCostEstimator,
+  DEFAULT_OLLAMA_MODELS,
+  DEFAULT_OLLAMA_PRICING,
+  type OllamaPricingTable,
+  validateOllamaPricingTable,
+} from "./ollama-pricing.ts";
+
+const OLLAMA_PROVIDER_KIND: ProviderKind = asProviderKind("ollama");
+
+const DEFAULT_OLLAMA_BASE_URL = "http://localhost:11434";
+
+/**
+ * Minimal slice of the Ollama SDK chat surface. Tests inject a fake;
+ * the real `Ollama` client matches.
+ *
+ * The signature mirrors `client.chat(request)` for the non-streaming
+ * (`stream: false`) variant. Streaming is out of scope for PR B.4;
+ * the gateway's response shape is a single completion.
+ *
+ * `OllamaMessage` deliberately omits the SDK's `thinking`, `images`,
+ * `tool_calls`, and `tool_name` fields — they're returned by the SDK
+ * but we don't surface them through `ProviderResponse` yet.
+ */
+export interface OllamaMessage {
+  readonly role: string;
+  readonly content: string;
+}
+
+export interface OllamaChatRequest {
+  readonly model: string;
+  readonly messages: ReadonlyArray<OllamaMessage>;
+  readonly stream: false;
+  readonly options?: {
+    /** Ollama's name for the generation token cap (≈ max_tokens). */
+    readonly num_predict?: number;
+  };
+}
+
+export interface OllamaChatResponse {
+  readonly model: string;
+  readonly message: OllamaMessage;
+  readonly done: boolean;
+  /** Tokens consumed parsing the prompt. Ollama-equivalent of input_tokens. */
+  readonly prompt_eval_count: number;
+  /** Tokens produced. Ollama-equivalent of output_tokens. */
+  readonly eval_count: number;
+}
+
+export interface OllamaClient {
+  chat(request: OllamaChatRequest): Promise<OllamaChatResponse>;
+}
+
+export interface CreateOllamaProviderArgs {
+  /**
+   * Ollama SDK client (production) or a fake matching `OllamaClient`
+   * (tests). The structural-client path does NOT pull in the `ollama`
+   * package.
+   */
+  readonly client: OllamaClient;
+  /**
+   * Pricing table override. Defaults to `DEFAULT_OLLAMA_PRICING` (all
+   * zero rates). Validated at construction; throws on missing/invalid
+   * entries.
+   */
+  readonly pricing?: OllamaPricingTable;
+}
+
+export function createOllamaProvider(args: CreateOllamaProviderArgs): Provider {
+  const pricing = args.pricing ?? DEFAULT_OLLAMA_PRICING;
+  // Same construction-time validation as the other adapters so a bad
+  // config never reaches a billable call (even when "billable" means
+  // "zero μUSD" — the validation catches NaN/negative/float rates that
+  // would corrupt the §15.A invariant under a host override).
+  validateOllamaPricingTable(pricing);
+  const models: readonly string[] =
+    args.pricing === undefined ? DEFAULT_OLLAMA_MODELS : Object.keys(pricing);
+  const modelSet = new Set<string>(models);
+  const costEstimator: CostEstimator = createOllamaCostEstimator(pricing);
+
+  return {
+    kind: OLLAMA_PROVIDER_KIND,
+    models,
+    costEstimator,
+    async complete(req: ProviderRequest): Promise<ProviderResponse> {
+      if (!modelSet.has(req.model)) {
+        // Defensive: the gateway already routed by exact-match. If we
+        // get here, the host built two providers claiming overlapping
+        // models and the gateway delivered to the wrong one — surface
+        // as UnknownModelError instead of dropping into the SDK.
+        throw new UnknownModelError(req.model);
+      }
+      // Pre-validate caller input. num_predict ≤ 0 is meaningless to
+      // Ollama (it would return nothing or treat 0 as "unbounded"
+      // depending on version). Pre-rejecting locally avoids ambiguity
+      // and matches the Anthropic/OpenAI contract for `maxOutputTokens`.
+      if (!Number.isSafeInteger(req.maxOutputTokens) || req.maxOutputTokens <= 0) {
+        throw new BadRequestError(OLLAMA_PROVIDER_KIND, new Error("maxOutputTokens_invalid"));
+      }
+      const request: OllamaChatRequest = {
+        model: req.model,
+        messages: [{ role: "user", content: req.prompt }],
+        stream: false,
+        options: { num_predict: req.maxOutputTokens },
+      };
+      let raw: OllamaChatResponse;
+      try {
+        raw = await args.client.chat(request);
+      } catch (err) {
+        // No status/headers/retry-after convention to extract from a
+        // local Ollama error — surface as ProviderError with cause
+        // attached. PR C's wire mapping treats this uniformly.
+        throw new ProviderError(OLLAMA_PROVIDER_KIND, err);
+      }
+      return {
+        text: raw.message?.content ?? "",
+        usage: usageToCostUnits(raw),
+      };
+    },
+  };
+}
+
+/**
+ * Translate Ollama's response counters to our `CostUnits` shape.
+ *
+ *   inputTokens  = prompt_eval_count
+ *   outputTokens = eval_count
+ *   cacheRead/cacheCreation = 0   (Ollama does not surface a cache
+ *                                  accounting split)
+ *
+ * Older or partial responses may omit these fields; coerce to 0 so the
+ * protocol `CostUnits` invariant (non-negative integer) holds.
+ */
+function usageToCostUnits(raw: OllamaChatResponse): CostUnits {
+  const promptEval = typeof raw.prompt_eval_count === "number" ? raw.prompt_eval_count : 0;
+  const evalCount = typeof raw.eval_count === "number" ? raw.eval_count : 0;
+  return {
+    inputTokens: Math.max(0, promptEval),
+    outputTokens: Math.max(0, evalCount),
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+  };
+}
+
+// Re-export pricing surface so hosts using the subpath get one import line:
+//   import {
+//     createOllamaProvider,
+//     DEFAULT_OLLAMA_PRICING,
+//     type OllamaPricingTable,
+//   } from "@wuphf/llm-router/ollama";
+export type { OllamaModelPricing, OllamaPricingTable } from "./ollama-pricing.ts";
+export {
+  createOllamaCostEstimator,
+  DEFAULT_OLLAMA_MODELS,
+  DEFAULT_OLLAMA_PRICING,
+  estimateOllamaCostMicroUsd,
+  validateOllamaPricingTable,
+} from "./ollama-pricing.ts";
+
+/**
+ * Convenience constructor for the real SDK client. The `ollama`
+ * package is an optional peer dependency; this function uses a
+ * dynamic import so a host that only uses the structural-client path
+ * (e.g. tests) never loads the SDK module.
+ *
+ * Unlike the Anthropic/OpenAI constructors there is no `apiKey` —
+ * Ollama runs locally with no auth. `baseUrl` defaults to
+ * `http://localhost:11434`, matching the SDK's own default; hosts
+ * pointing at a remote Ollama (over SSH tunnel or LAN) pass an
+ * explicit URL.
+ *
+ * Runtime validation: when `baseUrl` is provided it must be a
+ * non-empty string. We don't try to validate URL well-formedness
+ * here — the SDK will surface the failure at first call as a
+ * `ProviderError`.
+ */
+export async function createOllamaProviderWithUrl(
+  args: { readonly baseUrl?: string; readonly pricing?: OllamaPricingTable } = {},
+): Promise<Provider> {
+  if (args.baseUrl !== undefined) {
+    if (typeof args.baseUrl !== "string" || args.baseUrl.length === 0) {
+      throw new Error(
+        "createOllamaProviderWithUrl: baseUrl must be a non-empty string (got " +
+          typeof args.baseUrl +
+          ")",
+      );
+    }
+  }
+  const host = args.baseUrl ?? DEFAULT_OLLAMA_BASE_URL;
+  const sdk = await import("ollama");
+  const OllamaCtor = sdk.Ollama;
+  const client = new OllamaCtor({ host });
+  // The SDK's `chat()` is overloaded on the `stream` discriminator; the
+  // structural `OllamaClient` we expose only models the non-streaming
+  // form, so we widen via `unknown` rather than collapse the SDK's
+  // overload set on the public type.
+  return createOllamaProvider({
+    client: client as unknown as OllamaClient,
+    ...(args.pricing !== undefined ? { pricing: args.pricing } : {}),
+  });
+}

--- a/packages/llm-router/tests/providers/ollama.spec.ts
+++ b/packages/llm-router/tests/providers/ollama.spec.ts
@@ -1,0 +1,390 @@
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { asAgentSlug } from "@wuphf/protocol";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  BadRequestError,
+  createGateway,
+  ProviderError,
+  type SupervisorContext,
+  UnknownModelError,
+} from "../../src/index.ts";
+import {
+  createOllamaProvider,
+  DEFAULT_OLLAMA_PRICING,
+  estimateOllamaCostMicroUsd,
+  type OllamaChatRequest,
+  type OllamaChatResponse,
+  type OllamaClient,
+} from "../../src/providers/ollama.ts";
+
+function fakeClient(stub: (request: OllamaChatRequest) => OllamaChatResponse): {
+  readonly client: OllamaClient;
+  readonly chat: ReturnType<typeof vi.fn>;
+} {
+  const chat = vi.fn(async (request: OllamaChatRequest) => Promise.resolve(stub(request)));
+  return { client: { chat }, chat };
+}
+
+describe("Ollama pricing", () => {
+  it("returns zero cost for the default (free, local) pricing table", () => {
+    // Ollama runs locally; default rates are all zero. Any usage shape
+    // must still produce a non-negative integer (0).
+    const cost = estimateOllamaCostMicroUsd(DEFAULT_OLLAMA_PRICING, "llama3.3", {
+      inputTokens: 1_000,
+      outputTokens: 500,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    expect(cost as number).toBe(0);
+  });
+
+  it("returns zero across every default-table model", () => {
+    // Sanity: the contract is "every default model bills at $0".
+    for (const model of Object.keys(DEFAULT_OLLAMA_PRICING)) {
+      const cost = estimateOllamaCostMicroUsd(DEFAULT_OLLAMA_PRICING, model, {
+        inputTokens: 1_000_000,
+        outputTokens: 1_000_000,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      });
+      expect(cost as number).toBe(0);
+    }
+  });
+
+  it("throws UnknownModelError for unrecognized models", () => {
+    expect(() =>
+      estimateOllamaCostMicroUsd(DEFAULT_OLLAMA_PRICING, "llama-mystery", {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      }),
+    ).toThrow(UnknownModelError);
+  });
+
+  it("respects a host-supplied pricing-table override (GPU cost modeling)", () => {
+    // Host that wants to model GPU/electricity cost passes non-zero
+    // rates; the same integer-μUSD/MTok math applies.
+    const cost = estimateOllamaCostMicroUsd(
+      {
+        "llama3.3-local-gpu": {
+          inputMicroUsdPerMTok: 100_000, // $0.10/MTok hypothetical GPU cost
+          outputMicroUsdPerMTok: 200_000, // $0.20/MTok
+          cacheReadMicroUsdPerMTok: 0,
+          cacheCreationMicroUsdPerMTok: 0,
+        },
+      },
+      "llama3.3-local-gpu",
+      { inputTokens: 1_000, outputTokens: 500, cacheReadTokens: 0, cacheCreationTokens: 0 },
+    );
+    // (1000*100_000 + 500*200_000) / 1e6 = (1e8 + 1e8) / 1e6 = 200.
+    expect(cost as number).toBe(200);
+  });
+});
+
+describe("OllamaProvider", () => {
+  it("translates ProviderRequest → ollama chat request with num_predict", async () => {
+    const { client, chat } = fakeClient(() => ({
+      model: "llama3.3",
+      message: { role: "assistant", content: "hello world" },
+      done: true,
+      prompt_eval_count: 100,
+      eval_count: 50,
+    }));
+    const provider = createOllamaProvider({ client });
+
+    const res = await provider.complete({
+      model: "llama3.3",
+      prompt: "say hi",
+      maxOutputTokens: 64,
+    });
+
+    expect(chat).toHaveBeenCalledOnce();
+    expect(chat).toHaveBeenCalledWith({
+      model: "llama3.3",
+      messages: [{ role: "user", content: "say hi" }],
+      stream: false,
+      options: { num_predict: 64 },
+    });
+    expect(res.text).toBe("hello world");
+    expect(res.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+  });
+
+  it("does NOT pass an options/idempotency bag (local; no server dedup)", async () => {
+    // Sanity: the SDK's chat() takes a single request object — there is
+    // no second-argument options bag like Anthropic/OpenAI use for
+    // idempotency-key headers. The adapter must call chat with exactly
+    // one argument so a future SDK that tightens its overload signature
+    // still accepts our call shape.
+    const { client, chat } = fakeClient(() => emptyResponse());
+    const provider = createOllamaProvider({ client });
+    await provider.complete({ model: "llama3.3", prompt: "p", maxOutputTokens: 8 });
+    expect(chat.mock.calls[0]).toHaveLength(1);
+  });
+
+  it("declares models = pricing table keys for gateway routing", () => {
+    const provider = createOllamaProvider({ client: fakeClient(() => emptyResponse()).client });
+    expect(provider.models).toEqual(Object.keys(DEFAULT_OLLAMA_PRICING));
+    expect(provider.models).toContain("llama3.3");
+    expect(provider.models).toContain("qwen2.5");
+    expect(provider.models).toContain("gemma2");
+  });
+
+  it("uses pricing-override model list when provided", () => {
+    const provider = createOllamaProvider({
+      client: fakeClient(() => emptyResponse()).client,
+      pricing: {
+        "custom-local-model": {
+          inputMicroUsdPerMTok: 0,
+          outputMicroUsdPerMTok: 0,
+          cacheReadMicroUsdPerMTok: 0,
+          cacheCreationMicroUsdPerMTok: 0,
+        },
+      },
+    });
+    expect(provider.models).toEqual(["custom-local-model"]);
+  });
+
+  it("coerces missing eval counters to zero (older response shapes)", async () => {
+    // Some Ollama versions / partial responses omit prompt_eval_count or
+    // eval_count. The adapter must coerce to 0 so the CostUnits
+    // invariant (non-negative integer) holds.
+    const { client } = fakeClient(
+      () =>
+        ({
+          model: "llama3.3",
+          message: { role: "assistant", content: "ok" },
+          done: true,
+        }) as unknown as OllamaChatResponse,
+    );
+    const provider = createOllamaProvider({ client });
+    const res = await provider.complete({
+      model: "llama3.3",
+      prompt: "p",
+      maxOutputTokens: 8,
+    });
+    expect(res.usage).toEqual({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+  });
+
+  it("wraps SDK errors as ProviderError", async () => {
+    // Typical Ollama error: server not running, model not pulled,
+    // connection refused. We map all of them to ProviderError; there
+    // is no reliable HTTP-status convention to peel off as BadRequest.
+    const sdkErr = new Error("connect ECONNREFUSED 127.0.0.1:11434");
+    const provider = createOllamaProvider({
+      client: {
+        chat: async () => {
+          throw sdkErr;
+        },
+      },
+    });
+    const promise = provider.complete({
+      model: "llama3.3",
+      prompt: "p",
+      maxOutputTokens: 8,
+    });
+    await expect(promise).rejects.toBeInstanceOf(ProviderError);
+    await expect(promise).rejects.toMatchObject({
+      providerKind: "ollama",
+    });
+  });
+
+  it("rejects models not in the pricing table with UnknownModelError", async () => {
+    const provider = createOllamaProvider({ client: fakeClient(() => emptyResponse()).client });
+    await expect(
+      provider.complete({ model: "llama-not-real", prompt: "p", maxOutputTokens: 8 }),
+    ).rejects.toBeInstanceOf(UnknownModelError);
+  });
+
+  it("pre-rejects maxOutputTokens <= 0 without an SDK call", async () => {
+    const { client, chat } = fakeClient(() => emptyResponse());
+    const provider = createOllamaProvider({ client });
+    await expect(
+      provider.complete({ model: "llama3.3", prompt: "p", maxOutputTokens: 0 }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it("pre-rejects fractional maxOutputTokens without an SDK call", async () => {
+    const { client, chat } = fakeClient(() => emptyResponse());
+    const provider = createOllamaProvider({ client });
+    await expect(
+      provider.complete({ model: "llama3.3", prompt: "p", maxOutputTokens: 8.5 }),
+    ).rejects.toBeInstanceOf(BadRequestError);
+    expect(chat).not.toHaveBeenCalled();
+  });
+});
+
+describe("Ollama pricing-table validation", () => {
+  it("rejects an empty pricing table at construction", () => {
+    expect(() =>
+      createOllamaProvider({
+        client: fakeClient(() => emptyResponse()).client,
+        pricing: {},
+      }),
+    ).toThrow(/at least one model/);
+  });
+
+  it("rejects a non-integer rate at construction", () => {
+    expect(() =>
+      createOllamaProvider({
+        client: fakeClient(() => emptyResponse()).client,
+        pricing: {
+          "bad-model": {
+            inputMicroUsdPerMTok: 1.5,
+            outputMicroUsdPerMTok: 0,
+            cacheReadMicroUsdPerMTok: 0,
+            cacheCreationMicroUsdPerMTok: 0,
+          },
+        },
+      }),
+    ).toThrow(/non-negative safe integer/);
+  });
+
+  it("rejects a negative rate at construction", () => {
+    expect(() =>
+      createOllamaProvider({
+        client: fakeClient(() => emptyResponse()).client,
+        pricing: {
+          "bad-model": {
+            inputMicroUsdPerMTok: -1,
+            outputMicroUsdPerMTok: 0,
+            cacheReadMicroUsdPerMTok: 0,
+            cacheCreationMicroUsdPerMTok: 0,
+          },
+        },
+      }),
+    ).toThrow(/non-negative safe integer/);
+  });
+
+  it("accepts a table with all-zero rates (the default shape)", () => {
+    expect(() =>
+      createOllamaProvider({
+        client: fakeClient(() => emptyResponse()).client,
+        pricing: {
+          "all-zero": {
+            inputMicroUsdPerMTok: 0,
+            outputMicroUsdPerMTok: 0,
+            cacheReadMicroUsdPerMTok: 0,
+            cacheCreationMicroUsdPerMTok: 0,
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("OllamaProvider → Gateway → CostLedger end-to-end (mocked SDK)", () => {
+  it("writes a zero-amount cost_event row for a free local call", async () => {
+    // Hard rule #1: every successful Gateway.complete() writes one
+    // cost_event BEFORE returning. For Ollama that row's amount is 0
+    // (local execution, no provider charge), but the row MUST exist
+    // so cost_by_agent stays uniform across providers.
+    const { client } = fakeClient(() => ({
+      model: "llama3.3",
+      message: { role: "assistant", content: "ok" },
+      done: true,
+      prompt_eval_count: 1_000,
+      eval_count: 500,
+    }));
+    const provider = createOllamaProvider({ client });
+
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+    const gateway = createGateway({
+      ledger,
+      providers: [provider],
+      nowMs: () => clock.now,
+    });
+    try {
+      const ctx: SupervisorContext = { agentSlug: asAgentSlug("primary") };
+      const result = await gateway.complete(ctx, {
+        model: "llama3.3",
+        prompt: "go",
+        maxOutputTokens: 1_024,
+      });
+      // Free pricing → 0 μUSD spend, but the row was written:
+      // costEventLsn is non-null (its presence is the proof) and
+      // cost_by_agent reflects the zero entry as an existing day-row.
+      expect(result.costMicroUsd as number).toBe(0);
+      expect(result.costEventLsn).toBeDefined();
+      const agentRow = ledger.getAgentSpend("primary", "2026-05-12");
+      expect(agentRow?.totalMicroUsd as number).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("writes a non-zero cost_event row when host overrides pricing (GPU model)", async () => {
+    // Host wants to track GPU cost: same end-to-end shape, just with
+    // non-zero rates. Verifies the override path is wired the same way
+    // as the other adapters.
+    const { client } = fakeClient(() => ({
+      model: "llama3.3-gpu",
+      message: { role: "assistant", content: "ok" },
+      done: true,
+      prompt_eval_count: 1_000,
+      eval_count: 500,
+    }));
+    const provider = createOllamaProvider({
+      client,
+      pricing: {
+        "llama3.3-gpu": {
+          inputMicroUsdPerMTok: 100_000,
+          outputMicroUsdPerMTok: 200_000,
+          cacheReadMicroUsdPerMTok: 0,
+          cacheCreationMicroUsdPerMTok: 0,
+        },
+      },
+    });
+
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const clock = { now: new Date("2026-05-12T10:00:00.000Z").getTime() };
+    const gateway = createGateway({
+      ledger,
+      providers: [provider],
+      nowMs: () => clock.now,
+    });
+    try {
+      const ctx: SupervisorContext = { agentSlug: asAgentSlug("primary") };
+      const result = await gateway.complete(ctx, {
+        model: "llama3.3-gpu",
+        prompt: "go",
+        maxOutputTokens: 1_024,
+      });
+      // (1000*100_000 + 500*200_000) / 1e6 = 200.
+      expect(result.costMicroUsd as number).toBe(200);
+      const agentRow = ledger.getAgentSpend("primary", "2026-05-12");
+      expect(agentRow?.totalMicroUsd as number).toBe(200);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+function emptyResponse(): OllamaChatResponse {
+  return {
+    model: "llama3.3",
+    message: { role: "assistant", content: "" },
+    done: true,
+    prompt_eval_count: 0,
+    eval_count: 0,
+  };
+}


### PR DESCRIPTION
## Summary

PR B.4 of WUPHF v1 branch 7, **stacked on #830** (`feat/llm-router-openai`). Adds the third real-provider adapter (`@wuphf/llm-router/ollama`) — local model execution via [Ollama](https://ollama.com).

Built by a delegated codex agent in a worktree per the AGENTS.md sub-agent dispatch contract; I verified independently before pushing.

## What's different from Anthropic / OpenAI

| Concern | Anthropic | OpenAI | **Ollama** |
|---|---|---|---|
| API key | required | required | **none** (local) |
| Default URL | api.anthropic.com | api.openai.com | **localhost:11434** |
| Pricing | provider rates | provider rates | **$0 (local)** |
| Idempotency-key | server dedup | server dedup | **none** (local, no server contract) |
| Cache fields | read + creation (separate) | cached subset | none |

Cost rows are still written at amount 0 for accounting uniformity (Hard rule #1: no row, no response). Hosts that want to model GPU/electricity cost override the pricing table.

## What's in this PR

- `src/providers/ollama-pricing.ts` — pricing table for 6 models (llama3.3/3.2/3.1, qwen2.5, gemma2, mistral-small3.1) all at 0 μUSD/MTok. Validation accepts zero, rejects NaN/negatives/floats.
- `src/providers/ollama.ts` — adapter. `createOllamaProvider({ client, pricing? })` for DI; `createOllamaProviderWithUrl({ baseUrl?, pricing? })` async convenience constructor that lazy-imports the `ollama` SDK and constructs a client (default `http://localhost:11434`). `BadRequestError` pre-validation for `maxOutputTokens > 0`; SDK errors → `ProviderError`.
- `tests/providers/ollama.spec.ts` — 19 tests covering pricing math (zero AND host-override paths), adapter behavior, validation, and end-to-end ledger writes.
- `package.json` — `ollama@^0.5.0` peer dep (optional); subpath `./ollama` export.
- `README.md` — new Ollama section with usage, GPU-cost-override example, structural-client test example, rationale for no-idempotency-key.

## Validates the Provider abstraction (now 4 implementations)

| | Stub | Anthropic | OpenAI | **Ollama** |
|---|---|---|---|---|
| Auth | none | API key | API key | **none (local)** |
| Cost | fixed $0.01 | provider rates | provider rates | **$0** |
| Cache | none | 2 fields | 1 subset | **none** |
| Network | sync | remote HTTPS | remote HTTPS | **local HTTP** |

The same gateway code accepts all four without modification.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean (one pre-existing warning unrelated)
- [x] `bunx vitest run` — **74 passed** (was 55; +19 Ollama tests)
- [x] `bun run burn:nightly` — 3/3 §10.4 assertions pass
- [x] Pre-push lefthook — all green

## Out of scope (follow-on)

- Streaming
- Tool calls
- GPU-cost / token-throughput modeling (hosts override pricing)

## Review notes

- This PR is **stacked on #830** (OpenAI). GitHub diff is from `feat/llm-router-openai`, not `main`.
- The OpenAI adapter is currently going through triangulation #3 — findings may produce a fix commit on `feat/llm-router-openai` that this branch will inherit on rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)