### PR TITLE
fix(broker): cap messages and prune completed tasks to bound state growth

### DIFF
--- a/internal/team/broker_gc.go
+++ b/internal/team/broker_gc.go
@@ -1,0 +1,92 @@
+package team
+
+// broker_gc.go provides garbage-collection helpers that cap the growth of
+// in-memory broker collections. Without these, long-running brokers
+// accumulate messages and completed tasks indefinitely, bloating the state
+// file and slowing startup.
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+)
+
+// ── Messages ─────────────────────────────────────────────────────────────────
+
+// maxMessagesFromEnv returns the rolling cap on in-memory channel messages.
+// Defaults to 500; overridable via WUPHF_MAX_MESSAGES.
+func maxMessagesFromEnv() int {
+	if v, err := strconv.Atoi(os.Getenv("WUPHF_MAX_MESSAGES")); err == nil && v > 0 {
+		return v
+	}
+	return defaultMaxMessages
+}
+
+// ── Tasks ────────────────────────────────────────────────────────────────────
+
+// defaultTaskRetentionDays is how long completed (merged) tasks are kept
+// before pruning. 7 days gives operators enough time to review outcomes
+// while preventing unbounded growth.
+const defaultTaskRetentionDays = 7
+
+// taskRetentionFromEnv returns the retention duration for completed tasks.
+// Overridable via WUPHF_TASK_RETENTION_DAYS.
+func taskRetentionFromEnv() time.Duration {
+	if v, err := strconv.Atoi(os.Getenv("WUPHF_TASK_RETENTION_DAYS")); err == nil && v > 0 {
+		return time.Duration(v) * 24 * time.Hour
+	}
+	return defaultTaskRetentionDays * 24 * time.Hour
+}
+
+// pruneCompletedTasksLocked removes tasks in terminal lifecycle states
+// (merged) that are older than the retention window. Caller MUST hold b.mu.
+//
+// Returns the number of tasks pruned. Called from saveLocked so pruning
+// piggybacks on the existing persistence cadence without adding a separate
+// timer.
+func (b *Broker) pruneCompletedTasksLocked() int {
+	retention := taskRetentionFromEnv()
+	cutoff := time.Now().Add(-retention)
+	pruned := 0
+
+	kept := make([]teamTask, 0, len(b.tasks))
+	for _, t := range b.tasks {
+		if isTerminalTask(t) && taskCompletedBefore(t, cutoff) {
+			pruned++
+			continue
+		}
+		kept = append(kept, t)
+	}
+
+	if pruned > 0 {
+		b.tasks = kept
+		slog.Info("broker_gc: pruned completed tasks",
+			"pruned", pruned, "remaining", len(b.tasks),
+			"retention_days", int(retention.Hours()/24))
+	}
+	return pruned
+}
+
+// isTerminalTask returns true for tasks that are in a terminal lifecycle
+// state and safe to prune.
+func isTerminalTask(t teamTask) bool {
+	return t.LifecycleState == LifecycleStateMerged
+}
+
+// taskCompletedBefore checks whether a task's UpdatedAt is before the cutoff.
+// Falls back to CreatedAt if UpdatedAt is empty.
+func taskCompletedBefore(t teamTask, cutoff time.Time) bool {
+	ts := t.UpdatedAt
+	if ts == "" {
+		ts = t.CreatedAt
+	}
+	if ts == "" {
+		return false // No timestamp — keep the task.
+	}
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return false // Unparseable — keep the task.
+	}
+	return parsed.Before(cutoff)
+}

--- a/internal/team/broker_gc_test.go
+++ b/internal/team/broker_gc_test.go
@@ -1,0 +1,87 @@
+package team
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAppendMessageLocked_CapsAtMax(t *testing.T) {
+	t.Setenv("WUPHF_MAX_MESSAGES", "10")
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
+
+	b.mu.Lock()
+	for i := 0; i < 25; i++ {
+		b.appendMessageLocked(channelMessage{
+			ID:      "msg-" + time.Now().Format("150405.000000") + "-" + string(rune('a'+i%26)),
+			Content: "hello",
+			Channel: "general",
+		})
+	}
+	count := len(b.messages)
+	b.mu.Unlock()
+
+	if count != 10 {
+		t.Errorf("expected 10 messages after cap, got %d", count)
+	}
+}
+
+func TestPruneCompletedTasksLocked_RemovesMergedOldTasks(t *testing.T) {
+	t.Setenv("WUPHF_TASK_RETENTION_DAYS", "1")
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
+
+	old := time.Now().Add(-48 * time.Hour).UTC().Format(time.RFC3339)
+	recent := time.Now().UTC().Format(time.RFC3339)
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-1", LifecycleState: LifecycleStateMerged, UpdatedAt: old},
+		{ID: "task-2", LifecycleState: LifecycleStateRunning, UpdatedAt: old},
+		{ID: "task-3", LifecycleState: LifecycleStateMerged, UpdatedAt: recent},
+		{ID: "task-4", LifecycleState: LifecycleStateIntake, CreatedAt: old},
+	}
+	pruned := b.pruneCompletedTasksLocked()
+	remaining := len(b.tasks)
+	b.mu.Unlock()
+
+	if pruned != 1 {
+		t.Errorf("expected 1 pruned (old merged), got %d", pruned)
+	}
+	if remaining != 3 {
+		t.Errorf("expected 3 remaining, got %d", remaining)
+	}
+}
+
+func TestPruneCompletedTasksLocked_KeepsAllWhenNoneExpired(t *testing.T) {
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
+
+	recent := time.Now().UTC().Format(time.RFC3339)
+
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-1", LifecycleState: LifecycleStateMerged, UpdatedAt: recent},
+		{ID: "task-2", LifecycleState: LifecycleStateRunning, UpdatedAt: recent},
+	}
+	pruned := b.pruneCompletedTasksLocked()
+	remaining := len(b.tasks)
+	b.mu.Unlock()
+
+	if pruned != 0 {
+		t.Errorf("expected 0 pruned, got %d", pruned)
+	}
+	if remaining != 2 {
+		t.Errorf("expected 2 remaining, got %d", remaining)
+	}
+}
+
+func TestIsTerminalTask(t *testing.T) {
+	if !isTerminalTask(teamTask{LifecycleState: LifecycleStateMerged}) {
+		t.Error("expected merged task to be terminal")
+	}
+	if isTerminalTask(teamTask{LifecycleState: LifecycleStateRunning}) {
+		t.Error("expected running task to not be terminal")
+	}
+	if isTerminalTask(teamTask{LifecycleState: LifecycleStateIntake}) {
+		t.Error("expected intake task to not be terminal")
+	}
+}

