### PR TITLE
fix(headless): defer pw.Close to prevent goroutine leak on panic

### DIFF
--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -99,6 +99,12 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		agentStream = l.broker.AgentStream(slug)
 	}
 	pr, pw := io.Pipe()
+	// Ensure the pipe writer is always closed so the drain goroutine below
+	// cannot be orphaned. Normal-path callers still call pw.Close() explicitly
+	// at line 210; the deferred close is a no-op in that case (io.PipeWriter
+	// tolerates double-close). Guards against panics in ReadCodexJSONStream
+	// that would otherwise strand the reader goroutine forever.
+	defer func() { _ = pw.Close() }()
 	teedStdout := io.TeeReader(stdout, pw)
 	// Pipe every raw line from the provider to the web UI's live stream.
 	// No filtering — the user sees everything the agent sees. The reader-


### PR DESCRIPTION
## Summary

Add `defer pw.Close()` immediately after `io.Pipe()` creation in the headless codex runner to prevent the drain goroutine from being orphaned if `ReadCodexJSONStream` panics.

## Problem

The drain goroutine (line 108) reads from `pr`. If `ReadCodexJSONStream` (line 171) panics, the explicit `pw.Close()` at line 210 is never reached, and the reader goroutine blocks forever on the pipe.

## Fix

`defer pw.Close()` right after pipe creation. The normal-path close still runs first; the deferred call is a no-op (`io.PipeWriter` tolerates double-close).

## Test plan
- [x] `go build ./internal/team/...` clean
- [x] Existing headless codex tests unaffected (behavior-preserving change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during error scenarios to prevent potential resource leaks, enhancing system stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/857)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->