### PR TITLE
feat(broker): independent threshold-crossing oracle in replay-check (#836)

### DIFF
--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -16,7 +16,10 @@
 // task-attributed subset.
 //
 // Read-only: this function never writes. It is safe to call on a live
-// broker; SQLite's WAL gives it a consistent snapshot.
+// broker; the entire check runs inside a single `BEGIN DEFERRED`
+// transaction so concurrent writers can commit but won't be observed
+// mid-check (better-sqlite3's WAL does NOT give per-statement
+// snapshots on its own — round-2 review caught a stale claim here).
 
 import {
   type AuditEventKind,
@@ -31,8 +34,6 @@ import {
   parseLsn,
 } from "@wuphf/protocol";
 import type Database from "better-sqlite3";
-
-import type { EventLogRecord } from "../event-log/index.ts";
 
 export interface ReplayCheckReport {
   readonly ok: boolean;
@@ -287,12 +288,6 @@ interface BudgetDbRow {
 interface HighestLsnRow {
   readonly lsn: number;
 }
-
-const _COST_EVENT_TYPES = new Set<string>([
-  "cost.event",
-  "cost.budget.set",
-  "cost.budget.threshold.crossed",
-]);
 
 const BATCH_SIZE = 1_000;
 
@@ -1169,8 +1164,3 @@ function compareExpectedAndLoggedCrossings(
     });
   }
 }
-
-// Used only inside the batch loop; importing the type without using it
-// trips the lint. Re-exporting keeps the surface coherent for callers
-// that want to depend on the batch iterator.
-export type { EventLogRecord };

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -120,6 +120,48 @@ export type ReplayDiscrepancy =
       readonly stored: number;
     }
   | {
+      // Oracle: the independent threshold replay says this crossing
+      // should have fired, but no `cost.budget.threshold.crossed` event
+      // exists for it. Catches reactor under-emission bugs (e.g. a
+      // regression in `crossesThreshold`'s integer math) that the
+      // event-log-as-oracle replay can't see, because the missing event
+      // is missing in BOTH the log and the projection.
+      readonly kind: "threshold_crossing_unemitted";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly observedMicroUsd: MicroUsd;
+      readonly limitMicroUsd: MicroUsd;
+      readonly crossedAtLsn: EventLsn;
+    }
+  | {
+      // Oracle: a `cost.budget.threshold.crossed` event exists, but the
+      // independent threshold replay says it shouldn't fire. Distinct
+      // from `threshold_crossing_ghost` — that variant is projection-row
+      // drift from event log. This variant is event-log drift from the
+      // oracle's view of cost events + budgets.
+      readonly kind: "threshold_crossing_spurious";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly observedMicroUsd: MicroUsd;
+      readonly limitMicroUsd: MicroUsd;
+      readonly crossedAtLsn: EventLsn;
+    }
+  | {
+      // Oracle: same (budget, epoch, threshold) exists in both the event
+      // log and the oracle, but one of the recorded fields disagrees.
+      // Most likely cause: the reactor and oracle diverged on which
+      // cost_event was the trigger or what cumulative sum was observed.
+      readonly kind: "threshold_crossing_oracle_field_mismatch";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly field: "crossedAtLsn" | "observedMicroUsd" | "limitMicroUsd";
+      readonly expected: number;
+      readonly logged: number;
+    }
+  | {
       // Surface unparseable event-log rows distinctly so on-call sees the
       // failing LSN, event type, and parse reason instead of a bare
       // `internal_error` from the route.
@@ -202,6 +244,17 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
   const replayedTasks = new Map<string, number>();
   const replayedBudgets = new Map<string, ReplayedBudget>();
   const replayedCrossings = new Map<string, ReplayedCrossing>();
+  // Oracle: independent threshold replay. Tracks the same lifetime sums
+  // the reactor reads (`lifetimeFor` in reactor.ts), then re-runs the
+  // same integer/BigInt crossing math against current `replayedBudgets`
+  // to derive an expected crossing set without consulting the event log.
+  // Discrepancies between `expectedCrossings` and `replayedCrossings`
+  // surface reactor bugs (under-emission, spurious emission, field drift)
+  // that the event-log-as-oracle replay can't detect.
+  let oracleGlobalLifetime = 0;
+  const oracleAgentLifetime = new Map<string, number>();
+  const oracleTaskLifetime = new Map<string, number>();
+  const expectedCrossings = new Map<string, ExpectedCrossing>();
   // Collect per-row parse failures as structured discrepancies instead
   // of throwing out of the loop.
   const parseFailures: ReplayDiscrepancy[] = [];
@@ -221,16 +274,36 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
           ) as CostEventAuditPayload;
           const dayUtc = parsed.occurredAt.toISOString().slice(0, 10);
           const agentKey = agentDayKey(parsed.agentSlug, dayUtc);
-          replayedAgentDays.set(
-            agentKey,
-            (replayedAgentDays.get(agentKey) ?? 0) + (parsed.amountMicroUsd as number),
+          const amount = parsed.amountMicroUsd as number;
+          replayedAgentDays.set(agentKey, (replayedAgentDays.get(agentKey) ?? 0) + amount);
+          if (parsed.taskId !== undefined) {
+            replayedTasks.set(parsed.taskId, (replayedTasks.get(parsed.taskId) ?? 0) + amount);
+          }
+          // Oracle update: mirror the reactor's post-update lifetime read.
+          // The reactor runs after `cost_by_agent`/`cost_by_task` have
+          // been updated for the current event, so `observed` includes
+          // the event's own amount.
+          oracleGlobalLifetime += amount;
+          oracleAgentLifetime.set(
+            parsed.agentSlug,
+            (oracleAgentLifetime.get(parsed.agentSlug) ?? 0) + amount,
           );
           if (parsed.taskId !== undefined) {
-            replayedTasks.set(
+            oracleTaskLifetime.set(
               parsed.taskId,
-              (replayedTasks.get(parsed.taskId) ?? 0) + (parsed.amountMicroUsd as number),
+              (oracleTaskLifetime.get(parsed.taskId) ?? 0) + amount,
             );
           }
+          computeExpectedCrossings({
+            costEventLsn: row.lsn,
+            agentSlug: parsed.agentSlug,
+            taskId: parsed.taskId,
+            budgets: replayedBudgets,
+            globalLifetime: oracleGlobalLifetime,
+            agentLifetime: oracleAgentLifetime,
+            taskLifetime: oracleTaskLifetime,
+            out: expectedCrossings,
+          });
         } else if (kind === "budget_set") {
           const parsed = costAuditPayloadFromJsonValue(
             kind,
@@ -307,6 +380,11 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     storedCrossings.set(crossingKey(row.budgetId, row.budgetSetLsn, row.thresholdBps), row);
   }
   compareCrossings(replayedCrossings, storedCrossings, discrepancies);
+  // Oracle check: compare the independently-derived `expectedCrossings`
+  // against the crossings replayed from the event log itself. Catches
+  // reactor bugs the event-log-as-oracle replay misses (the missing
+  // event is missing in both the log and the projection).
+  compareExpectedAndLoggedCrossings(expectedCrossings, replayedCrossings, discrepancies);
 
   const highest = highestLsnStmt.get()?.lsn ?? 0;
   return {
@@ -588,6 +666,154 @@ function eventTypeToKind(type: string): AuditEventKind | "other" {
   if (type === "cost.budget.set") return "budget_set";
   if (type === "cost.budget.threshold.crossed") return "budget_threshold_crossed";
   return "other";
+}
+
+interface ExpectedCrossing {
+  readonly budgetId: string;
+  readonly budgetSetLsn: number;
+  readonly thresholdBps: number;
+  readonly crossedAtLsn: number;
+  readonly observedMicroUsd: number;
+  readonly limitMicroUsd: number;
+}
+
+interface ComputeExpectedCrossingsArgs {
+  readonly costEventLsn: number;
+  readonly agentSlug: string;
+  readonly taskId: string | undefined;
+  readonly budgets: ReadonlyMap<string, ReplayedBudget>;
+  readonly globalLifetime: number;
+  readonly agentLifetime: ReadonlyMap<string, number>;
+  readonly taskLifetime: ReadonlyMap<string, number>;
+  readonly out: Map<string, ExpectedCrossing>;
+}
+
+// Independent threshold-crossing oracle for a single cost_event. Mirrors
+// the reactor's logic (`processCostEventForCrossings` in reactor.ts) but
+// derives `observed` from oracle-maintained lifetime trackers rather than
+// reading `cost_by_agent` / `cost_by_task` from disk. The crossing math
+// (`crossesThresholdBigInt`) MUST stay byte-identical with the reactor's
+// `crossesThreshold`; if they diverge, this oracle becomes a tautology.
+function computeExpectedCrossings(args: ComputeExpectedCrossingsArgs): void {
+  for (const [budgetId, budget] of args.budgets.entries()) {
+    if (budget.tombstoned) continue;
+    if (!isOracleApplicable(budget, args.agentSlug, args.taskId)) continue;
+    const observed = oracleObservedFor(budget, args);
+    if (observed === 0 && budget.limitMicroUsd === 0) continue;
+    for (const thresholdBps of budget.thresholdsBps) {
+      const key = crossingKey(budgetId, budget.setAtLsn, thresholdBps);
+      if (args.out.has(key)) continue;
+      if (!crossesThresholdBigInt(observed, budget.limitMicroUsd, thresholdBps)) continue;
+      args.out.set(key, {
+        budgetId,
+        budgetSetLsn: budget.setAtLsn,
+        thresholdBps,
+        crossedAtLsn: args.costEventLsn,
+        observedMicroUsd: observed,
+        limitMicroUsd: budget.limitMicroUsd,
+      });
+    }
+  }
+}
+
+function isOracleApplicable(
+  budget: ReplayedBudget,
+  agentSlug: string,
+  taskId: string | undefined,
+): boolean {
+  if (budget.scope === "global") return true;
+  if (budget.scope === "agent") return budget.subjectId === agentSlug;
+  if (budget.scope === "task") return taskId !== undefined && budget.subjectId === taskId;
+  return false;
+}
+
+function oracleObservedFor(budget: ReplayedBudget, args: ComputeExpectedCrossingsArgs): number {
+  if (budget.scope === "global") return args.globalLifetime;
+  if (budget.scope === "agent") return args.agentLifetime.get(args.agentSlug) ?? 0;
+  // task scope — caller already gated on taskId !== undefined.
+  if (args.taskId === undefined) return 0;
+  return args.taskLifetime.get(args.taskId) ?? 0;
+}
+
+/**
+ * Integer threshold test in BigInt — byte-identical to the reactor's
+ * `crossesThreshold` (see reactor.ts:313). The operand bounds make the
+ * intermediate product reach 1e16, above Number.MAX_SAFE_INTEGER, so
+ * Number-multiplication would silently truncate; BigInt is exact across
+ * the full documented range. If you change the reactor's math, change
+ * this too — otherwise the oracle becomes a tautology.
+ */
+function crossesThresholdBigInt(observed: number, limit: number, thresholdBps: number): boolean {
+  if (limit === 0) return false;
+  return BigInt(observed) * 10_000n >= BigInt(limit) * BigInt(thresholdBps);
+}
+
+function compareExpectedAndLoggedCrossings(
+  expected: ReadonlyMap<string, ExpectedCrossing>,
+  logged: ReadonlyMap<string, ReplayedCrossing>,
+  out: ReplayDiscrepancy[],
+): void {
+  for (const [key, exp] of expected.entries()) {
+    const log = logged.get(key);
+    if (log === undefined) {
+      out.push({
+        kind: "threshold_crossing_unemitted",
+        budgetId: exp.budgetId as BudgetId,
+        budgetSetLsn: lsnFromV1Number(exp.budgetSetLsn),
+        thresholdBps: exp.thresholdBps,
+        observedMicroUsd: exp.observedMicroUsd as MicroUsd,
+        limitMicroUsd: exp.limitMicroUsd as MicroUsd,
+        crossedAtLsn: lsnFromV1Number(exp.crossedAtLsn),
+      });
+      continue;
+    }
+    if (log.crossedAtLsn !== exp.crossedAtLsn) {
+      out.push({
+        kind: "threshold_crossing_oracle_field_mismatch",
+        budgetId: exp.budgetId as BudgetId,
+        budgetSetLsn: lsnFromV1Number(exp.budgetSetLsn),
+        thresholdBps: exp.thresholdBps,
+        field: "crossedAtLsn",
+        expected: exp.crossedAtLsn,
+        logged: log.crossedAtLsn,
+      });
+    }
+    if (log.observedMicroUsd !== exp.observedMicroUsd) {
+      out.push({
+        kind: "threshold_crossing_oracle_field_mismatch",
+        budgetId: exp.budgetId as BudgetId,
+        budgetSetLsn: lsnFromV1Number(exp.budgetSetLsn),
+        thresholdBps: exp.thresholdBps,
+        field: "observedMicroUsd",
+        expected: exp.observedMicroUsd,
+        logged: log.observedMicroUsd,
+      });
+    }
+    if (log.limitMicroUsd !== exp.limitMicroUsd) {
+      out.push({
+        kind: "threshold_crossing_oracle_field_mismatch",
+        budgetId: exp.budgetId as BudgetId,
+        budgetSetLsn: lsnFromV1Number(exp.budgetSetLsn),
+        thresholdBps: exp.thresholdBps,
+        field: "limitMicroUsd",
+        expected: exp.limitMicroUsd,
+        logged: log.limitMicroUsd,
+      });
+    }
+  }
+  for (const [key, log] of logged.entries()) {
+    if (!expected.has(key)) {
+      out.push({
+        kind: "threshold_crossing_spurious",
+        budgetId: log.budgetId as BudgetId,
+        budgetSetLsn: lsnFromV1Number(log.budgetSetLsn),
+        thresholdBps: log.thresholdBps,
+        observedMicroUsd: log.observedMicroUsd as MicroUsd,
+        limitMicroUsd: log.limitMicroUsd as MicroUsd,
+        crossedAtLsn: lsnFromV1Number(log.crossedAtLsn),
+      });
+    }
+  }
 }
 
 // Used only inside the batch loop; importing the type without using it

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -214,6 +214,40 @@ export type ReplayDiscrepancy =
       readonly crossedAtLsn: EventLsn;
     }
   | {
+      // Oracle: the reactor's strongest invariant is that threshold
+      // events are appended SYNCHRONOUSLY immediately after their
+      // triggering `cost.event`, all inside the same SQLite
+      // transaction. So for a cost.event at LSN X with K legitimate
+      // crossings, the threshold-event LSNs MUST be {X+1, …, X+K}.
+      // A forged or delayed event appended much later (after a
+      // tombstone, budget reset, or arbitrary gap) would otherwise
+      // pass causal-order + reference + field checks. This variant
+      // catches the gap.
+      readonly kind: "threshold_crossing_delayed_emission";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly eventLsn: EventLsn;
+      readonly crossedAtLsn: EventLsn;
+      readonly expectedWindowMinLsn: EventLsn;
+      readonly expectedWindowMaxLsn: EventLsn;
+    }
+  | {
+      // Oracle: a `cost.budget.threshold.crossed` event names a
+      // `budgetSetLsn` that has no corresponding `cost.budget.set` in
+      // event_log. Sibling of `dangling_reference` for the budget
+      // side. Catches forgeries that point at an unrelated row OR
+      // at a budgetSet for a different budgetId.
+      readonly kind: "threshold_crossing_invalid_budget_set_reference";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly eventLsn: EventLsn;
+      readonly reason: "lsn_not_a_budget_set" | "budget_id_mismatch";
+      /** When `reason === "budget_id_mismatch"`, the actual budgetId at the named LSN. */
+      readonly actualBudgetId?: BudgetId;
+    }
+  | {
       // Surface unparseable event-log rows distinctly so on-call sees the
       // failing LSN, event type, and parse reason instead of a bare
       // `internal_error` from the route.
@@ -317,6 +351,10 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     // (the reactor sets it from `input.occurredAt`). Stored as ms-
     // since-epoch for cheap comparison.
     const costEventOccurredAtMs = new Map<number, number>();
+    // Budget-set LSN → budgetId map for validating logged threshold
+    // events' `budgetSetLsn` references — sibling to the
+    // `costEventOccurredAtMs` check for `crossedAtLsn`.
+    const budgetSetLsnToBudgetId = new Map<number, string>();
     // Oracle: independent threshold replay. Tracks the same lifetime
     // sums the reactor reads (`lifetimeFor` in reactor.ts), then
     // re-runs the same integer/BigInt crossing math against current
@@ -394,6 +432,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
               setAtLsn: row.lsn,
               tombstoned: (parsed.limitMicroUsd as number) === 0,
             });
+            budgetSetLsnToBudgetId.set(row.lsn, parsed.budgetId);
           } else if (kind === "budget_threshold_crossed") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
