### PR TITLE
fix(dlq): wire context through DLQ methods and sync writes to disk

### DIFF
--- a/internal/team/wiki_dlq.go
+++ b/internal/team/wiki_dlq.go
@@ -166,8 +166,10 @@ func (d *DLQ) ensureDir() error {
 // Callers should set FirstFailedAt and NextRetryNotBefore; if zero they are
 // defaulted to now and now+base_backoff respectively.
 func (d *DLQ) Enqueue(ctx context.Context, e DLQEntry) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("dlq: enqueue: %w", err)
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("dlq: enqueue: %w", err)
+		}
 	}
 	now := time.Now().UTC()
 	e = coerceDLQEntry(e, now)
@@ -191,8 +193,10 @@ func (d *DLQ) Enqueue(ctx context.Context, e DLQEntry) error {
 //
 // Read-only: holds the read lock so concurrent Inspect calls do not block.
 func (d *DLQ) ReadyForReplay(ctx context.Context, now time.Time) ([]DLQEntry, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("dlq: ready for replay: %w", err)
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("dlq: ready for replay: %w", err)
+		}
 	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -223,8 +227,10 @@ func (d *DLQ) ReadyForReplay(ctx context.Context, now time.Time) ([]DLQEntry, er
 // max_retries, the entry is promoted to permanent-failures. cat is the
 // error category of the new attempt.
 func (d *DLQ) RecordAttempt(ctx context.Context, artifactSHA string, attemptErr error, cat string) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("dlq: record attempt: %w", err)
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("dlq: record attempt: %w", err)
+		}
 	}
 	now := time.Now().UTC()
 
@@ -293,8 +299,10 @@ type Snapshot struct {
 // Uses the read lock so multiple operator dashboards polling GET /wiki/dlq
 // do not serialise on each other.
 func (d *DLQ) Inspect(ctx context.Context) (Snapshot, error) {
-	if err := ctx.Err(); err != nil {
-		return Snapshot{}, fmt.Errorf("dlq: inspect: %w", err)
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return Snapshot{}, fmt.Errorf("dlq: inspect: %w", err)
+		}
 	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()
@@ -399,8 +407,10 @@ func sortEntriesByFirstFailedAt(entries []DLQEntry) {
 // MarkResolved appends a resolved_at tombstone. ReadyForReplay will skip this
 // artifact_sha from now on.
 func (d *DLQ) MarkResolved(ctx context.Context, artifactSHA string) error {
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("dlq: mark resolved: %w", err)
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("dlq: mark resolved: %w", err)
+		}
 	}
 	now := time.Now().UTC()
 	d.mu.Lock()

--- a/internal/team/wiki_dlq.go
+++ b/internal/team/wiki_dlq.go
@@ -165,7 +165,10 @@ func (d *DLQ) ensureDir() error {
 // is coerced to DLQValidationMaxRetries when ErrorCategory is "validation".
 // Callers should set FirstFailedAt and NextRetryNotBefore; if zero they are
 // defaulted to now and now+base_backoff respectively.
-func (d *DLQ) Enqueue(_ context.Context, e DLQEntry) error {
+func (d *DLQ) Enqueue(ctx context.Context, e DLQEntry) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("dlq: enqueue: %w", err)
+	}
 	now := time.Now().UTC()
 	e = coerceDLQEntry(e, now)
 
@@ -187,7 +190,10 @@ func (d *DLQ) Enqueue(_ context.Context, e DLQEntry) error {
 // updated backoff window rather than an old eligible row.
 //
 // Read-only: holds the read lock so concurrent Inspect calls do not block.
-func (d *DLQ) ReadyForReplay(_ context.Context, now time.Time) ([]DLQEntry, error) {
+func (d *DLQ) ReadyForReplay(ctx context.Context, now time.Time) ([]DLQEntry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("dlq: ready for replay: %w", err)
+	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -216,7 +222,10 @@ func (d *DLQ) ReadyForReplay(_ context.Context, now time.Time) ([]DLQEntry, erro
 // next_retry_not_before, and appends the updated state. If the bump crosses
 // max_retries, the entry is promoted to permanent-failures. cat is the
 // error category of the new attempt.
-func (d *DLQ) RecordAttempt(_ context.Context, artifactSHA string, attemptErr error, cat string) error {
+func (d *DLQ) RecordAttempt(ctx context.Context, artifactSHA string, attemptErr error, cat string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("dlq: record attempt: %w", err)
+	}
 	now := time.Now().UTC()
 
 	d.mu.Lock()
@@ -283,7 +292,10 @@ type Snapshot struct {
 //
 // Uses the read lock so multiple operator dashboards polling GET /wiki/dlq
 // do not serialise on each other.
-func (d *DLQ) Inspect(_ context.Context) (Snapshot, error) {
+func (d *DLQ) Inspect(ctx context.Context) (Snapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return Snapshot{}, fmt.Errorf("dlq: inspect: %w", err)
+	}
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -386,7 +398,10 @@ func sortEntriesByFirstFailedAt(entries []DLQEntry) {
 
 // MarkResolved appends a resolved_at tombstone. ReadyForReplay will skip this
 // artifact_sha from now on.
-func (d *DLQ) MarkResolved(_ context.Context, artifactSHA string) error {
+func (d *DLQ) MarkResolved(ctx context.Context, artifactSHA string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("dlq: mark resolved: %w", err)
+	}
 	now := time.Now().UTC()
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -477,8 +492,13 @@ func appendLine(path string, v any) error {
 	}
 	defer func() { _ = f.Close() }()
 	line = append(line, '\n')
-	_, werr := f.Write(line)
-	return werr
+	if _, err = f.Write(line); err != nil {
+		return fmt.Errorf("dlq: write %s: %w", filepath.Base(path), err)
+	}
+	if err = f.Sync(); err != nil {
+		return fmt.Errorf("dlq: sync %s: %w", filepath.Base(path), err)
+	}
+	return nil
 }
 
 // coerceDLQEntry normalises defaults and applies policy constraints.


### PR DESCRIPTION
## Summary

- **C4**: All 5 public DLQ methods (`Enqueue`, `ReadyForReplay`, `RecordAttempt`, `Inspect`, `MarkResolved`) now respect their context parameter — check `ctx.Err()` before I/O so cancelled requests return immediately
- **H1**: `appendLine` now calls `f.Sync()` after write, ensuring DLQ entries reach disk before returning success

## Problem

DLQ methods discarded context with `(_ context.Context)`, making them immune to cancellation. A massive DLQ file would block `Inspect` indefinitely even if the HTTP request timed out. Additionally, `appendLine` never synced — entries could be lost on crash.

## Test plan
- [x] All existing DLQ tests pass (17 tests)
- [x] `go build ./internal/team/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dead Letter Queue operations now respect cancelled/expired operations and return clearer, distinct errors for write vs sync failures, improving reliability and observability while preserving existing queue format and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/856)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->