### PR TITLE
feat(agent-runners): openai-compat HTTP adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ All notable changes to WUPHF will be documented in this file.
   writes authoritative receipts, and fails the run when receipt storage fails.
   Broker runner routes add `POST /api/runners` plus
   `GET /api/runners/:id/events` SSE with bearer-to-agent gating.
+- **OpenAI-compatible HTTP agent runner adapter.** `@wuphf/agent-runners` now
+  includes `createOpenAICompatRunner()` for streaming chat-completions endpoints
+  that speak OpenAI-style SSE. The adapter uses `AbortController` for
+  termination and timeouts, selects bearer vs `x-api-key` auth from
+  `CredentialScope`, writes authoritative receipts, records provider usage as
+  cost events, and emits a zero-cost usage-missing note when providers omit
+  usage data.
 - **Channel participant rail for conversations.** Channel views now include a Slack-like participants list that shows which agents are part of the current channel, opens an agent panel from each row, filters out human seats, and keeps lead agents pinned. The rail supports adding available office agents, disabling or enabling specific channel participants, removing agents from only the current channel, and undoing a remove from the toast within five seconds.
 - **Skills app reskinned as pixel-art trading cards.** Every entry in the Skills tab is now a TCG-style card with a procedurally-generated 144px pixel-art portrait (using the existing `drawPixelAvatar` system), status-driven type palette (active = electric, proposed = psychic with "NEEDS REVIEW" stamp, disabled = dark, archived = steel), and a 3D card flip (700ms, ease-out-expo, respects `prefers-reduced-motion`).
   - **Front face:** Title + creator byline, procedural portrait, status/owner stat strip, promoted "Triggers on" row, and scrollable flavor-text description.

--- a/packages/agent-runners/README.md
+++ b/packages/agent-runners/README.md
@@ -1,6 +1,6 @@
 # @wuphf/agent-runners
 
-Subprocess-backed agent runners for WUPHF v1.
+Agent runners for WUPHF v1.
 
 The package freezes the `AgentRunner` interface and ships the first concrete
 adapter, Claude CLI in `--print` streaming JSON mode. Codex CLI and
@@ -15,9 +15,9 @@ the secret once at spawn time, injects it as `ANTHROPIC_API_KEY`, and then only
 emits `RunnerEvent` values from `@wuphf/protocol`.
 
 Receipt writes are authoritative. If `receiptStore.put` throws or reports that
-the receipt was not stored, the run emits `failed` and does not emit
-`finished`. This is the v1 guard against the v0 `appendTaskLogEntry`
-best-effort receipt anti-pattern.
+the receipt was not stored, the run emits `failed` and does not emit `finished`.
+This is the v1 guard against the v0 `appendTaskLogEntry` best-effort receipt
+anti-pattern.
 
 Lifecycle state is owned by the runner fiber. Output consumers subscribe to a
 `ReadableStream<RunnerEvent>` but cannot mutate state, and `terminate()` waits
@@ -39,3 +39,45 @@ live consumers rely on `ReadableStream` backpressure.
 
 Real CLI smoke coverage is deferred until a gated
 `WUPHF_REAL_CLAUDE_CLI=1` test lands in a follow-up.