@@ -474,6 +513,11 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     // (LSN not a cost.event) and per-duplicate `crossedAt` drift that
     // the first-entry-only oracle comparator can't see.
     validateLoggedCrossingReferences(replayedCrossings, costEventOccurredAtMs, discrepancies);
+    validateBudgetSetReferences(replayedCrossings, budgetSetLsnToBudgetId, discrepancies);
+    // Contiguous-emission window check: enforces the reactor's
+    // same-transaction invariant. Catches forgeries that pass every
+    // other check by being appended much later than the cost.event.
+    detectDelayedEmissions(replayedCrossings, expectedCrossings, discrepancies);
     compareExpectedAndLoggedCrossings(expectedCrossings, replayedCrossings, discrepancies);
 
     const highest = highestLsnStmt.get()?.lsn ?? 0;
@@ -617,6 +661,82 @@ function detectCausalOrderViolations(
           thresholdBps: entry.thresholdBps,
           eventLsn: lsnFromV1Number(entry.eventLsn),
           crossedAtLsn: lsnFromV1Number(entry.crossedAtLsn),
+        });
+      }
+    }
+  }
+}
+
+function validateBudgetSetReferences(
+  replayed: ReadonlyMap<string, readonly ReplayedCrossing[]>,
+  budgetSetLsnToBudgetId: ReadonlyMap<number, string>,
+  out: ReplayDiscrepancy[],
+): void {
+  for (const entries of replayed.values()) {
+    for (const entry of entries) {
+      const actualBudgetId = budgetSetLsnToBudgetId.get(entry.budgetSetLsn);
+      if (actualBudgetId === undefined) {
+        out.push({
+          kind: "threshold_crossing_invalid_budget_set_reference",
+          budgetId: entry.budgetId as BudgetId,
+          budgetSetLsn: lsnFromV1Number(entry.budgetSetLsn),
+          thresholdBps: entry.thresholdBps,
+          eventLsn: lsnFromV1Number(entry.eventLsn),
+          reason: "lsn_not_a_budget_set",
+        });
+        continue;
+      }
+      if (actualBudgetId !== entry.budgetId) {
+        out.push({
+          kind: "threshold_crossing_invalid_budget_set_reference",
+          budgetId: entry.budgetId as BudgetId,
+          budgetSetLsn: lsnFromV1Number(entry.budgetSetLsn),
+          thresholdBps: entry.thresholdBps,
+          eventLsn: lsnFromV1Number(entry.eventLsn),
+          reason: "budget_id_mismatch",
+          actualBudgetId: actualBudgetId as BudgetId,
+        });
+      }
+    }
+  }
+}
+
+function detectDelayedEmissions(
+  replayed: ReadonlyMap<string, readonly ReplayedCrossing[]>,
+  expected: ReadonlyMap<string, ExpectedCrossing>,
+  out: ReplayDiscrepancy[],
+): void {
+  // Count expected crossings per triggering cost-event LSN. That count
+  // IS the size of the contiguous emission window the reactor would
+  // produce in the same SQLite transaction as the cost.event.
+  const expectedCountByCostEventLsn = new Map<number, number>();
+  for (const exp of expected.values()) {
+    expectedCountByCostEventLsn.set(
+      exp.crossedAtLsn,
+      (expectedCountByCostEventLsn.get(exp.crossedAtLsn) ?? 0) + 1,
+    );
+  }
+  for (const entries of replayed.values()) {
+    for (const entry of entries) {
+      // Spurious entries (no expected crossing for this key) are
+      // surfaced by `compareExpectedAndLoggedCrossings`; skip them
+      // here to avoid double-noise.
+      const key = crossingKey(entry.budgetId, entry.budgetSetLsn, entry.thresholdBps);
+      if (!expected.has(key)) continue;
+      const expectedCount = expectedCountByCostEventLsn.get(entry.crossedAtLsn) ?? 0;
+      if (expectedCount === 0) continue; // unreachable: expected.has(key) implies the count is ≥1
+      const minLsn = entry.crossedAtLsn + 1;
+      const maxLsn = entry.crossedAtLsn + expectedCount;
+      if (entry.eventLsn < minLsn || entry.eventLsn > maxLsn) {
+        out.push({
+          kind: "threshold_crossing_delayed_emission",
+          budgetId: entry.budgetId as BudgetId,
+          budgetSetLsn: lsnFromV1Number(entry.budgetSetLsn),
+          thresholdBps: entry.thresholdBps,
+          eventLsn: lsnFromV1Number(entry.eventLsn),
+          crossedAtLsn: lsnFromV1Number(entry.crossedAtLsn),
+          expectedWindowMinLsn: lsnFromV1Number(minLsn),
+          expectedWindowMaxLsn: lsnFromV1Number(maxLsn),
         });
       }
     }
@@ -855,8 +975,18 @@ function parseStoredThresholds(raw: string): readonly number[] | { readonly erro
   if (!Array.isArray(parsed)) {
     return { error: "thresholds_bps is not an array" };
   }
-  if (parsed.some((n) => typeof n !== "number")) {
-    return { error: "thresholds_bps contains non-number entries" };
+  // Mirror the protocol's `BudgetSetAuditPayload.thresholdsBps`
+  // validation: each entry must be a positive safe-integer ≤ 10_000.
+  // Round-3 hardening: a bare `typeof === "number"` check accepted
+  // `Infinity` (from `JSON.parse("[1e999]")`), which would later JSON-
+  // serialize as `null` and lose the corruption signal. Round-3 fix:
+  // explicit `Number.isSafeInteger` + bounds.
+  for (const n of parsed) {
+    if (typeof n !== "number" || !Number.isSafeInteger(n) || n <= 0 || n > 10_000) {
+      return {
+        error: `thresholds_bps contains invalid entry ${String(n)} (expected positive safe integer ≤ 10000)`,
+      };
+    }
   }
   return parsed as readonly number[];
 }

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -200,6 +200,20 @@ export type ReplayDiscrepancy =
       readonly crossedAtLsn: EventLsn;
     }
   | {
+      // Oracle: a `cost.budget.threshold.crossed` event names a
+      // `crossedAtLsn` that has no corresponding `cost.event` in
+      // event_log. Catches forged references that name an unrelated
+      // LSN (e.g. a `cost.budget.set` row) — the existing causal-order
+      // check only validates the numeric ordering, not that the
+      // referenced row is actually a cost event.
+      readonly kind: "threshold_crossing_dangling_reference";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly eventLsn: EventLsn;
+      readonly crossedAtLsn: EventLsn;
+    }
+  | {
       // Surface unparseable event-log rows distinctly so on-call sees the
       // failing LSN, event type, and parse reason instead of a bare
       // `internal_error` from the route.
@@ -454,6 +468,12 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     // most actionable findings at the top of the list.
     detectDuplicateLoggedCrossings(replayedCrossings, discrepancies);
     detectCausalOrderViolations(replayedCrossings, discrepancies);
+    // Per-entry reference validation: every logged threshold event
+    // names a `crossedAtLsn`; this checks each one against the actual
+    // cost-event LSN→occurredAt map. Catches forged dangling refs
+    // (LSN not a cost.event) and per-duplicate `crossedAt` drift that
+    // the first-entry-only oracle comparator can't see.
+    validateLoggedCrossingReferences(replayedCrossings, costEventOccurredAtMs, discrepancies);
     compareExpectedAndLoggedCrossings(expectedCrossings, replayedCrossings, discrepancies);
 
     const highest = highestLsnStmt.get()?.lsn ?? 0;
@@ -603,6 +623,49 @@ function detectCausalOrderViolations(
   }
 }
 
+function validateLoggedCrossingReferences(
+  replayed: ReadonlyMap<string, readonly ReplayedCrossing[]>,
+  costEventOccurredAtMs: ReadonlyMap<number, number>,
+  out: ReplayDiscrepancy[],
+): void {
+  for (const entries of replayed.values()) {
+    for (const entry of entries) {
+      const referencedMs = costEventOccurredAtMs.get(entry.crossedAtLsn);
+      if (referencedMs === undefined) {
+        // The named trigger LSN doesn't correspond to any cost.event
+        // we replayed. Either the threshold event names a non-cost
+        // row (e.g. a `cost.budget.set` LSN) or an LSN that doesn't
+        // exist in event_log.
+        out.push({
+          kind: "threshold_crossing_dangling_reference",
+          budgetId: entry.budgetId as BudgetId,
+          budgetSetLsn: lsnFromV1Number(entry.budgetSetLsn),
+          thresholdBps: entry.thresholdBps,
+          eventLsn: lsnFromV1Number(entry.eventLsn),
+          crossedAtLsn: lsnFromV1Number(entry.crossedAtLsn),
+        });
+        continue;
+      }
+      if (referencedMs !== entry.crossedAtMs) {
+        // The threshold event's payload `crossedAt` doesn't match the
+        // cost.event it names as trigger. Catches forged timestamps
+        // (key matches but timestamp drifts) AND per-duplicate
+        // divergence the first-entry-only oracle comparator misses.
+        out.push({
+          kind: "threshold_crossing_oracle_field_mismatch",
+          budgetId: entry.budgetId as BudgetId,
+          budgetSetLsn: lsnFromV1Number(entry.budgetSetLsn),
+          thresholdBps: entry.thresholdBps,
+          field: "crossedAtMs",
+          expected: referencedMs,
+          logged: entry.crossedAtMs,
+          eventLsn: lsnFromV1Number(entry.eventLsn),
+        });
+      }
+    }
+  }
+}
+
 interface ReplayedBudget {
   readonly scope: "global" | "agent" | "task";
   readonly subjectId: string | null;
@@ -718,7 +781,20 @@ function compareBudgets(
       });
     }
     const storedThresholds = parseStoredThresholds(storedRow.thresholdsBps);
-    if (!arraysEqual(storedThresholds, replayedRow.thresholdsBps)) {
+    if ("error" in storedThresholds) {
+      // Corrupted/unparseable `thresholds_bps` projection cell. A bare
+      // `JSON.parse` here used to throw out of `runReplayCheck`,
+      // blinding the diagnostic; surface a structured discrepancy so
+      // on-call sees the exact budget + reason and the rest of the
+      // check still runs.
+      out.push({
+        kind: "budget_state_mismatch",
+        budgetId: budgetId as BudgetId,
+        field: "thresholdsBps",
+        replayed: replayedRow.thresholdsBps,
+        stored: { unparseable: storedThresholds.error, raw: storedRow.thresholdsBps },
+      });
+    } else if (!arraysEqual(storedThresholds, replayedRow.thresholdsBps)) {
       out.push({
         kind: "budget_state_mismatch",
         budgetId: budgetId as BudgetId,
@@ -769,10 +845,18 @@ function splitAgentDayKey(key: string): { readonly agentSlug: string; readonly d
   return { agentSlug: key.slice(0, idx), dayUtc: key.slice(idx + 1) };
 }
 
-function parseStoredThresholds(raw: string): readonly number[] {
-  const parsed: unknown = JSON.parse(raw);
-  if (!Array.isArray(parsed) || parsed.some((n) => typeof n !== "number")) {
-    return [];
+function parseStoredThresholds(raw: string): readonly number[] | { readonly error: string } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+  if (!Array.isArray(parsed)) {
+    return { error: "thresholds_bps is not an array" };
+  }
+  if (parsed.some((n) => typeof n !== "number")) {
+    return { error: "thresholds_bps contains non-number entries" };
   }
   return parsed as readonly number[];
 }
@@ -935,21 +1019,9 @@ function compareExpectedAndLoggedCrossings(
         eventLsn: lsnFromV1Number(log.eventLsn),
       });
     }
-    if (log.crossedAtMs !== exp.crossedAtMs) {
-      // Reactor sets `crossedAt` from the triggering cost event's
-      // `occurredAt`. Drift here means the audit timestamp was forged
-      // or the reactor desynced from the cost-event payload.
-      out.push({
-        kind: "threshold_crossing_oracle_field_mismatch",
-        budgetId: exp.budgetId as BudgetId,
-        budgetSetLsn: lsnFromV1Number(exp.budgetSetLsn),
-        thresholdBps: exp.thresholdBps,
-        field: "crossedAtMs",
-        expected: exp.crossedAtMs,
-        logged: log.crossedAtMs,
-        eventLsn: lsnFromV1Number(log.eventLsn),
-      });
-    }
+    // `crossedAtMs` is validated per-entry against the cost-event LSN
+    // map in `validateLoggedCrossingReferences`, which also covers
+    // duplicates and spurious entries that this comparator skips.
   }
   for (const [key, entries] of logged.entries()) {
     if (expected.has(key)) continue;

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -140,6 +140,9 @@ export type ReplayDiscrepancy =
       // from `threshold_crossing_ghost` — that variant is projection-row
       // drift from event log. This variant is event-log drift from the
       // oracle's view of cost events + budgets.
+      //
+      // `eventLsn` is the `event_log.lsn` of the offending threshold
+      // audit row so on-call can locate and surgically inspect it.
       readonly kind: "threshold_crossing_spurious";
       readonly budgetId: BudgetId;
       readonly budgetSetLsn: EventLsn;
@@ -147,19 +150,54 @@ export type ReplayDiscrepancy =
       readonly observedMicroUsd: MicroUsd;
       readonly limitMicroUsd: MicroUsd;
       readonly crossedAtLsn: EventLsn;
+      readonly eventLsn: EventLsn;
     }
   | {
       // Oracle: same (budget, epoch, threshold) exists in both the event
       // log and the oracle, but one of the recorded fields disagrees.
       // Most likely cause: the reactor and oracle diverged on which
       // cost_event was the trigger or what cumulative sum was observed.
+      //
+      // `crossedAtMs` is the `crossedAt` timestamp converted to ms-since-
+      // epoch so all four fields share a `number` shape; on-call who
+      // wants the human-readable timestamp can `new Date(value)`.
       readonly kind: "threshold_crossing_oracle_field_mismatch";
       readonly budgetId: BudgetId;
       readonly budgetSetLsn: EventLsn;
       readonly thresholdBps: number;
-      readonly field: "crossedAtLsn" | "observedMicroUsd" | "limitMicroUsd";
+      readonly field: "crossedAtLsn" | "observedMicroUsd" | "limitMicroUsd" | "crossedAtMs";
       readonly expected: number;
       readonly logged: number;
+      readonly eventLsn: EventLsn;
+    }
+  | {
+      // Oracle: more than one `cost.budget.threshold.crossed` event in
+      // event_log shares the same `(budgetId, budgetSetLsn, thresholdBps)`
+      // key. The projection PK suppresses duplicate rows
+      // (`cost_threshold_crossings`) and `replayedCrossings` keys would
+      // collapse duplicates into one entry, so the prior comparator
+      // couldn't see this. A reactor over-emission bug or a forged
+      // duplicate audit event surfaces here.
+      readonly kind: "threshold_crossing_duplicate_event";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly eventLsns: readonly EventLsn[];
+    }
+  | {
+      // Oracle: the reactor invariant is that a `cost.budget.threshold.crossed`
+      // event is appended AFTER its triggering `cost.event` in the same
+      // SQLite transaction, so `eventLsn > crossedAtLsn` must hold. A
+      // payload claiming a later cost-event LSN than its own
+      // event_log row LSN means either a forgery or a reactor regression
+      // that violates the §15.A "every commit reproduces state at every
+      // LSN" invariant.
+      readonly kind: "threshold_crossing_causal_order_violation";
+      readonly budgetId: BudgetId;
+      readonly budgetSetLsn: EventLsn;
+      readonly thresholdBps: number;
+      readonly eventLsn: EventLsn;
+      readonly crossedAtLsn: EventLsn;
     }
   | {
       // Surface unparseable event-log rows distinctly so on-call sees the
@@ -240,159 +278,193 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
      FROM cost_threshold_crossings`,
   );
 
-  const replayedAgentDays = new Map<string, number>();
-  const replayedTasks = new Map<string, number>();
-  const replayedBudgets = new Map<string, ReplayedBudget>();
-  const replayedCrossings = new Map<string, ReplayedCrossing>();
-  // Oracle: independent threshold replay. Tracks the same lifetime sums
-  // the reactor reads (`lifetimeFor` in reactor.ts), then re-runs the
-  // same integer/BigInt crossing math against current `replayedBudgets`
-  // to derive an expected crossing set without consulting the event log.
-  // Discrepancies between `expectedCrossings` and `replayedCrossings`
-  // surface reactor bugs (under-emission, spurious emission, field drift)
-  // that the event-log-as-oracle replay can't detect.
-  let oracleGlobalLifetime = 0;
-  const oracleAgentLifetime = new Map<string, number>();
-  const oracleTaskLifetime = new Map<string, number>();
-  const expectedCrossings = new Map<string, ExpectedCrossing>();
-  // Collect per-row parse failures as structured discrepancies instead
-  // of throwing out of the loop.
-  const parseFailures: ReplayDiscrepancy[] = [];
+  // Round-2 fix: run all reads inside a single SQLite snapshot. The
+  // file header used to claim WAL gave us this for free; it doesn't —
+  // better-sqlite3 only snapshots within an explicit transaction.
+  // `.deferred()` acquires a SHARED lock on first read and holds it
+  // through the rest of the function; concurrent writers can still
+  // commit but this function won't observe them, so replay-vs-stored
+  // can't mix snapshots.
+  const txn = db.transaction((): ReplayCheckReport => {
+    const replayedAgentDays = new Map<string, number>();
+    const replayedTasks = new Map<string, number>();
+    const replayedBudgets = new Map<string, ReplayedBudget>();
+    // Logged crossings: one entry per (budgetId, budgetSetLsn,
+    // thresholdBps) key, BUT each entry carries every event_log row
+    // that claimed the key. The projection PK suppresses duplicate
+    // rows, so a duplicate threshold-crossed event would silently
+    // collapse — without this we'd miss reactor over-emission and
+    // forged duplicates. `compareCrossings` continues to compare on
+    // the first entry per key for log-vs-projection drift; the new
+    // duplicate check fires when `length > 1`.
+    const replayedCrossings = new Map<string, ReplayedCrossing[]>();
+    // Cost-event triggering timestamps, keyed by cost-event LSN, so
+    // `crossedAt` can be validated against the actual triggering event
+    // (the reactor sets it from `input.occurredAt`). Stored as ms-
+    // since-epoch for cheap comparison.
+    const costEventOccurredAtMs = new Map<number, number>();
+    // Oracle: independent threshold replay. Tracks the same lifetime
+    // sums the reactor reads (`lifetimeFor` in reactor.ts), then
+    // re-runs the same integer/BigInt crossing math against current
+    // `replayedBudgets` to derive an expected crossing set without
+    // consulting the event log. Discrepancies between
+    // `expectedCrossings` and `replayedCrossings` surface reactor bugs
+    // (under-emission, spurious, field drift, duplicate, causal order)
+    // that the event-log-as-oracle replay can't detect.
+    let oracleGlobalLifetime = 0;
+    const oracleAgentLifetime = new Map<string, number>();
+    const oracleTaskLifetime = new Map<string, number>();
+    const expectedCrossings = new Map<string, ExpectedCrossing>();
+    // Collect per-row parse failures as structured discrepancies
+    // instead of throwing out of the loop.
+    const parseFailures: ReplayDiscrepancy[] = [];
 
-  let cursor = 0;
-  let scanned = 0;
-  for (;;) {
-    const rows = readBatchStmt.all(cursor, BATCH_SIZE);
-    if (rows.length === 0) break;
-    for (const row of rows) {
-      const kind = eventTypeToKind(row.type);
-      try {
-        if (kind === "cost_event") {
-          const parsed = costAuditPayloadFromJsonValue(
-            kind,
-            JSON.parse(row.payload.toString("utf8")),
-          ) as CostEventAuditPayload;
-          const dayUtc = parsed.occurredAt.toISOString().slice(0, 10);
-          const agentKey = agentDayKey(parsed.agentSlug, dayUtc);
-          const amount = parsed.amountMicroUsd as number;
-          replayedAgentDays.set(agentKey, (replayedAgentDays.get(agentKey) ?? 0) + amount);
-          if (parsed.taskId !== undefined) {
-            replayedTasks.set(parsed.taskId, (replayedTasks.get(parsed.taskId) ?? 0) + amount);
-          }
-          // Oracle update: mirror the reactor's post-update lifetime read.
-          // The reactor runs after `cost_by_agent`/`cost_by_task` have
-          // been updated for the current event, so `observed` includes
-          // the event's own amount.
-          oracleGlobalLifetime += amount;
-          oracleAgentLifetime.set(
-            parsed.agentSlug,
-            (oracleAgentLifetime.get(parsed.agentSlug) ?? 0) + amount,
-          );
-          if (parsed.taskId !== undefined) {
-            oracleTaskLifetime.set(
-              parsed.taskId,
-              (oracleTaskLifetime.get(parsed.taskId) ?? 0) + amount,
+    let cursor = 0;
+    let scanned = 0;
+    for (;;) {
+      const rows = readBatchStmt.all(cursor, BATCH_SIZE);
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        const kind = eventTypeToKind(row.type);
+        try {
+          if (kind === "cost_event") {
+            const parsed = costAuditPayloadFromJsonValue(
+              kind,
+              JSON.parse(row.payload.toString("utf8")),
+            ) as CostEventAuditPayload;
+            const occurredAtMs = parsed.occurredAt.getTime();
+            costEventOccurredAtMs.set(row.lsn, occurredAtMs);
+            const dayUtc = parsed.occurredAt.toISOString().slice(0, 10);
+            const agentKey = agentDayKey(parsed.agentSlug, dayUtc);
+            const amount = parsed.amountMicroUsd as number;
+            replayedAgentDays.set(agentKey, (replayedAgentDays.get(agentKey) ?? 0) + amount);
+            if (parsed.taskId !== undefined) {
+              replayedTasks.set(parsed.taskId, (replayedTasks.get(parsed.taskId) ?? 0) + amount);
+            }
+            // Oracle update: mirror the reactor's post-update lifetime
+            // read. The reactor runs after `cost_by_agent` /
+            // `cost_by_task` have been updated for the current event,
+            // so `observed` includes the event's own amount.
+            oracleGlobalLifetime += amount;
+            oracleAgentLifetime.set(
+              parsed.agentSlug,
+              (oracleAgentLifetime.get(parsed.agentSlug) ?? 0) + amount,
             );
+            if (parsed.taskId !== undefined) {
+              oracleTaskLifetime.set(
+                parsed.taskId,
+                (oracleTaskLifetime.get(parsed.taskId) ?? 0) + amount,
+              );
+            }
+            computeExpectedCrossings({
+              costEventLsn: row.lsn,
+              costEventOccurredAtMs: occurredAtMs,
+              agentSlug: parsed.agentSlug,
+              taskId: parsed.taskId,
+              budgets: replayedBudgets,
+              globalLifetime: oracleGlobalLifetime,
+              agentLifetime: oracleAgentLifetime,
+              taskLifetime: oracleTaskLifetime,
+              out: expectedCrossings,
+            });
+          } else if (kind === "budget_set") {
+            const parsed = costAuditPayloadFromJsonValue(
+              kind,
+              JSON.parse(row.payload.toString("utf8")),
+            ) as BudgetSetAuditPayload;
+            replayedBudgets.set(parsed.budgetId, {
+              scope: parsed.scope,
+              subjectId: parsed.subjectId ?? null,
+              limitMicroUsd: parsed.limitMicroUsd as number,
+              thresholdsBps: [...parsed.thresholdsBps],
+              setAtLsn: row.lsn,
+              tombstoned: (parsed.limitMicroUsd as number) === 0,
+            });
+          } else if (kind === "budget_threshold_crossed") {
+            const parsed = costAuditPayloadFromJsonValue(
+              kind,
+              JSON.parse(row.payload.toString("utf8")),
+            ) as BudgetThresholdCrossedAuditPayload;
+            const budgetSetLsnInt = parseLsn(parsed.budgetSetLsn).localLsn;
+            const crossedAtLsnInt = parseLsn(parsed.crossedAtLsn).localLsn;
+            const key = crossingKey(parsed.budgetId, budgetSetLsnInt, parsed.thresholdBps);
+            const entry: ReplayedCrossing = {
+              budgetId: parsed.budgetId,
+              budgetSetLsn: budgetSetLsnInt,
+              thresholdBps: parsed.thresholdBps,
+              crossedAtLsn: crossedAtLsnInt,
+              observedMicroUsd: parsed.observedMicroUsd as number,
+              limitMicroUsd: parsed.limitMicroUsd as number,
+              crossedAtMs: parsed.crossedAt.getTime(),
+              eventLsn: row.lsn,
+            };
+            const existing = replayedCrossings.get(key);
+            if (existing === undefined) {
+              replayedCrossings.set(key, [entry]);
+            } else {
+              existing.push(entry);
+            }
           }
-          computeExpectedCrossings({
-            costEventLsn: row.lsn,
-            agentSlug: parsed.agentSlug,
-            taskId: parsed.taskId,
-            budgets: replayedBudgets,
-            globalLifetime: oracleGlobalLifetime,
-            agentLifetime: oracleAgentLifetime,
-            taskLifetime: oracleTaskLifetime,
-            out: expectedCrossings,
-          });
-        } else if (kind === "budget_set") {
-          const parsed = costAuditPayloadFromJsonValue(
-            kind,
-            JSON.parse(row.payload.toString("utf8")),
-          ) as BudgetSetAuditPayload;
-          replayedBudgets.set(parsed.budgetId, {
-            scope: parsed.scope,
-            subjectId: parsed.subjectId ?? null,
-            limitMicroUsd: parsed.limitMicroUsd as number,
-            thresholdsBps: [...parsed.thresholdsBps],
-            setAtLsn: row.lsn,
-            tombstoned: (parsed.limitMicroUsd as number) === 0,
-          });
-        } else if (kind === "budget_threshold_crossed") {
-          // H1 fix: replay every threshold-crossed event into an expected
-          // (budget_id, budget_set_lsn, threshold_bps) → row map. The
-          // comparison below catches missing, ghost, and field-mismatch
-          // drift against cost_threshold_crossings.
-          const parsed = costAuditPayloadFromJsonValue(
-            kind,
-            JSON.parse(row.payload.toString("utf8")),
-          ) as BudgetThresholdCrossedAuditPayload;
-          const budgetSetLsnInt = parseLsn(parsed.budgetSetLsn).localLsn;
-          const crossedAtLsnInt = parseLsn(parsed.crossedAtLsn).localLsn;
-          const key = crossingKey(parsed.budgetId, budgetSetLsnInt, parsed.thresholdBps);
-          replayedCrossings.set(key, {
-            budgetId: parsed.budgetId,
-            budgetSetLsn: budgetSetLsnInt,
-            thresholdBps: parsed.thresholdBps,
-            crossedAtLsn: crossedAtLsnInt,
-            observedMicroUsd: parsed.observedMicroUsd as number,
-            limitMicroUsd: parsed.limitMicroUsd as number,
+        } catch (err) {
+          parseFailures.push({
+            kind: "event_payload_unparseable",
+            lsn: lsnFromV1Number(row.lsn),
+            type: row.type,
+            reason: err instanceof Error ? err.message : String(err),
           });
         }
-      } catch (err) {
-        parseFailures.push({
-          kind: "event_payload_unparseable",
-          lsn: lsnFromV1Number(row.lsn),
-          type: row.type,
-          reason: err instanceof Error ? err.message : String(err),
-        });
+        scanned += 1;
       }
-      scanned += 1;
+      cursor = rows[rows.length - 1]?.lsn ?? cursor;
     }
-    cursor = rows[rows.length - 1]?.lsn ?? cursor;
-  }
 
-  // Surface per-row parse failures first so on-call sees them at the top
-  // of the discrepancies list; downstream comparators may emit
-  // sum-mismatch discrepancies for the same rows but the parse-failure
-  // is the root cause.
-  const discrepancies: ReplayDiscrepancy[] = [...parseFailures];
+    // Surface per-row parse failures first so on-call sees them at the
+    // top of the discrepancies list; downstream comparators may emit
+    // sum-mismatch discrepancies for the same rows but the
+    // parse-failure is the root cause.
+    const discrepancies: ReplayDiscrepancy[] = [...parseFailures];
 
-  const storedAgentDays = new Map<string, number>();
-  for (const row of listAgentDaysStmt.all()) {
-    storedAgentDays.set(agentDayKey(row.agentSlug, row.dayUtc), row.totalMicroUsd);
-  }
-  compareAgentDays(replayedAgentDays, storedAgentDays, discrepancies);
+    const storedAgentDays = new Map<string, number>();
+    for (const row of listAgentDaysStmt.all()) {
+      storedAgentDays.set(agentDayKey(row.agentSlug, row.dayUtc), row.totalMicroUsd);
+    }
+    compareAgentDays(replayedAgentDays, storedAgentDays, discrepancies);
 
-  const storedTasks = new Map<string, number>();
-  for (const row of listTasksStmt.all()) {
-    storedTasks.set(row.taskId, row.totalMicroUsd);
-  }
-  compareTasks(replayedTasks, storedTasks, discrepancies);
+    const storedTasks = new Map<string, number>();
+    for (const row of listTasksStmt.all()) {
+      storedTasks.set(row.taskId, row.totalMicroUsd);
+    }
+    compareTasks(replayedTasks, storedTasks, discrepancies);
 
-  const storedBudgets = new Map<string, BudgetDbRow>();
-  for (const row of listBudgetsStmt.all()) {
-    storedBudgets.set(row.budgetId, row);
-  }
-  compareBudgets(replayedBudgets, storedBudgets, discrepancies);
+    const storedBudgets = new Map<string, BudgetDbRow>();
+    for (const row of listBudgetsStmt.all()) {
+      storedBudgets.set(row.budgetId, row);
+    }
+    compareBudgets(replayedBudgets, storedBudgets, discrepancies);
 
-  const storedCrossings = new Map<string, ThresholdCrossingDbRow>();
-  for (const row of listCrossingsStmt.all()) {
-    storedCrossings.set(crossingKey(row.budgetId, row.budgetSetLsn, row.thresholdBps), row);
-  }
-  compareCrossings(replayedCrossings, storedCrossings, discrepancies);
-  // Oracle check: compare the independently-derived `expectedCrossings`
-  // against the crossings replayed from the event log itself. Catches
-  // reactor bugs the event-log-as-oracle replay misses (the missing
-  // event is missing in both the log and the projection).
-  compareExpectedAndLoggedCrossings(expectedCrossings, replayedCrossings, discrepancies);
+    const storedCrossings = new Map<string, ThresholdCrossingDbRow>();
+    for (const row of listCrossingsStmt.all()) {
+      storedCrossings.set(crossingKey(row.budgetId, row.budgetSetLsn, row.thresholdBps), row);
+    }
+    compareCrossings(replayedCrossings, storedCrossings, discrepancies);
+    // Oracle checks: duplicates, causal-ordering, then the
+    // expected-vs-logged comparison. Order matters for on-call: a
+    // duplicate or causal-order violation is a more pointed signal
+    // than an oracle mismatch, so surfacing those first keeps the
+    // most actionable findings at the top of the list.
+    detectDuplicateLoggedCrossings(replayedCrossings, discrepancies);
+    detectCausalOrderViolations(replayedCrossings, discrepancies);
+    compareExpectedAndLoggedCrossings(expectedCrossings, replayedCrossings, discrepancies);
 
-  const highest = highestLsnStmt.get()?.lsn ?? 0;
-  return {
-    ok: discrepancies.length === 0,
-    highestLsn: lsnFromV1Number(highest),
-    eventsScanned: scanned,
-    discrepancies,
-  };
+    const highest = highestLsnStmt.get()?.lsn ?? 0;
+    return {
+      ok: discrepancies.length === 0,
+      highestLsn: lsnFromV1Number(highest),
+      eventsScanned: scanned,
+      discrepancies,
+    };
+  });
+  return txn.deferred();
 }
 
 interface ThresholdCrossingDbRow {
@@ -411,6 +483,10 @@ interface ReplayedCrossing {
   readonly crossedAtLsn: number;
   readonly observedMicroUsd: number;
   readonly limitMicroUsd: number;
+  /** `crossedAt` from the audit payload, as ms-since-epoch. */
+  readonly crossedAtMs: number;
+  /** The `event_log.lsn` of this threshold-crossed audit row itself. */
+  readonly eventLsn: number;
 }
 
 function crossingKey(budgetId: string, budgetSetLsn: number, thresholdBps: number): string {
@@ -418,11 +494,17 @@ function crossingKey(budgetId: string, budgetSetLsn: number, thresholdBps: numbe
 }
 
 function compareCrossings(
-  replayed: ReadonlyMap<string, ReplayedCrossing>,
+  replayed: ReadonlyMap<string, readonly ReplayedCrossing[]>,
   stored: ReadonlyMap<string, ThresholdCrossingDbRow>,
   out: ReplayDiscrepancy[],
 ): void {
-  for (const [key, expected] of replayed.entries()) {
+  for (const [key, entries] of replayed.entries()) {
+    // The projection PK collapses duplicate audit events into one row,
+    // so log-vs-projection comparison uses the first event seen. The
+    // duplicate case is surfaced separately by
+    // `detectDuplicateLoggedCrossings`.
+    const expected = entries[0];
+    if (expected === undefined) continue; // unreachable: map only holds non-empty arrays
     const actual = stored.get(key);
     if (actual === undefined) {
       out.push({
@@ -475,6 +557,48 @@ function compareCrossings(
         budgetSetLsn: lsnFromV1Number(actual.budgetSetLsn),
         thresholdBps: actual.thresholdBps,
       });
+    }
+  }
+}
+
+function detectDuplicateLoggedCrossings(
+  replayed: ReadonlyMap<string, readonly ReplayedCrossing[]>,
+  out: ReplayDiscrepancy[],
+): void {
+  for (const entries of replayed.values()) {
+    if (entries.length <= 1) continue;
+    const first = entries[0];
+    if (first === undefined) continue; // unreachable
+    out.push({
+      kind: "threshold_crossing_duplicate_event",
+      budgetId: first.budgetId as BudgetId,
+      budgetSetLsn: lsnFromV1Number(first.budgetSetLsn),
+      thresholdBps: first.thresholdBps,
+      eventLsns: entries.map((e) => lsnFromV1Number(e.eventLsn)),
+    });
+  }
+}
+
+function detectCausalOrderViolations(
+  replayed: ReadonlyMap<string, readonly ReplayedCrossing[]>,
+  out: ReplayDiscrepancy[],
+): void {
+  for (const entries of replayed.values()) {
+    for (const entry of entries) {
+      // The reactor appends `cost.budget.threshold.crossed` AFTER its
+      // triggering `cost.event` in the same SQLite transaction, so the
+      // threshold event's own LSN must strictly exceed the LSN it
+      // names as the trigger.
+      if (entry.eventLsn <= entry.crossedAtLsn) {
+        out.push({
+          kind: "threshold_crossing_causal_order_violation",
+          budgetId: entry.budgetId as BudgetId,
+          budgetSetLsn: lsnFromV1Number(entry.budgetSetLsn),
+          thresholdBps: entry.thresholdBps,
+          eventLsn: lsnFromV1Number(entry.eventLsn),
+          crossedAtLsn: lsnFromV1Number(entry.crossedAtLsn),
+        });
+      }
     }
   }
 }
@@ -675,10 +799,13 @@ interface ExpectedCrossing {
   readonly crossedAtLsn: number;
   readonly observedMicroUsd: number;
   readonly limitMicroUsd: number;
+  /** `crossedAt` derived from the triggering cost event, as ms-since-epoch. */
+  readonly crossedAtMs: number;
 }
 
 interface ComputeExpectedCrossingsArgs {
   readonly costEventLsn: number;
+  readonly costEventOccurredAtMs: number;
   readonly agentSlug: string;
   readonly taskId: string | undefined;
   readonly budgets: ReadonlyMap<string, ReplayedBudget>;
@@ -711,6 +838,7 @@ function computeExpectedCrossings(args: ComputeExpectedCrossingsArgs): void {
         crossedAtLsn: args.costEventLsn,
         observedMicroUsd: observed,
         limitMicroUsd: budget.limitMicroUsd,
+        crossedAtMs: args.costEventOccurredAtMs,
       });
     }
   }
@@ -750,11 +878,15 @@ function crossesThresholdBigInt(observed: number, limit: number, thresholdBps: n
 
 function compareExpectedAndLoggedCrossings(
   expected: ReadonlyMap<string, ExpectedCrossing>,
-  logged: ReadonlyMap<string, ReplayedCrossing>,
+  logged: ReadonlyMap<string, readonly ReplayedCrossing[]>,
   out: ReplayDiscrepancy[],
 ): void {
   for (const [key, exp] of expected.entries()) {
-    const log = logged.get(key);
+    const entries = logged.get(key);
+    // Compare against the first logged event per key. Duplicates are
+    // surfaced by `detectDuplicateLoggedCrossings` so the
+    // oracle-vs-log comparator focuses on shape drift.
+    const log = entries?.[0];
     if (log === undefined) {
       out.push({
         kind: "threshold_crossing_unemitted",
@@ -776,6 +908,7 @@ function compareExpectedAndLoggedCrossings(
         field: "crossedAtLsn",
         expected: exp.crossedAtLsn,
         logged: log.crossedAtLsn,
+        eventLsn: lsnFromV1Number(log.eventLsn),
       });
     }
     if (log.observedMicroUsd !== exp.observedMicroUsd) {
@@ -787,6 +920,7 @@ function compareExpectedAndLoggedCrossings(
         field: "observedMicroUsd",
         expected: exp.observedMicroUsd,
         logged: log.observedMicroUsd,
+        eventLsn: lsnFromV1Number(log.eventLsn),
       });
     }
     if (log.limitMicroUsd !== exp.limitMicroUsd) {
@@ -798,21 +932,39 @@ function compareExpectedAndLoggedCrossings(
         field: "limitMicroUsd",
         expected: exp.limitMicroUsd,
         logged: log.limitMicroUsd,
+        eventLsn: lsnFromV1Number(log.eventLsn),
+      });
+    }
+    if (log.crossedAtMs !== exp.crossedAtMs) {
+      // Reactor sets `crossedAt` from the triggering cost event's
+      // `occurredAt`. Drift here means the audit timestamp was forged
+      // or the reactor desynced from the cost-event payload.
+      out.push({
+        kind: "threshold_crossing_oracle_field_mismatch",
+        budgetId: exp.budgetId as BudgetId,
+        budgetSetLsn: lsnFromV1Number(exp.budgetSetLsn),
+        thresholdBps: exp.thresholdBps,
+        field: "crossedAtMs",
+        expected: exp.crossedAtMs,
+        logged: log.crossedAtMs,
+        eventLsn: lsnFromV1Number(log.eventLsn),
       });
     }
   }
-  for (const [key, log] of logged.entries()) {
-    if (!expected.has(key)) {
-      out.push({
-        kind: "threshold_crossing_spurious",
-        budgetId: log.budgetId as BudgetId,
-        budgetSetLsn: lsnFromV1Number(log.budgetSetLsn),
-        thresholdBps: log.thresholdBps,
-        observedMicroUsd: log.observedMicroUsd as MicroUsd,
-        limitMicroUsd: log.limitMicroUsd as MicroUsd,
-        crossedAtLsn: lsnFromV1Number(log.crossedAtLsn),
-      });
-    }
+  for (const [key, entries] of logged.entries()) {
+    if (expected.has(key)) continue;
+    const log = entries[0];
+    if (log === undefined) continue; // unreachable
+    out.push({
+      kind: "threshold_crossing_spurious",
+      budgetId: log.budgetId as BudgetId,
+      budgetSetLsn: lsnFromV1Number(log.budgetSetLsn),
+      thresholdBps: log.thresholdBps,
+      observedMicroUsd: log.observedMicroUsd as MicroUsd,
+      limitMicroUsd: log.limitMicroUsd as MicroUsd,
+      crossedAtLsn: lsnFromV1Number(log.crossedAtLsn),
+      eventLsn: lsnFromV1Number(log.eventLsn),
+    });
   }
 }
 

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -11,6 +11,7 @@ import {
   type CostEventAuditPayload,
   costAuditPayloadToBytes,
   lsnFromV1Number,
+  parseLsn,
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
 import { createCostLedger, parseIdempotencyKey, runReplayCheck } from "../src/cost-ledger/index.ts";
@@ -378,7 +379,7 @@ describe("replay-check", () => {
     const setResult = ledger.appendBudgetSet(
       buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }),
     );
-    const budgetSetLsnInt = Number(setResult.lsn.slice(3)); // "v1:N" → N
+    const budgetSetLsnInt = parseLsn(setResult.lsn).localLsn;
     // Inject a stray crossing row that points to the existing budget_set
     // event LSN (so the FK is satisfied), but with a threshold the
     // event_log has no matching `cost.budget.threshold.crossed` for.
@@ -514,7 +515,7 @@ describe("replay-check oracle (#836)", () => {
 
     // Hand-craft a stray `cost.budget.threshold.crossed` event and matching
     // projection row that the oracle's math says shouldn't exist.
-    const budgetSetLsnInt = Number(setResult.lsn.slice(3)); // "v1:N" → N
+    const budgetSetLsnInt = parseLsn(setResult.lsn).localLsn;
     const crossingPayload: BudgetThresholdCrossedAuditPayload = {
       budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
       budgetSetLsn: setResult.lsn,
@@ -742,5 +743,168 @@ describe("replay-check oracle (#836)", () => {
           d.kind === "threshold_crossing_oracle_field_mismatch",
       ),
     ).toEqual([]);
+  });
+});
+
+describe("replay-check oracle round-2 fixes (#841)", () => {
+  it("flags threshold_crossing_duplicate_event when same key appears twice in event_log", () => {
+    // Reactor over-emission OR a forged duplicate audit event. The
+    // projection PK collapses duplicates to one row, so the prior
+    // log-vs-projection comparator can't see it. Multi-entry tracking
+    // surfaces both event LSNs.
+    const { db, eventLog, ledger } = setup();
+    const setResult = ledger.appendBudgetSet(
+      buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }),
+    );
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    // Inject a SECOND threshold-crossed event with the same crossing key.
+    const budgetSetLsnInt = parseLsn(setResult.lsn).localLsn;
+    const dupPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: setResult.lsn,
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(2), // matches the legitimate trigger
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const dupBytes = costAuditPayloadToBytes("budget_threshold_crossed", dupPayload);
+    const dupLsn = eventLog.append({
+      type: "cost.budget.threshold.crossed",
+      payload: Buffer.from(dupBytes),
+    });
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const duplicate = report.discrepancies.find(
+      (d) => d.kind === "threshold_crossing_duplicate_event",
+    );
+    expect(duplicate).toBeDefined();
+    if (duplicate?.kind === "threshold_crossing_duplicate_event") {
+      expect(duplicate.thresholdBps).toBe(5_000);
+      expect(duplicate.eventLsns.length).toBe(2);
+      // First entry is the legitimate emit at LSN 3; second is dup at dupLsn.
+      expect(duplicate.eventLsns[1]).toBe(lsnFromV1Number(dupLsn));
+    }
+    // Sanity: budgetSetLsnInt is used to construct the payload's
+    // budgetSetLsn; assert the duplicate references it.
+    if (duplicate?.kind === "threshold_crossing_duplicate_event") {
+      expect(duplicate.budgetSetLsn).toBe(lsnFromV1Number(budgetSetLsnInt));
+    }
+  });
+
+  it("flags threshold_crossing_causal_order_violation when eventLsn <= crossedAtLsn", () => {
+    // The reactor appends threshold-crossed AFTER its triggering cost
+    // event, so threshold-event-LSN must strictly exceed crossedAtLsn.
+    // Tamper a payload to claim a LATER trigger LSN than the event row
+    // itself.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+    // Legitimate threshold event landed at LSN 3 with crossedAtLsn=2.
+    // Tamper crossedAtLsn to LSN 99 (which would make 99 a "future"
+    // cost event the threshold event claims as its trigger — causal
+    // order violated).
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(1),
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(99),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const violation = report.discrepancies.find(
+      (d) => d.kind === "threshold_crossing_causal_order_violation",
+    );
+    expect(violation).toBeDefined();
+    if (violation?.kind === "threshold_crossing_causal_order_violation") {
+      expect(violation.eventLsn).toBe(lsnFromV1Number(3));
+      expect(violation.crossedAtLsn).toBe(lsnFromV1Number(99));
+    }
+  });
+
+  it("flags threshold_crossing_oracle_field_mismatch on crossedAt (forged timestamp)", () => {
+    // Forged `crossedAt` payload field. Reactor sets crossedAt from the
+    // triggering cost event's occurredAt; tampering this field should
+    // surface as field=crossedAtMs.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(1),
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(2),
+      crossedAt: new Date("2099-12-31T23:59:59.000Z"), // future timestamp
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const mismatch = report.discrepancies.find(
+      (d): d is Extract<typeof d, { kind: "threshold_crossing_oracle_field_mismatch" }> =>
+        d.kind === "threshold_crossing_oracle_field_mismatch" && d.field === "crossedAtMs",
+    );
+    expect(mismatch).toBeDefined();
+    if (mismatch !== undefined) {
+      expect(mismatch.expected).toBe(new Date("2026-05-08T10:00:00.000Z").getTime());
+      expect(mismatch.logged).toBe(new Date("2099-12-31T23:59:59.000Z").getTime());
+    }
+  });
+
+  it("surfaces eventLsn on threshold_crossing_spurious for on-call repair", () => {
+    // Reuse the spurious setup: oracle says no crossing should fire,
+    // but a stray event was injected. The new `eventLsn` field must
+    // point at that injected event_log row.
+    const { db, eventLog, ledger } = setup();
+    const setResult = ledger.appendBudgetSet(
+      buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }),
+    );
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 50_000 }));
+
+    const budgetSetLsnInt = parseLsn(setResult.lsn).localLsn;
+    const strayPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: setResult.lsn,
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(budgetSetLsnInt),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const strayBytes = costAuditPayloadToBytes("budget_threshold_crossed", strayPayload);
+    const strayLsn = eventLog.append({
+      type: "cost.budget.threshold.crossed",
+      payload: Buffer.from(strayBytes),
+    });
+    db.prepare<[string, number, number, number, number, number]>(
+      `INSERT INTO cost_threshold_crossings
+         (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("01ARZ3NDEKTSV4RRFFQ69G5FAZ", budgetSetLsnInt, 5_000, strayLsn, 2_500_000, 5_000_000);
+
+    const report = runReplayCheck(db);
+    const spurious = report.discrepancies.find((d) => d.kind === "threshold_crossing_spurious");
+    expect(spurious).toBeDefined();
+    if (spurious?.kind === "threshold_crossing_spurious") {
+      expect(spurious.eventLsn).toBe(lsnFromV1Number(strayLsn));
+    }
   });
 });

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -1013,3 +1013,165 @@ describe("replay-check oracle round-2 fixes (PR #841 r2)", () => {
     }
   });
 });
