### PR TITLE
fix(dlq): surface corruption counts in Snapshot and GET /wiki/dlq

### DIFF
--- a/internal/team/wiki_dlq.go
+++ b/internal/team/wiki_dlq.go
@@ -275,6 +275,11 @@ type Snapshot struct {
 	// were promoted to permanent-failures.jsonl. Append-only; callers
 	// should treat the order as oldest-first (file order).
 	PermanentFailures []DLQEntry `json:"permanent_failures"`
+	// CorruptLines is the running count of malformed JSONL rows skipped
+	// in extractions.jsonl. Non-zero means the queue file has corruption.
+	CorruptLines uint64 `json:"corrupt_lines"`
+	// CorruptLinesPerm is the same counter for permanent-failures.jsonl.
+	CorruptLinesPerm uint64 `json:"corrupt_lines_permanent"`
 }
 
 // Inspect returns a Snapshot of the current DLQ state. Read-only: does not
@@ -307,9 +312,12 @@ func (d *DLQ) Inspect(_ context.Context) (Snapshot, error) {
 		return Snapshot{}, fmt.Errorf("dlq: read permanent: %w", err)
 	}
 
+	corruptExt, corruptPerm := d.CorruptLineCounts()
 	return Snapshot{
 		Pending:           pending,
 		PermanentFailures: permanent,
+		CorruptLines:      corruptExt,
+		CorruptLinesPerm:  corruptPerm,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Add `corrupt_lines` and `corrupt_lines_permanent` fields to the DLQ `Snapshot` struct. The existing `GET /wiki/dlq` endpoint now surfaces these counts automatically.

## Problem

The DLQ silently skips corrupt JSONL lines during reads. Atomic counters existed (`corruptLineCount`, `permCorruptLineCnt`) but no operator surface exposed them — dashboards showed an empty DLQ when the queue file was actually corrupted.

## Fix

Two new `uint64` fields on `Snapshot`, populated from `CorruptLineCounts()` in `Inspect()`. No new routes needed.

## Test plan
- [x] All existing DLQ tests pass
- [x] `go build ./internal/team/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Snapshot diagnostics now include corruption metrics for error handling files, allowing you to track and monitor data quality issues in your processing pipeline.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/861)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->