### PR TITLE
fix(telegram): replace http.DefaultClient with timeout-aware client

### DIFF
--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -23,6 +23,12 @@ const (
 	telegramPollTimeout = 30 // seconds for long-poll
 )
 
+// telegramClient is a shared HTTP client for standalone Telegram API functions
+// (VerifyBot, SendTypingAction, etc.) that don't have access to the transport's
+// per-instance client. Using a shared client with a timeout instead of
+// http.DefaultClient ensures connections are reused and timeouts are enforced.
+var telegramClient = &http.Client{Timeout: 60 * time.Second}
+
 // telegramUpdate represents a single update from the Telegram Bot API.
 type telegramUpdate struct {
 	UpdateID int64        `json:"update_id"`
@@ -637,7 +643,7 @@ func SendTypingAction(ctx context.Context, token string, chatID int64) error {
 		return fmt.Errorf("telegram typing: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := telegramClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("telegram typing: %w", err)
 	}
@@ -678,7 +684,7 @@ func VerifyBot(token string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("telegram getMe: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := telegramClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("telegram getMe: %w", err)
 	}
@@ -723,7 +729,7 @@ func DiscoverGroups(token string) ([]TelegramGroup, error) {
 	if err != nil {
 		return nil, fmt.Errorf("telegram getUpdates: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := telegramClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("telegram getUpdates: %w", err)
 	}
@@ -787,7 +793,7 @@ func SendTelegramMessage(token string, chatID int64, text string) error {
 		return fmt.Errorf("telegram send: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := telegramClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("telegram send: %w", err)
 	}
@@ -817,7 +823,7 @@ func VerifyChat(token string, chatID int64) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("telegram getChat: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := telegramClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("telegram getChat: %w", err)
 	}


### PR DESCRIPTION
## Summary

Replace 5 uses of `http.DefaultClient` in standalone Telegram API functions with a package-level `telegramClient` that has a 60s timeout.

## Problem

`SendTypingAction`, `VerifyBot`, `DiscoverGroups`, `SendTelegramMessage`, and `VerifyChat` all used `http.DefaultClient` (no timeout). A stalled Telegram API connection would hang the caller indefinitely.

## Fix

Add `var telegramClient = &http.Client{Timeout: 60 * time.Second}` and replace all 5 `http.DefaultClient.Do(req)` calls.

## Test plan
- [x] `go build ./internal/team/...` clean
- [x] Behavior-preserving — same HTTP calls, just with timeout enforcement

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved Telegram API communication reliability by standardizing HTTP client configuration with consistent timeout handling across all Telegram operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/858)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->