+
+describe("replay-check oracle round-3 fixes (PR #841 r3)", () => {
+  it("flags threshold_crossing_delayed_emission when a forged event is appended outside the contiguous window", () => {
+    // Reactor invariant: threshold events are appended SYNCHRONOUSLY
+    // right after their cost.event. A legitimate cost.event at LSN 2
+    // that crosses one threshold yields a threshold-crossed at LSN 3
+    // — window {3}. A forger appending another threshold-crossed for
+    // the same key MUCH LATER (after intervening events) would
+    // otherwise pass duplicate, causal-order, reference, and
+    // crossedAt checks if the duplicate's payload is otherwise
+    // identical to the first. The window check catches the gap.
+    //
+    // We provoke a delayed emission by emitting a legitimate first
+    // crossing, appending unrelated events that push the LSN forward,
+    // then injecting a forged duplicate at a much later LSN.
+    const { db, eventLog, ledger } = setup();
+    const setResult = ledger.appendBudgetSet(
+      buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }),
+    );
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+    // Push LSN forward with two more cost events that don't fire any
+    // new threshold (cumulative stays under 80%).
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 100_000 }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 100_000 }));
+    // Now inject a forged duplicate threshold-crossed event MUCH later
+    // — outside the reactor's contiguous {LSN 3} window.
+    const forgedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: setResult.lsn,
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(2),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const forgedBytes = costAuditPayloadToBytes("budget_threshold_crossed", forgedPayload);
+    const forgedLsn = eventLog.append({
+      type: "cost.budget.threshold.crossed",
+      payload: Buffer.from(forgedBytes),
+    });
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const delayed = report.discrepancies.find(
+      (d) => d.kind === "threshold_crossing_delayed_emission",
+    );
+    expect(delayed).toBeDefined();
+    if (delayed?.kind === "threshold_crossing_delayed_emission") {
+      expect(delayed.eventLsn).toBe(lsnFromV1Number(forgedLsn));
+      expect(delayed.crossedAtLsn).toBe(lsnFromV1Number(2));
+      expect(delayed.expectedWindowMinLsn).toBe(lsnFromV1Number(3));
+      expect(delayed.expectedWindowMaxLsn).toBe(lsnFromV1Number(3));
+    }
+  });
+
+  it("flags threshold_crossing_invalid_budget_set_reference when budgetSetLsn names a non-budget LSN", () => {
+    // Tamper budgetSetLsn to point at the cost.event LSN (LSN 2),
+    // not the actual budget_set LSN (LSN 1). The threshold-event row
+    // itself is at LSN 3.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(2), // tampered: LSN 2 is the cost.event, not budget_set
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(2),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const invalid = report.discrepancies.find(
+      (d) => d.kind === "threshold_crossing_invalid_budget_set_reference",
+    );
+    expect(invalid).toBeDefined();
+    if (invalid?.kind === "threshold_crossing_invalid_budget_set_reference") {
+      expect(invalid.reason).toBe("lsn_not_a_budget_set");
+      expect(invalid.eventLsn).toBe(lsnFromV1Number(3));
+    }
+  });
+
+  it("flags threshold_crossing_invalid_budget_set_reference on budgetId mismatch", () => {
+    // Two budgets exist. Tamper a threshold event so its budgetSetLsn
+    // points at the OTHER budget's set event (real budget_set row,
+    // but for a different budgetId).
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01ARZ3NDEKTSV4RRFFQ69G5FAZ",
+        limitMicroUsd: 5_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    // Second budget at LSN 2.
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01BRZ3NDEKTSV4RRFFQ69G5FB1",
+        limitMicroUsd: 10_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 })); // LSN 3, fires LSN 4 for budget 1
+
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(2), // tampered: LSN 2 is budget #2's set event
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(3),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const mismatch = report.discrepancies.find(
+      (d): d is Extract<typeof d, { kind: "threshold_crossing_invalid_budget_set_reference" }> =>
+        d.kind === "threshold_crossing_invalid_budget_set_reference" &&
+        d.reason === "budget_id_mismatch",
+    );
+    expect(mismatch).toBeDefined();
+    if (mismatch !== undefined) {
+      expect(mismatch.actualBudgetId).toBe("01BRZ3NDEKTSV4RRFFQ69G5FB1");
+    }
+  });
+
+  it("parseStoredThresholds rejects Infinity / non-safe-integer entries (round-3 LOW)", () => {
+    // `JSON.parse("[1e999]")` returns `[Infinity]`. The round-2 check
+    // only filtered non-numbers; round-3 strengthens to require
+    // positive safe integers ≤ 10000.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    db.exec("UPDATE cost_budgets SET thresholds_bps = '[1e999]' WHERE 1=1");
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const mismatch = report.discrepancies.find(
+      (d): d is Extract<typeof d, { kind: "budget_state_mismatch" }> =>
+        d.kind === "budget_state_mismatch" && d.field === "thresholdsBps",
+    );
+    expect(mismatch).toBeDefined();
+    if (mismatch !== undefined) {
+      const stored = mismatch.stored as { unparseable?: string };
+      expect(typeof stored.unparseable).toBe("string");
+      expect(stored.unparseable).toContain("invalid entry");
+    }
+  });
+});

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -695,6 +695,22 @@ describe("replay-check oracle (#836)", () => {
     // oracle should agree.
     const report = runReplayCheck(db);
     expect(report.ok).toBe(true);
+    // Stronger assertion: verify BOTH epochs produced a logged threshold
+    // event. A future regression that skipped the second epoch would
+    // still pass `ok === true` if no spurious entry fires.
+    const crossingCount = db
+      .prepare<[], { readonly n: number }>(
+        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.budget.threshold.crossed'",
+      )
+      .get();
+    expect(crossingCount?.n).toBe(2);
+    const projectionRows = db
+      .prepare<[], { readonly budgetSetLsn: number }>(
+        "SELECT budget_set_lsn AS budgetSetLsn FROM cost_threshold_crossings ORDER BY budget_set_lsn ASC",
+      )
+      .all();
+    expect(projectionRows.length).toBe(2);
+    expect(projectionRows[0]?.budgetSetLsn).not.toBe(projectionRows[1]?.budgetSetLsn);
   });
 
   it("oracle covers global + agent + task budgets independently", () => {

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -7,7 +7,9 @@ import {
   asSignerIdentity,
   asTaskId,
   type BudgetSetAuditPayload,
+  type BudgetThresholdCrossedAuditPayload,
   type CostEventAuditPayload,
+  costAuditPayloadToBytes,
   lsnFromV1Number,
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
@@ -468,5 +470,277 @@ describe("replay-check", () => {
       expect(typeof parseFail.reason).toBe("string");
       expect(parseFail.reason.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("replay-check oracle (#836)", () => {
+  it("flags threshold_crossing_unemitted when reactor under-emits", () => {
+    // Simulates a reactor bug that fails to emit a crossing: the threshold
+    // event AND its projection row are both missing, so the event-log-as-
+    // oracle replay can't see the omission. The oracle's independent
+    // computation should still flag it.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+    db.exec("DELETE FROM event_log WHERE type = 'cost.budget.threshold.crossed'");
+    db.exec("DELETE FROM cost_threshold_crossings");
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const unemitted = report.discrepancies.find((d) => d.kind === "threshold_crossing_unemitted");
+    expect(unemitted).toBeDefined();
+    if (unemitted?.kind === "threshold_crossing_unemitted") {
+      expect(unemitted.thresholdBps).toBe(5_000);
+      expect(unemitted.observedMicroUsd as number).toBe(2_500_000);
+      expect(unemitted.limitMicroUsd as number).toBe(5_000_000);
+    }
+    // The existing event-log replay sees nothing wrong (both projection
+    // and log are silent), so the only discrepancy is the oracle's.
+    expect(
+      report.discrepancies.filter(
+        (d) => d.kind === "threshold_crossing_missing" || d.kind === "threshold_crossing_ghost",
+      ),
+    ).toEqual([]);
+  });
+
+  it("flags threshold_crossing_spurious when reactor over-emits", () => {
+    const { db, eventLog, ledger } = setup();
+    const setResult = ledger.appendBudgetSet(
+      buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }),
+    );
+    // A tiny cost event: cumulative spend stays at 1% of the limit, so no
+    // threshold should fire.
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 50_000 }));
+
+    // Hand-craft a stray `cost.budget.threshold.crossed` event and matching
+    // projection row that the oracle's math says shouldn't exist.
+    const budgetSetLsnInt = Number(setResult.lsn.slice(3)); // "v1:N" → N
+    const crossingPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: setResult.lsn,
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(budgetSetLsnInt),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const bytes = costAuditPayloadToBytes("budget_threshold_crossed", crossingPayload);
+    const crossingLsn = eventLog.append({
+      type: "cost.budget.threshold.crossed",
+      payload: Buffer.from(bytes),
+    });
+    db.prepare<[string, number, number, number, number, number]>(
+      `INSERT INTO cost_threshold_crossings
+         (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run("01ARZ3NDEKTSV4RRFFQ69G5FAZ", budgetSetLsnInt, 5_000, crossingLsn, 2_500_000, 5_000_000);
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const spurious = report.discrepancies.find((d) => d.kind === "threshold_crossing_spurious");
+    expect(spurious).toBeDefined();
+    if (spurious?.kind === "threshold_crossing_spurious") {
+      expect(spurious.thresholdBps).toBe(5_000);
+    }
+  });
+
+  it("flags threshold_crossing_oracle_field_mismatch when observed disagrees", () => {
+    // Reactor emits a crossing, but the recorded observedMicroUsd is
+    // tampered to a different value. The oracle's independent computation
+    // should disagree even though the keys match.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    // Tamper the threshold-crossed event payload in event_log so the
+    // replayed observedMicroUsd doesn't match the oracle. Need a valid
+    // payload — just change the observed value.
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(1),
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_001), // off by one
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(2),
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+    // Also tamper the projection so the existing log-vs-projection
+    // comparator doesn't fire its own discrepancy and obscure the test.
+    db.exec("UPDATE cost_threshold_crossings SET observed_micro_usd = 2500001");
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const mismatch = report.discrepancies.find(
+      (d) => d.kind === "threshold_crossing_oracle_field_mismatch",
+    );
+    expect(mismatch).toBeDefined();
+    if (mismatch?.kind === "threshold_crossing_oracle_field_mismatch") {
+      expect(mismatch.field).toBe("observedMicroUsd");
+      expect(mismatch.expected).toBe(2_500_000);
+      expect(mismatch.logged).toBe(2_500_001);
+    }
+  });
+
+  it("flags threshold_crossing_oracle_field_mismatch on crossedAtLsn + limitMicroUsd drift", () => {
+    // Cover the remaining two field-mismatch branches in one shot: tamper
+    // the threshold-crossed event payload so BOTH crossedAtLsn and
+    // limitMicroUsd disagree with the oracle's computed values.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(1),
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_001), // off by one
+      crossedAtLsn: lsnFromV1Number(99), // wrong LSN
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+    // The projection row stays at the original (correct) values, so the
+    // existing log-vs-projection comparator will ALSO fire field_mismatch
+    // discrepancies for the same fields. That's expected — the new
+    // oracle_field_mismatch variant is what this test verifies.
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const fields = new Set(
+      report.discrepancies
+        .filter(
+          (d): d is Extract<typeof d, { kind: "threshold_crossing_oracle_field_mismatch" }> =>
+            d.kind === "threshold_crossing_oracle_field_mismatch",
+        )
+        .map((d) => d.field),
+    );
+    expect(fields.has("crossedAtLsn")).toBe(true);
+    expect(fields.has("limitMicroUsd")).toBe(true);
+  });
+
+  it("oracle stays silent on a healthy flow with multiple crossings", () => {
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(
+      buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000, 8_000, 10_000] }),
+    );
+    // 50% crosses 5000bps.
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+    // 90% crosses 5000+8000bps (already fired) — only 8000 newly fires.
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_000_000 }));
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+    expect(
+      report.discrepancies.filter(
+        (d) =>
+          d.kind === "threshold_crossing_unemitted" ||
+          d.kind === "threshold_crossing_spurious" ||
+          d.kind === "threshold_crossing_oracle_field_mismatch",
+      ),
+    ).toEqual([]);
+  });
+
+  it("oracle skips tombstoned budgets", () => {
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    // Tombstone (set limit to 0) BEFORE any cost event: same budgetId,
+    // limit=0 marks it tombstoned in replay.
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01ARZ3NDEKTSV4RRFFQ69G5FAZ",
+        limitMicroUsd: 0,
+        thresholdsBps: [5_000],
+      }),
+    );
+    // Spend that WOULD have crossed the original threshold; tombstoned
+    // budget must produce no expected crossing.
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+    expect(report.discrepancies.filter((d) => d.kind === "threshold_crossing_unemitted")).toEqual(
+      [],
+    );
+  });
+
+  it("oracle re-arms thresholds on new budget_set epoch", () => {
+    const { db, ledger } = setup();
+    // Epoch 1: limit 1_000_000, threshold 50%, observed 500_000 — crosses.
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 1_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 500_000 }));
+    // Re-set the SAME budgetId at a higher limit — new setAtLsn re-arms.
+    // Cumulative spend is now 500_000; at limit 10_000_000, that's 5%,
+    // below the 50% threshold. The next cost_event brings it to 5_500_000
+    // (55%) which crosses 5000bps under the NEW epoch.
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01ARZ3NDEKTSV4RRFFQ69G5FAZ",
+        limitMicroUsd: 10_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 5_000_000 }));
+
+    // Both crossings are emitted by the reactor + present in the log; the
+    // oracle should agree.
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+  });
+
+  it("oracle covers global + agent + task budgets independently", () => {
+    const { db, ledger } = setup();
+    // 3 budgets of different scope, all targeting the same agent+task.
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01ARZ3NDEKTSV4RRFFQ69G5FAZ",
+        scope: "global",
+        limitMicroUsd: 5_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01BRZ3NDEKTSV4RRFFQ69G5FB1",
+        scope: "agent",
+        subjectId: "primary",
+        limitMicroUsd: 3_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: "01CRZ3NDEKTSV4RRFFQ69G5FB2",
+        scope: "task",
+        subjectId: "01DRZ3NDEKTSV4RRFFQ69G5FB3",
+        limitMicroUsd: 1_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    // One cost event that crosses 50% on the task budget (smallest).
+    // Cumulative for global=600_000 (12% — under), agent=600_000 (20% —
+    // under), task=600_000 (60% — crosses).
+    ledger.appendCostEvent(
+      buildCostEvent({ amountMicroUsd: 600_000, taskId: "01DRZ3NDEKTSV4RRFFQ69G5FB3" }),
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+    expect(
+      report.discrepancies.filter(
+        (d) =>
+          d.kind === "threshold_crossing_unemitted" ||
+          d.kind === "threshold_crossing_spurious" ||
+          d.kind === "threshold_crossing_oracle_field_mismatch",
+      ),
+    ).toEqual([]);
   });
 });

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -908,3 +908,108 @@ describe("replay-check oracle round-2 fixes (#841)", () => {
     }
   });
 });
+
+describe("replay-check oracle round-2 fixes (PR #841 r2)", () => {
+  it("flags threshold_crossing_dangling_reference when crossedAtLsn names a non-cost-event row", () => {
+    // Tamper the threshold-crossed event payload so crossedAtLsn points
+    // at the budget_set LSN (LSN 1) — a real event_log row, but not a
+    // cost.event. The numeric causal-order check passes because the
+    // event row LSN (3) > crossedAtLsn (1); only the per-entry reference
+    // validator can see this.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    const tamperedPayload: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: lsnFromV1Number(1),
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(1), // tampered: LSN 1 is the budget_set, not a cost.event
+      crossedAt: new Date("2026-05-08T10:00:00.000Z"),
+    };
+    const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
+    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+      Buffer.from(tamperedBytes),
+      "cost.budget.threshold.crossed",
+    );
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const dangling = report.discrepancies.find(
+      (d) => d.kind === "threshold_crossing_dangling_reference",
+    );
+    expect(dangling).toBeDefined();
+    if (dangling?.kind === "threshold_crossing_dangling_reference") {
+      expect(dangling.eventLsn).toBe(lsnFromV1Number(3));
+      expect(dangling.crossedAtLsn).toBe(lsnFromV1Number(1));
+    }
+  });
+
+  it("survives unparseable thresholds_bps projection cell without crashing the diagnostic", () => {
+    // Round-2 finding (security MED): `parseStoredThresholds` used to
+    // bare `JSON.parse` the projection cell — a corrupted DB row would
+    // throw out of `runReplayCheck` and blind the diagnostic. Now the
+    // bad cell surfaces as a structured discrepancy.
+    const { db, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }));
+    // Corrupt the stored thresholds JSON.
+    db.exec("UPDATE cost_budgets SET thresholds_bps = '{invalid json' WHERE 1=1");
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(false);
+    const mismatch = report.discrepancies.find(
+      (d): d is Extract<typeof d, { kind: "budget_state_mismatch" }> =>
+        d.kind === "budget_state_mismatch" && d.field === "thresholdsBps",
+    );
+    expect(mismatch).toBeDefined();
+    if (mismatch !== undefined) {
+      const stored = mismatch.stored as { unparseable?: string; raw?: string };
+      expect(typeof stored.unparseable).toBe("string");
+      expect(stored.raw).toBe("{invalid json");
+    }
+  });
+
+  it("per-entry validation catches duplicate with divergent crossedAt", () => {
+    // Two threshold events for the same key. The first agrees with the
+    // oracle's expected timestamp; the second tampers `crossedAt`. The
+    // existing `_oracle_field_mismatch` check only looks at the first
+    // entry, but per-entry validation should still flag the second.
+    const { db, eventLog, ledger } = setup();
+    const setResult = ledger.appendBudgetSet(
+      buildBudgetSet({ limitMicroUsd: 5_000_000, thresholdsBps: [5_000] }),
+    );
+    ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 2_500_000 }));
+
+    const tamperedDuplicate: BudgetThresholdCrossedAuditPayload = {
+      budgetId: asBudgetId("01ARZ3NDEKTSV4RRFFQ69G5FAZ"),
+      budgetSetLsn: setResult.lsn,
+      thresholdBps: 5_000,
+      observedMicroUsd: asMicroUsd(2_500_000),
+      limitMicroUsd: asMicroUsd(5_000_000),
+      crossedAtLsn: lsnFromV1Number(2),
+      crossedAt: new Date("2099-12-31T00:00:00.000Z"), // forged
+    };
+    const dupBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedDuplicate);
+    const dupLsn = eventLog.append({
+      type: "cost.budget.threshold.crossed",
+      payload: Buffer.from(dupBytes),
+    });
+
+    const report = runReplayCheck(db);
+    // Both the duplicate and a per-entry crossedAt mismatch should fire.
+    const dupes = report.discrepancies.find((d) => d.kind === "threshold_crossing_duplicate_event");
+    expect(dupes).toBeDefined();
+    const crossedAtMismatches = report.discrepancies.filter(
+      (d): d is Extract<typeof d, { kind: "threshold_crossing_oracle_field_mismatch" }> =>
+        d.kind === "threshold_crossing_oracle_field_mismatch" && d.field === "crossedAtMs",
+    );
+    // The duplicate's eventLsn should appear in a crossedAtMs mismatch.
+    const dupEntry = crossedAtMismatches.find((d) => d.eventLsn === lsnFromV1Number(dupLsn));
+    expect(dupEntry).toBeDefined();
+    if (dupEntry !== undefined) {
+      expect(dupEntry.logged).toBe(new Date("2099-12-31T00:00:00.000Z").getTime());
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR #834 round-2 codex adversarial finding (MED): `runReplayCheck` used the event log itself as the oracle for which threshold crossings should exist. A reactor bug that under-emits a crossing (e.g. a regression in `crossesThreshold`'s BigInt math) would leave both the `cost.budget.threshold.crossed` event AND the projection row absent — nothing to compare against, drift invisible.

This PR adds an independent threshold-crossing oracle inside the replay loop so reactor bugs surface as discrepancies, not silent under-emission.

## What changed

- `runReplayCheck` now maintains `oracleGlobalLifetime` / `oracleAgentLifetime` / `oracleTaskLifetime` alongside the existing aggregates — mirrors the reactor's `lifetimeFor` read.
- After every `cost.event`, `computeExpectedCrossings` runs the same integer/BigInt math the reactor uses (`crossesThresholdBigInt` is byte-identical to `crossesThreshold`) against the current `replayedBudgets` snapshot, building `expectedCrossings` keyed by `(budgetId, budgetSetLsn, thresholdBps)`.
- `compareExpectedAndLoggedCrossings` emits three new `ReplayDiscrepancy` variants:
  - **`threshold_crossing_unemitted`** — oracle expected a crossing, log is silent. This is the bug class #836 exists for.
  - **`threshold_crossing_spurious`** — log has a `cost.budget.threshold.crossed` event, oracle says it shouldn't fire.
  - **`threshold_crossing_oracle_field_mismatch`** — same key, but `observedMicroUsd` / `limitMicroUsd` / `crossedAtLsn` disagree.

The oracle reuses the reactor's exact scope-resolution and observed-derivation logic. A code comment on `crossesThresholdBigInt` calls out that the reactor and oracle math must stay in lockstep — otherwise the oracle becomes a tautology.

```mermaid
flowchart LR
  EL[event_log] -->|replay in LSN order| RL[replayedCrossings]
  EL -->|cost events + budgets| OR[oracle: independent compute]
  OR --> EX[expectedCrossings]
  DB[(cost_threshold_crossings)] --> ST[storedCrossings]
  RL -- existing compare --> D1[missing/ghost/field_mismatch]
  EX -- NEW compare --> RL
  EX -.->|expected ∖ logged| D2[threshold_crossing_unemitted]
  RL -.->|logged ∖ expected| D3[threshold_crossing_spurious]
  EX -.->|fields disagree| D4[threshold_crossing_oracle_field_mismatch]
```

## Tests (8 new)

| # | Scenario | Asserts |
|---|----------|---------|
| 1 | Reactor under-emits (delete event + projection row) | `threshold_crossing_unemitted` |
| 2 | Reactor over-emits (inject stray event) | `threshold_crossing_spurious` |
| 3 | Tampered `observedMicroUsd` | `oracle_field_mismatch(observedMicroUsd)` |
| 4 | Tampered `crossedAtLsn` + `limitMicroUsd` | `oracle_field_mismatch` on both |
| 5 | Healthy multi-threshold flow | oracle silent |
| 6 | Tombstoned budget | oracle silent |
| 7 | Re-set budget epoch (re-arms) | oracle agrees across epochs |
| 8 | Multi-scope (global+agent+task) | oracle agrees on all three |

## Verification

- [x] `bun run --cwd packages/broker typecheck` — clean
- [x] `bun run --cwd packages/broker test` — 199/199 pass
- [x] `bun run --cwd packages/broker check` — biome clean
- [x] `bun run --cwd packages/broker check:invariants` — pass
- [x] `bun run --cwd packages/protocol typecheck` — clean
- [x] `bun run --cwd packages/llm-router typecheck` — clean

Coverage on the broker package moves +1.55% (83.56% → 85.11% on All Files). The 87/87/93/75 ratchet is below the gate, but that's pre-existing on `main` since before #834; CI runs `vitest run` without `--coverage` so it doesn't block merge.

## Test plan

- [ ] Reviewer confirms `crossesThresholdBigInt` is byte-identical with `reactor.ts:crossesThreshold` (any future divergence makes the oracle a tautology).
- [ ] Reviewer reviews the new comparator's discrepancy ordering — oracle discrepancies are appended after the existing log-vs-projection ones, so on-call sees stored drift first.
- [ ] Reviewer sanity-checks that the oracle is read-only (no writes to db).

Closes #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Independent oracle-based verification for cost budget threshold crossing events.
  * Expanded discrepancy detection including duplicate events, ordering violations, and field mismatches.

* **Bug Fixes**
  * Improved replay check consistency with snapshot-based transaction isolation.
  * Hardened threshold configuration parsing with structured validation and error reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/841)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->