### PR TITLE
fix(synth): close queue saturation race in EnqueueSynthesis

### DIFF
--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -266,17 +266,17 @@ func (s *EntitySynthesizer) EnqueueSynthesis(kind EntityKind, slug, requestBy st
 		EnqueuedAt: time.Now().UTC(),
 		ID:         id,
 	}
-	s.queued[key] = true
 	s.mu.Unlock()
 
 	select {
 	case s.jobs <- job:
+		// Mark as queued only after successful send so IsInflightOrQueued
+		// never returns true for a job that failed to enter the channel.
+		s.mu.Lock()
+		s.queued[key] = true
+		s.mu.Unlock()
 		return id, nil
 	default:
-		// Queue saturated — undo the reservation so future calls can retry.
-		s.mu.Lock()
-		delete(s.queued, key)
-		s.mu.Unlock()
 		return 0, ErrSynthesisQueueSaturated
 	}
 }

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -266,17 +266,17 @@ func (s *EntitySynthesizer) EnqueueSynthesis(kind EntityKind, slug, requestBy st
 		EnqueuedAt: time.Now().UTC(),
 		ID:         id,
 	}
-	s.mu.Unlock()
-
+	// Hold s.mu across the non-blocking send so the check, send, and
+	// queued-state update are atomic. The select uses default, so the
+	// send cannot block — holding the lock here is safe (drain receives
+	// from s.jobs without holding s.mu).
 	select {
 	case s.jobs <- job:
-		// Mark as queued only after successful send so IsInflightOrQueued
-		// never returns true for a job that failed to enter the channel.
-		s.mu.Lock()
 		s.queued[key] = true
 		s.mu.Unlock()
 		return id, nil
 	default:
+		s.mu.Unlock()
 		return 0, ErrSynthesisQueueSaturated
 	}
 }


### PR DESCRIPTION
## Summary

Move `s.queued[key] = true` after the successful channel send in `EnqueueSynthesis`.

## Problem

`queued[key]` was set before the channel send, then undone on failure. Between the unlock and cleanup, `IsInflightOrQueued` could return true for a job that never entered the channel.

## Fix

Set `queued[key]` only after send succeeds. Failure path needs no cleanup since the key was never set.

## Test plan
- [x] All 13 synthesizer tests pass
- [x] `go build ./internal/team/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed entity synthesis queueing so entities are marked as queued only after their job is successfully enqueued. When the queue is full, the operation now fails cleanly without leaving entities in a reserved/incorrect queued state, preventing prior timing-related inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/862)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->