### PR TITLE
fix(facts): deterministic fact IDs and append-time dedup

### DIFF
--- a/internal/team/entity_facts.go
+++ b/internal/team/entity_facts.go
@@ -19,6 +19,8 @@ package team
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,8 +32,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // EntityKind is the narrow set of wiki subtrees we treat as "entities" for
@@ -142,8 +142,13 @@ func (l *FactLog) Append(ctx context.Context, kind EntityKind, slug, text, sourc
 		return Fact{}, err
 	}
 
+	// Deterministic ID: hash of immutable content fields so the same fact
+	// recorded twice produces the same ID. This enables dedup at both the
+	// JSONL append layer (below) and the SQLite UpsertFact layer.
+	factID := deterministicFactID(kind, slug, text, recordedBy)
+
 	fact := Fact{
-		ID:         uuid.NewString(),
+		ID:         factID,
 		Kind:       kind,
 		Slug:       slug,
 		Text:       text,
@@ -165,6 +170,13 @@ func (l *FactLog) Append(ctx context.Context, kind EntityKind, slug, text, sourc
 	defer l.mu.Unlock()
 
 	existing := l.readExistingLocked(relPath)
+
+	// Dedup: skip append if a fact with the same ID already exists in the
+	// file. This prevents duplicate entries when the same observation is
+	// recorded multiple times (e.g. re-extraction, retry after timeout).
+	if factExistsInJSONL(existing, factID) {
+		return fact, nil
+	}
 	buf := make([]byte, 0, len(existing)+len(line)+1)
 	if len(existing) > 0 {
 		buf = append(buf, existing...)
@@ -314,4 +326,50 @@ func (l *FactLog) commitTimestamp(ctx context.Context, sha string) (time.Time, e
 		return time.Time{}, fmt.Errorf("entity facts: parse timestamp %q: %w", line, err)
 	}
 	return ts.UTC(), nil
+}
+
+// deterministicFactID computes a stable ID from the immutable content fields.
+// The same observation recorded twice produces the same ID, enabling dedup at
+// both the JSONL append layer and the SQLite UpsertFact layer. The ID is a
+// 16-character hex prefix of SHA-256 — collision probability is negligible for
+// the expected fact counts per entity (hundreds, not millions).
+func deterministicFactID(kind EntityKind, slug, text, recordedBy string) string {
+	h := sha256.New()
+	h.Write([]byte(string(kind)))
+	h.Write([]byte{0}) // separator
+	h.Write([]byte(slug))
+	h.Write([]byte{0})
+	h.Write([]byte(text))
+	h.Write([]byte{0})
+	h.Write([]byte(recordedBy))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// factExistsInJSONL scans existing JSONL bytes for a fact with the given ID.
+// Returns true if found, enabling dedup on the append path.
+func factExistsInJSONL(existing []byte, factID string) bool {
+	if len(existing) == 0 || factID == "" {
+		return false
+	}
+	// Fast path: search for the ID string in the raw bytes before parsing.
+	// This avoids JSON decoding when the ID is clearly absent.
+	if !strings.Contains(string(existing), factID) {
+		return false
+	}
+	// Slow path: confirm it's actually an "id" field match, not a substring
+	// of some other field.
+	scanner := bufio.NewScanner(strings.NewReader(string(existing)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var partial struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal([]byte(line), &partial) == nil && partial.ID == factID {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/team/entity_facts.go
+++ b/internal/team/entity_facts.go
@@ -18,6 +18,7 @@ package team
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -174,8 +175,9 @@ func (l *FactLog) Append(ctx context.Context, kind EntityKind, slug, text, sourc
 	// Dedup: skip append if a fact with the same ID already exists in the
 	// file. This prevents duplicate entries when the same observation is
 	// recorded multiple times (e.g. re-extraction, retry after timeout).
-	if factExistsInJSONL(existing, factID) {
-		return fact, nil
+	// Return the persisted fact so callers see the original CreatedAt.
+	if existingFact, found := findFactInJSONL(existing, factID); found {
+		return existingFact, nil
 	}
 	buf := make([]byte, 0, len(existing)+len(line)+1)
 	if len(existing) > 0 {
@@ -335,7 +337,7 @@ func (l *FactLog) commitTimestamp(ctx context.Context, sha string) (time.Time, e
 // the expected fact counts per entity (hundreds, not millions).
 func deterministicFactID(kind EntityKind, slug, text, recordedBy string) string {
 	h := sha256.New()
-	h.Write([]byte(string(kind)))
+	h.Write([]byte(kind))
 	h.Write([]byte{0}) // separator
 	h.Write([]byte(slug))
 	h.Write([]byte{0})
@@ -345,31 +347,29 @@ func deterministicFactID(kind EntityKind, slug, text, recordedBy string) string 
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 
-// factExistsInJSONL scans existing JSONL bytes for a fact with the given ID.
-// Returns true if found, enabling dedup on the append path.
-func factExistsInJSONL(existing []byte, factID string) bool {
+// findFactInJSONL scans existing JSONL bytes for a fact with the given ID.
+// Returns the full Fact and true if found, so callers get the original
+// CreatedAt rather than a freshly minted timestamp.
+func findFactInJSONL(existing []byte, factID string) (Fact, bool) {
 	if len(existing) == 0 || factID == "" {
-		return false
+		return Fact{}, false
 	}
 	// Fast path: search for the ID string in the raw bytes before parsing.
 	// This avoids JSON decoding when the ID is clearly absent.
-	if !strings.Contains(string(existing), factID) {
-		return false
+	if !bytes.Contains(existing, []byte(factID)) {
+		return Fact{}, false
 	}
-	// Slow path: confirm it's actually an "id" field match, not a substring
-	// of some other field.
-	scanner := bufio.NewScanner(strings.NewReader(string(existing)))
+	// Slow path: decode each line to confirm it's an "id" field match.
+	scanner := bufio.NewScanner(bytes.NewReader(existing))
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
 			continue
 		}
-		var partial struct {
-			ID string `json:"id"`
-		}
-		if json.Unmarshal([]byte(line), &partial) == nil && partial.ID == factID {
-			return true
+		var f Fact
+		if json.Unmarshal(line, &f) == nil && f.ID == factID {
+			return f, true
 		}
 	}
-	return false
+	return Fact{}, false
 }

--- a/internal/team/entity_facts_test.go
+++ b/internal/team/entity_facts_test.go
@@ -162,13 +162,88 @@ func TestFactLog_ConcurrentAppendsAllLand(t *testing.T) {
 	if len(facts) != N {
 		t.Fatalf("expected %d facts, got %d", N, len(facts))
 	}
-	// All IDs should be unique.
+	// All IDs should be unique (each goroutine records a different text).
 	seen := map[string]bool{}
 	for _, f := range facts {
 		if seen[f.ID] {
 			t.Errorf("duplicate fact id: %s", f.ID)
 		}
 		seen[f.ID] = true
+	}
+}
+
+func TestFactLog_DeterministicID(t *testing.T) {
+	// Same inputs produce the same ID every time.
+	id1 := deterministicFactID(EntityKindPeople, "sarah", "CEO of Acme", "pm")
+	id2 := deterministicFactID(EntityKindPeople, "sarah", "CEO of Acme", "pm")
+	if id1 != id2 {
+		t.Errorf("expected deterministic ID; got %q and %q", id1, id2)
+	}
+	if len(id1) != 16 {
+		t.Errorf("expected 16-char hex ID; got %q (len %d)", id1, len(id1))
+	}
+
+	// Different inputs produce different IDs.
+	id3 := deterministicFactID(EntityKindPeople, "sarah", "CTO of Acme", "pm")
+	if id1 == id3 {
+		t.Error("expected different ID for different text")
+	}
+
+	id4 := deterministicFactID(EntityKindCompanies, "sarah", "CEO of Acme", "pm")
+	if id1 == id4 {
+		t.Error("expected different ID for different kind")
+	}
+}
+
+func TestFactLog_DedupSameFactTwice(t *testing.T) {
+	log, _, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	f1, err := log.Append(ctx, EntityKindPeople, "nazz", "Likes coffee", "", "pm")
+	if err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+
+	// Append the exact same fact again — should be silently deduped.
+	f2, err := log.Append(ctx, EntityKindPeople, "nazz", "Likes coffee", "", "pm")
+	if err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+
+	// Same ID returned both times.
+	if f1.ID != f2.ID {
+		t.Errorf("expected same ID on dedup; got %q and %q", f1.ID, f2.ID)
+	}
+
+	// Only one fact in the file.
+	facts, err := log.List(EntityKindPeople, "nazz")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("expected 1 fact after dedup, got %d", len(facts))
+	}
+}
+
+func TestFactLog_DifferentTextNotDeduped(t *testing.T) {
+	log, _, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	if _, err := log.Append(ctx, EntityKindPeople, "nazz", "Likes coffee", "", "pm"); err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	if _, err := log.Append(ctx, EntityKindPeople, "nazz", "Likes tea", "", "pm"); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+
+	facts, err := log.List(EntityKindPeople, "nazz")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(facts) != 2 {
+		t.Fatalf("expected 2 facts for different text, got %d", len(facts))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace random UUID fact IDs with deterministic SHA-256 hash of `(kind, slug, text, recorded_by)`
- Add JSONL append-time dedup: `factExistsInJSONL` scans existing lines before writing, skipping if a matching ID is present
- Enables dedup at both the JSONL layer and the SQLite `UpsertFact` layer (same ID = `INSERT OR REPLACE`)

## Problem

`FactLog.Append` generated a random `uuid.NewString()` for every call. The same observation recorded twice produced different IDs, bypassing the SQLite upsert dedup and causing duplicate facts in entity briefs.

## Test plan
- [x] `TestFactLog_DeterministicID` — same inputs produce same ID; different inputs produce different IDs
- [x] `TestFactLog_DedupSameFactTwice` — second append of identical fact is silently deduped; only 1 fact in file
- [x] `TestFactLog_DifferentTextNotDeduped` — different fact text still creates separate entries
- [x] All existing fact log tests pass (append, validation, malformed recovery, concurrent appends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Fact records now use deterministic IDs based on immutable inputs, enabling reliable identity across writes.
  * Appends perform on-disk deduplication: identical facts are not stored twice and original creation timestamps are preserved.

* **Tests**
  * Added unit tests verifying deterministic ID generation, deduplication behavior, and that distinct text entries are not deduplicated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/855)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->