+
+## OpenAI-Compatible HTTP Adapter
+
+`createOpenAICompatRunner()` drives chat-completions endpoints that implement
+OpenAI-style streaming SSE. It does not spawn a subprocess; the runner is the
+in-flight HTTP request, and `terminate()` aborts through `AbortController`.
+
+The wire-frozen `RunnerSpawnRequest` has no provider-options field, so this
+adapter exposes a typed local extension:
+
+```ts
+import {
+  createOpenAICompatRunner,
+  type OpenAICompatRunnerSpawnRequest,
+} from "@wuphf/agent-runners";
+
+const request: OpenAICompatRunnerSpawnRequest = {
+  kind: "openai-compat",
+  agentId,
+  credential,
+  prompt: "Summarize the change",
+  model: "gpt-5-mini",
+  options: {
+    endpoint: "https://api.openai.com/v1/chat/completions",
+    headers: { "OpenAI-Organization": "org_..." },
+    timeoutMs: 60_000,
+  },
+};
+```
+
+The broker-provided secret is read once at spawn time. Scope `openai` and
+`openai-compat` use `Authorization: Bearer <secret>`; scope `anthropic` uses
+`x-api-key: <secret>`. Other scopes fall back to bearer auth and emit a
+structured `stderr` event documenting the assumption.
+
+SSE `delta.content` chunks become `stdout` events. A provider-reported `usage`
+object becomes a cost ledger entry and `cost` event; if the provider omits
+usage, the adapter records a zero-cost entry and marks the emitted cost event
+with `note: "provider_did_not_report_usage"` for operational visibility.
+
+Retries are intentionally not implemented in the adapter. TODO(#NEW): add a
+cost-ledger-aware, idempotency-aware retry middleware above concrete adapters.

--- a/packages/agent-runners/src/adapters/openai-compat.ts
+++ b/packages/agent-runners/src/adapters/openai-compat.ts
@@ -1,0 +1,753 @@
+import { randomBytes } from "node:crypto";
+
+import {
+  type AgentId,
+  asAgentSlug,
+  asMicroUsd,
+  asProviderKind,
+  asReceiptId,
+  asRunnerId,
+  asTaskId,
+  type CostLedgerEntry,
+  CredentialHandle,
+  type CredentialScope,
+  type ProviderKind,
+  type ReceiptId,
+  type ReceiptSnapshot,
+  type RunnerEvent,
+  type RunnerId,
+  type RunnerSpawnRequest,
+  SanitizedString,
+  sha256Hex,
+  type TaskId,
+} from "@wuphf/protocol";
+
+import { ReceiptWriteFailed, RunnerSpawnFailed } from "../errors.ts";
+import { DEFAULT_MAX_EVENT_HISTORY, RunnerEventHub } from "../internal/event-hub.ts";
+import { LifecycleStateMachine } from "../lifecycle.ts";
+import type { AgentRunner, RunnerSpawnDeps, SpawnAgentRunner } from "../runner.ts";
+
+export interface OpenAICompatRunnerOptions {
+  readonly endpoint: string;
+  readonly headers?: Readonly<Record<string, string>> | undefined;
+  readonly timeoutMs?: number | undefined;
+}
+
+export type OpenAICompatRunnerSpawnRequest = RunnerSpawnRequest & {
+  readonly options?: OpenAICompatRunnerOptions | undefined;
+};
+
+export type OpenAICompatFetch = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface OpenAICompatAdapterOptions {
+  readonly fetchFn?: OpenAICompatFetch | undefined;
+  readonly now?: (() => Date) | undefined;
+  readonly runnerIdFactory?: (() => RunnerId) | undefined;
+  readonly receiptIdFactory?: (() => ReceiptId) | undefined;
+  readonly taskIdFactory?: (() => TaskId) | undefined;
+  readonly maxEventHistory?: number | undefined;
+}
+
+interface OpenAICompatUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheCreationTokens: number;
+  readonly model?: string | undefined;
+}
+
+interface AuthSelection {
+  readonly headers: Headers;
+  readonly warning?: string | undefined;
+}
+
+interface FailureCause {
+  readonly name?: string | undefined;
+  readonly message: string;
+}
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+export const OPENAI_COMPAT_DEFAULT_TIMEOUT_MS = 60_000;
+const DEFAULT_MODEL = "openai-compat";
+const SAFE_HTTP_ERROR_BODY_BYTES = 2_048;
+const SAFE_FAILURE_MESSAGE_BYTES = 7_500;
+
+export function createOpenAICompatRunner(
+  options: OpenAICompatAdapterOptions = {},
+): SpawnAgentRunner {
+  const fetchFn = options.fetchFn ?? ((input, init) => globalThis.fetch(input, init));
+  return async (request, deps) => {
+    if (request.kind !== "openai-compat") {
+      throw new RunnerSpawnFailed(`OpenAI-compatible adapter cannot run ${request.kind}`);
+    }
+    const runnerOptions = parseRunnerOptions(request);
+    const secret = await deps.secretReader(deps.credential);
+    const runner = new OpenAICompatAgentRunner({
+      deps,
+      fetchFn,
+      maxEventHistory: options.maxEventHistory ?? DEFAULT_MAX_EVENT_HISTORY,
+      now: options.now ?? (() => new Date()),
+      receiptIdFactory: options.receiptIdFactory ?? randomReceiptId,
+      request,
+      runnerId: options.runnerIdFactory?.() ?? randomRunnerId(),
+      runnerOptions,
+      secret,
+      taskIdFactory: options.taskIdFactory ?? randomTaskId,
+    });
+    runner.start();
+    return runner;
+  };
+}
+
+class OpenAICompatAgentRunner implements AgentRunner {
+  readonly id: RunnerId;
+  readonly kind = "openai-compat" as const;
+  readonly agentId: AgentId;
+
+  readonly #abortController = new AbortController();
+  readonly #deps: RunnerSpawnDeps;
+  readonly #fetchFn: OpenAICompatFetch;
+  readonly #hub: RunnerEventHub;
+  readonly #lifecycle: LifecycleStateMachine;
+  readonly #now: () => Date;
+  readonly #providerKind: ProviderKind;
+  readonly #receiptIdFactory: () => ReceiptId;
+  readonly #request: RunnerSpawnRequest;
+  readonly #runnerOptions: OpenAICompatRunnerOptions;
+  readonly #secret: string;
+  readonly #taskIdFactory: () => TaskId;
+  #costEmitted = false;
+  #done: Promise<void> | null = null;
+  #failed = false;
+  #finalText = "";
+  #lastUsage: OpenAICompatUsage | null = null;
+  #startedAt: Date;
+  #terminatePromise: Promise<void> | null = null;
+  #terminateRequested = false;
+
+  constructor(args: {
+    readonly deps: RunnerSpawnDeps;
+    readonly fetchFn: OpenAICompatFetch;
+    readonly maxEventHistory: number;
+    readonly now: () => Date;
+    readonly receiptIdFactory: () => ReceiptId;
+    readonly request: RunnerSpawnRequest;
+    readonly runnerId: RunnerId;
+    readonly runnerOptions: OpenAICompatRunnerOptions;
+    readonly secret: string;
+    readonly taskIdFactory: () => TaskId;
+  }) {
+    this.id = args.runnerId;
+    this.agentId = args.request.agentId;
+    this.#deps = args.deps;
+    this.#fetchFn = args.fetchFn;
+    this.#hub = new RunnerEventHub(args.maxEventHistory);
+    this.#lifecycle = new LifecycleStateMachine(args.runnerId);
+    this.#now = args.now;
+    this.#providerKind = providerKindForScope(CredentialHandle.scope(args.deps.credential));
+    this.#receiptIdFactory = args.receiptIdFactory;
+    this.#request = args.request;
+    this.#runnerOptions = args.runnerOptions;
+    this.#secret = args.secret;
+    this.#startedAt = args.now();
+    this.#taskIdFactory = args.taskIdFactory;
+  }
+
+  events() {
+    return this.#hub.events();
+  }
+
+  start(): void {
+    if (this.#done !== null) return;
+    this.#done = this.#run().finally(() => {
+      this.#hub.close();
+    });
+  }
+
+  async terminate(): Promise<void> {
+    if (this.#terminatePromise === null) {
+      this.#terminatePromise = Promise.resolve().then(async () => {
+        const transitioned = this.#lifecycle.beginStopping();
+        if (transitioned) {
+          this.#terminateRequested = true;
+          this.#abortController.abort(new DOMException("terminated", "AbortError"));
+        }
+        await (this.#done ?? this.#lifecycle.stopped());
+      });
+    }
+    return this.#terminatePromise;
+  }
+
+  async #run(): Promise<void> {
+    const timeoutSignal = AbortSignal.timeout(
+      this.#runnerOptions.timeoutMs ?? OPENAI_COMPAT_DEFAULT_TIMEOUT_MS,
+    );
+    const signal = AbortSignal.any([this.#abortController.signal, timeoutSignal]);
+    try {
+      this.#lifecycle.markRunning();
+      this.#startedAt = this.#now();
+      const auth = this.#authSelection();
+      // TODO(#NEW): put retries in ledger/idempotency-aware middleware above adapters.
+      const response = await withAbort(
+        this.#fetchFn(this.#runnerOptions.endpoint, {
+          body: JSON.stringify(this.#requestBody()),
+          headers: auth.headers,
+          method: "POST",
+          signal,
+        }),
+        signal,
+      );
+      if (!response.ok) {
+        const body = await safeResponseText(response, signal);
+        const message = failureMessage("openai_compat_http_error", {
+          body,
+          exitCode: 1,
+          status: response.status,
+          statusText: response.statusText,
+        });
+        await this.#fail(message);
+        this.#lifecycle.markStopped({ exitCode: 1, error: message });
+        return;
+      }
+      await this.#emit({ kind: "started", runnerId: this.id, at: this.#isoNow() });
+      if (auth.warning !== undefined) {
+        await this.#emit({
+          kind: "stderr",
+          runnerId: this.id,
+          chunk: auth.warning,
+          at: this.#isoNow(),
+        });
+      }
+      const sawDone = await this.#consumeSse(response.body, signal);
+      if (!sawDone) {
+        const message = failureMessage("openai_compat_stream_ended_without_done", {
+          exitCode: 1,
+        });
+        await this.#fail(message);
+        this.#lifecycle.markStopped({ exitCode: 1, error: message });
+        return;
+      }
+      if (!this.#costEmitted) {
+        await this.#emitCost(zeroUsage(), "provider_did_not_report_usage");
+      }
+      await this.#writeReceiptAndFinish(0);
+      this.#lifecycle.markStopped({ exitCode: 0 });
+    } catch (error) {
+      const message = this.#failureMessageForCaughtError(error, timeoutSignal);
+      await this.#fail(message);
+      this.#lifecycle.markStopped({ exitCode: 1, error: message });
+    }
+  }
+
+  #requestBody(): Readonly<Record<string, unknown>> {
+    return {
+      messages: [{ role: "user", content: this.#request.prompt }],
+      model: this.#request.model ?? DEFAULT_MODEL,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+  }
+
+  #authSelection(): AuthSelection {
+    const scope = String(CredentialHandle.scope(this.#deps.credential));
+    const headers = new Headers();
+    headers.set("Accept", "text/event-stream");
+    headers.set("Content-Type", "application/json");
+    for (const [key, value] of Object.entries(this.#runnerOptions.headers ?? {})) {
+      headers.set(key, value);
+    }
+    if (scope === "anthropic") {
+      headers.set("x-api-key", this.#secret);
+      headers.delete("Authorization");
+      return { headers };
+    }
+    headers.set("Authorization", `Bearer ${this.#secret}`);
+    headers.delete("x-api-key");
+    if (scope === "openai" || scope === "openai-compat") {
+      return { headers };
+    }
+    return {
+      headers,
+      warning: JSON.stringify({
+        assumedAuthShape: "authorization_bearer",
+        code: "openai_compat_unknown_credential_scope",
+        scope,
+      }),
+    };
+  }
+
+  async #consumeSse(
+    body: ReadableStream<Uint8Array> | null,
+    signal: AbortSignal,
+  ): Promise<boolean> {
+    if (body === null) {
+      throw new Error("openai_compat_response_body_missing");
+    }
+    const reader = body.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    try {
+      while (true) {
+        const next = await withAbort(reader.read(), signal);
+        if (next.done) break;
+        buffered += decoder.decode(next.value, { stream: true });
+        const done = await this.#drainBufferedSseLines(buffered, (remaining) => {
+          buffered = remaining;
+        });
+        if (done) {
+          await reader.cancel();
+          return true;
+        }
+      }
+      buffered += decoder.decode();
+      if (buffered.length > 0) {
+        return await this.#handleSseLine(stripTrailingCarriageReturn(buffered));
+      }
+      return false;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async #drainBufferedSseLines(
+    buffered: string,
+    setRemaining: (remaining: string) => void,
+  ): Promise<boolean> {
+    let remaining = buffered;
+    let newline = remaining.indexOf("\n");
+    while (newline >= 0) {
+      const line = stripTrailingCarriageReturn(remaining.slice(0, newline));
+      remaining = remaining.slice(newline + 1);
+      if (await this.#handleSseLine(line)) {
+        setRemaining(remaining);
+        return true;
+      }
+      newline = remaining.indexOf("\n");
+    }
+    setRemaining(remaining);
+    return false;
+  }
+
+  async #handleSseLine(line: string): Promise<boolean> {
+    if (line.length === 0 || line.startsWith(":")) return false;
+    if (!line.startsWith("data:")) return false;
+    const payload = line.slice("data:".length).trimStart();
+    if (payload === "[DONE]") return true;
+    const parsed = parseJsonRecord(payload, "openai_compat_sse_json_invalid");
+    const content = extractDeltaContent(parsed);
+    if (content.length > 0) {
+      this.#finalText += content;
+      await this.#emit({ kind: "stdout", runnerId: this.id, chunk: content, at: this.#isoNow() });
+    }
+    const usage = extractUsage(parsed);
+    if (usage !== null && !this.#costEmitted) {
+      await this.#emitCost(usage);
+    }
+    return false;
+  }
+
+  async #emitCost(
+    usage: OpenAICompatUsage,
+    note?: "provider_did_not_report_usage" | undefined,
+  ): Promise<void> {
+    this.#lastUsage = usage;
+    this.#costEmitted = true;
+    const ledgerEntry = this.#costEntry(usage);
+    await this.#deps.costLedger.record(ledgerEntry);
+    const eventEntry =
+      note === undefined
+        ? ledgerEntry
+        : ({ ...ledgerEntry, note } satisfies CostLedgerEntry & { readonly note: string });
+    await this.#emit({
+      kind: "cost",
+      runnerId: this.id,
+      entry: eventEntry,
+      at: this.#isoNow(),
+    });
+  }
+
+  #costEntry(usage: OpenAICompatUsage): CostLedgerEntry {
+    const amount =
+      usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreationTokens;
+    return {
+      agentSlug: asAgentSlug(this.agentId),
+      providerKind: this.#providerKind,
+      model: usage.model ?? this.#request.model ?? DEFAULT_MODEL,
+      amountMicroUsd: asMicroUsd(amount),
+      units: {
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadTokens,
+        cacheCreationTokens: usage.cacheCreationTokens,
+      },
+      occurredAt: this.#now(),
+    };
+  }
+
+  async #writeReceiptAndFinish(exitCode: number): Promise<void> {
+    const receipt = this.#buildReceipt();
+    try {
+      const stored = await this.#deps.receiptStore.put(receipt);
+      if (!stored.stored) {
+        throw new ReceiptWriteFailed(this.id, "receipt store reported stored=false");
+      }
+    } catch (error) {
+      const message = errorMessage(error);
+      await this.#fail(message);
+      throw new ReceiptWriteFailed(this.id, message, { cause: error });
+    }
+    await this.#emit({
+      kind: "receipt",
+      runnerId: this.id,
+      receiptId: receipt.id,
+      at: this.#isoNow(),
+    });
+    await this.#emit({ kind: "finished", runnerId: this.id, exitCode, at: this.#isoNow() });
+  }
+
+  #buildReceipt(): ReceiptSnapshot {
+    const usage = this.#lastUsage ?? zeroUsage();
+    const amount =
+      usage.inputTokens + usage.outputTokens + usage.cacheReadTokens + usage.cacheCreationTokens;
+    const finishedAt = this.#now();
+    return {
+      id: this.#receiptIdFactory(),
+      agentSlug: asAgentSlug(this.agentId),
+      taskId: this.#request.taskId ?? this.#taskIdFactory(),
+      triggerKind: "human_message",
+      triggerRef: this.id,
+      startedAt: this.#startedAt,
+      finishedAt,
+      status: "ok",
+      providerKind: this.#providerKind,
+      model: usage.model ?? this.#request.model ?? DEFAULT_MODEL,
+      promptHash: sha256Hex(this.#request.prompt),
+      toolManifest: sha256Hex("openai-compat-http:v1"),
+      toolCalls: [],
+      approvals: [],
+      filesChanged: [],
+      commits: [],
+      sourceReads: [],
+      writes: [],
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      cacheReadTokens: usage.cacheReadTokens,
+      cacheCreationTokens: usage.cacheCreationTokens,
+      costUsd: amount / 1_000_000,
+      finalMessage: SanitizedString.fromUnknown(this.#finalText),
+      error: SanitizedString.fromUnknown(""),
+      notebookWrites: [],
+      wikiWrites: [],
+      schemaVersion: 2,
+    };
+  }
+
+  async #emit(event: RunnerEvent): Promise<void> {
+    await this.#deps.eventLog.append(event);
+    this.#hub.publish(event);
+  }
+
+  async #fail(message: string): Promise<void> {
+    if (this.#failed) return;
+    this.#failed = true;
+    const event: RunnerEvent = {
+      kind: "failed",
+      runnerId: this.id,
+      error: truncateUtf8(message, SAFE_FAILURE_MESSAGE_BYTES),
+      at: this.#isoNow(),
+    };
+    try {
+      await this.#deps.eventLog.append(event);
+    } finally {
+      this.#hub.publish(event);
+    }
+  }
+
+  #failureMessageForCaughtError(error: unknown, timeoutSignal: AbortSignal): string {
+    const cause = failureCause(error);
+    if (this.#terminateRequested) {
+      return failureMessage("openai_compat_aborted", { cause, exitCode: 1 });
+    }
+    if (timeoutSignal.aborted) {
+      return failureMessage("openai_compat_timeout", {
+        cause,
+        exitCode: 1,
+        timeoutMs: this.#runnerOptions.timeoutMs ?? OPENAI_COMPAT_DEFAULT_TIMEOUT_MS,
+      });
+    }
+    return failureMessage("openai_compat_network_error", { cause, exitCode: 1 });
+  }
+
+  #isoNow(): string {
+    return this.#now().toISOString();
+  }
+}
+
+function parseRunnerOptions(request: RunnerSpawnRequest): OpenAICompatRunnerOptions {
+  const rawOptions = (request as { readonly options?: unknown }).options;
+  if (!isRecord(rawOptions)) {
+    throw new RunnerSpawnFailed("OpenAI-compatible runner requires options.endpoint");
+  }
+  const endpoint = recordString(rawOptions, "endpoint");
+  if (endpoint === null || endpoint.length === 0) {
+    throw new RunnerSpawnFailed("OpenAI-compatible runner requires options.endpoint");
+  }
+  validateHttpEndpoint(endpoint);
+  const headers = optionalHeaders(rawOptions);
+  const timeoutMs = optionalTimeoutMs(rawOptions);
+  return {
+    endpoint,
+    ...(headers === undefined ? {} : { headers }),
+    ...(timeoutMs === undefined ? {} : { timeoutMs }),
+  };
+}
+
+function validateHttpEndpoint(endpoint: string): void {
+  try {
+    const url = new URL(endpoint);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new RunnerSpawnFailed("OpenAI-compatible endpoint must use http or https");
+    }
+  } catch (error) {
+    if (error instanceof RunnerSpawnFailed) throw error;
+    throw new RunnerSpawnFailed("OpenAI-compatible endpoint must be a valid URL", {
+      cause: error,
+    });
+  }
+}
+
+function optionalHeaders(
+  record: Readonly<Record<string, unknown>>,
+): Record<string, string> | undefined {
+  const raw = recordValue(record, "headers");
+  if (raw === undefined) return undefined;
+  if (!isRecord(raw)) {
+    throw new RunnerSpawnFailed("OpenAI-compatible options.headers must be an object");
+  }
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== "string") {
+      throw new RunnerSpawnFailed("OpenAI-compatible options.headers values must be strings");
+    }
+    headers[key] = value;
+  }
+  return headers;
+}
+
+function optionalTimeoutMs(record: Readonly<Record<string, unknown>>): number | undefined {
+  const raw = recordValue(record, "timeoutMs");
+  if (raw === undefined) return undefined;
+  if (typeof raw !== "number" || !Number.isSafeInteger(raw) || raw <= 0) {
+    throw new RunnerSpawnFailed("OpenAI-compatible options.timeoutMs must be a positive integer");
+  }
+  return raw;
+}
+
+function providerKindForScope(scope: CredentialScope): ProviderKind {
+  try {
+    return asProviderKind(String(scope));
+  } catch {
+    return asProviderKind("openai-compat");
+  }
+}
+
+async function safeResponseText(response: Response, signal: AbortSignal): Promise<string> {
+  try {
+    return truncateUtf8(await withAbort(response.text(), signal), SAFE_HTTP_ERROR_BODY_BYTES);
+  } catch (error) {
+    return failureMessage("openai_compat_error_body_unavailable", {
+      cause: failureCause(error),
+    });
+  }
+}
+
+function extractDeltaContent(record: Readonly<Record<string, unknown>>): string {
+  const choices = recordValue(record, "choices");
+  if (!Array.isArray(choices)) return "";
+  const first = choices[0];
+  if (!isRecord(first)) return "";
+  const delta = recordValue(first, "delta");
+  if (!isRecord(delta)) return "";
+  const content = recordValue(delta, "content");
+  return typeof content === "string" ? content : "";
+}
+
+function extractUsage(record: Readonly<Record<string, unknown>>): OpenAICompatUsage | null {
+  const usage = recordValue(record, "usage");
+  if (!isRecord(usage)) return null;
+  const model = recordString(record, "model");
+  const promptTokens = nonNegativeInteger(usage, "prompt_tokens", "usage.prompt_tokens") ?? 0;
+  const completionTokens =
+    nonNegativeInteger(usage, "completion_tokens", "usage.completion_tokens") ?? 0;
+  const promptDetails = recordValue(usage, "prompt_tokens_details");
+  const cachedTokensRaw = isRecord(promptDetails)
+    ? (nonNegativeInteger(
+        promptDetails,
+        "cached_tokens",
+        "usage.prompt_tokens_details.cached_tokens",
+      ) ?? 0)
+    : 0;
+  const inputTokens = nonNegativeInteger(usage, "input_tokens", "usage.input_tokens");
+  const outputTokens = nonNegativeInteger(usage, "output_tokens", "usage.output_tokens");
+  const cacheReadTokens = nonNegativeInteger(
+    usage,
+    "cache_read_input_tokens",
+    "usage.cache_read_input_tokens",
+  );
+  const cacheCreationTokens = nonNegativeInteger(
+    usage,
+    "cache_creation_input_tokens",
+    "usage.cache_creation_input_tokens",
+  );
+  if (inputTokens !== undefined || outputTokens !== undefined) {
+    return {
+      inputTokens: inputTokens ?? 0,
+      outputTokens: outputTokens ?? 0,
+      cacheReadTokens: cacheReadTokens ?? 0,
+      cacheCreationTokens: cacheCreationTokens ?? 0,
+      ...(model === null ? {} : { model }),
+    };
+  }
+  const cachedTokens = Math.min(Math.max(0, cachedTokensRaw), promptTokens);
+  return {
+    inputTokens: Math.max(0, promptTokens - cachedTokens),
+    outputTokens: completionTokens,
+    cacheReadTokens: cachedTokens,
+    cacheCreationTokens: 0,
+    ...(model === null ? {} : { model }),
+  };
+}
+
+function zeroUsage(): OpenAICompatUsage {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+  };
+}
+
+function nonNegativeInteger(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  path: string,
+): number | undefined {
+  const value = recordValue(record, key);
+  if (value === undefined) return undefined;
+  if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0) {
+    return value;
+  }
+  throw new Error(`${path}: must be a non-negative safe integer`);
+}
+
+function parseJsonRecord(payload: string, code: string): Readonly<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch (error) {
+    throw new Error(failureMessage(code, { cause: failureCause(error) }));
+  }
+  if (!isRecord(parsed)) {
+    throw new Error(failureMessage(code, { cause: { message: "data payload was not an object" } }));
+  }
+  return parsed;
+}
+
+async function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw abortError(signal);
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(abortError(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (reason: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(reason);
+      },
+    );
+  });
+}
+
+function abortError(signal: AbortSignal): unknown {
+  return signal.reason ?? new DOMException("aborted", "AbortError");
+}
+
+function failureMessage(code: string, fields: Readonly<Record<string, unknown>>): string {
+  return `${code}: ${JSON.stringify(fields)}`;
+}
+
+function failureCause(error: unknown): FailureCause {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+  return { message: String(error) };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  const encoded = new TextEncoder().encode(value);
+  if (encoded.byteLength <= maxBytes) return value;
+  const truncated = new TextDecoder().decode(encoded.slice(0, maxBytes));
+  return `${truncated}[truncated]`;
+}
+
+function stripTrailingCarriageReturn(value: string): string {
+  return value.endsWith("\r") ? value.slice(0, -1) : value;
+}
+
+function recordString(record: Readonly<Record<string, unknown>>, key: string): string | null {
+  const value = recordValue(record, key);
+  return typeof value === "string" ? value : null;
+}
+
+function recordValue(record: Readonly<Record<string, unknown>>, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+  return descriptor !== undefined && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function randomRunnerId(): RunnerId {
+  return asRunnerId(`run_${randomBase32(32)}`);
+}
+
+function randomReceiptId(): ReceiptId {
+  return asReceiptId(randomBase32(26));
+}
+
+function randomTaskId(): TaskId {
+  return asTaskId(randomBase32(26));
+}
+
+function randomBase32(length: number): string {
+  const bytes = randomBytes(length);
+  let out = "";
+  for (let index = 0; index < length; index += 1) {
+    const byte = bytes[index];
+    if (byte === undefined) {
+      throw new Error("random byte missing");
+    }
+    const char = CROCKFORD[byte % CROCKFORD.length];
+    if (char === undefined) {
+      throw new Error("random alphabet lookup failed");
+    }
+    out += char;
+  }
+  return out;
+}

--- a/packages/agent-runners/src/index.ts
+++ b/packages/agent-runners/src/index.ts
@@ -5,6 +5,16 @@ export type {
   ClaudeCliSpawnOptions,
 } from "./adapters/claude-cli.ts";
 export { createClaudeCliRunner } from "./adapters/claude-cli.ts";
+export type {
+  OpenAICompatAdapterOptions,
+  OpenAICompatFetch,
+  OpenAICompatRunnerOptions,
+  OpenAICompatRunnerSpawnRequest,
+} from "./adapters/openai-compat.ts";
+export {
+  createOpenAICompatRunner,
+  OPENAI_COMPAT_DEFAULT_TIMEOUT_MS,
+} from "./adapters/openai-compat.ts";
 export {
   AgentRunnerError,
   ClaudeCliNotAvailable,

--- a/packages/agent-runners/tests/adapters/openai-compat.spec.ts
+++ b/packages/agent-runners/tests/adapters/openai-compat.spec.ts
@@ -1,0 +1,557 @@
+import type { ReadableStream as RunnerEventStream } from "node:stream/web";
+
+import {
+  asAgentId,
+  asCredentialHandleId,
+  asCredentialScope,
+  asReceiptId,
+  asRunnerId,
+  asTaskId,
+  type CostLedgerEntry,
+  type CredentialHandle,
+  type CredentialScope,
+  credentialHandleFromJson,
+  type RunnerEvent,
+} from "@wuphf/protocol";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createBrokerIdentityForTesting } from "../../../protocol/src/credential-handle.ts";
+import {
+  createOpenAICompatRunner,
+  OPENAI_COMPAT_DEFAULT_TIMEOUT_MS,
+  type OpenAICompatFetch,
+  type OpenAICompatRunnerOptions,
+  type OpenAICompatRunnerSpawnRequest,
+} from "../../src/adapters/openai-compat.ts";
+import type { Receipt, RunnerSpawnDeps } from "../../src/runner.ts";
+
+const agentId = asAgentId("agent_alpha");
+const credentialId = asCredentialHandleId("cred_runner0123456789ABCDEFGHIJKLMN");
+const runnerId = asRunnerId("run_0123456789ABCDEFGHIJKLMNOPQRSTUV");
+const receiptId = asReceiptId("01ARZ3NDEKTSV4RRFFQ69G5FAV");
+const taskId = asTaskId("01ARZ3NDEKTSV4RRFFQ69G5FAW");
+const fixedDate = new Date("2026-05-08T18:00:00.000Z");
+const endpoint = "https://provider.test/v1/chat/completions";
+const encoder = new TextEncoder();
+
+interface FetchCall {
+  readonly input: string | URL | Request;
+  readonly init?: RequestInit | undefined;
+}
+
+interface Harness {
+  readonly credential: CredentialHandle;
+  readonly costs: CostLedgerEntry[];
+  readonly deps: RunnerSpawnDeps;
+  readonly events: RunnerEvent[];
+  readonly receipts: Receipt[];
+  readonly secretReads: CredentialHandle[];
+}
+
+class ControlledSseStream {
+  readonly body: ReadableStream<Uint8Array>;
+  #controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+  constructor() {
+    this.body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        this.#controller = controller;
+      },
+    });
+  }
+
+  enqueue(text: string): void {
+    const controller = this.#controller;
+    if (controller === null) throw new Error("stream controller was not ready");
+    controller.enqueue(encoder.encode(text));
+  }
+
+  close(): void {
+    const controller = this.#controller;
+    if (controller === null) throw new Error("stream controller was not ready");
+    controller.close();
+  }
+
+  error(error: Error): void {
+    const controller = this.#controller;
+    if (controller === null) throw new Error("stream controller was not ready");
+    controller.error(error);
+  }
+}
+
+function makeHarness(
+  args: {
+    readonly receiptPut?: ((receipt: Receipt) => Promise<{ readonly stored: boolean }>) | undefined;
+    readonly scope?: CredentialScope | undefined;
+  } = {},
+): Harness {
+  const credential = credentialForScope(args.scope ?? asCredentialScope("openai"));
+  const costs: CostLedgerEntry[] = [];
+  const events: RunnerEvent[] = [];
+  const receipts: Receipt[] = [];
+  const secretReads: CredentialHandle[] = [];
+  const receiptPut =
+    args.receiptPut ??
+    (async (receipt: Receipt) => {
+      receipts.push(receipt);
+      return { stored: true };
+    });
+  return {
+    credential,
+    costs,
+    events,
+    receipts,
+    secretReads,
+    deps: {
+      credential,
+      secretReader: async (handle) => {
+        secretReads.push(handle);
+        return "sk-test-secret";
+      },
+      costLedger: {
+        record: async (entry) => {
+          costs.push(entry);
+        },
+      },
+      receiptStore: { put: receiptPut },
+      eventLog: {
+        append: async (event) => {
+          events.push(event);
+        },
+      },
+    },
+  };
+}
+
+function credentialForScope(scope: CredentialScope): CredentialHandle {
+  return credentialHandleFromJson(
+    { version: 1, id: credentialId },
+    {
+      agentId,
+      broker: createBrokerIdentityForTesting({ agentId }),
+      scope,
+    },
+  );
+}
+
+function spawnRequest(
+  options: OpenAICompatRunnerOptions = { endpoint },
+): OpenAICompatRunnerSpawnRequest {
+  return {
+    kind: "openai-compat",
+    agentId,
+    credential: { version: 1, id: credentialId },
+    prompt: "Say hello",
+    model: "gpt-5-mini",
+    taskId,
+    options,
+  };
+}
+
+function createSpawner(fetchFn: OpenAICompatFetch) {
+  return createOpenAICompatRunner({
+    fetchFn,
+    now: () => fixedDate,
+    receiptIdFactory: () => receiptId,
+    runnerIdFactory: () => runnerId,
+    taskIdFactory: () => taskId,
+  });
+}
+
+function sseData(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+function doneData(): string {
+  return "data: [DONE]\n\n";
+}
+
+async function collectAll(stream: RunnerEventStream<RunnerEvent>): Promise<RunnerEvent[]> {
+  const reader = stream.getReader();
+  const events: RunnerEvent[] = [];
+  while (true) {
+    const next = await reader.read();
+    if (next.done) return events;
+    events.push(next.value);
+  }
+}
+
+async function waitForEvent(
+  events: readonly RunnerEvent[],
+  predicate: (event: RunnerEvent) => boolean,
+): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (events.some(predicate)) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error("timed out waiting for event");
+}
+
+function firstCall(calls: readonly FetchCall[]): FetchCall {
+  const call = calls[0];
+  if (call === undefined) throw new Error("missing fetch call");
+  return call;
+}
+
+function headersFrom(call: FetchCall): Headers {
+  return new Headers(call.init?.headers);
+}
+
+function bodyRecord(call: FetchCall): Readonly<Record<string, unknown>> {
+  if (typeof call.init?.body !== "string") throw new Error("request body was not a string");
+  const parsed: unknown = JSON.parse(call.init.body);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("request body was not an object");
+  }
+  return parsed as Readonly<Record<string, unknown>>;
+}
+
+function recordValue(record: object, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+  return descriptor !== undefined && "value" in descriptor ? descriptor.value : undefined;
+}
+
+function costEvent(events: readonly RunnerEvent[]): Extract<RunnerEvent, { kind: "cost" }> {
+  const event = events.find((item): item is Extract<RunnerEvent, { kind: "cost" }> => {
+    return item.kind === "cost";
+  });
+  if (event === undefined) throw new Error("missing cost event");
+  return event;
+}
+
+describe("createOpenAICompatRunner", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("streams a successful turn, records cost, writes a receipt, and finishes", async () => {
+    const harness = makeHarness();
+    const stream = new ControlledSseStream();
+    const calls: FetchCall[] = [];
+    const fetchFn: OpenAICompatFetch = async (input, init) => {
+      calls.push({ input, init });
+      return new Response(stream.body, {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      });
+    };
+    const spawnRunner = createSpawner(fetchFn);
+
+    const runner = await spawnRunner(
+      spawnRequest({ endpoint, headers: { "X-Trace-Id": "trace-1" } }),
+      harness.deps,
+    );
+    const eventsPromise = collectAll(runner.events());
+    stream.enqueue(sseData({ choices: [{ delta: { content: "hel" } }] }));
+    stream.enqueue(sseData({ choices: [{ delta: { content: "lo" } }] }));
+    stream.enqueue(
+      sseData({
+        choices: [{ delta: {}, finish_reason: "stop" }],
+        model: "gpt-5-mini-2026-05-08",
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 5,
+          prompt_tokens_details: { cached_tokens: 2 },
+        },
+      }),
+    );
+    stream.enqueue(doneData());
+    const events = await eventsPromise;
+
+    expect(harness.secretReads).toEqual([harness.credential]);
+    expect(events.map((event) => event.kind)).toEqual([
+      "started",
+      "stdout",
+      "stdout",
+      "cost",
+      "receipt",
+      "finished",
+    ]);
+    expect(events.filter((event) => event.kind === "stdout").map((event) => event.chunk)).toEqual([
+      "hel",
+      "lo",
+    ]);
+    expect(harness.events.map((event) => event.kind)).toEqual(events.map((event) => event.kind));
+
+    const call = firstCall(calls);
+    expect(call.input).toBe(endpoint);
+    expect(call.init?.method).toBe("POST");
+    expect(headersFrom(call).get("Authorization")).toBe("Bearer sk-test-secret");
+    expect(headersFrom(call).get("x-api-key")).toBeNull();
+    expect(headersFrom(call).get("X-Trace-Id")).toBe("trace-1");
+    expect(bodyRecord(call)).toMatchObject({
+      model: "gpt-5-mini",
+      stream: true,
+      stream_options: { include_usage: true },
+    });
+
+    expect(harness.costs).toHaveLength(1);
+    expect(harness.costs[0]).toMatchObject({
+      amountMicroUsd: 15,
+      model: "gpt-5-mini-2026-05-08",
+      providerKind: "openai",
+      units: {
+        inputTokens: 8,
+        outputTokens: 5,
+        cacheReadTokens: 2,
+        cacheCreationTokens: 0,
+      },
+    });
+    expect(harness.receipts).toHaveLength(1);
+    expect(harness.receipts[0]).toMatchObject({
+      id: receiptId,
+      inputTokens: 8,
+      outputTokens: 5,
+      cacheReadTokens: 2,
+      providerKind: "openai",
+      taskId,
+    });
+    const receipt = harness.receipts[0];
+    if (receipt === undefined) throw new Error("missing receipt");
+    if (receipt.finalMessage === undefined) throw new Error("missing receipt finalMessage");
+    expect(receipt.finalMessage.toString()).toBe("hello");
+  });
+
+  it("fails the runner when receipt put fails and does not emit finished", async () => {
+    const harness = makeHarness({
+      receiptPut: async () => {
+        throw new Error("disk full");
+      },
+    });
+    const stream = new ControlledSseStream();
+    const fetchFn: OpenAICompatFetch = async () =>
+      new Response(stream.body, {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      });
+    const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+    const eventsPromise = collectAll(runner.events());
+
+    stream.enqueue(sseData({ choices: [{ delta: { content: "hello" } }] }));
+    stream.enqueue(sseData({ choices: [], usage: { prompt_tokens: 1, completion_tokens: 1 } }));
+    stream.enqueue(doneData());
+    const events = await eventsPromise;
+    await runner.terminate();
+
+    expect(events.map((event) => event.kind)).toContain("failed");
+    expect(
+      events.some((event) => event.kind === "failed" && event.error.includes("disk full")),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "finished")).toBe(false);
+    expect(events.some((event) => event.kind === "receipt")).toBe(false);
+  });
+
+  it("emits failed with structured cause on network failure mid-stream", async () => {
+    const harness = makeHarness();
+    const stream = new ControlledSseStream();
+    const fetchFn: OpenAICompatFetch = async () =>
+      new Response(stream.body, {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      });
+    const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+    const eventsPromise = collectAll(runner.events());
+
+    stream.enqueue(sseData({ choices: [{ delta: { content: "partial" } }] }));
+    await waitForEvent(harness.events, (event) => event.kind === "stdout");
+    stream.error(new Error("socket reset"));
+    const events = await eventsPromise;
+
+    expect(events.map((event) => event.kind)).toContain("stdout");
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "failed" &&
+          event.error.includes("openai_compat_network_error") &&
+          event.error.includes("socket reset"),
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "finished")).toBe(false);
+  });
+
+  it("maps HTTP 5xx responses to failed with a safely truncated response body", async () => {
+    const harness = makeHarness();
+    const longBody = `upstream unavailable ${"x".repeat(4_000)}`;
+    const fetchFn: OpenAICompatFetch = async () =>
+      new Response(longBody, { status: 503, statusText: "Service Unavailable" });
+
+    const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+    const events = await collectAll(runner.events());
+
+    expect(events.map((event) => event.kind)).toEqual(["failed"]);
+    const failed = events[0];
+    if (failed?.kind !== "failed") throw new Error("expected failed event");
+    expect(failed.error).toContain("openai_compat_http_error");
+    expect(failed.error).toContain('"status":503');
+    expect(failed.error).toContain("upstream unavailable");
+    expect(failed.error).toContain("[truncated]");
+    expect(failed.error.length).toBeLessThan(longBody.length);
+  });
+
+  it("aborts and waits for drain when terminate is called during streaming", async () => {
+    const harness = makeHarness();
+    const stream = new ControlledSseStream();
+    const abortSeen = deferred<void>();
+    const signalSeen = deferred<AbortSignal>();
+    const fetchFn: OpenAICompatFetch = async (_input, init) => {
+      const signal = init?.signal;
+      if (!(signal instanceof AbortSignal)) throw new Error("missing abort signal");
+      signalSeen.resolve(signal);
+      signal.addEventListener("abort", () => abortSeen.resolve(), { once: true });
+      return new Response(stream.body, {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      });
+    };
+    const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+    const eventsPromise = collectAll(runner.events());
+
+    stream.enqueue(sseData({ choices: [{ delta: { content: "partial" } }] }));
+    await waitForEvent(harness.events, (event) => event.kind === "stdout");
+    const terminatePromise = runner.terminate();
+    await abortSeen.promise;
+    await terminatePromise;
+    const events = await eventsPromise;
+
+    const signal = await signalSeen.promise;
+    expect(signal.aborted).toBe(true);
+    expect(events.map((event) => event.kind)).toContain("stdout");
+    expect(events.some((event) => event.kind === "failed")).toBe(true);
+    expect(events.some((event) => event.kind === "finished")).toBe(false);
+  });
+
+  it("selects provider auth shape from CredentialScope", async () => {
+    const openai = await completedAuthRun(asCredentialScope("openai"));
+    expect(headersFrom(firstCall(openai.calls)).get("Authorization")).toBe("Bearer sk-test-secret");
+    expect(headersFrom(firstCall(openai.calls)).get("x-api-key")).toBeNull();
+    expect(openai.events.some((event) => event.kind === "stderr")).toBe(false);
+
+    const anthropic = await completedAuthRun(asCredentialScope("anthropic"));
+    expect(headersFrom(firstCall(anthropic.calls)).get("x-api-key")).toBe("sk-test-secret");
+    expect(headersFrom(firstCall(anthropic.calls)).get("Authorization")).toBeNull();
+    expect(anthropic.events.some((event) => event.kind === "stderr")).toBe(false);
+
+    const unknown = await completedAuthRun(asCredentialScope("github"));
+    expect(headersFrom(firstCall(unknown.calls)).get("Authorization")).toBe(
+      "Bearer sk-test-secret",
+    );
+    expect(
+      unknown.events.some(
+        (event) =>
+          event.kind === "stderr" &&
+          event.chunk.includes("openai_compat_unknown_credential_scope") &&
+          event.chunk.includes("authorization_bearer"),
+      ),
+    ).toBe(true);
+  });
+
+  it("emits a zero-cost ledger entry with a structured note when usage is missing", async () => {
+    const harness = makeHarness();
+    const stream = new ControlledSseStream();
+    const fetchFn: OpenAICompatFetch = async () =>
+      new Response(stream.body, {
+        headers: { "Content-Type": "text/event-stream" },
+        status: 200,
+      });
+    const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+    const eventsPromise = collectAll(runner.events());
+
+    stream.enqueue(sseData({ choices: [{ delta: { content: "hello" } }] }));
+    stream.enqueue(doneData());
+    const events = await eventsPromise;
+
+    const event = costEvent(events);
+    expect(event.entry).toMatchObject({
+      amountMicroUsd: 0,
+      units: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+      },
+    });
+    expect(recordValue(event.entry, "note")).toBe("provider_did_not_report_usage");
+    expect(harness.costs).toHaveLength(1);
+    expect(recordValue(harness.costs[0] ?? {}, "note")).toBeUndefined();
+    expect(events.map((item) => item.kind)).toEqual([
+      "started",
+      "stdout",
+      "cost",
+      "receipt",
+      "finished",
+    ]);
+  });
+
+  it("fails unresolved fetches when the default timeout signal fires", async () => {
+    const harness = makeHarness();
+    const timeoutController = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeoutController.signal);
+    const fetchFn: OpenAICompatFetch = async () =>
+      await new Promise<Response>(() => {
+        return undefined;
+      });
+
+    const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+    const eventsPromise = collectAll(runner.events());
+    timeoutController.abort(new DOMException("timed out", "TimeoutError"));
+    const events = await eventsPromise;
+
+    expect(timeoutSpy).toHaveBeenCalledWith(OPENAI_COMPAT_DEFAULT_TIMEOUT_MS);
+    expect(
+      events.some(
+        (event) =>
+          event.kind === "failed" &&
+          event.error.includes("openai_compat_timeout") &&
+          event.error.includes("60000"),
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.kind === "finished")).toBe(false);
+  });
+});
+
+async function completedAuthRun(scope: CredentialScope): Promise<{
+  readonly calls: FetchCall[];
+  readonly events: RunnerEvent[];
+}> {
+  const harness = makeHarness({ scope });
+  const stream = new ControlledSseStream();
+  const calls: FetchCall[] = [];
+  const fetchFn: OpenAICompatFetch = async (input, init) => {
+    calls.push({ input, init });
+    return new Response(stream.body, {
+      headers: { "Content-Type": "text/event-stream" },
+      status: 200,
+    });
+  };
+  const runner = await createSpawner(fetchFn)(spawnRequest(), harness.deps);
+  const eventsPromise = collectAll(runner.events());
+
+  stream.enqueue(sseData({ choices: [], usage: { prompt_tokens: 0, completion_tokens: 0 } }));
+  stream.enqueue(doneData());
+  const events = await eventsPromise;
+  return { calls, events };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  readonly resolve: (value: T | PromiseLike<T>) => void;
+  readonly reject: (reason: unknown) => void;
+} {
+  let resolveFn: ((value: T | PromiseLike<T>) => void) | null = null;
+  let rejectFn: ((reason: unknown) => void) | null = null;
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return {
+    promise,
+    resolve(value) {
+      if (resolveFn === null) throw new Error("deferred resolve not initialized");
+      resolveFn(value);
+    },
+    reject(reason) {
+      if (rejectFn === null) throw new Error("deferred reject not initialized");
+      rejectFn(reason);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `createOpenAICompatRunner`, an HTTP `AgentRunner` adapter for OpenAI-compatible streaming chat completions endpoints.
- Parses SSE incrementally, maps deltas to frozen `RunnerEvent` shapes, records cost ledger entries, writes receipts, and aborts via `AbortController`.
- Documents adapter-local typed options for endpoint/headers/timeout and adds fake-fetch tests for streaming, failure, auth-shape, timeout, and missing-usage behavior.

## Stack
- Parent: #850
- Transitive: #848

## Verification
- `bun install`
- `cd packages/agent-runners && bunx tsc --noEmit && bunx vitest run && bunx biome check src/ tests/`
- `cd packages/protocol && bunx tsc --noEmit && bunx vitest run --coverage && bunx biome check src/ tests/ scripts/` (coverage: 97.22% statements/lines, 91.7% branches, 99.8% functions)
- `cd packages/broker && bunx tsc --noEmit && bunx vitest run && bunx biome check src/ tests/`
- `bash scripts/test-protocol.sh`
- `bun run packages/protocol/scripts/demo.ts`
- `cd packages/protocol/testdata && go run verifier-reference.go`
- `bunx secretlint "**/*"`
- pre-push hook suite on push