### PR TITLE
chore(synth): lower auto-synthesis threshold from 5 to 3 facts

### DIFF
--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -42,7 +42,7 @@ const ArchivistAuthor = "archivist"
 // DefaultSynthesisThreshold is the number of new facts that must accumulate
 // before an automatic synthesis is triggered. Configurable per deployment
 // via WUPHF_ENTITY_BRIEF_THRESHOLD.
-const DefaultSynthesisThreshold = 5
+const DefaultSynthesisThreshold = 3
 
 // DefaultSynthesisTimeout bounds a single LLM shell-out. Configurable via
 // WUPHF_ENTITY_BRIEF_TIMEOUT (seconds).


### PR DESCRIPTION
## Summary

Lower `DefaultSynthesisThreshold` from 5 to 3 so entity briefs synthesize after 3 new facts instead of 5.

## Why

Agents get fresher context sooner — 3 facts is enough signal to produce a useful brief update without waiting for 5 to accumulate.

Still overridable via `WUPHF_ENTITY_BRIEF_THRESHOLD` env var.

## Change

One-line change in `internal/team/entity_synthesizer.go:45`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted automatic entity synthesis frequency to activate more often during normal operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/860)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->