--- a/internal/team/broker_gc_test.go
+++ b/internal/team/broker_gc_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -13,16 +14,25 @@ func TestAppendMessageLocked_CapsAtMax(t *testing.T) {
 	b.mu.Lock()
 	for i := 0; i < 25; i++ {
 		b.appendMessageLocked(channelMessage{
-			ID:      "msg-" + time.Now().Format("150405.000000") + "-" + string(rune('a'+i%26)),
-			Content: "hello",
+			ID:      fmt.Sprintf("msg-%03d", i),
+			Content: fmt.Sprintf("hello-%d", i),
 			Channel: "general",
 		})
 	}
 	count := len(b.messages)
+	// Verify the newest 10 messages are retained (msg-015 through msg-024).
+	firstID := b.messages[0].ID
+	lastID := b.messages[count-1].ID
 	b.mu.Unlock()
 
 	if count != 10 {
 		t.Errorf("expected 10 messages after cap, got %d", count)
+	}
+	if firstID != "msg-015" {
+		t.Errorf("expected oldest retained message to be msg-015, got %q", firstID)
+	}
+	if lastID != "msg-024" {
+		t.Errorf("expected newest retained message to be msg-024, got %q", lastID)
 	}
 }
 

--- a/internal/team/broker_persistence.go
+++ b/internal/team/broker_persistence.go
@@ -201,6 +201,9 @@ func (b *Broker) loadState() error {
 }
 
 func (b *Broker) saveLocked() error {
+	// Prune completed tasks before serializing to keep the state file lean.
+	b.pruneCompletedTasksLocked()
+
 	write, err := b.prepareBrokerStateWriteLocked()
 	if err != nil {
 		return err

--- a/internal/team/broker_publish.go
+++ b/internal/team/broker_publish.go
@@ -18,9 +18,19 @@ import "strings"
 // All entries require the caller to hold b.mu — the *Locked suffix
 // is the contract.
 
+// maxMessages is the rolling cap on in-memory channel messages. Oldest
+// messages are dropped when the cap is exceeded. 500 is enough for the
+// web UI's scroll-back while keeping the state file under ~1MB for this
+// slice. Configurable via WUPHF_MAX_MESSAGES env var.
+const defaultMaxMessages = 500
+
 func (b *Broker) appendMessageLocked(msg channelMessage) channelMessage {
 	msg = sanitizeChannelMessageSecrets(msg)
 	b.messages = append(b.messages, msg)
+	cap := maxMessagesFromEnv()
+	if len(b.messages) > cap {
+		b.messages = append([]channelMessage(nil), b.messages[len(b.messages)-cap:]...)
+	}
 	b.publishMessageLocked(msg)
 	// First-run nudge dismissal: track the very first human-authored message
 	// so the office sidebar can drop the "→ tag @<agent> in #general" hint.


### PR DESCRIPTION
## Summary

- **Messages**: `appendMessageLocked` now caps at 500 (configurable via `WUPHF_MAX_MESSAGES`), dropping oldest when exceeded
- **Tasks**: `saveLocked` prunes `LifecycleStateMerged` tasks older than 7 days (configurable via `WUPHF_TASK_RETENTION_DAYS`)

## Problem

`b.messages` and `b.tasks` grew without bound. Long-running brokers accumulated thousands of entries, bloating the state file and slowing startup. The ledger (actions/signals/decisions) already had caps; these core collections did not.

## Design

- Messages: same rolling-window pattern as `ledger.go` — O(1) per append
- Tasks: filter on save — only terminal (`merged`) tasks past retention are removed; active tasks are never touched
- Both caps configurable via env vars for operator control
- New file `broker_gc.go` keeps GC logic isolated from core broker code

## Test plan
- [x] `TestAppendMessageLocked_CapsAtMax` — 25 messages with cap=10 → 10 remain
- [x] `TestPruneCompletedTasksLocked_RemovesMergedOldTasks` — old merged pruned, active/recent kept
- [x] `TestPruneCompletedTasksLocked_KeepsAllWhenNoneExpired` — no false pruning
- [x] `TestIsTerminalTask` — only merged is terminal
- [x] `go build ./internal/team/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic garbage collection to limit in-memory message buffering (default cap 500, configurable).
  * Automatic cleanup of completed tasks with a configurable retention window (default 7 days).
  * Pruning now runs before broker state is persisted to storage.

* **Tests**
  * Added unit tests covering message capping, task pruning, and terminal-task detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/859)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->