### PR TITLE
perf(broker): filter budgets by scope/subject in replay-check oracle (#842)

### DIFF
--- a/internal/team/promotion_demand.go
+++ b/internal/team/promotion_demand.go
@@ -192,13 +192,33 @@ type NotebookDemandIndex struct {
 // and threshold honour env overrides; invalid env values fall back to the
 // defaults with a warn log.
 func NewNotebookDemandIndex(logPath string) (*NotebookDemandIndex, error) {
+	return newNotebookDemandIndex(logPath, time.Now)
+}
+
+// NewNotebookDemandIndexForTest mirrors NewNotebookDemandIndex but lets the
+// caller inject a clock used during the initial replay. SetClockForTest can
+// only override the clock AFTER construction, but replay() uses the clock to
+// compute the window cutoff and runs inside the constructor — so a test that
+// records events at a fixed past date and then reloads the index needs the
+// fake clock from the start. Production code uses NewNotebookDemandIndex.
+func NewNotebookDemandIndexForTest(
+	logPath string,
+	clock func() time.Time,
+) (*NotebookDemandIndex, error) {
+	if clock == nil {
+		clock = time.Now
+	}
+	return newNotebookDemandIndex(logPath, clock)
+}
+
+func newNotebookDemandIndex(logPath string, clock func() time.Time) (*NotebookDemandIndex, error) {
 	idx := &NotebookDemandIndex{
 		logPath:    logPath,
 		windowDays: resolveWindowDays(),
 		threshold:  resolveThreshold(),
 		events:     make(map[string]map[demandRecordKey]demandRecord),
 		escalated:  make(map[string]struct{}),
-		clock:      time.Now,
+		clock:      clock,
 	}
 	idx.progressCond = sync.NewCond(&idx.progressMu)
 	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {

--- a/internal/team/promotion_demand_test.go
+++ b/internal/team/promotion_demand_test.go
@@ -76,6 +76,7 @@ func TestSignalWeight_Mapping(t *testing.T) {
 func TestDemandScoring_CrossAgentSearch(t *testing.T) {
 	idx := newDemandIndex(t)
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
 	path := "agents/pm/notebook/2026-05-06-retro.md"
 
 	// Two distinct agents searching the same entry → score = 2.0.
@@ -133,6 +134,7 @@ func TestDemandScoring_CrossAgentSearch(t *testing.T) {
 func TestDemandScoring_DifferentDays(t *testing.T) {
 	idx := newDemandIndex(t)
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
 	path := "agents/pm/notebook/entry.md"
 
 	// Same agent, different days → both events count.
@@ -162,6 +164,7 @@ func TestDemandScoring_DifferentDays(t *testing.T) {
 func TestDemandScoring_RejectionCooldown(t *testing.T) {
 	idx := newDemandIndex(t)
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	idx.SetClockForTest(func() time.Time { return now })
 	path := "agents/pm/notebook/entry.md"
 
 	// Build score above threshold (3 distinct searchers).
@@ -342,13 +345,17 @@ func TestNotebookDemandIndex_ReloadFromJSONL(t *testing.T) {
 	dir := t.TempDir()
 	logPath := filepath.Join(dir, "events.jsonl")
 	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	clock := func() time.Time { return now }
 	path := "agents/pm/notebook/entry.md"
 
-	idx1, err := NewNotebookDemandIndex(logPath)
+	// Use the test constructor so the initial replay() uses the fake clock
+	// instead of `time.Now`. Without this, events recorded at `now` would
+	// be filtered out during reload once real wall-clock time advances
+	// past `now + 7d`.
+	idx1, err := NewNotebookDemandIndexForTest(logPath, clock)
 	if err != nil {
 		t.Fatalf("init1: %v", err)
 	}
-	idx1.SetClockForTest(func() time.Time { return now })
 	for _, slug := range []string{"eng", "design"} {
 		if err := idx1.Record(PromotionDemandEvent{
 			EntryPath:    path,
@@ -365,11 +372,10 @@ func TestNotebookDemandIndex_ReloadFromJSONL(t *testing.T) {
 	}
 
 	// Reopen the index against the same JSONL — events must replay.
-	idx2, err := NewNotebookDemandIndex(logPath)
+	idx2, err := NewNotebookDemandIndexForTest(logPath, clock)
 	if err != nil {
 		t.Fatalf("init2: %v", err)
 	}
-	idx2.SetClockForTest(func() time.Time { return now })
 	if got := idx2.Score(path); got != 2.0 {
 		t.Fatalf("idx2 score after reload = %v, want 2.0", got)
 	}

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -424,9 +424,6 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
               JSON.parse(row.payload.toString("utf8")),
             ) as BudgetSetAuditPayload;
             const previous = replayedBudgets.get(parsed.budgetId);
-            if (previous !== undefined) {
-              removeBudgetFromIndex(budgetIndexes, parsed.budgetId, previous);
-            }
             const replayedBudget: ReplayedBudget = {
               scope: parsed.scope,
               subjectId: parsed.subjectId ?? null,
@@ -436,14 +433,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
               tombstoned: (parsed.limitMicroUsd as number) === 0,
             };
             replayedBudgets.set(parsed.budgetId, replayedBudget);
-            // Re-set events may move a budget between scopes/subjects. Remove
-            // the old placement before adding the new one; tombstones add
-            // nothing back, so the transition is symmetric.
-            if (replayedBudget.tombstoned) {
-              removeBudgetFromIndex(budgetIndexes, parsed.budgetId, replayedBudget);
-            } else {
-              addBudgetToIndex(budgetIndexes, parsed.budgetId, replayedBudget);
-            }
+            replaceBudgetInIndex(budgetIndexes, parsed.budgetId, previous, replayedBudget);
             budgetSetLsnToBudgetId.set(row.lsn, parsed.budgetId);
           } else if (kind === "budget_threshold_crossed") {
             const parsed = costAuditPayloadFromJsonValue(
@@ -855,6 +845,26 @@ function removeBudgetFromIndex(
   );
 }
 
+// Single-call lifecycle transition for the budget candidate indexes. The
+// replay loop calls this on every `budget_set` event so a budget moves
+// between scopes/subjects/tombstone-states without ever existing in two
+// scope sets simultaneously. The disjointness invariant is what lets
+// `computeExpectedCrossings` iterate the three scope indexes without
+// dedupe. Tombstones (`next.tombstoned === true`) remove without re-adding;
+// the post-condition is "exactly the placement implied by `next`".
+function replaceBudgetInIndex(
+  indexes: BudgetCandidateIndexes,
+  budgetId: string,
+  previous: ReplayedBudget | undefined,
+  next: ReplayedBudget,
+): void {
+  if (previous !== undefined) {
+    removeBudgetFromIndex(indexes, budgetId, previous);
+  }
+  if (next.tombstoned) return;
+  addBudgetToIndex(indexes, budgetId, next);
+}
+
 function addBudgetToSubjectIndex(
   index: Map<string, Set<string>>,
   subjectId: string,
@@ -895,6 +905,7 @@ export function __createBudgetCandidateIndexesForTesting(): BudgetCandidateIndex
 export const __replayCheckTesting = Object.freeze({
   addBudgetToIndex,
   removeBudgetFromIndex,
+  replaceBudgetInIndex,
   computeExpectedCrossings,
 });
 
@@ -1142,14 +1153,16 @@ interface ComputeExpectedCrossingsArgs {
 // (`crossesThresholdBigInt`) MUST stay byte-identical with the reactor's
 // `crossesThreshold`; if they diverge, this oracle becomes a tautology.
 function computeExpectedCrossings(args: ComputeExpectedCrossingsArgs): void {
-  // Round-2 fix (PR #846 triangulation perf + adversarial, 2-of-2 MEDIUM):
-  // visit each scope index directly instead of allocating a transient
-  // `Set<string>` per cost.event. The index lifecycle guarantees a
-  // budget is placed in exactly one scope index at a time
-  // (`addBudgetToIndex` removes from the prior scope before adding to
-  // the new one), so the three iterations are disjoint — no dedupe
-  // required. This drops 1 short-lived Set per cost event and
-  // O(events × globalBudgetIds.size) hash inserts.
+  // Visit each scope index directly. The replay loop's
+  // `replaceBudgetInIndex` keeps a budget in exactly one scope/subject
+  // bucket at a time, so the three iterations below are disjoint and
+  // no dedupe is required. This avoids one transient Set allocation
+  // and O(events × globalBudgetIds.size) hash inserts per cost event.
+  // The disjointness invariant is asserted by the perf-regression test
+  // in cost-ledger.spec.ts: a hostile Proxy on `args.budgets` blocks
+  // universe iteration, and hostile Proxies on the agent/task scope
+  // maps block `.entries()`/`.values()` regressions that would scan
+  // subjects rather than `.get(slug)` directly.
   visitCandidates(args, args.globalBudgetIds, evalBudget);
   visitCandidates(args, args.agentBudgetIds.get(args.agentSlug), evalBudget);
   if (args.taskId !== undefined) {
@@ -1176,10 +1189,13 @@ function evalBudget(
   budget: ReplayedBudget,
 ): void {
   // Defensive guards retained from the original pre-#842 oracle. The
-  // index lifecycle should keep tombstones out of the scope sets and
-  // `isOracleApplicable` should always return true on a candidate
-  // pulled from its own scope index — but these checks are cheap and
-  // catch any future drift between the index and `replayedBudgets`.
+  // index lifecycle (replaceBudgetInIndex) keeps tombstones out of the
+  // scope sets and `isOracleApplicable` should always be true on a
+  // candidate pulled from its own scope index. Note: these guards only
+  // catch STALE/EXTRA entries — they cannot catch the more dangerous
+  // failure mode where a live, applicable budget is missing from all
+  // candidate indexes (an under-emission, masked here as silent).
+  // The lifecycle tests cover that path directly.
   if (budget.tombstoned) return;
   if (!isOracleApplicable(budget, args.agentSlug, args.taskId)) return;
   const observed = oracleObservedFor(budget, args);

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -332,6 +332,11 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     const replayedAgentDays = new Map<string, number>();
     const replayedTasks = new Map<string, number>();
     const replayedBudgets = new Map<string, ReplayedBudget>();
+    const budgetIndexes: BudgetCandidateIndexes = {
+      globalBudgetIds: new Set<string>(),
+      agentBudgetIds: new Map<string, Set<string>>(),
+      taskBudgetIds: new Map<string, Set<string>>(),
+    };
     // Logged crossings: one entry per (budgetId, budgetSetLsn,
     // thresholdBps) key, BUT each entry carries every event_log row
     // that claimed the key. The projection PK suppresses duplicate
@@ -409,6 +414,9 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
               agentSlug: parsed.agentSlug,
               taskId: parsed.taskId,
               budgets: replayedBudgets,
+              globalBudgetIds: budgetIndexes.globalBudgetIds,
+              agentBudgetIds: budgetIndexes.agentBudgetIds,
+              taskBudgetIds: budgetIndexes.taskBudgetIds,
               globalLifetime: oracleGlobalLifetime,
               agentLifetime: oracleAgentLifetime,
               taskLifetime: oracleTaskLifetime,
@@ -419,14 +427,27 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
               kind,
               JSON.parse(row.payload.toString("utf8")),
             ) as BudgetSetAuditPayload;
-            replayedBudgets.set(parsed.budgetId, {
+            const previous = replayedBudgets.get(parsed.budgetId);
+            if (previous !== undefined) {
+              removeBudgetFromIndex(budgetIndexes, parsed.budgetId, previous);
+            }
+            const replayedBudget: ReplayedBudget = {
               scope: parsed.scope,
               subjectId: parsed.subjectId ?? null,
               limitMicroUsd: parsed.limitMicroUsd as number,
               thresholdsBps: [...parsed.thresholdsBps],
               setAtLsn: row.lsn,
               tombstoned: (parsed.limitMicroUsd as number) === 0,
-            });
+            };
+            replayedBudgets.set(parsed.budgetId, replayedBudget);
+            // Re-set events may move a budget between scopes/subjects. Remove
+            // the old placement before adding the new one; tombstones add
+            // nothing back, so the transition is symmetric.
+            if (replayedBudget.tombstoned) {
+              removeBudgetFromIndex(budgetIndexes, parsed.budgetId, replayedBudget);
+            } else {
+              addBudgetToIndex(budgetIndexes, parsed.budgetId, replayedBudget);
+            }
             budgetSetLsnToBudgetId.set(row.lsn, parsed.budgetId);
           } else if (kind === "budget_threshold_crossed") {
             const parsed = costAuditPayloadFromJsonValue(
@@ -790,6 +811,72 @@ interface ReplayedBudget {
   readonly tombstoned: boolean;
 }
 
+interface BudgetCandidateIndexes {
+  readonly globalBudgetIds: Set<string>;
+  readonly agentBudgetIds: Map<string, Set<string>>;
+  readonly taskBudgetIds: Map<string, Set<string>>;
+}
+
+function addBudgetToIndex(
+  indexes: BudgetCandidateIndexes,
+  budgetId: string,
+  budget: ReplayedBudget,
+): void {
+  if (budget.scope === "global") {
+    indexes.globalBudgetIds.add(budgetId);
+    return;
+  }
+  if (budget.subjectId === null) return;
+  addBudgetToSubjectIndex(
+    budget.scope === "agent" ? indexes.agentBudgetIds : indexes.taskBudgetIds,
+    budget.subjectId,
+    budgetId,
+  );
+}
+
+function removeBudgetFromIndex(
+  indexes: BudgetCandidateIndexes,
+  budgetId: string,
+  budget: ReplayedBudget,
+): void {
+  if (budget.scope === "global") {
+    indexes.globalBudgetIds.delete(budgetId);
+    return;
+  }
+  if (budget.subjectId === null) return;
+  removeBudgetFromSubjectIndex(
+    budget.scope === "agent" ? indexes.agentBudgetIds : indexes.taskBudgetIds,
+    budget.subjectId,
+    budgetId,
+  );
+}
+
+function addBudgetToSubjectIndex(
+  index: Map<string, Set<string>>,
+  subjectId: string,
+  budgetId: string,
+): void {
+  const existing = index.get(subjectId);
+  if (existing !== undefined) {
+    existing.add(budgetId);
+    return;
+  }
+  index.set(subjectId, new Set<string>([budgetId]));
+}
+
+function removeBudgetFromSubjectIndex(
+  index: Map<string, Set<string>>,
+  subjectId: string,
+  budgetId: string,
+): void {
+  const existing = index.get(subjectId);
+  if (existing === undefined) return;
+  existing.delete(budgetId);
+  if (existing.size === 0) {
+    index.delete(subjectId);
+  }
+}
+
 function compareAgentDays(
   replayed: ReadonlyMap<string, number>,
   stored: ReadonlyMap<string, number>,
@@ -1018,6 +1105,9 @@ interface ComputeExpectedCrossingsArgs {
   readonly agentSlug: string;
   readonly taskId: string | undefined;
   readonly budgets: ReadonlyMap<string, ReplayedBudget>;
+  readonly globalBudgetIds: ReadonlySet<string>;
+  readonly agentBudgetIds: ReadonlyMap<string, ReadonlySet<string>>;
+  readonly taskBudgetIds: ReadonlyMap<string, ReadonlySet<string>>;
   readonly globalLifetime: number;
   readonly agentLifetime: ReadonlyMap<string, number>;
   readonly taskLifetime: ReadonlyMap<string, number>;
@@ -1031,7 +1121,25 @@ interface ComputeExpectedCrossingsArgs {
 // (`crossesThresholdBigInt`) MUST stay byte-identical with the reactor's
 // `crossesThreshold`; if they diverge, this oracle becomes a tautology.
 function computeExpectedCrossings(args: ComputeExpectedCrossingsArgs): void {
-  for (const [budgetId, budget] of args.budgets.entries()) {
+  const candidateBudgetIds = new Set<string>(args.globalBudgetIds);
+  const agentBudgetIds = args.agentBudgetIds.get(args.agentSlug);
+  if (agentBudgetIds !== undefined) {
+    for (const budgetId of agentBudgetIds) {
+      candidateBudgetIds.add(budgetId);
+    }
+  }
+  if (args.taskId !== undefined) {
+    const taskBudgetIds = args.taskBudgetIds.get(args.taskId);
+    if (taskBudgetIds !== undefined) {
+      for (const budgetId of taskBudgetIds) {
+        candidateBudgetIds.add(budgetId);
+      }
+    }
+  }
+
+  for (const budgetId of candidateBudgetIds) {
+    const budget = args.budgets.get(budgetId);
+    if (budget === undefined) continue;
     if (budget.tombstoned) continue;
     if (!isOracleApplicable(budget, args.agentSlug, args.taskId)) continue;
     const observed = oracleObservedFor(budget, args);

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -890,10 +890,13 @@ export function __createBudgetCandidateIndexesForTesting(): BudgetCandidateIndex
     taskBudgetIds: new Map<string, Set<string>>(),
   };
 }
-export const __replayCheckTesting = {
+// Frozen so a test cannot mutate the seam and pollute subsequent
+// imports (modules are singletons).
+export const __replayCheckTesting = Object.freeze({
   addBudgetToIndex,
   removeBudgetFromIndex,
-};
+  computeExpectedCrossings,
+});
 
 function compareAgentDays(
   replayed: ReadonlyMap<string, number>,

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -332,11 +332,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     const replayedAgentDays = new Map<string, number>();
     const replayedTasks = new Map<string, number>();
     const replayedBudgets = new Map<string, ReplayedBudget>();
-    const budgetIndexes: BudgetCandidateIndexes = {
-      globalBudgetIds: new Set<string>(),
-      agentBudgetIds: new Map<string, Set<string>>(),
-      taskBudgetIds: new Map<string, Set<string>>(),
-    };
+    const budgetIndexes = createBudgetCandidateIndexes();
     // Logged crossings: one entry per (budgetId, budgetSetLsn,
     // thresholdBps) key, BUT each entry carries every event_log row
     // that claimed the key. The projection PK suppresses duplicate
@@ -817,6 +813,14 @@ interface BudgetCandidateIndexes {
   readonly taskBudgetIds: Map<string, Set<string>>;
 }
 
+function createBudgetCandidateIndexes(): BudgetCandidateIndexes {
+  return {
+    globalBudgetIds: new Set<string>(),
+    agentBudgetIds: new Map<string, Set<string>>(),
+    taskBudgetIds: new Map<string, Set<string>>(),
+  };
+}
+
 function addBudgetToIndex(
   indexes: BudgetCandidateIndexes,
   budgetId: string,
@@ -884,11 +888,7 @@ function removeBudgetFromSubjectIndex(
 // candidate-set shape after a sequence of `cost.budget.set` events.
 // NOT part of `@wuphf/broker/cost-ledger`'s public surface.
 export function __createBudgetCandidateIndexesForTesting(): BudgetCandidateIndexes {
-  return {
-    globalBudgetIds: new Set<string>(),
-    agentBudgetIds: new Map<string, Set<string>>(),
-    taskBudgetIds: new Map<string, Set<string>>(),
-  };
+  return createBudgetCandidateIndexes();
 }
 // Frozen so a test cannot mutate the seam and pollute subsequent
 // imports (modules are singletons).

--- a/packages/broker/src/cost-ledger/replay-check.ts
+++ b/packages/broker/src/cost-ledger/replay-check.ts
@@ -877,6 +877,24 @@ function removeBudgetFromSubjectIndex(
   }
 }
 
+// Internal test seam. Round-2 fix for PR #846's perf-test gap (the
+// existing test only asserted `eventsScanned > 1_000`, which a revert
+// to the O(events × budgets) iteration would still satisfy). Exports
+// the index helpers + a constructor so tests can directly assert the
+// candidate-set shape after a sequence of `cost.budget.set` events.
+// NOT part of `@wuphf/broker/cost-ledger`'s public surface.
+export function __createBudgetCandidateIndexesForTesting(): BudgetCandidateIndexes {
+  return {
+    globalBudgetIds: new Set<string>(),
+    agentBudgetIds: new Map<string, Set<string>>(),
+    taskBudgetIds: new Map<string, Set<string>>(),
+  };
+}
+export const __replayCheckTesting = {
+  addBudgetToIndex,
+  removeBudgetFromIndex,
+};
+
 function compareAgentDays(
   replayed: ReadonlyMap<string, number>,
   stored: ReadonlyMap<string, number>,
@@ -1121,43 +1139,61 @@ interface ComputeExpectedCrossingsArgs {
 // (`crossesThresholdBigInt`) MUST stay byte-identical with the reactor's
 // `crossesThreshold`; if they diverge, this oracle becomes a tautology.
 function computeExpectedCrossings(args: ComputeExpectedCrossingsArgs): void {
-  const candidateBudgetIds = new Set<string>(args.globalBudgetIds);
-  const agentBudgetIds = args.agentBudgetIds.get(args.agentSlug);
-  if (agentBudgetIds !== undefined) {
-    for (const budgetId of agentBudgetIds) {
-      candidateBudgetIds.add(budgetId);
-    }
-  }
+  // Round-2 fix (PR #846 triangulation perf + adversarial, 2-of-2 MEDIUM):
+  // visit each scope index directly instead of allocating a transient
+  // `Set<string>` per cost.event. The index lifecycle guarantees a
+  // budget is placed in exactly one scope index at a time
+  // (`addBudgetToIndex` removes from the prior scope before adding to
+  // the new one), so the three iterations are disjoint — no dedupe
+  // required. This drops 1 short-lived Set per cost event and
+  // O(events × globalBudgetIds.size) hash inserts.
+  visitCandidates(args, args.globalBudgetIds, evalBudget);
+  visitCandidates(args, args.agentBudgetIds.get(args.agentSlug), evalBudget);
   if (args.taskId !== undefined) {
-    const taskBudgetIds = args.taskBudgetIds.get(args.taskId);
-    if (taskBudgetIds !== undefined) {
-      for (const budgetId of taskBudgetIds) {
-        candidateBudgetIds.add(budgetId);
-      }
-    }
+    visitCandidates(args, args.taskBudgetIds.get(args.taskId), evalBudget);
   }
+}
 
-  for (const budgetId of candidateBudgetIds) {
+function visitCandidates(
+  args: ComputeExpectedCrossingsArgs,
+  budgetIds: ReadonlySet<string> | undefined,
+  visit: (args: ComputeExpectedCrossingsArgs, budgetId: string, budget: ReplayedBudget) => void,
+): void {
+  if (budgetIds === undefined) return;
+  for (const budgetId of budgetIds) {
     const budget = args.budgets.get(budgetId);
     if (budget === undefined) continue;
-    if (budget.tombstoned) continue;
-    if (!isOracleApplicable(budget, args.agentSlug, args.taskId)) continue;
-    const observed = oracleObservedFor(budget, args);
-    if (observed === 0 && budget.limitMicroUsd === 0) continue;
-    for (const thresholdBps of budget.thresholdsBps) {
-      const key = crossingKey(budgetId, budget.setAtLsn, thresholdBps);
-      if (args.out.has(key)) continue;
-      if (!crossesThresholdBigInt(observed, budget.limitMicroUsd, thresholdBps)) continue;
-      args.out.set(key, {
-        budgetId,
-        budgetSetLsn: budget.setAtLsn,
-        thresholdBps,
-        crossedAtLsn: args.costEventLsn,
-        observedMicroUsd: observed,
-        limitMicroUsd: budget.limitMicroUsd,
-        crossedAtMs: args.costEventOccurredAtMs,
-      });
-    }
+    visit(args, budgetId, budget);
+  }
+}
+
+function evalBudget(
+  args: ComputeExpectedCrossingsArgs,
+  budgetId: string,
+  budget: ReplayedBudget,
+): void {
+  // Defensive guards retained from the original pre-#842 oracle. The
+  // index lifecycle should keep tombstones out of the scope sets and
+  // `isOracleApplicable` should always return true on a candidate
+  // pulled from its own scope index — but these checks are cheap and
+  // catch any future drift between the index and `replayedBudgets`.
+  if (budget.tombstoned) return;
+  if (!isOracleApplicable(budget, args.agentSlug, args.taskId)) return;
+  const observed = oracleObservedFor(budget, args);
+  if (observed === 0 && budget.limitMicroUsd === 0) return;
+  for (const thresholdBps of budget.thresholdsBps) {
+    const key = crossingKey(budgetId, budget.setAtLsn, thresholdBps);
+    if (args.out.has(key)) continue;
+    if (!crossesThresholdBigInt(observed, budget.limitMicroUsd, thresholdBps)) continue;
+    args.out.set(key, {
+      budgetId,
+      budgetSetLsn: budget.setAtLsn,
+      thresholdBps,
+      crossedAtLsn: args.costEventLsn,
+      observedMicroUsd: observed,
+      limitMicroUsd: budget.limitMicroUsd,
+      crossedAtMs: args.costEventOccurredAtMs,
+    });
   }
 }
 

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -15,6 +15,10 @@ import {
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
 import { createCostLedger, parseIdempotencyKey, runReplayCheck } from "../src/cost-ledger/index.ts";
+import {
+  __createBudgetCandidateIndexesForTesting,
+  __replayCheckTesting,
+} from "../src/cost-ledger/replay-check.ts";
 import { createEventLog, openDatabase, runMigrations } from "../src/event-log/index.ts";
 
 function setup() {
@@ -1330,5 +1334,93 @@ describe("replay-check oracle round-3 fixes (PR #841 r3)", () => {
       expect(typeof stored.unparseable).toBe("string");
       expect(stored.unparseable).toContain("invalid entry");
     }
+  });
+});
+
+describe("BudgetCandidateIndexes (#846 round-2)", () => {
+  // Round-2 fix for the perf-test gap flagged 2-of-2 by triangulation
+  // (perf + adversarial, LOW): the existing #842 regression test only
+  // asserts `eventsScanned > 1_000`, which a revert to the
+  // O(events × budgets) iteration would still satisfy. These tests
+  // exercise the index helpers directly so a regression of the
+  // candidate filter is caught structurally.
+  const { addBudgetToIndex, removeBudgetFromIndex } = __replayCheckTesting;
+
+  function makeReplayedBudget(opts: {
+    scope: "global" | "agent" | "task";
+    subjectId?: string;
+    tombstoned?: boolean;
+  }) {
+    return {
+      scope: opts.scope,
+      subjectId: opts.subjectId ?? null,
+      limitMicroUsd: opts.tombstoned ? 0 : 1_000_000,
+      thresholdsBps: [5_000],
+      setAtLsn: 1,
+      tombstoned: opts.tombstoned ?? false,
+    } as const;
+  }
+
+  it("adds and removes a global budget", () => {
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    const budget = makeReplayedBudget({ scope: "global" });
+    addBudgetToIndex(indexes, "B1", budget);
+    expect(indexes.globalBudgetIds.has("B1")).toBe(true);
+    removeBudgetFromIndex(indexes, "B1", budget);
+    expect(indexes.globalBudgetIds.has("B1")).toBe(false);
+  });
+
+  it("adds and removes an agent-scoped budget under its slug", () => {
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    const budget = makeReplayedBudget({ scope: "agent", subjectId: "primary" });
+    addBudgetToIndex(indexes, "B2", budget);
+    expect(indexes.agentBudgetIds.get("primary")?.has("B2")).toBe(true);
+    removeBudgetFromIndex(indexes, "B2", budget);
+    // Empty subject set is cleaned up (Map.delete fires when set size hits 0).
+    expect(indexes.agentBudgetIds.has("primary")).toBe(false);
+  });
+
+  it("isolates agent budgets across different slugs", () => {
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    addBudgetToIndex(indexes, "B3", makeReplayedBudget({ scope: "agent", subjectId: "primary" }));
+    addBudgetToIndex(indexes, "B4", makeReplayedBudget({ scope: "agent", subjectId: "secondary" }));
+    expect(indexes.agentBudgetIds.get("primary")?.has("B3")).toBe(true);
+    expect(indexes.agentBudgetIds.get("secondary")?.has("B4")).toBe(true);
+    expect(indexes.agentBudgetIds.get("primary")?.has("B4")).toBe(false);
+    expect(indexes.agentBudgetIds.get("secondary")?.has("B3")).toBe(false);
+  });
+
+  it("handles agent → global scope transitions symmetrically", () => {
+    // The replay loop removes-then-adds on every budget_set, so the
+    // helper must move a budget cleanly between scope indexes.
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    const agentForm = makeReplayedBudget({ scope: "agent", subjectId: "primary" });
+    const globalForm = makeReplayedBudget({ scope: "global" });
+    addBudgetToIndex(indexes, "B5", agentForm);
+    removeBudgetFromIndex(indexes, "B5", agentForm);
+    addBudgetToIndex(indexes, "B5", globalForm);
+    expect(indexes.agentBudgetIds.has("primary")).toBe(false);
+    expect(indexes.globalBudgetIds.has("B5")).toBe(true);
+  });
+
+  it("noise budgets (tombstoned) leave the index empty after the lifecycle", () => {
+    // Validates the reviewer's specific perf concern: with 1000
+    // tombstoned budgets, the candidate index has 0 entries — no
+    // matter how many cost events scan it.
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    for (let i = 0; i < 1_000; i += 1) {
+      const id = `B${i}`;
+      const live = makeReplayedBudget({ scope: "agent", subjectId: `slug-${i}` });
+      const tombstoned = makeReplayedBudget({
+        scope: "agent",
+        subjectId: `slug-${i}`,
+        tombstoned: true,
+      });
+      addBudgetToIndex(indexes, id, live);
+      removeBudgetFromIndex(indexes, id, tombstoned);
+    }
+    expect(indexes.globalBudgetIds.size).toBe(0);
+    expect(indexes.agentBudgetIds.size).toBe(0);
+    expect(indexes.taskBudgetIds.size).toBe(0);
   });
 });

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -61,6 +61,10 @@ function buildBudgetSet(opts: {
   };
 }
 
+function budgetIdFromNumber(n: number): string {
+  return `01${String(n).padStart(24, "0")}`;
+}
+
 describe("cost ledger projections", () => {
   it("appendCostEvent inserts event_log row and projection rows atomically", () => {
     const { db, ledger } = setup();
@@ -813,6 +817,81 @@ describe("replay-check oracle (#836)", () => {
 
     const report = runReplayCheck(db);
     expect(report.ok).toBe(true);
+    expect(
+      report.discrepancies.filter(
+        (d) =>
+          d.kind === "threshold_crossing_unemitted" ||
+          d.kind === "threshold_crossing_spurious" ||
+          d.kind === "threshold_crossing_oracle_field_mismatch",
+      ),
+    ).toEqual([]);
+  });
+
+  it("oracle filters candidates across tombstones and scope transitions (#842)", () => {
+    const { db, ledger } = setup();
+    for (let i = 1; i <= 1_000; i += 1) {
+      const budgetId = budgetIdFromNumber(i);
+      const subjectId = `noise-${i}`;
+      ledger.appendBudgetSet(
+        buildBudgetSet({
+          budgetId,
+          scope: "agent",
+          subjectId,
+          limitMicroUsd: 1_000_000,
+          thresholdsBps: [5_000],
+        }),
+      );
+      ledger.appendBudgetSet(
+        buildBudgetSet({
+          budgetId,
+          scope: "agent",
+          subjectId,
+          limitMicroUsd: 0,
+          thresholdsBps: [5_000],
+        }),
+      );
+    }
+
+    const transitioningBudgetId = "01ARZ3NDEKTSV4RRFFQ69G5FAZ";
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: transitioningBudgetId,
+        scope: "agent",
+        subjectId: "legacy",
+        limitMicroUsd: 10_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: transitioningBudgetId,
+        scope: "global",
+        limitMicroUsd: 1_000_000,
+        thresholdsBps: [5_000],
+      }),
+    );
+
+    const crossed = ledger.appendCostEvent(
+      buildCostEvent({ agentSlug: "primary", amountMicroUsd: 600_000 }),
+    );
+    expect(crossed.newCrossings.length).toBe(1);
+
+    ledger.appendBudgetSet(
+      buildBudgetSet({
+        budgetId: transitioningBudgetId,
+        scope: "global",
+        limitMicroUsd: 0,
+        thresholdsBps: [5_000],
+      }),
+    );
+    const afterTombstone = ledger.appendCostEvent(
+      buildCostEvent({ agentSlug: "primary", amountMicroUsd: 600_000 }),
+    );
+    expect(afterTombstone.newCrossings).toEqual([]);
+
+    const report = runReplayCheck(db);
+    expect(report.ok).toBe(true);
+    expect(report.eventsScanned).toBeGreaterThan(1_000);
     expect(
       report.discrepancies.filter(
         (d) =>

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -1346,8 +1346,12 @@ describe("BudgetCandidateIndexes (#846 round-2)", () => {
   // candidate filter is caught structurally. Round-3 (staff review)
   // adds direct coverage of `computeExpectedCrossings` (the hot path)
   // plus positive task-scope coverage.
-  const { addBudgetToIndex, removeBudgetFromIndex, computeExpectedCrossings } =
-    __replayCheckTesting;
+  const {
+    addBudgetToIndex,
+    removeBudgetFromIndex,
+    replaceBudgetInIndex,
+    computeExpectedCrossings,
+  } = __replayCheckTesting;
 
   function makeReplayedBudget(opts: {
     scope: "global" | "agent" | "task";
@@ -1580,6 +1584,199 @@ describe("BudgetCandidateIndexes (#846 round-2)", () => {
 
       expect(getCalls).toEqual(["G"]);
       expect(out.size).toBe(1);
+    });
+
+    // Round-4 fix (PR #846 triangulation adversarial #1 MEDIUM): the
+    // hostile-budgets Proxy above only protects `args.budgets`. A
+    // future refactor that scans `agentBudgetIds.entries()` /
+    // `taskBudgetIds.entries()` to find a matching subject would still
+    // call `budgets.get()` only for matched candidates and pass the
+    // test, while reintroducing O(events × subjects) behavior. These
+    // tests additionally wrap the agent/task scope maps in proxies
+    // that allow `.get(slug)` but throw on `.entries()`, `.values()`,
+    // `.keys()`, `.forEach(...)`, and iteration — locking in the
+    // direct-lookup invariant.
+    describe("with hostile index maps", () => {
+      function makeHostileSubjectIndex(
+        underlying: Map<string, Set<string>>,
+      ): ReadonlyMap<string, ReadonlySet<string>> {
+        return new Proxy(underlying, {
+          get(_target, prop) {
+            if (prop === "get") return (key: string) => underlying.get(key);
+            if (prop === "has") return (key: string) => underlying.has(key);
+            if (prop === "size") return underlying.size;
+            throw new Error(
+              `computeExpectedCrossings must access scope index only via .get(subjectId); attempted .${String(prop)}`,
+            );
+          },
+        }) as unknown as ReadonlyMap<string, ReadonlySet<string>>;
+      }
+
+      it("hostile agentBudgetIds: only .get(slug) reaches the underlying map", () => {
+        const indexes = __createBudgetCandidateIndexesForTesting();
+        const myAgentBudget = makeReplayedBudget({ scope: "agent", subjectId: "MY_AGENT" });
+        addBudgetToIndex(indexes, "MY", myAgentBudget);
+        for (let i = 0; i < 50; i += 1) {
+          addBudgetToIndex(
+            indexes,
+            `OTHER_${i}`,
+            makeReplayedBudget({ scope: "agent", subjectId: `OTHER_${i}` }),
+          );
+        }
+        const allEntries: Array<[string, ReplayedBudgetShape]> = Array.from(
+          indexes.agentBudgetIds.entries(),
+        ).flatMap(([subjectId, ids]) =>
+          Array.from(ids).map((id): [string, ReplayedBudgetShape] => [
+            id,
+            makeReplayedBudget({ scope: "agent", subjectId }),
+          ]),
+        );
+
+        const { budgets } = makeHostileBudgets(allEntries);
+        const out: ComputeExpectedCrossingsArgs["out"] = new Map();
+        computeExpectedCrossings({
+          costEventLsn: 11,
+          costEventOccurredAtMs: 1_700_000_000_000,
+          agentSlug: "MY_AGENT",
+          taskId: undefined,
+          budgets,
+          globalBudgetIds: indexes.globalBudgetIds,
+          agentBudgetIds: makeHostileSubjectIndex(indexes.agentBudgetIds),
+          taskBudgetIds: makeHostileSubjectIndex(indexes.taskBudgetIds),
+          globalLifetime: 600_000,
+          agentLifetime: new Map([["MY_AGENT", 600_000]]),
+          taskLifetime: new Map(),
+          out,
+        });
+        expect(out.size).toBe(1);
+        expect(out.has("MY|1|5000")).toBe(true);
+      });
+
+      it("hostile taskBudgetIds: only .get(taskId) reaches the underlying map", () => {
+        const indexes = __createBudgetCandidateIndexesForTesting();
+        addBudgetToIndex(
+          indexes,
+          "MY",
+          makeReplayedBudget({ scope: "task", subjectId: "MY_TASK" }),
+        );
+        for (let i = 0; i < 50; i += 1) {
+          addBudgetToIndex(
+            indexes,
+            `OTHER_${i}`,
+            makeReplayedBudget({ scope: "task", subjectId: `OTHER_${i}` }),
+          );
+        }
+        const allEntries: Array<[string, ReplayedBudgetShape]> = Array.from(
+          indexes.taskBudgetIds.entries(),
+        ).flatMap(([subjectId, ids]) =>
+          Array.from(ids).map((id): [string, ReplayedBudgetShape] => [
+            id,
+            makeReplayedBudget({ scope: "task", subjectId }),
+          ]),
+        );
+
+        const { budgets } = makeHostileBudgets(allEntries);
+        const out: ComputeExpectedCrossingsArgs["out"] = new Map();
+        computeExpectedCrossings({
+          costEventLsn: 13,
+          costEventOccurredAtMs: 1_700_000_000_000,
+          agentSlug: "ANY",
+          taskId: "MY_TASK",
+          budgets,
+          globalBudgetIds: indexes.globalBudgetIds,
+          agentBudgetIds: makeHostileSubjectIndex(indexes.agentBudgetIds),
+          taskBudgetIds: makeHostileSubjectIndex(indexes.taskBudgetIds),
+          globalLifetime: 0,
+          agentLifetime: new Map(),
+          taskLifetime: new Map([["MY_TASK", 600_000]]),
+          out,
+        });
+        expect(out.size).toBe(1);
+        expect(out.has("MY|1|5000")).toBe(true);
+      });
+    });
+  });
+
+  // Round-4 fix (PR #846 triangulation perf+architecture 2-of-3 MEDIUM
+  // / 3-of-3 LOW): the original lifecycle tests cover scope transitions
+  // and the noise-budget perf path, but miss the same-scope subject
+  // moves (agent A→B / task A→B), tombstone→live reactivation, and
+  // tombstone-with-changed-scope. A regression that left stale subject
+  // entries behind would be masked by `evalBudget`'s defensive
+  // `isOracleApplicable` filter while degrading the hot path. These
+  // tests pin `replaceBudgetInIndex` to the exact post-condition.
+  describe("replaceBudgetInIndex (lifecycle invariant)", () => {
+    it("agent → agent: same scope, different subject — moves the entry", () => {
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const a = makeReplayedBudget({ scope: "agent", subjectId: "agent-A" });
+      const b = makeReplayedBudget({ scope: "agent", subjectId: "agent-B" });
+      replaceBudgetInIndex(indexes, "B1", undefined, a);
+      replaceBudgetInIndex(indexes, "B1", a, b);
+      expect(indexes.agentBudgetIds.has("agent-A")).toBe(false);
+      expect(indexes.agentBudgetIds.get("agent-B")?.has("B1")).toBe(true);
+      expect(indexes.agentBudgetIds.size).toBe(1);
+    });
+
+    it("task → task: same scope, different subject — moves the entry", () => {
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const a = makeReplayedBudget({ scope: "task", subjectId: "task-A" });
+      const b = makeReplayedBudget({ scope: "task", subjectId: "task-B" });
+      replaceBudgetInIndex(indexes, "B2", undefined, a);
+      replaceBudgetInIndex(indexes, "B2", a, b);
+      expect(indexes.taskBudgetIds.has("task-A")).toBe(false);
+      expect(indexes.taskBudgetIds.get("task-B")?.has("B2")).toBe(true);
+      expect(indexes.taskBudgetIds.size).toBe(1);
+    });
+
+    it("live → tombstone → live: reactivation returns to the index cleanly", () => {
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const live = makeReplayedBudget({ scope: "agent", subjectId: "primary" });
+      const tombstoned = makeReplayedBudget({
+        scope: "agent",
+        subjectId: "primary",
+        tombstoned: true,
+      });
+      const reactivated = makeReplayedBudget({ scope: "agent", subjectId: "primary" });
+      replaceBudgetInIndex(indexes, "B3", undefined, live);
+      replaceBudgetInIndex(indexes, "B3", live, tombstoned);
+      expect(indexes.agentBudgetIds.has("primary")).toBe(false);
+      replaceBudgetInIndex(indexes, "B3", tombstoned, reactivated);
+      expect(indexes.agentBudgetIds.get("primary")?.has("B3")).toBe(true);
+    });
+
+    it("live agent → tombstone global: removed from agent, never added to global", () => {
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const liveAgent = makeReplayedBudget({ scope: "agent", subjectId: "primary" });
+      const tombstonedGlobal = makeReplayedBudget({ scope: "global", tombstoned: true });
+      replaceBudgetInIndex(indexes, "B4", undefined, liveAgent);
+      replaceBudgetInIndex(indexes, "B4", liveAgent, tombstonedGlobal);
+      expect(indexes.agentBudgetIds.has("primary")).toBe(false);
+      expect(indexes.globalBudgetIds.has("B4")).toBe(false);
+      expect(indexes.taskBudgetIds.size).toBe(0);
+    });
+
+    it("scope move on a tombstoned record: remove-then-no-add (single index, no leak)", () => {
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const liveTask = makeReplayedBudget({ scope: "task", subjectId: "task-A" });
+      const tombstonedTask = makeReplayedBudget({
+        scope: "task",
+        subjectId: "task-A",
+        tombstoned: true,
+      });
+      const tombstonedAgent = makeReplayedBudget({
+        scope: "agent",
+        subjectId: "primary",
+        tombstoned: true,
+      });
+      replaceBudgetInIndex(indexes, "B5", undefined, liveTask);
+      replaceBudgetInIndex(indexes, "B5", liveTask, tombstonedTask);
+      // A subsequent scope-move tombstone must not re-add anywhere
+      // (the prior placement is already empty, but the helper still
+      // needs to not panic on an undefined-subject lookup).
+      replaceBudgetInIndex(indexes, "B5", tombstonedTask, tombstonedAgent);
+      expect(indexes.globalBudgetIds.size).toBe(0);
+      expect(indexes.agentBudgetIds.size).toBe(0);
+      expect(indexes.taskBudgetIds.size).toBe(0);
     });
   });
 });

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -1343,8 +1343,11 @@ describe("BudgetCandidateIndexes (#846 round-2)", () => {
   // asserts `eventsScanned > 1_000`, which a revert to the
   // O(events × budgets) iteration would still satisfy. These tests
   // exercise the index helpers directly so a regression of the
-  // candidate filter is caught structurally.
-  const { addBudgetToIndex, removeBudgetFromIndex } = __replayCheckTesting;
+  // candidate filter is caught structurally. Round-3 (staff review)
+  // adds direct coverage of `computeExpectedCrossings` (the hot path)
+  // plus positive task-scope coverage.
+  const { addBudgetToIndex, removeBudgetFromIndex, computeExpectedCrossings } =
+    __replayCheckTesting;
 
   function makeReplayedBudget(opts: {
     scope: "global" | "agent" | "task";
@@ -1422,5 +1425,161 @@ describe("BudgetCandidateIndexes (#846 round-2)", () => {
     expect(indexes.globalBudgetIds.size).toBe(0);
     expect(indexes.agentBudgetIds.size).toBe(0);
     expect(indexes.taskBudgetIds.size).toBe(0);
+  });
+
+  // Task-scope positive coverage (round-3 staff finding 2). Round-2
+  // only exercised global and agent scopes directly; a typo swapping
+  // `taskBudgetIds`/`agentBudgetIds` in either helper would have left
+  // the suite green.
+  it("adds and removes a task-scoped budget under its task id", () => {
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    const budget = makeReplayedBudget({ scope: "task", subjectId: "task-A" });
+    addBudgetToIndex(indexes, "B6", budget);
+    expect(indexes.taskBudgetIds.get("task-A")?.has("B6")).toBe(true);
+    expect(indexes.agentBudgetIds.has("task-A")).toBe(false);
+    removeBudgetFromIndex(indexes, "B6", budget);
+    expect(indexes.taskBudgetIds.has("task-A")).toBe(false);
+  });
+
+  it("isolates task budgets across different task ids", () => {
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    addBudgetToIndex(indexes, "B7", makeReplayedBudget({ scope: "task", subjectId: "task-A" }));
+    addBudgetToIndex(indexes, "B8", makeReplayedBudget({ scope: "task", subjectId: "task-B" }));
+    expect(indexes.taskBudgetIds.get("task-A")?.has("B7")).toBe(true);
+    expect(indexes.taskBudgetIds.get("task-B")?.has("B8")).toBe(true);
+    expect(indexes.taskBudgetIds.get("task-A")?.has("B8")).toBe(false);
+    expect(indexes.taskBudgetIds.get("task-B")?.has("B7")).toBe(false);
+  });
+
+  it("handles agent → task scope transitions symmetrically", () => {
+    const indexes = __createBudgetCandidateIndexesForTesting();
+    const agentForm = makeReplayedBudget({ scope: "agent", subjectId: "primary" });
+    const taskForm = makeReplayedBudget({ scope: "task", subjectId: "task-A" });
+    addBudgetToIndex(indexes, "B9", agentForm);
+    removeBudgetFromIndex(indexes, "B9", agentForm);
+    addBudgetToIndex(indexes, "B9", taskForm);
+    expect(indexes.agentBudgetIds.has("primary")).toBe(false);
+    expect(indexes.taskBudgetIds.get("task-A")?.has("B9")).toBe(true);
+  });
+
+  // Round-3 staff finding 1: direct coverage of `computeExpectedCrossings`,
+  // the actual hot path. The five helper tests above test the index
+  // shape; they would not catch a regression that re-introduces
+  // `new Set(globalBudgetIds)` + merge in the hot path or, worse, a
+  // regression that iterates the full `args.budgets` universe.
+  // This test wraps `args.budgets` in a Proxy that throws on any
+  // access other than `.get(id)` and `.has(id)`, proving the
+  // implementation never iterates the universe; it also records every
+  // `.get()` to assert only scope-matched ids are visited.
+  describe("computeExpectedCrossings (hot path)", () => {
+    type ReplayedBudgetShape = ReturnType<typeof makeReplayedBudget>;
+    type ComputeExpectedCrossingsArgs = Parameters<typeof computeExpectedCrossings>[0];
+
+    function makeHostileBudgets(entries: ReadonlyArray<[string, ReplayedBudgetShape]>) {
+      const underlying = new Map(entries);
+      const getCalls: string[] = [];
+      const proxy = new Proxy(underlying, {
+        get(_target, prop) {
+          if (prop === "get") {
+            return (key: string) => {
+              getCalls.push(key);
+              return underlying.get(key);
+            };
+          }
+          if (prop === "has") return (key: string) => underlying.has(key);
+          if (prop === "size") return underlying.size;
+          throw new Error(
+            `computeExpectedCrossings must access args.budgets only via .get(id); attempted .${String(prop)}`,
+          );
+        },
+      });
+      return { budgets: proxy as unknown as ReadonlyMap<string, ReplayedBudgetShape>, getCalls };
+    }
+
+    it("visits only scope-matched candidates, never iterates the universe", () => {
+      // 100 noise budgets under agent "OTHER_AGENT" + 1 candidate
+      // under "MY_AGENT" + 1 global + 1 under task "MY_TASK" + 5
+      // noise budgets under task "OTHER_TASK". Call with
+      // agentSlug="MY_AGENT", taskId="MY_TASK": expected 3 visits.
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const allBudgets: Array<[string, ReplayedBudgetShape]> = [];
+
+      const myAgentBudget = makeReplayedBudget({ scope: "agent", subjectId: "MY_AGENT" });
+      const globalBudget = makeReplayedBudget({ scope: "global" });
+      const myTaskBudget = makeReplayedBudget({ scope: "task", subjectId: "MY_TASK" });
+      addBudgetToIndex(indexes, "MY", myAgentBudget);
+      addBudgetToIndex(indexes, "GLOBAL", globalBudget);
+      addBudgetToIndex(indexes, "TASK_MY", myTaskBudget);
+      allBudgets.push(["MY", myAgentBudget], ["GLOBAL", globalBudget], ["TASK_MY", myTaskBudget]);
+
+      for (let i = 0; i < 100; i += 1) {
+        const id = `OTHER_AGENT_${i}`;
+        const noise = makeReplayedBudget({ scope: "agent", subjectId: "OTHER_AGENT" });
+        addBudgetToIndex(indexes, id, noise);
+        allBudgets.push([id, noise]);
+      }
+      for (let i = 0; i < 5; i += 1) {
+        const id = `OTHER_TASK_${i}`;
+        const noise = makeReplayedBudget({ scope: "task", subjectId: "OTHER_TASK" });
+        addBudgetToIndex(indexes, id, noise);
+        allBudgets.push([id, noise]);
+      }
+
+      const { budgets, getCalls } = makeHostileBudgets(allBudgets);
+      const out: ComputeExpectedCrossingsArgs["out"] = new Map();
+      // limitMicroUsd = 1_000_000 with threshold 5000bps fires when
+      // observed >= 500_000. globalLifetime = 600_000 forces a
+      // crossing on the visited candidates.
+      computeExpectedCrossings({
+        costEventLsn: 42,
+        costEventOccurredAtMs: 1_700_000_000_000,
+        agentSlug: "MY_AGENT",
+        taskId: "MY_TASK",
+        budgets,
+        globalBudgetIds: indexes.globalBudgetIds,
+        agentBudgetIds: indexes.agentBudgetIds,
+        taskBudgetIds: indexes.taskBudgetIds,
+        globalLifetime: 600_000,
+        agentLifetime: new Map([["MY_AGENT", 600_000]]),
+        taskLifetime: new Map([["MY_TASK", 600_000]]),
+        out,
+      });
+
+      // Three .get() calls — one per scope-matched candidate. If the
+      // Proxy didn't trigger an iteration error AND the call count is
+      // exactly 3, no universe walk and no transient merge-Set
+      // construction visiting noise IDs.
+      expect(getCalls.sort()).toEqual(["GLOBAL", "MY", "TASK_MY"]);
+      expect(out.size).toBe(3);
+    });
+
+    it("handles missing agent index entry without iteration", () => {
+      // No agent budget at all under `agentSlug`. visitCandidates
+      // must early-return on undefined; the Proxy is not even
+      // touched for the agent branch.
+      const indexes = __createBudgetCandidateIndexesForTesting();
+      const globalBudget = makeReplayedBudget({ scope: "global" });
+      addBudgetToIndex(indexes, "G", globalBudget);
+
+      const { budgets, getCalls } = makeHostileBudgets([["G", globalBudget]]);
+      const out: ComputeExpectedCrossingsArgs["out"] = new Map();
+      computeExpectedCrossings({
+        costEventLsn: 7,
+        costEventOccurredAtMs: 1_700_000_000_000,
+        agentSlug: "UNKNOWN_AGENT",
+        taskId: undefined,
+        budgets,
+        globalBudgetIds: indexes.globalBudgetIds,
+        agentBudgetIds: indexes.agentBudgetIds,
+        taskBudgetIds: indexes.taskBudgetIds,
+        globalLifetime: 600_000,
+        agentLifetime: new Map(),
+        taskLifetime: new Map(),
+        out,
+      });
+
+      expect(getCalls).toEqual(["G"]);
+      expect(out.size).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
Links #842.

## Summary
- Maintains replay-check budget candidate indexes keyed by global, agent slug, and task ID while scanning `cost.budget.set` events.
- Updates the threshold-crossing oracle to evaluate only `global ∪ matching agent ∪ matching task` budget IDs per cost event, while keeping the existing defensive applicability and tombstone checks.
- Adds a replay-check regression test with 1,000 tombstoned budgets plus a scope transition and tombstone on the active budget.

## Verification
- `bash scripts/test-web.sh packages/broker/tests/cost-ledger.spec.ts` attempted; wrapper is web-scoped and reported no broker test files.
- `cd packages/broker && bun run test tests/cost-ledger.spec.ts`
- `cd packages/broker && bun run typecheck`
- `bunx biome check --write packages/broker/src/cost-ledger/replay-check.ts packages/broker/tests/cost-ledger.spec.ts`
- `cd packages/broker && bun run test`
- `cd packages/broker && bun run check`
- `cd packages/broker && bun run check:invariants`
- `cd packages/protocol && bunx tsc --noEmit`
- `cd packages/protocol && bunx biome check src/ tests/ scripts/`
- `bash scripts/test-protocol.sh`
- `bun run packages/protocol/scripts/demo.ts`
- Pre-push hook passed: broker invariants, broker tests, broker typecheck, complexity baseline, file-size check.

| # | Finding | Status | Notes |
|---|---------|--------|-------|
| 1 | Maintain scope-keyed budget indexes | FIXED | commit ab9622078d6a619c28bded8f86badc85e3b90931 |
| 2 | Update computeExpectedCrossings iteration | FIXED | commit ab9622078d6a619c28bded8f86badc85e3b90931 |
| 3 | Handle scope transitions + tombstones | FIXED | commit ab9622078d6a619c28bded8f86badc85e3b90931 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and performance of cost ledger replay checking by optimizing how budget threshold crossings are evaluated.

* **Tests**
  * Added comprehensive test coverage for budget candidate filtering and scope transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/846)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->