### PR TITLE
chore(llm-router,broker): b-series triangulation follow-ups bundle

### DIFF
--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -7,6 +7,7 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./cost-ledger": "./src/cost-ledger/index.ts",
     "./sqlite": "./src/sqlite-receipt-store.ts"
   },
   "scripts": {

--- a/packages/broker/src/cost-ledger/index.ts
+++ b/packages/broker/src/cost-ledger/index.ts
@@ -1,3 +1,32 @@
+// Public surface of `@wuphf/broker/cost-ledger` — everything a host
+// needs to build, drive, and audit the cost ledger from outside the
+// broker package. Split off the broker root export (#820) so the root
+// stays scoped to `createBroker` per `packages/broker/AGENTS.md:3`.
+
+// Event log primitives. Hosts constructing a cost ledger need these to
+// open the database, apply migrations, and instantiate the event log
+// the ledger writes through. Re-exported from the cost-ledger subpath
+// so the broker root doesn't surface storage internals.
+export type {
+  AppendArgs,
+  EventLog,
+  EventLogRecord,
+  EventType,
+  OpenDatabaseArgs,
+} from "../event-log/index.ts";
+export {
+  CURRENT_SCHEMA_VERSION,
+  createEventLog,
+  openDatabase,
+  runMigrations,
+} from "../event-log/index.ts";
+
+// Idempotency parsing primitives. The atomic-append paths
+// (`CostLedger.appendCostEventIdempotent` etc.) take a `ParsedIdempotencyKey`
+// and do the lookup/store inside the same SQLite transaction.
+export type { CostCommand, ParsedIdempotencyKey } from "./idempotency.ts";
+export { COST_COMMAND_VALUES, parseIdempotencyKey } from "./idempotency.ts";
+// Projection store + ledger writer.
 export type {
   AgentSpendRow,
   BudgetRow,
@@ -12,3 +41,7 @@ export type {
   ThresholdCrossingRow,
 } from "./projections.ts";
 export { createCostLedger } from "./projections.ts";
+// Replay-check, used by the cost-ledger health route + nightly drift
+// checks. The report shape is the authoritative discrepancy surface.
+export type { ReplayCheckReport, ReplayDiscrepancy } from "./replay-check.ts";
+export { runReplayCheck } from "./replay-check.ts";

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -118,6 +118,17 @@ export type ReplayDiscrepancy =
       readonly field: "crossedAtLsn" | "observedMicroUsd" | "limitMicroUsd";
       readonly replayed: number;
       readonly stored: number;
+    }
+  | {
+      // #822: surface unparseable event-log rows distinctly so on-call
+      // sees the failing LSN, event type, and parse reason instead of
+      // a bare `internal_error` from the route. The route returns
+      // 200 with `ok: false` so this is observable in the same shape
+      // as any other drift discrepancy.
+      readonly kind: "event_payload_unparseable";
+      readonly lsn: EventLsn;
+      readonly type: string;
+      readonly reason: string;
     };
 
 interface CostEventBatchRow {
@@ -193,6 +204,10 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
   const replayedTasks = new Map<string, number>();
   const replayedBudgets = new Map<string, ReplayedBudget>();
   const replayedCrossings = new Map<string, ReplayedCrossing>();
+  // #822: collect per-row parse failures as structured discrepancies
+  // instead of throwing out of the loop. On-call sees the failing LSN
+  // + event type + reason without grepping the listener log.
+  const parseFailures: ReplayDiscrepancy[] = [];
 
   let cursor = 0;
   let scanned = 0;
@@ -201,55 +216,64 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     if (rows.length === 0) break;
     for (const row of rows) {
       const kind = eventTypeToKind(row.type);
-      if (kind === "cost_event") {
-        const parsed = costAuditPayloadFromJsonValue(
-          kind,
-          JSON.parse(row.payload.toString("utf8")),
-        ) as CostEventAuditPayload;
-        const dayUtc = parsed.occurredAt.toISOString().slice(0, 10);
-        const agentKey = agentDayKey(parsed.agentSlug, dayUtc);
-        replayedAgentDays.set(
-          agentKey,
-          (replayedAgentDays.get(agentKey) ?? 0) + (parsed.amountMicroUsd as number),
-        );
-        if (parsed.taskId !== undefined) {
-          replayedTasks.set(
-            parsed.taskId,
-            (replayedTasks.get(parsed.taskId) ?? 0) + (parsed.amountMicroUsd as number),
+      try {
+        if (kind === "cost_event") {
+          const parsed = costAuditPayloadFromJsonValue(
+            kind,
+            JSON.parse(row.payload.toString("utf8")),
+          ) as CostEventAuditPayload;
+          const dayUtc = parsed.occurredAt.toISOString().slice(0, 10);
+          const agentKey = agentDayKey(parsed.agentSlug, dayUtc);
+          replayedAgentDays.set(
+            agentKey,
+            (replayedAgentDays.get(agentKey) ?? 0) + (parsed.amountMicroUsd as number),
           );
+          if (parsed.taskId !== undefined) {
+            replayedTasks.set(
+              parsed.taskId,
+              (replayedTasks.get(parsed.taskId) ?? 0) + (parsed.amountMicroUsd as number),
+            );
+          }
+        } else if (kind === "budget_set") {
+          const parsed = costAuditPayloadFromJsonValue(
+            kind,
+            JSON.parse(row.payload.toString("utf8")),
+          ) as BudgetSetAuditPayload;
+          replayedBudgets.set(parsed.budgetId, {
+            scope: parsed.scope,
+            subjectId: parsed.subjectId ?? null,
+            limitMicroUsd: parsed.limitMicroUsd as number,
+            thresholdsBps: [...parsed.thresholdsBps],
+            setAtLsn: row.lsn,
+            tombstoned: (parsed.limitMicroUsd as number) === 0,
+          });
+        } else if (kind === "budget_threshold_crossed") {
+          // H1 fix: replay every threshold-crossed event into an expected
+          // (budget_id, budget_set_lsn, threshold_bps) → row map. The
+          // comparison below catches missing, ghost, and field-mismatch
+          // drift against cost_threshold_crossings.
+          const parsed = costAuditPayloadFromJsonValue(
+            kind,
+            JSON.parse(row.payload.toString("utf8")),
+          ) as BudgetThresholdCrossedAuditPayload;
+          const budgetSetLsnInt = parseLsn(parsed.budgetSetLsn).localLsn;
+          const crossedAtLsnInt = parseLsn(parsed.crossedAtLsn).localLsn;
+          const key = crossingKey(parsed.budgetId, budgetSetLsnInt, parsed.thresholdBps);
+          replayedCrossings.set(key, {
+            budgetId: parsed.budgetId,
+            budgetSetLsn: budgetSetLsnInt,
+            thresholdBps: parsed.thresholdBps,
+            crossedAtLsn: crossedAtLsnInt,
+            observedMicroUsd: parsed.observedMicroUsd as number,
+            limitMicroUsd: parsed.limitMicroUsd as number,
+          });
         }
-      } else if (kind === "budget_set") {
-        const parsed = costAuditPayloadFromJsonValue(
-          kind,
-          JSON.parse(row.payload.toString("utf8")),
-        ) as BudgetSetAuditPayload;
-        replayedBudgets.set(parsed.budgetId, {
-          scope: parsed.scope,
-          subjectId: parsed.subjectId ?? null,
-          limitMicroUsd: parsed.limitMicroUsd as number,
-          thresholdsBps: [...parsed.thresholdsBps],
-          setAtLsn: row.lsn,
-          tombstoned: (parsed.limitMicroUsd as number) === 0,
-        });
-      } else if (kind === "budget_threshold_crossed") {
-        // H1 fix: replay every threshold-crossed event into an expected
-        // (budget_id, budget_set_lsn, threshold_bps) → row map. The
-        // comparison below catches missing, ghost, and field-mismatch
-        // drift against cost_threshold_crossings.
-        const parsed = costAuditPayloadFromJsonValue(
-          kind,
-          JSON.parse(row.payload.toString("utf8")),
-        ) as BudgetThresholdCrossedAuditPayload;
-        const budgetSetLsnInt = parseLsn(parsed.budgetSetLsn).localLsn;
-        const crossedAtLsnInt = parseLsn(parsed.crossedAtLsn).localLsn;
-        const key = crossingKey(parsed.budgetId, budgetSetLsnInt, parsed.thresholdBps);
-        replayedCrossings.set(key, {
-          budgetId: parsed.budgetId,
-          budgetSetLsn: budgetSetLsnInt,
-          thresholdBps: parsed.thresholdBps,
-          crossedAtLsn: crossedAtLsnInt,
-          observedMicroUsd: parsed.observedMicroUsd as number,
-          limitMicroUsd: parsed.limitMicroUsd as number,
+      } catch (err) {
+        parseFailures.push({
+          kind: "event_payload_unparseable",
+          lsn: lsnFromV1Number(row.lsn),
+          type: row.type,
+          reason: err instanceof Error ? err.message : String(err),
         });
       }
       scanned += 1;
@@ -257,7 +281,11 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     cursor = rows[rows.length - 1]?.lsn ?? cursor;
   }
 
-  const discrepancies: ReplayDiscrepancy[] = [];
+  // Surface per-row parse failures first so on-call sees them at the top
+  // of the discrepancies list; downstream comparators may emit
+  // sum-mismatch discrepancies for the same rows but the parse-failure
+  // is the root cause.
+  const discrepancies: ReplayDiscrepancy[] = [...parseFailures];
 
   const storedAgentDays = new Map<string, number>();
   for (const row of listAgentDaysStmt.all()) {

--- a/packages/broker/src/index.ts
+++ b/packages/broker/src/index.ts
@@ -2,52 +2,12 @@
 // HTTP+SSE+WebSocket listener with a DNS-rebinding guard and bearer-token
 // auth. Hosts (Electron utility process, future `wuphf serve --headless`)
 // import `createBroker` and ignore the rest of the module graph.
+//
+// Cost-ledger and event-log primitives live on the `@wuphf/broker/cost-ledger`
+// subpath (#820) so consumers that only need the listener don't pull in
+// the storage internals. `SqliteReceiptStore` is on `@wuphf/broker/sqlite`
+// for the same reason (native binding load cost).
 
-// Idempotency parsing primitives. The atomic-append paths
-// (`CostLedger.appendCostEventIdempotent` etc.) take a `ParsedIdempotencyKey`
-// and do the lookup/store inside the same SQLite transaction, so consumers
-// no longer compose their own `CommandIdempotencyStore` — the parser is the
-// only piece they need.
-export type {
-  CostCommand,
-  ParsedIdempotencyKey,
-} from "./cost-ledger/idempotency.ts";
-export {
-  COST_COMMAND_VALUES,
-  parseIdempotencyKey,
-} from "./cost-ledger/idempotency.ts";
-export type {
-  AgentSpendRow,
-  BudgetRow,
-  BudgetSetAppendResult,
-  CostEventAppendResult,
-  CostLedger,
-  IdempotentAppendResult,
-  IdempotentBudgetSetArgs,
-  IdempotentCostEventArgs,
-  TaskSpendRow,
-  ThresholdCrossedAppendResult,
-  ThresholdCrossingRow,
-} from "./cost-ledger/index.ts";
-export { createCostLedger } from "./cost-ledger/index.ts";
-export type { ReplayCheckReport, ReplayDiscrepancy } from "./cost-ledger/replay-check.ts";
-export { runReplayCheck } from "./cost-ledger/replay-check.ts";
-// Event log primitives. Hosts constructing a cost ledger need these to
-// open the database, apply migrations, and instantiate the event log
-// the ledger writes through.
-export type {
-  AppendArgs,
-  EventLog,
-  EventLogRecord,
-  EventType,
-  OpenDatabaseArgs,
-} from "./event-log/index.ts";
-export {
-  CURRENT_SCHEMA_VERSION,
-  createEventLog,
-  openDatabase,
-  runMigrations,
-} from "./event-log/index.ts";
 export { createBroker } from "./listener.ts";
 export type {
   InMemoryReceiptStoreConfig,
@@ -65,12 +25,6 @@ export {
   ReceiptStoreFullError,
   ReceiptStoreUnavailableError,
 } from "./receipt-store.ts";
-// `SqliteReceiptStore` is intentionally NOT re-exported from the root.
-// It pulls in the native `better-sqlite3` binding via static import,
-// which evaluates at module load. Hosts that want the durable store
-// import it from the `@wuphf/broker/sqlite` subpath so consumers that
-// only need the listener + in-memory store don't pay the native-load
-// cost. See `docs/event-log-projections-design.md` § "Package surface".
 export { generateApiToken } from "./token.ts";
 export type {
   BrokerConfig,

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -11,8 +11,8 @@ import {
   lsnFromV1Number,
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
+import { createCostLedger, parseIdempotencyKey, runReplayCheck } from "../src/cost-ledger/index.ts";
 import { createEventLog, openDatabase, runMigrations } from "../src/event-log/index.ts";
-import { createCostLedger, parseIdempotencyKey, runReplayCheck } from "../src/index.ts";
 
 function setup() {
   const db = openDatabase({ path: ":memory:" });
@@ -438,5 +438,35 @@ describe("replay-check", () => {
     const report = runReplayCheck(db);
     expect(report.ok).toBe(true);
     expect(report.discrepancies).toEqual([]);
+  });
+
+  it("surfaces unparseable cost event payload as structured discrepancy (#822)", () => {
+    const { db, ledger } = setup();
+    // One good event so the projection has something to compare against,
+    // then tamper a later row to be unparseable.
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 100_000 }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 250_000 }));
+    // Overwrite the second cost.event payload with garbage JSON so the
+    // codec rejects it. (We pick the highest cost.event LSN.)
+    const tamperedLsn = db
+      .prepare<[], { readonly lsn: number }>(
+        "SELECT MAX(lsn) AS lsn FROM event_log WHERE type = 'cost.event'",
+      )
+      .get();
+    if (tamperedLsn === undefined) throw new Error("no cost.event row to tamper");
+    db.prepare<[Buffer, number]>("UPDATE event_log SET payload = ? WHERE lsn = ?").run(
+      Buffer.from('{"not":"a valid cost event"}', "utf8"),
+      tamperedLsn.lsn,
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const parseFail = report.discrepancies.find((d) => d.kind === "event_payload_unparseable");
+    expect(parseFail).toBeDefined();
+    if (parseFail?.kind === "event_payload_unparseable") {
+      expect(parseFail.type).toBe("cost.event");
+      expect(typeof parseFail.reason).toBe("string");
+      expect(parseFail.reason.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/packages/broker/tests/cost-routes.spec.ts
+++ b/packages/broker/tests/cost-routes.spec.ts
@@ -12,9 +12,11 @@ import {
   costAuditPayloadToJsonValue,
 } from "@wuphf/protocol";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CostLedger } from "../src/cost-ledger/index.ts";
+import { createCostLedger } from "../src/cost-ledger/index.ts";
 import { createEventLog, openDatabase, runMigrations } from "../src/event-log/index.ts";
-import type { BrokerHandle, CostLedger } from "../src/index.ts";
-import { createBroker, createCostLedger } from "../src/index.ts";
+import type { BrokerHandle } from "../src/index.ts";
+import { createBroker } from "../src/index.ts";
 
 const FIXED_TOKEN = asApiToken("test-token-with-enough-entropy-AAAAAAAAA");
 const BUDGET_ID = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";

--- a/packages/llm-router/scripts/ci-burn-nightly.ts
+++ b/packages/llm-router/scripts/ci-burn-nightly.ts
@@ -22,7 +22,7 @@
 //
 // Exits 0 on all assertions passing; 1 on any failure.
 
-import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker/cost-ledger";
 import { asAgentSlug } from "@wuphf/protocol";
 
 import {

--- a/packages/llm-router/src/caps.ts
+++ b/packages/llm-router/src/caps.ts
@@ -12,7 +12,7 @@
 // `noteHumanActivity` to reset the clock. Agent-initiated activity does NOT
 // reset the clock; otherwise an agent loop would keep itself awake.
 
-import type { CostLedger } from "@wuphf/broker";
+import type { CostLedger } from "@wuphf/broker/cost-ledger";
 
 import { CapExceededError, CircuitBreakerOpenError, IdleModeError } from "./errors.ts";
 import type { AgentInspection, BreakerState, GatewayInspection } from "./types.ts";

--- a/packages/llm-router/src/gateway.ts
+++ b/packages/llm-router/src/gateway.ts
@@ -17,8 +17,15 @@
 // `costEventLsn` to put in the result. No other code path returns a
 // completion. That's the type-system enforcement.
 
-import type { CostLedger } from "@wuphf/broker";
-import type { CostEventAuditPayload, CostUnits, MicroUsd, ProviderKind } from "@wuphf/protocol";
+import type { CostLedger } from "@wuphf/broker/cost-ledger";
+import {
+  type CostEventAuditPayload,
+  type CostUnits,
+  isProviderKind,
+  MAX_COST_EVENT_AMOUNT_MICRO_USD,
+  type MicroUsd,
+  type ProviderKind,
+} from "@wuphf/protocol";
 
 import { Caps, type CapsConfig, DEFAULT_CAPS_CONFIG } from "./caps.ts";
 import { DEFAULT_DEDUPE_CONFIG, DedupeCache, type DedupeConfig, hashRequest } from "./dedupe.ts";
@@ -107,6 +114,16 @@ export function createGateway(deps: GatewayDeps): Gateway {
     let appended: ReturnType<CostLedger["appendCostEvent"]>;
     try {
       costMicroUsd = provider.costEstimator.estimate(req.model, providerResponse.usage);
+      // Defense-in-depth (#824): MicroUsd allows up to $1M (budget limit
+      // ceiling), but a single cost_event is capped at $100. Catch the
+      // out-of-range case here so the breaker reacts to a runaway
+      // estimator instead of letting the codec reject AFTER the paid
+      // provider call has already happened.
+      if ((costMicroUsd as number) > MAX_COST_EVENT_AMOUNT_MICRO_USD) {
+        throw new Error(
+          `cost estimate ${String(costMicroUsd)} exceeds per-event cap ${MAX_COST_EVENT_AMOUNT_MICRO_USD}`,
+        );
+      }
 
       // The "row before response" point: appendCostEvent is the only
       // place an EventLsn for this completion is produced. If this
@@ -114,7 +131,11 @@ export function createGateway(deps: GatewayDeps): Gateway {
       // completion without a matching ledger row.
       const payload: CostEventAuditPayload = buildCostEventPayload(
         ctx,
-        req,
+        // Audit-stable model id (#827): prefer the served snapshot the
+        // SDK echoed back (e.g. claude-haiku-4-5-20251001) over the
+        // request alias (claude-haiku-4-5). Adapters that don't expose
+        // it fall back to req.model so the gateway path stays uniform.
+        providerResponse.model ?? req.model,
         provider.kind,
         providerResponse.usage,
         costMicroUsd,
@@ -160,7 +181,7 @@ export function createGateway(deps: GatewayDeps): Gateway {
 
 function buildCostEventPayload(
   ctx: SupervisorContext,
-  req: ProviderRequest,
+  model: string,
   providerKind: ProviderKind,
   usage: CostUnits,
   costMicroUsd: MicroUsd,
@@ -173,7 +194,7 @@ function buildCostEventPayload(
   const base: CostEventAuditPayload = {
     agentSlug: ctx.agentSlug,
     providerKind,
-    model: req.model,
+    model,
     amountMicroUsd: costMicroUsd,
     units: usage,
     occurredAt: new Date(nowMs),
@@ -202,6 +223,15 @@ function buildCostEventPayload(
 function indexProvidersByModel(providers: readonly Provider[]): Map<string, Provider> {
   const out = new Map<string, Provider>();
   for (const provider of providers) {
+    // Defense-in-depth (#828): Provider.kind is a brand, but a custom
+    // provider can forge it with `as ProviderKind`. Verify at construction
+    // so a bad kind cannot reach a billable provider.complete() call —
+    // the ledger codec would otherwise reject AFTER the paid call.
+    if (!isProviderKind(provider.kind)) {
+      throw new Error(
+        `invalid Provider.kind: ${JSON.stringify(provider.kind)} is not a registered ProviderKind`,
+      );
+    }
     for (const model of provider.models) {
       const existing = out.get(model);
       if (existing !== undefined && existing !== provider) {

--- a/packages/llm-router/src/providers/anthropic.ts
+++ b/packages/llm-router/src/providers/anthropic.ts
@@ -110,6 +110,14 @@ export interface AnthropicMessage {
   readonly content: ReadonlyArray<{ readonly type: string; readonly text?: string }>;
   readonly usage: AnthropicMessageUsage;
   /**
+   * Served model id — typically a dated snapshot like
+   * `claude-haiku-4-5-20251001` while the request alias was
+   * `claude-haiku-4-5`. Surfaced through `ProviderResponse.model` so the
+   * cost_event audit row records the actual served snapshot. See
+   * triangulation B2-defer #827.
+   */
+  readonly model?: string;
+  /**
    * Why the model stopped. `end_turn` is a normal completion;
    * `max_tokens` is truncation; `stop_sequence` matched a configured
    * stop; `tool_use` paused for a tool call; `refusal` is a policy
@@ -206,6 +214,7 @@ export function createAnthropicProvider(args: CreateAnthropicProviderArgs): Prov
         usage: usageToCostUnits(raw.usage),
         ...(finishReason !== null ? { finishReason } : {}),
         ...(isRefusal ? { refusal: extractedText } : {}),
+        ...(typeof raw.model === "string" && raw.model.length > 0 ? { model: raw.model } : {}),
       };
     },
   };
@@ -408,7 +417,53 @@ export async function createAnthropicProviderWithKey(args: {
   const AnthropicCtor = sdk.default;
   const client = new AnthropicCtor({ apiKey: args.apiKey });
   return createAnthropicProvider({
-    client: client as unknown as AnthropicClient,
+    client: adaptAnthropicSdkClient(client),
     ...(args.pricing !== undefined ? { pricing: args.pricing } : {}),
   });
+}
+
+/**
+ * Type-checked adapter from the real SDK client to our structural
+ * `AnthropicClient` interface (#829). The previous `as unknown as`
+ * double-cast told tsc nothing about the actual SDK signature, so a
+ * future SDK version that drifted on `messages.create()` overloads or
+ * return shape would silently break at runtime. This wrapper forces
+ * tsc to verify the SDK still satisfies our contract.
+ *
+ * The structural `params.messages` is `ReadonlyArray` (our adapter is
+ * a read-only consumer), but the SDK declares it as mutable
+ * `MessageParam[]`. The clone makes that assignment legal without
+ * weakening our internal immutability guarantee, and the per-call cost
+ * is negligible at one shallow array copy per LLM request.
+ */
+type AnthropicSdkClient = {
+  readonly messages: {
+    create(
+      params: {
+        readonly model: string;
+        readonly max_tokens: number;
+        readonly messages: ReadonlyArray<{
+          readonly role: "user" | "assistant";
+          readonly content: string;
+        }>;
+      } & { messages: Array<{ role: "user" | "assistant"; content: string }> },
+      options?: AnthropicRequestOptions,
+    ): Promise<AnthropicMessage>;
+  };
+};
+
+function adaptAnthropicSdkClient(sdkClient: AnthropicSdkClient): AnthropicClient {
+  return {
+    messages: {
+      create: (params, options) =>
+        sdkClient.messages.create(
+          {
+            model: params.model,
+            max_tokens: params.max_tokens,
+            messages: params.messages.map((m) => ({ role: m.role, content: m.content })),
+          },
+          options,
+        ),
+    },
+  };
 }

--- a/packages/llm-router/src/providers/ollama.ts
+++ b/packages/llm-router/src/providers/ollama.ts
@@ -173,6 +173,10 @@ export function createOllamaProvider(args: CreateOllamaProviderArgs): Provider {
       return {
         text: raw.message?.content ?? "",
         usage: usageToCostUnits(raw),
+        // #827: Ollama echoes the served model back; surface it so the
+        // audit row records the exact served identifier (host-side
+        // model pulls can pin to a digest).
+        ...(typeof raw.model === "string" && raw.model.length > 0 ? { model: raw.model } : {}),
       };
     },
   };

--- a/packages/llm-router/src/providers/openai.ts
+++ b/packages/llm-router/src/providers/openai.ts
@@ -362,6 +362,9 @@ function buildProviderResponse(raw: OpenAIChatCompletion): ProviderResponse {
     usage,
     ...(finishReason !== null ? { finishReason } : {}),
     ...(refusal !== null ? { refusal } : {}),
+    // #827: surface served snapshot id (e.g. gpt-5-2025-08-07) so the
+    // audit row records the actual served model.
+    ...(typeof raw.model === "string" && raw.model.length > 0 ? { model: raw.model } : {}),
   };
 }
 

--- a/packages/llm-router/src/providers/opencode.ts
+++ b/packages/llm-router/src/providers/opencode.ts
@@ -82,6 +82,14 @@ export interface OpenCodeChatResponse {
   readonly text: string;
   readonly usage: OpenCodeUsage;
   /**
+   * Served model id — typically the underlying upstream the runner is
+   * configured to use (e.g. `claude-sonnet-4-6-20251015`). Surfaced
+   * through `ProviderResponse.model` so the audit row pins the served
+   * snapshot. See #827. Optional — runners that don't expose it leave
+   * this undefined.
+   */
+  readonly model?: string;
+  /**
    * Surface a finish-reason if the runner reports one (e.g.
    * `"stop" | "length" | "tool_call"`). Optional — runners that don't
    * track it leave it undefined.
@@ -224,6 +232,9 @@ function buildProviderResponse(
     usage,
     ...(raw.finishReason !== undefined ? { finishReason: raw.finishReason } : {}),
     ...(isRefusal ? { refusal: raw.refusal as string } : {}),
+    // #827: surface served model id so the audit row pins the upstream
+    // snapshot the runner actually used.
+    ...(typeof raw.model === "string" && raw.model.length > 0 ? { model: raw.model } : {}),
   };
 }
 
@@ -371,6 +382,7 @@ function parseSubprocessResponse(raw: unknown): OpenCodeChatResponse {
   const finishReason =
     typeof obj["finishReason"] === "string" ? (obj["finishReason"] as string) : undefined;
   const refusal = typeof obj["refusal"] === "string" ? (obj["refusal"] as string) : undefined;
+  const model = typeof obj["model"] === "string" ? (obj["model"] as string) : undefined;
   return {
     text,
     usage: {
@@ -378,6 +390,7 @@ function parseSubprocessResponse(raw: unknown): OpenCodeChatResponse {
       outputTokens,
       ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
     },
+    ...(model !== undefined ? { model } : {}),
     ...(finishReason !== undefined ? { finishReason } : {}),
     ...(refusal !== undefined ? { refusal } : {}),
   };

--- a/packages/llm-router/src/types.ts
+++ b/packages/llm-router/src/types.ts
@@ -65,6 +65,15 @@ export interface ProviderResponse {
   readonly usage: CostUnits;
   readonly finishReason?: string;
   readonly refusal?: string;
+  /**
+   * Model id actually served by the upstream — typically a dated
+   * snapshot like `claude-haiku-4-5-20251001` while `ProviderRequest.model`
+   * carries the alias `claude-haiku-4-5`. The gateway records this in the
+   * cost_event audit row when present, falling back to `req.model` so
+   * replay across runtime versions stays stable. See triangulation B2-defer
+   * #827. Adapters that don't expose the served model leave this undefined.
+   */
+  readonly model?: string;
 }
 
 export interface CostEstimator {

--- a/packages/llm-router/tests/gateway.spec.ts
+++ b/packages/llm-router/tests/gateway.spec.ts
@@ -1,4 +1,4 @@
-import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker/cost-ledger";
 import { asAgentSlug, asProviderKind, asReceiptId, asTaskId } from "@wuphf/protocol";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -404,6 +404,137 @@ describe("inspect()", () => {
       expect(agent?.breaker.status).toBe("closed");
     } finally {
       fix.db.close();
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Followups #827 + #828 + #824 — surgical gateway-side fixes
+// ─────────────────────────────────────────────────────────────────────
+
+describe("gateway construction-time validation (#828)", () => {
+  it("rejects a Provider whose .kind is not a registered ProviderKind", () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const stub = createStubProvider();
+    // Forge a fake kind via `as` cast — the defense is the construction
+    // check, not the type system.
+    const forged: Provider = { ...stub, kind: "not-a-real-kind" as never };
+    try {
+      expect(() =>
+        createGateway({ ledger, providers: [forged], nowMs: () => Date.now() }),
+      ).toThrow(/not a registered ProviderKind/);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("audit row records served model id (#827)", () => {
+  it("uses ProviderResponse.model when the adapter supplies it", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const fixedKind = asProviderKind("openai-compat");
+    const estimator: CostEstimator = {
+      estimate: (_model, _usage) => 0 as never,
+    };
+    const provider: Provider = {
+      kind: fixedKind,
+      models: ["alias-model"],
+      costEstimator: estimator,
+      complete: async (_req) => ({
+        text: "ok",
+        usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreationTokens: 0 },
+        // Adapter returns a pinned snapshot identifier; gateway should record THIS.
+        model: "alias-model-2025-04-12-snapshot",
+      }),
+    };
+    const gateway = createGateway({ ledger, providers: [provider], nowMs: () => Date.now() });
+    try {
+      await gateway.complete(
+        { agentSlug: asAgentSlug("a") },
+        { model: "alias-model", prompt: "p", maxOutputTokens: 8 },
+      );
+      const row = db
+        .prepare<[], { readonly payload: Buffer }>(
+          "SELECT payload FROM event_log WHERE type = 'cost.event' LIMIT 1",
+        )
+        .get();
+      if (row === undefined) throw new Error("no cost.event row");
+      const parsed = JSON.parse(row.payload.toString("utf8")) as { model: string };
+      expect(parsed.model).toBe("alias-model-2025-04-12-snapshot");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("falls back to ProviderRequest.model when adapter does not supply one", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const gateway = createGateway({
+      ledger,
+      providers: [createStubProvider()],
+      nowMs: () => Date.now(),
+    });
+    try {
+      await gateway.complete(CTX, REQ);
+      const row = db
+        .prepare<[], { readonly payload: Buffer }>(
+          "SELECT payload FROM event_log WHERE type = 'cost.event' LIMIT 1",
+        )
+        .get();
+      if (row === undefined) throw new Error("no cost.event row");
+      const parsed = JSON.parse(row.payload.toString("utf8")) as { model: string };
+      expect(parsed.model).toBe(STUB_MODEL_FIXED_COST);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("gateway rejects runaway cost estimate before ledger append (#824)", () => {
+  it("treats an over-cap estimator output as breaker-worthy and skips the ledger write", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    runMigrations(db);
+    const eventLog = createEventLog(db);
+    const ledger = createCostLedger(db, eventLog);
+    const kind = asProviderKind("openai-compat");
+    // 200 million μUSD = $200 — exceeds the $100 per-event cap.
+    const estimator: CostEstimator = {
+      estimate: (_model, _usage) => 200_000_000 as never,
+    };
+    const provider: Provider = {
+      kind,
+      models: ["runaway-model"],
+      costEstimator: estimator,
+      complete: async () => ({
+        text: "ok",
+        usage: { inputTokens: 1, outputTokens: 1, cacheReadTokens: 0, cacheCreationTokens: 0 },
+      }),
+    };
+    const gateway = createGateway({ ledger, providers: [provider], nowMs: () => Date.now() });
+    try {
+      await expect(
+        gateway.complete(
+          { agentSlug: asAgentSlug("a") },
+          { model: "runaway-model", prompt: "p", maxOutputTokens: 8 },
+        ),
+      ).rejects.toThrow(/exceeds per-event cap/);
+      // No cost_event written for the over-cap call.
+      const count = db
+        .prepare<[], { readonly n: number }>(
+          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
+        )
+        .get();
+      expect(count?.n).toBe(0);
+    } finally {
+      db.close();
     }
   });
 });

--- a/packages/llm-router/tests/providers/anthropic.spec.ts
+++ b/packages/llm-router/tests/providers/anthropic.spec.ts
@@ -1,4 +1,4 @@
-import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker/cost-ledger";
 import { asAgentSlug, asMicroUsd } from "@wuphf/protocol";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/packages/llm-router/tests/providers/ollama.spec.ts
+++ b/packages/llm-router/tests/providers/ollama.spec.ts
@@ -1,4 +1,4 @@
-import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker/cost-ledger";
 import { asAgentSlug } from "@wuphf/protocol";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/llm-router/tests/providers/openai.spec.ts
+++ b/packages/llm-router/tests/providers/openai.spec.ts
@@ -1,4 +1,4 @@
-import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker/cost-ledger";
 import { asAgentSlug } from "@wuphf/protocol";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/llm-router/tests/providers/opencode.spec.ts
+++ b/packages/llm-router/tests/providers/opencode.spec.ts
@@ -1,4 +1,4 @@
-import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker";
+import { createCostLedger, createEventLog, openDatabase, runMigrations } from "@wuphf/broker/cost-ledger";
 import { asAgentSlug } from "@wuphf/protocol";
 import { describe, expect, it, vi } from "vitest";
 

--- a/packages/llm-router/tests/threshold-integration.spec.ts
+++ b/packages/llm-router/tests/threshold-integration.spec.ts
@@ -14,7 +14,7 @@ import {
   openDatabase,
   runMigrations,
   runReplayCheck,
-} from "@wuphf/broker";
+} from "@wuphf/broker/cost-ledger";
 import {
   asAgentSlug,
   asBudgetId,


### PR DESCRIPTION
## Summary

Surgical fixes for 6 deferred findings from the PR A→B.4 triangulation rounds. Bundled because each fix is small, orthogonal, and benefits from being reviewed together. Stacked on top of PR B.5 (#832) so every adapter — including opencode/opencodego — is in scope.

| # | Issue | Fix |
|---|---|---|
| 1 | [#820](https://github.com/nex-crm/wuphf/issues/820) | Move event-log + cost-ledger primitives off the broker root export to a new `@wuphf/broker/cost-ledger` subpath. Root stays scoped to `createBroker` per AGENTS.md:3. 9 consumers updated. |
| 2 | [#822](https://github.com/nex-crm/wuphf/issues/822) | `runReplayCheck` per-row parse failures now surface as structured `ReplayDiscrepancy { kind: "event_payload_unparseable", lsn, type, reason }` instead of throwing. On-call sees the failing LSN + reason without grepping the listener log. |
| 3 | [#824](https://github.com/nex-crm/wuphf/issues/824) | Gateway validates estimator output against `MAX_COST_EVENT_AMOUNT_MICRO_USD` ($100/event) before calling `appendCostEvent` so a runaway estimator trips the breaker instead of letting the codec reject AFTER the paid call. |
| 4 | [#827](https://github.com/nex-crm/wuphf/issues/827) | `ProviderResponse` gains optional `model`. Adapters that get an SDK-echoed served snapshot (anthropic, openai, ollama, opencode) surface it; gateway records it in the cost_event audit row, falling back to `req.model` otherwise. |
| 5 | [#828](https://github.com/nex-crm/wuphf/issues/828) | `indexProvidersByModel` calls `isProviderKind` on each provider at gateway construction. A forged-brand provider can no longer reach a billable `provider.complete()` call. |
| 6 | [#829](https://github.com/nex-crm/wuphf/issues/829) | Replace `client as unknown as AnthropicClient` double cast in `createAnthropicProviderWithKey` with a typed wrapper that forces tsc to verify the SDK still satisfies our structural contract. Catches future SDK overload drift at compile time. |

## Why bundled

Each fix is small and orthogonal — splitting into 6 PRs would be churn for reviewers. Memory note from the user: \"for refactors in this area, user prefers one bundled PR over many small ones.\"

## Verification

```
broker:      189 tests passing  (1 new — event_payload_unparseable discrepancy)
llm-router:  113 tests passing  (4 new — Provider.kind validation, served-model recorded, fallback, over-cap rejection)
protocol:    547 tests passing  (unchanged — no wire change)
typecheck:   clean across broker + llm-router + protocol
pre-push:    go-unit, broker-test, broker-typecheck, desktop-test, desktop-typecheck, protocol-demo,
             protocol-invariants, protocol-wire-contract all green
```

## Stack

```mermaid
graph LR
  A[main] --> B[feat/llm-router-cost-ledger #816]
  B --> C[feat/llm-router-gateway #818]
  C --> D[feat/llm-router-anthropic #825]
  D --> E[feat/llm-router-openai #830]
  E --> F[feat/llm-router-ollama #831]
  F --> G[feat/llm-router-opencode #832]
  G --> H[feat/llm-router-followups this PR]
```

## Test plan

- [x] \`bunx tsc --noEmit\` across broker, llm-router, protocol
- [x] \`bunx vitest run\` in each package (849 total tests, 5 new)
- [x] Pre-push hook (go-unit, broker, desktop, protocol-demo + invariants + wire-contract)
- [ ] CodeRabbit pass
- [ ] Codex triangulation
- [ ] staff-code-reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)