### PR TITLE
feat(broker): branch 10 — per-agent provider routing

### DIFF
--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -77,6 +77,8 @@ store.close();
 | GET | `/api/v1/cost/budgets/:id` | bearer | Returns one projected budget, or 404 on malformed/missing id. |
 | GET | `/api/v1/cost/summary` | bearer | Returns current cost projections: agent spend, budgets, and threshold crossings. |
 | GET | `/api/v1/cost/replay-check` | bearer | Replays cost events and compares projections. 200 when `ok: true`; 500 with structured discrepancies when drift or unparseable cost payloads are found. |
+| GET | `/api/agents/:agentId/provider-routing` | bearer | Returns the per-agent provider-routing config via `agentProviderRoutingToJsonValue`. Mounted when `createBroker({ runners: { agentProviderRoutingStore } })` is supplied. |
+| PUT | `/api/agents/:agentId/provider-routing` | bearer | Replaces all routes for the agent. Body parses through `agentProviderRoutingWriteRequestFromJson`; the body `agentId` must match the path `agentId`. |
 | POST | `/api/runners` | bearer + runner agent map | Body: `RunnerSpawnRequest`. The bearer maps to one `agentId`; mismatches return 403. The broker mints/injects `BrokerIdentity`, resolves the `CredentialHandle`, and returns `{ runnerId }`. Mounted only when `createBroker({ runners })` is supplied. |
 | GET | `/api/runners/:id/events` | bearer + runner agent map | SSE stream of `RunnerEvent` values. The caller's bearer-mapped `agentId` must match the runner owner. |
 | GET | `/`, `/index.html` | none (loopback) | Renderer bundle (404 if `renderer: null`). |
@@ -116,6 +118,8 @@ GET /api/threads/01ARZ3NDEKTSV4RRFFQ69G5FAZ/receipts?cursor=bHNuOjI&limit=2
    tokens to `AgentId`, injects the `BrokerIdentity`, and passes runners only a
    `secretReader` closure. Runner processes never receive or construct broker
    identity.
+9. **Provider-routing writes are path-bound.** The URL `agentId` and request
+   body `agentId` must match before the broker writes routing state.
 
 ## Spec anchors
 

--- a/packages/broker/docs/modules/listener.md
+++ b/packages/broker/docs/modules/listener.md
@@ -27,6 +27,7 @@ flowchart LR
   dispatch -- "GET /api/receipts/:id" --> read["ReceiptStore.get<br/>200 / 404"]
   dispatch -- "GET /api/threads/:tid/receipts" --> list["ReceiptStore.list({threadId, cursor?, limit?})<br/>200 JSON array (+ Link rel=next when more pages)<br/>400 on invalid cursor/limit"]
   dispatch -- "/api/v1/cost/*" --> cost["cost ledger routes<br/>read: bearer<br/>mutate: bearer + operator capability"]
+  dispatch -- "/api/agents/:id/provider-routing" --> routing["provider-routing routes<br/>GET read · PUT replace"]
   dispatch -- "/api/runners*" --> runners["runner routes<br/>POST spawn · GET events SSE<br/>bearer maps to AgentId"]
   dispatch -- "unknown /api/*" --> apinotfound["404"]
   dispatch -- "/, /index.html, /assets/*" --> static["GET/HEAD only · RendererBundleSource"]
@@ -68,6 +69,18 @@ unknown authenticated API routes and return 404.
 
 See [cost-ledger.md](./cost-ledger.md) for the full route table, idempotency
 keys, replay-check discrepancy contract, and public subpath exports.
+
+### Agent provider-routing routes
+
+When `createBroker({ runners: { agentProviderRoutingStore } })` is supplied,
+the listener mounts per-agent provider-routing under
+`/api/agents/:agentId/provider-routing`. Without a routing store, those paths
+behave like unknown authenticated API routes and return 404.
+
+| Method | Path | Auth | Contract |
+|---|---|---|---|
+| GET | `/api/agents/:agentId/provider-routing` | bearer | Returns `agentProviderRoutingToJsonValue(await store.get(agentId))`. |
+| PUT | `/api/agents/:agentId/provider-routing` | bearer | Parses the body through `agentProviderRoutingWriteRequestFromJson`, rejects body/path `agentId` mismatches with 400, atomically replaces the routes via `store.put`, and returns `{ applied: true }`. |
 
 ### Runner routes
 

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -7,6 +7,7 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
+    "./agent-provider-routing": "./src/agent-provider-routing/index.ts",
     "./cost-ledger": "./src/cost-ledger/index.ts",
     "./sqlite": "./src/sqlite-receipt-store.ts"
   },

--- a/packages/broker/scripts/branch-10-demo.ts
+++ b/packages/broker/scripts/branch-10-demo.ts
@@ -57,9 +57,20 @@ const broker = await createBroker({
   },
 });
 
+let cleanupStarted = false;
 const cleanup = async () => {
-  await broker.stop();
-  db.close();
+  if (cleanupStarted) return;
+  cleanupStarted = true;
+  try {
+    await broker.stop();
+  } catch (err) {
+    console.error("[demo] Error stopping broker:", err);
+  }
+  try {
+    db.close();
+  } catch (err) {
+    console.error("[demo] Error closing DB:", err);
+  }
   rmSync(tmp, { recursive: true, force: true });
   process.exit(0);
 };

--- a/packages/broker/scripts/branch-10-demo.ts
+++ b/packages/broker/scripts/branch-10-demo.ts
@@ -1,0 +1,117 @@
+// Manual-verification harness for branch 10 (per-agent provider routing).
+//
+// Boots a broker on a random loopback port with the SQLite-backed
+// AgentProviderRoutingStore wired in, then prints the URL, bearer token,
+// and a ready-to-paste curl recipe.
+//
+// Run from the broker package:
+//   cd packages/broker
+//   bunx tsx scripts/branch-10-demo.ts
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { forBrokerTests } from "@wuphf/credentials/testing";
+import { asAgentId, asApiToken } from "@wuphf/protocol";
+import BetterSqlite3 from "better-sqlite3";
+
+import { createAgentProviderRoutingStore } from "../src/agent-provider-routing/index.ts";
+import { runMigrations } from "../src/event-log/index.ts";
+import { createBroker } from "../src/index.ts";
+
+const tmp = mkdtempSync(join(tmpdir(), "wuphf-branch-10-"));
+const dbPath = join(tmp, "broker.db");
+
+console.log(`[demo] SQLite DB: ${dbPath}`);
+const db = new BetterSqlite3(dbPath);
+runMigrations(db);
+const agentProviderRoutingStore = createAgentProviderRoutingStore(db);
+
+const token = asApiToken("demo-token-with-enough-entropy-AAAAAAAAA");
+const agentId = asAgentId("agent_alice_001");
+
+const broker = await createBroker({
+  token,
+  runners: {
+    tokenAgentIds: new Map([[token, agentId]]),
+    brokerIdentityForAgent: (id) => forBrokerTests({ agentId: id }),
+    credentialStore: {
+      write: async () => {
+        throw new Error("demo does not spawn runners; no credential write");
+      },
+      read: async () => {
+        throw new Error("demo does not spawn runners; no credential read");
+      },
+      readWithOwnership: async () => {
+        throw new Error("demo does not spawn runners; no credential read");
+      },
+      delete: async () => undefined,
+    },
+    costLedger: { record: async () => undefined },
+    eventLog: { append: async () => 1 },
+    spawnRunner: async () => {
+      throw new Error("demo does not spawn runners");
+    },
+    agentProviderRoutingStore,
+  },
+});
+
+const cleanup = async () => {
+  await broker.stop();
+  db.close();
+  rmSync(tmp, { recursive: true, force: true });
+  process.exit(0);
+};
+process.on("SIGINT", cleanup);
+process.on("SIGTERM", cleanup);
+
+const writeBody = JSON.stringify({
+  agentId,
+  routes: [
+    { kind: "claude-cli", credentialScope: "anthropic", providerKind: "anthropic" },
+    { kind: "codex-cli", credentialScope: "openai", providerKind: "openai" },
+  ],
+});
+
+console.log("");
+console.log("=== Broker up. ===");
+console.log(`URL:    ${broker.url}`);
+console.log(`Token:  ${broker.token}`);
+console.log("");
+console.log("Copy-paste these curl commands to verify branch 10 behavior:");
+console.log("");
+console.log("# 1. Empty config for a fresh agent → { routes: [] }");
+console.log(
+  `curl -s -H "Authorization: Bearer ${broker.token}" \\\n     "${broker.url}/api/agents/${agentId}/provider-routing"; echo`,
+);
+console.log("");
+console.log("# 2. Set per-agent routing (Claude→Anthropic, Codex→OpenAI)");
+console.log(
+  `curl -s -X PUT -H "Authorization: Bearer ${broker.token}" \\\n     -H "Content-Type: application/json" \\\n     -d '${writeBody}' \\\n     "${broker.url}/api/agents/${agentId}/provider-routing"; echo`,
+);
+console.log("");
+console.log("# 3. Read back → routes appear in deterministic kind order");
+console.log(
+  `curl -s -H "Authorization: Bearer ${broker.token}" \\\n     "${broker.url}/api/agents/${agentId}/provider-routing"; echo`,
+);
+console.log("");
+console.log("# 4. Confused-deputy guard: body.agentId != URL.agentId → 400");
+console.log(
+  `curl -s -i -X PUT -H "Authorization: Bearer ${broker.token}" \\\n     -H "Content-Type: application/json" \\\n     -d '{"agentId":"agent_mallory","routes":[]}' \\\n     "${broker.url}/api/agents/${agentId}/provider-routing" | head -1`,
+);
+console.log("");
+console.log("# 5. Wrong method → 405 with Allow header");
+console.log(
+  `curl -s -i -X POST -H "Authorization: Bearer ${broker.token}" \\\n     "${broker.url}/api/agents/${agentId}/provider-routing" | head -3`,
+);
+console.log("");
+console.log("# 6. Missing bearer → 401");
+console.log(`curl -s -i "${broker.url}/api/agents/${agentId}/provider-routing" | head -1`);
+console.log("");
+console.log("# 7. Clear routes (idempotent reset to defaults)");
+console.log(
+  `curl -s -X PUT -H "Authorization: Bearer ${broker.token}" \\\n     -H "Content-Type: application/json" \\\n     -d '{"agentId":"${agentId}","routes":[]}' \\\n     "${broker.url}/api/agents/${agentId}/provider-routing"; echo`,
+);
+console.log("");
+console.log("Ctrl-C to stop. Temp DB will be cleaned up on shutdown.");

--- a/packages/broker/src/agent-provider-routing/index.ts
+++ b/packages/broker/src/agent-provider-routing/index.ts
@@ -1,0 +1,6 @@
+export {
+  createAgentProviderRoutingStore,
+  SqliteAgentProviderRoutingStore,
+  type SqliteAgentProviderRoutingStoreConfig,
+} from "./store.ts";
+export type { AgentProviderRoutingStore } from "./types.ts";

--- a/packages/broker/src/agent-provider-routing/route.ts
+++ b/packages/broker/src/agent-provider-routing/route.ts
@@ -5,7 +5,7 @@ import {
   type ApiToken,
   agentProviderRoutingToJsonValue,
   agentProviderRoutingWriteRequestFromJson,
-  agentProviderRoutingWriteResponseFromJson,
+  agentProviderRoutingWriteResponseToJsonValue,
 } from "@wuphf/protocol";
 
 import { agentIdForBearer } from "../auth.ts";
@@ -93,7 +93,7 @@ async function handlePut(
     routeCount: request.routes.length,
     kinds: request.routes.map((entry) => entry.kind),
   });
-  writeJson(res, 200, agentProviderRoutingWriteResponseFromJson({ applied: true }));
+  writeJson(res, 200, agentProviderRoutingWriteResponseToJsonValue({ applied: true }));
 }
 
 async function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {

--- a/packages/broker/src/agent-provider-routing/route.ts
+++ b/packages/broker/src/agent-provider-routing/route.ts
@@ -2,29 +2,53 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 import {
   type AgentId,
+  type ApiToken,
   agentProviderRoutingToJsonValue,
   agentProviderRoutingWriteRequestFromJson,
   agentProviderRoutingWriteResponseFromJson,
 } from "@wuphf/protocol";
 
+import { agentIdForBearer } from "../auth.ts";
+import { isCompatibleRunnerProviderRoute } from "../runners/factory.ts";
+import type { BrokerLogger } from "../types.ts";
 import type { AgentProviderRoutingStore } from "./types.ts";
 
 const MAX_AGENT_PROVIDER_ROUTING_BODY_BYTES = 256 * 1024;
 const ALLOW_AGENT_PROVIDER_ROUTING = "GET, PUT";
 
+export interface AgentProviderRoutingRouteDeps {
+  readonly store: AgentProviderRoutingStore;
+  readonly tokenAgentIds: ReadonlyMap<ApiToken, AgentId>;
+  readonly logger: BrokerLogger;
+}
+
 export async function handleAgentProviderRoutingRoute(
   req: IncomingMessage,
   res: ServerResponse,
   agentId: AgentId,
-  store: AgentProviderRoutingStore,
+  deps: AgentProviderRoutingRouteDeps,
 ): Promise<void> {
+  // Bearer→agent binding mirrors POST /api/runners (runners/route.ts).
+  // The global /api/* bearer gate proves "someone with the token", but a
+  // bearer pinned to agent_alpha must not be able to PUT or even read
+  // agent_beta's routing. Without this check, any authenticated caller
+  // could swap a different agent's credential scope / provider.
+  const callerAgentId = agentIdForBearer(req, deps.tokenAgentIds);
+  if (callerAgentId === null || callerAgentId !== agentId) {
+    deps.logger.warn("agent_provider_routing_rejected", {
+      reason: callerAgentId === null ? "no_bearer_binding" : "agent_mismatch",
+      method: req.method ?? null,
+    });
+    forbidden(res, "agent_provider_routing_not_authorized");
+    return;
+  }
   if (req.method === "GET") {
-    const routing = await store.get(agentId);
+    const routing = await deps.store.get(agentId);
     writeJson(res, 200, agentProviderRoutingToJsonValue(routing));
     return;
   }
   if (req.method === "PUT") {
-    await handlePut(req, res, agentId, store);
+    await handlePut(req, res, agentId, deps);
     return;
   }
   methodNotAllowed(res);
@@ -34,7 +58,7 @@ async function handlePut(
   req: IncomingMessage,
   res: ServerResponse,
   agentId: AgentId,
-  store: AgentProviderRoutingStore,
+  deps: AgentProviderRoutingRouteDeps,
 ): Promise<void> {
   let request: ReturnType<typeof agentProviderRoutingWriteRequestFromJson>;
   try {
@@ -50,7 +74,25 @@ async function handlePut(
     writeJson(res, 400, { error: "agent_id_mismatch" });
     return;
   }
-  await store.put({ agentId, routes: request.routes });
+  // Reject configs the spawn-time factory would reject anyway. Without this
+  // an incompatible route persists, returns 200 {applied:true}, then breaks
+  // every matching spawn with a `ProviderKindMismatch` — far from the write
+  // that caused it.
+  for (const entry of request.routes) {
+    if (!isCompatibleRunnerProviderRoute(entry.kind, entry.credentialScope, entry.providerKind)) {
+      writeJson(res, 400, {
+        error: "incompatible_provider_route",
+        detail: `runner kind ${entry.kind} does not support credentialScope=${entry.credentialScope} / providerKind=${entry.providerKind}`,
+      });
+      return;
+    }
+  }
+  await deps.store.put({ agentId, routes: request.routes });
+  deps.logger.info("agent_provider_routing_put_applied", {
+    agentId,
+    routeCount: request.routes.length,
+    kinds: request.routes.map((entry) => entry.kind),
+  });
   writeJson(res, 200, agentProviderRoutingWriteResponseFromJson({ applied: true }));
 }
 
@@ -82,6 +124,16 @@ function methodNotAllowed(res: ServerResponse): void {
   const body = JSON.stringify({ error: "method_not_allowed" });
   res.writeHead(405, {
     Allow: ALLOW_AGENT_PROVIDER_ROUTING,
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+    "Content-Length": String(Buffer.byteLength(body, "utf8")),
+  });
+  res.end(body);
+}
+
+function forbidden(res: ServerResponse, reason: string): void {
+  const body = JSON.stringify({ error: reason });
+  res.writeHead(403, {
     "Content-Type": "application/json; charset=utf-8",
     "Cache-Control": "no-store",
     "Content-Length": String(Buffer.byteLength(body, "utf8")),

--- a/packages/broker/src/agent-provider-routing/route.ts
+++ b/packages/broker/src/agent-provider-routing/route.ts
@@ -1,0 +1,90 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import {
+  type AgentId,
+  agentProviderRoutingToJsonValue,
+  agentProviderRoutingWriteRequestFromJson,
+  agentProviderRoutingWriteResponseFromJson,
+} from "@wuphf/protocol";
+
+import type { AgentProviderRoutingStore } from "./types.ts";
+
+const MAX_AGENT_PROVIDER_ROUTING_BODY_BYTES = 256 * 1024;
+const ALLOW_AGENT_PROVIDER_ROUTING = "GET, PUT";
+
+export async function handleAgentProviderRoutingRoute(
+  req: IncomingMessage,
+  res: ServerResponse,
+  agentId: AgentId,
+  store: AgentProviderRoutingStore,
+): Promise<void> {
+  if (req.method === "GET") {
+    const routing = await store.get(agentId);
+    writeJson(res, 200, agentProviderRoutingToJsonValue(routing));
+    return;
+  }
+  if (req.method === "PUT") {
+    await handlePut(req, res, agentId, store);
+    return;
+  }
+  methodNotAllowed(res);
+}
+
+async function handlePut(
+  req: IncomingMessage,
+  res: ServerResponse,
+  agentId: AgentId,
+  store: AgentProviderRoutingStore,
+): Promise<void> {
+  let request: ReturnType<typeof agentProviderRoutingWriteRequestFromJson>;
+  try {
+    const parsed = JSON.parse(
+      await readBody(req, MAX_AGENT_PROVIDER_ROUTING_BODY_BYTES),
+    ) as unknown;
+    request = agentProviderRoutingWriteRequestFromJson(parsed);
+  } catch (err) {
+    writeJson(res, 400, { error: err instanceof Error ? err.message : String(err) });
+    return;
+  }
+  if (request.agentId !== agentId) {
+    writeJson(res, 400, { error: "agent_id_mismatch" });
+    return;
+  }
+  await store.put({ agentId, routes: request.routes });
+  writeJson(res, 200, agentProviderRoutingWriteResponseFromJson({ applied: true }));
+}
+
+async function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
+  let total = 0;
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), "utf8");
+    total += buffer.length;
+    if (total > maxBytes) {
+      throw new Error("agentProviderRoutingWriteRequest: body too large");
+    }
+    chunks.push(buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function writeJson(res: ServerResponse, status: number, bodyValue: unknown): void {
+  const body = JSON.stringify(bodyValue);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+    "Content-Length": String(Buffer.byteLength(body, "utf8")),
+  });
+  res.end(body);
+}
+
+function methodNotAllowed(res: ServerResponse): void {
+  const body = JSON.stringify({ error: "method_not_allowed" });
+  res.writeHead(405, {
+    Allow: ALLOW_AGENT_PROVIDER_ROUTING,
+    "Content-Type": "application/json; charset=utf-8",
+    "Cache-Control": "no-store",
+    "Content-Length": String(Buffer.byteLength(body, "utf8")),
+  });
+  res.end(body);
+}

--- a/packages/broker/src/agent-provider-routing/store.ts
+++ b/packages/broker/src/agent-provider-routing/store.ts
@@ -1,0 +1,232 @@
+import {
+  type AgentId,
+  type AgentProviderRouting,
+  type AgentProviderRoutingEntry,
+  type CredentialScope,
+  isAgentId,
+  isCredentialScope,
+  isProviderKind,
+  isRunnerKind,
+  MAX_AGENT_PROVIDER_ROUTES,
+  type ProviderKind,
+  RUNNER_KIND_VALUES,
+  type RunnerKind,
+} from "@wuphf/protocol";
+import type Database from "better-sqlite3";
+
+import { type OpenDatabaseArgs, openDatabase, runMigrations } from "../event-log/index.ts";
+import type { AgentProviderRoutingStore } from "./types.ts";
+
+export interface SqliteAgentProviderRoutingStoreConfig extends OpenDatabaseArgs {}
+
+interface SqliteAgentProviderRoutingStoreOptions {
+  readonly closeDatabase?: boolean;
+}
+
+interface RoutingEntryDbRow {
+  readonly kind: string;
+  readonly credentialScope: string;
+  readonly providerKind: string;
+}
+
+type InsertRouteParams = [AgentId, RunnerKind, CredentialScope, ProviderKind];
+
+const KIND_ORDER: ReadonlyMap<RunnerKind, number> = new Map(
+  RUNNER_KIND_VALUES.map((kind, index) => [kind, index] as const),
+);
+
+export class SqliteAgentProviderRoutingStore implements AgentProviderRoutingStore {
+  private readonly closeDatabase: boolean;
+  private readonly listRoutesStmt: Database.Statement<[AgentId], RoutingEntryDbRow>;
+  private readonly getEntryStmt: Database.Statement<[AgentId, RunnerKind], RoutingEntryDbRow>;
+  private readonly deleteAgentStmt: Database.Statement<[AgentId]>;
+  private readonly insertRouteStmt: Database.Statement<InsertRouteParams>;
+  private readonly putTransaction: Database.Transaction<(config: AgentProviderRouting) => void>;
+  private closed = false;
+
+  static open(config: SqliteAgentProviderRoutingStoreConfig): SqliteAgentProviderRoutingStore {
+    const db = openDatabase(config);
+    try {
+      runMigrations(db);
+      return new SqliteAgentProviderRoutingStore(db, { closeDatabase: true });
+    } catch (err) {
+      db.close();
+      throw err;
+    }
+  }
+
+  constructor(
+    private readonly db: Database.Database,
+    options: SqliteAgentProviderRoutingStoreOptions = {},
+  ) {
+    this.closeDatabase = options.closeDatabase ?? false;
+    this.listRoutesStmt = db.prepare<[AgentId], RoutingEntryDbRow>(
+      `SELECT runner_kind AS kind,
+              credential_scope AS credentialScope,
+              provider_kind AS providerKind
+       FROM agent_provider_routing
+       WHERE agent_id = ?`,
+    );
+    this.getEntryStmt = db.prepare<[AgentId, RunnerKind], RoutingEntryDbRow>(
+      `SELECT runner_kind AS kind,
+              credential_scope AS credentialScope,
+              provider_kind AS providerKind
+       FROM agent_provider_routing
+       WHERE agent_id = ? AND runner_kind = ?`,
+    );
+    this.deleteAgentStmt = db.prepare<[AgentId]>(
+      "DELETE FROM agent_provider_routing WHERE agent_id = ?",
+    );
+    this.insertRouteStmt = db.prepare<InsertRouteParams>(
+      `INSERT INTO agent_provider_routing
+         (agent_id, runner_kind, credential_scope, provider_kind)
+       VALUES (?, ?, ?, ?)`,
+    );
+    this.putTransaction = db.transaction((config: AgentProviderRouting) => {
+      this.deleteAgentStmt.run(config.agentId);
+      for (const route of config.routes) {
+        this.insertRouteStmt.run(
+          config.agentId,
+          route.kind,
+          route.credentialScope,
+          route.providerKind,
+        );
+      }
+    });
+  }
+
+  async get(agentId: AgentId): Promise<AgentProviderRouting> {
+    this.assertOpen();
+    const validAgentId = validateAgentId(agentId, "agentProviderRoutingStore.get.agentId");
+    const routes = this.listRoutesStmt.all(validAgentId).map(rowToEntry).sort(compareEntriesByKind);
+    return { agentId: validAgentId, routes };
+  }
+
+  async getEntry(
+    agentId: AgentId,
+    kind: RunnerKind,
+  ): Promise<{
+    readonly credentialScope: CredentialScope;
+    readonly providerKind: ProviderKind;
+  } | null> {
+    this.assertOpen();
+    const validAgentId = validateAgentId(agentId, "agentProviderRoutingStore.getEntry.agentId");
+    const validKind = validateRunnerKind(kind, "agentProviderRoutingStore.getEntry.kind");
+    const row = this.getEntryStmt.get(validAgentId, validKind);
+    if (row === undefined) {
+      return null;
+    }
+    const entry = rowToEntry(row);
+    return {
+      credentialScope: entry.credentialScope,
+      providerKind: entry.providerKind,
+    };
+  }
+
+  async put(config: AgentProviderRouting): Promise<void> {
+    this.assertOpen();
+    this.putTransaction.immediate(validateConfig(config));
+  }
+
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+    if (this.closeDatabase) {
+      this.db.close();
+    }
+    this.closed = true;
+  }
+
+  private assertOpen(): void {
+    if (this.closed) {
+      throw new Error("SqliteAgentProviderRoutingStore is closed");
+    }
+  }
+}
+
+export function createAgentProviderRoutingStore(db: Database.Database): AgentProviderRoutingStore {
+  return new SqliteAgentProviderRoutingStore(db);
+}
+
+function validateConfig(config: AgentProviderRouting): AgentProviderRouting {
+  const agentId = validateAgentId(config.agentId, "agentProviderRouting.agentId");
+  if (!Array.isArray(config.routes)) {
+    throw new Error("agentProviderRouting.routes: must be an array");
+  }
+  if (config.routes.length > MAX_AGENT_PROVIDER_ROUTES) {
+    throw new Error(
+      `agentProviderRouting.routes: exceeds ${MAX_AGENT_PROVIDER_ROUTES} entries (got ${config.routes.length})`,
+    );
+  }
+
+  const seenKinds = new Set<RunnerKind>();
+  const routes: AgentProviderRoutingEntry[] = [];
+  for (let index = 0; index < config.routes.length; index += 1) {
+    const route = config.routes[index];
+    if (route === undefined) {
+      throw new Error(`agentProviderRouting.routes/${index}: is required`);
+    }
+    const kind = validateRunnerKind(route.kind, `agentProviderRouting.routes/${index}.kind`);
+    if (seenKinds.has(kind)) {
+      throw new Error(`agentProviderRouting.routes/${index}.kind: duplicate route for "${kind}"`);
+    }
+    seenKinds.add(kind);
+    routes.push({
+      kind,
+      credentialScope: validateCredentialScope(
+        route.credentialScope,
+        `agentProviderRouting.routes/${index}.credentialScope`,
+      ),
+      providerKind: validateProviderKind(
+        route.providerKind,
+        `agentProviderRouting.routes/${index}.providerKind`,
+      ),
+    });
+  }
+
+  return { agentId, routes };
+}
+
+function rowToEntry(row: RoutingEntryDbRow): AgentProviderRoutingEntry {
+  return {
+    kind: validateRunnerKind(row.kind, "agent_provider_routing.runner_kind"),
+    credentialScope: validateCredentialScope(
+      row.credentialScope,
+      "agent_provider_routing.credential_scope",
+    ),
+    providerKind: validateProviderKind(row.providerKind, "agent_provider_routing.provider_kind"),
+  };
+}
+
+function compareEntriesByKind(a: AgentProviderRoutingEntry, b: AgentProviderRoutingEntry): number {
+  return (KIND_ORDER.get(a.kind) ?? 0) - (KIND_ORDER.get(b.kind) ?? 0);
+}
+
+function validateAgentId(value: unknown, path: string): AgentId {
+  if (isAgentId(value)) {
+    return value;
+  }
+  throw new Error(`${path}: not an AgentId`);
+}
+
+function validateRunnerKind(value: unknown, path: string): RunnerKind {
+  if (isRunnerKind(value)) {
+    return value;
+  }
+  throw new Error(`${path}: not a supported RunnerKind`);
+}
+
+function validateCredentialScope(value: unknown, path: string): CredentialScope {
+  if (isCredentialScope(value)) {
+    return value;
+  }
+  throw new Error(`${path}: not a supported CredentialScope`);
+}
+
+function validateProviderKind(value: unknown, path: string): ProviderKind {
+  if (isProviderKind(value)) {
+    return value;
+  }
+  throw new Error(`${path}: not a supported ProviderKind`);
+}

--- a/packages/broker/src/agent-provider-routing/types.ts
+++ b/packages/broker/src/agent-provider-routing/types.ts
@@ -1,0 +1,48 @@
+// Branch 10 — per-agent provider routing.
+//
+// Shared interface between the SQLite-backed store (implemented in `store.ts`)
+// and the HTTP route + factory consumers (implemented in `route.ts` and
+// `packages/broker/src/runners/factory.ts`).
+//
+// The store is the only source of truth for per-agent routing state.
+// `RunnerSpawnRequest` arriving without an inline `providerRoute` triggers a
+// store lookup; a hit fills in `providerRoute` before the request reaches
+// `@wuphf/agent-runners`. A miss falls back to the default route derived from
+// `runnerKindToProviderKind(request.kind)` — the existing v0 behavior — so
+// configuring no routes for an agent does not break it.
+
+import type { AgentId, AgentProviderRouting, RunnerKind } from "@wuphf/protocol";
+
+export interface AgentProviderRoutingStore {
+  /**
+   * Return the routing configuration for an agent. If no routes are stored,
+   * resolves to a config with an empty `routes` array (callers should treat
+   * this as "use defaults," not "agent not found"). The agentId in the
+   * returned object always equals the requested agentId.
+   */
+  get(agentId: AgentId): Promise<AgentProviderRouting>;
+
+  /**
+   * Look up the route for a single (agent, kind) pair. Returns `null` when no
+   * entry exists for that pair. The factory uses this on every spawn — keep
+   * the implementation O(1) per call.
+   */
+  getEntry(
+    agentId: AgentId,
+    kind: RunnerKind,
+  ): Promise<{
+    readonly credentialScope: import("@wuphf/protocol").CredentialScope;
+    readonly providerKind: import("@wuphf/protocol").ProviderKind;
+  } | null>;
+
+  /**
+   * Atomically replace all routes for the agent. The implementation MUST run
+   * the delete + inserts inside a single transaction. Passing an empty
+   * `routes` array clears all stored routes for the agent and is the canonical
+   * "reset to defaults" call.
+   */
+  put(config: AgentProviderRouting): Promise<void>;
+
+  /** Release any held resources (DB handles, prepared statements). */
+  close(): void;
+}

--- a/packages/broker/src/auth.ts
+++ b/packages/broker/src/auth.ts
@@ -11,8 +11,9 @@
 // reached `127.0.0.1`) cannot recover the token byte-by-byte.
 
 import { timingSafeEqual } from "node:crypto";
+import type { IncomingMessage } from "node:http";
 
-import type { ApiToken } from "@wuphf/protocol";
+import type { AgentId, ApiToken } from "@wuphf/protocol";
 
 const BEARER_PREFIX = "Bearer ";
 
@@ -29,4 +30,23 @@ export function tokenMatches(presented: string | null, expected: ApiToken): bool
   const b = Buffer.from(expected, "utf8");
   if (a.length !== b.length) return false;
   return timingSafeEqual(a, b);
+}
+
+// Resolve the AgentId bound to the bearer on the request, or null when no
+// match. Used by agent-scoped routes (runner spawn, provider routing) to
+// enforce that the caller can only act on their own agent's state — even
+// when the URL path embeds a different agentId.
+export function agentIdForBearer(
+  req: IncomingMessage,
+  tokenAgentIds: ReadonlyMap<ApiToken, AgentId>,
+): AgentId | null {
+  const presented = extractBearerFromHeader(headerString(req.headers.authorization));
+  for (const [token, agentId] of tokenAgentIds) {
+    if (tokenMatches(presented, token)) return agentId;
+  }
+  return null;
+}
+
+function headerString(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
 }

--- a/packages/broker/src/event-log/003_agent_provider_routing.sql
+++ b/packages/broker/src/event-log/003_agent_provider_routing.sql
@@ -12,11 +12,47 @@ PRAGMA foreign_keys = ON;
 -- - No timestamps. Per broker rule 8, `Date.now()` is forbidden for ordering;
 --   the table has no semantic need for timestamps and adding them invites
 --   drift with the renderer's own time.
+-- - Enum values are duplicated from packages/protocol/src/runner.ts,
+--   packages/protocol/src/credential-handle.ts, and
+--   packages/protocol/src/receipt.ts. If a future branch adds a value to
+--   those enums, ship a new migration that recreates this table; do not edit
+--   this file post-merge.
 CREATE TABLE agent_provider_routing (
   agent_id          TEXT NOT NULL,
-  runner_kind       TEXT NOT NULL,
-  credential_scope  TEXT NOT NULL,
-  provider_kind     TEXT NOT NULL,
+  runner_kind       TEXT NOT NULL
+    CONSTRAINT agent_provider_routing_runner_kind_check
+    CHECK (runner_kind IN ('claude-cli', 'codex-cli', 'openai-compat')),
+  credential_scope  TEXT NOT NULL
+    CONSTRAINT agent_provider_routing_credential_scope_check
+    CHECK (
+      credential_scope IN (
+        'anthropic',
+        'openai',
+        'openai-compat',
+        'ollama',
+        'openclaw',
+        'hermes-agent',
+        'openclaw-http',
+        'opencode',
+        'opencodego',
+        'github'
+      )
+    ),
+  provider_kind     TEXT NOT NULL
+    CONSTRAINT agent_provider_routing_provider_kind_check
+    CHECK (
+      provider_kind IN (
+        'anthropic',
+        'openai',
+        'openai-compat',
+        'ollama',
+        'openclaw',
+        'hermes-agent',
+        'openclaw-http',
+        'opencode',
+        'opencodego'
+      )
+    ),
   PRIMARY KEY (agent_id, runner_kind)
 ) STRICT, WITHOUT ROWID;
 

--- a/packages/broker/src/event-log/003_agent_provider_routing.sql
+++ b/packages/broker/src/event-log/003_agent_provider_routing.sql
@@ -1,0 +1,23 @@
+PRAGMA foreign_keys = ON;
+
+-- Rationale:
+-- - Composite PK on (agent_id, runner_kind) makes `getEntry(agentId, kind)` an
+--   O(1) point lookup and makes `put`'s replace-all semantics a simple
+--   `DELETE FROM ... WHERE agent_id = ?` + bulk insert in one transaction.
+-- - `STRICT` rejects type mismatches (e.g. an integer in a TEXT column).
+-- - `WITHOUT ROWID` is appropriate because the PK is composite text and the
+--   table will never have more rows than (agent count × RunnerKind count).
+-- - No FK on `agent_id` — the broker does not enforce a global agent registry.
+--   A stored route for a deleted agent is dead weight, not a correctness bug.
+-- - No timestamps. Per broker rule 8, `Date.now()` is forbidden for ordering;
+--   the table has no semantic need for timestamps and adding them invites
+--   drift with the renderer's own time.
+CREATE TABLE agent_provider_routing (
+  agent_id          TEXT NOT NULL,
+  runner_kind       TEXT NOT NULL,
+  credential_scope  TEXT NOT NULL,
+  provider_kind     TEXT NOT NULL,
+  PRIMARY KEY (agent_id, runner_kind)
+) STRICT, WITHOUT ROWID;
+
+PRAGMA user_version = 3;

--- a/packages/broker/src/event-log/migrations.ts
+++ b/packages/broker/src/event-log/migrations.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 
 import type Database from "better-sqlite3";
 
-export const CURRENT_SCHEMA_VERSION = 2;
+export const CURRENT_SCHEMA_VERSION = 3;
 
 interface Migration {
   readonly version: number;
@@ -17,6 +17,10 @@ const MIGRATIONS: readonly Migration[] = [
   {
     version: 2,
     sql: readFileSync(new URL("./002_cost_ledger.sql", import.meta.url), "utf8"),
+  },
+  {
+    version: 3,
+    sql: readFileSync(new URL("./003_agent_provider_routing.sql", import.meta.url), "utf8"),
   },
 ];
 

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -16,6 +16,8 @@
 //   POST /api/v1/cost/budgets             — bearer + operator capability required.
 //   DELETE /api/v1/cost/budgets/:id       — bearer + operator capability required.
 //   POST /api/v1/cost/idempotency/prune   — bearer + operator capability required.
+//   GET  /api/agents/:id/provider-routing — bearer required. Per-agent provider routes.
+//   PUT  /api/agents/:id/provider-routing — bearer required. Replace provider routes.
 //   POST /api/runners                     — bearer + runner agent map required.
 //   GET  /api/runners/:id/events          — bearer + runner agent map required. SSE.
 //   GET  /                                — static (renderer bundle) or 404 if disabled.
@@ -32,15 +34,19 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import type { AddressInfo } from "node:net";
 
 import {
+  type AgentId,
   type ApiBootstrap,
   type ApiToken,
   apiBootstrapToJson,
+  asAgentId,
   asBrokerPort,
   asBrokerUrl,
   type BrokerPort,
 } from "@wuphf/protocol";
 import { WebSocketServer } from "ws";
 
+import { handleAgentProviderRoutingRoute } from "./agent-provider-routing/route.ts";
+import type { AgentProviderRoutingStore } from "./agent-provider-routing/types.ts";
 import { extractBearerFromHeader, tokenMatches } from "./auth.ts";
 import { DEFAULT_COMMAND_IDEMPOTENCY_TTL_MS } from "./cost-ledger/idempotency.ts";
 import { type CostRouteDeps, handleCostRoute } from "./cost-ledger/routes.ts";
@@ -65,6 +71,7 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
   // 6 hosts will pass a durable event-log-backed store; this default keeps
   // the package self-contained for tests and dev runs.
   const receiptStore: ReceiptStore = config.receiptStore ?? new InMemoryReceiptStore();
+  const agentProviderRoutingStore = config.runners?.agentProviderRoutingStore ?? null;
   const cost =
     config.cost === undefined
       ? null
@@ -103,6 +110,7 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
       receiptStore,
       cost,
       runnerRoutes,
+      agentProviderRoutingStore,
     }).catch((err: unknown) => {
       logger.error("listener_route_failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -150,6 +158,7 @@ interface RouteDeps {
   readonly receiptStore: ReceiptStore;
   readonly cost: CostRouteDeps | null;
   readonly runnerRoutes: RunnerRouteState | null;
+  readonly agentProviderRoutingStore: AgentProviderRoutingStore | null;
 }
 
 async function routeRequest(
@@ -282,6 +291,13 @@ async function routeRequest(
   if (deps.cost !== null && pathname.startsWith("/api/v1/cost/")) {
     const handled = await handleCostRoute(req, res, pathname, deps.cost);
     if (handled) return;
+  }
+  if (deps.agentProviderRoutingStore !== null) {
+    const agentId = agentProviderRoutingAgentIdFromPathname(pathname);
+    if (agentId !== null) {
+      await handleAgentProviderRoutingRoute(req, res, agentId, deps.agentProviderRoutingStore);
+      return;
+    }
   }
   if (deps.runnerRoutes !== null && pathname.startsWith("/api/runners")) {
     const handled = await deps.runnerRoutes.handle(req, res, pathname);
@@ -456,8 +472,24 @@ function classifyApiRoute(pathname: string): string {
     return "thread_receipts";
   }
   if (pathname.startsWith("/api/v1/cost/")) return "cost";
+  if (pathname.startsWith("/api/agents/") && pathname.endsWith("/provider-routing")) {
+    return "agent_provider_routing";
+  }
   if (pathname.startsWith("/api/runners")) return "runners";
   return "unknown";
+}
+
+function agentProviderRoutingAgentIdFromPathname(pathname: string): AgentId | null {
+  const prefix = "/api/agents/";
+  const suffix = "/provider-routing";
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return null;
+  const encoded = pathname.slice(prefix.length, pathname.length - suffix.length);
+  if (encoded.length === 0 || encoded.includes("/")) return null;
+  try {
+    return asAgentId(decodeURIComponent(encoded));
+  } catch {
+    return null;
+  }
 }
 
 async function listen(server: Server, port: number): Promise<number> {

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -72,6 +72,9 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
   // the package self-contained for tests and dev runs.
   const receiptStore: ReceiptStore = config.receiptStore ?? new InMemoryReceiptStore();
   const agentProviderRoutingStore = config.runners?.agentProviderRoutingStore ?? null;
+  // Reuse the same bearer→agent binding map that runner spawn uses so a
+  // bearer pinned to agent_alpha cannot read or PUT agent_beta's routing.
+  const tokenAgentIds = config.runners?.tokenAgentIds ?? null;
   const cost =
     config.cost === undefined
       ? null
@@ -111,6 +114,7 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
       cost,
       runnerRoutes,
       agentProviderRoutingStore,
+      tokenAgentIds,
     }).catch((err: unknown) => {
       logger.error("listener_route_failed", {
         error: err instanceof Error ? err.message : String(err),
@@ -159,6 +163,7 @@ interface RouteDeps {
   readonly cost: CostRouteDeps | null;
   readonly runnerRoutes: RunnerRouteState | null;
   readonly agentProviderRoutingStore: AgentProviderRoutingStore | null;
+  readonly tokenAgentIds: ReadonlyMap<ApiToken, AgentId> | null;
 }
 
 async function routeRequest(
@@ -292,10 +297,14 @@ async function routeRequest(
     const handled = await handleCostRoute(req, res, pathname, deps.cost);
     if (handled) return;
   }
-  if (deps.agentProviderRoutingStore !== null) {
+  if (deps.agentProviderRoutingStore !== null && deps.tokenAgentIds !== null) {
     const agentId = agentProviderRoutingAgentIdFromPathname(pathname);
     if (agentId !== null) {
-      await handleAgentProviderRoutingRoute(req, res, agentId, deps.agentProviderRoutingStore);
+      await handleAgentProviderRoutingRoute(req, res, agentId, {
+        store: deps.agentProviderRoutingStore,
+        tokenAgentIds: deps.tokenAgentIds,
+        logger: deps.logger,
+      });
       return;
     }
   }

--- a/packages/broker/src/runners/factory.ts
+++ b/packages/broker/src/runners/factory.ts
@@ -65,10 +65,14 @@ export async function createAgentRunnerForBroker(
     effectiveProviderRoute?.credentialScope ?? credentialScopeForRunnerKind(request.kind);
   const resolvedProviderKind =
     effectiveProviderRoute?.providerKind ?? runnerKindToProviderKind(request.kind);
-  // 2. Validate provider kind against the credential scope resolved for this spawn.
-  if (!providerKindMatchesCredentialScope(credentialScope, resolvedProviderKind)) {
+  // 2. Validate provider kind against the credential scope resolved for this spawn,
+  // AND that the runner kind itself can use that scope. The second check
+  // prevents a confused-deputy where, for example, a `claude-cli → openai/openai`
+  // route passes the equality check and the claude-cli adapter then exports
+  // the OpenAI secret as `ANTHROPIC_API_KEY`.
+  if (!isCompatibleRunnerProviderRoute(request.kind, credentialScope, resolvedProviderKind)) {
     throw new ProviderKindMismatch(
-      `providerKind ${resolvedProviderKind} does not match credential scope ${credentialScope}`,
+      `providerKind ${resolvedProviderKind} / scope ${credentialScope} not compatible with runner kind ${request.kind}`,
     );
   }
   const credential = credentialHandleFromJson(request.credential, {
@@ -329,6 +333,29 @@ function runnerKindToProviderKind(kind: RunnerKind): ProviderKind {
     case "openai-compat":
       return asProviderKind("openai-compat");
   }
+}
+
+// Kind → set of credential scopes the adapter actually knows how to use.
+// Without this allowlist, `providerKindMatchesCredentialScope` would happily
+// accept any (kind, scope, scope) — e.g. `claude-cli → openai/openai` — and
+// the claude-cli adapter would unconditionally export the secret as
+// `ANTHROPIC_API_KEY` (see packages/agent-runners/src/adapters/claude-cli.ts).
+// That misroutes the OpenAI key to Anthropic's endpoint. The matrix mirrors
+// each adapter's own env-var dispatch (e.g. codex-cli's `secretEnvVarForScope`).
+const SUPPORTED_SCOPES_BY_KIND: Readonly<Record<RunnerKind, readonly string[]>> = {
+  "claude-cli": ["anthropic"],
+  "codex-cli": ["openai", "openai-compat", "anthropic"],
+  "openai-compat": ["openai-compat"],
+};
+
+export function isCompatibleRunnerProviderRoute(
+  kind: RunnerKind,
+  credentialScope: CredentialScope,
+  providerKind: ProviderKind,
+): boolean {
+  if (!providerKindMatchesCredentialScope(credentialScope, providerKind)) return false;
+  const supported = SUPPORTED_SCOPES_BY_KIND[kind];
+  return supported.includes(String(credentialScope));
 }
 
 function providerKindMatchesCredentialScope(

--- a/packages/broker/src/runners/factory.ts
+++ b/packages/broker/src/runners/factory.ts
@@ -16,6 +16,7 @@ import type {
   ProviderKind,
   RunnerEvent,
   RunnerKind,
+  RunnerProviderRoute,
   RunnerSpawnRequest,
 } from "@wuphf/protocol";
 import {
@@ -25,6 +26,7 @@ import {
   credentialHandleToJson,
 } from "@wuphf/protocol";
 
+import type { AgentProviderRoutingStore } from "../agent-provider-routing/types.ts";
 import type { ReceiptStore } from "../receipt-store.ts";
 
 export interface RunnerCostLedger {
@@ -42,6 +44,7 @@ export interface AgentRunnerFactoryDeps {
   readonly eventLog: RunnerEventLog;
   readonly spawnRunner: SpawnAgentRunner;
   readonly endpointAllowlist?: readonly string[] | undefined;
+  readonly agentProviderRoutingStore?: AgentProviderRoutingStore | undefined;
 }
 
 export async function createAgentRunnerForBroker(
@@ -51,15 +54,19 @@ export async function createAgentRunnerForBroker(
 ): Promise<AgentRunner> {
   // 1. Validate endpoint policy before invoking an OpenAI-compatible runner.
   validateOpenAICompatEndpointForBroker(request, deps.endpointAllowlist ?? []);
+  const effectiveProviderRoute =
+    request.providerRoute ??
+    (await providerRouteFromStore(request, deps.agentProviderRoutingStore));
+  const effectiveRequest =
+    request.providerRoute === undefined && effectiveProviderRoute !== undefined
+      ? { ...request, providerRoute: effectiveProviderRoute }
+      : request;
   const credentialScope =
-    request.providerRoute?.credentialScope ?? credentialScopeForRunnerKind(request.kind);
+    effectiveProviderRoute?.credentialScope ?? credentialScopeForRunnerKind(request.kind);
   const resolvedProviderKind =
-    request.providerRoute?.providerKind ?? runnerKindToProviderKind(request.kind);
+    effectiveProviderRoute?.providerKind ?? runnerKindToProviderKind(request.kind);
   // 2. Validate provider kind against the credential scope resolved for this spawn.
-  if (
-    request.providerRoute?.providerKind !== undefined &&
-    !providerKindMatchesCredentialScope(credentialScope, resolvedProviderKind)
-  ) {
+  if (!providerKindMatchesCredentialScope(credentialScope, resolvedProviderKind)) {
     throw new ProviderKindMismatch(
       `providerKind ${resolvedProviderKind} does not match credential scope ${credentialScope}`,
     );
@@ -70,7 +77,7 @@ export async function createAgentRunnerForBroker(
     scope: credentialScope,
   });
 
-  return deps.spawnRunner(request, {
+  return deps.spawnRunner(effectiveRequest, {
     credential,
     resolvedProviderKind,
     // 3. Validate credential ownership immediately before exposing secret material.
@@ -95,6 +102,19 @@ export async function createAgentRunnerForBroker(
     },
     eventLog: deps.eventLog,
   });
+}
+
+async function providerRouteFromStore(
+  request: RunnerSpawnRequest,
+  store: AgentProviderRoutingStore | undefined,
+): Promise<RunnerProviderRoute | undefined> {
+  if (store === undefined) return undefined;
+  const entry = await store.getEntry(request.agentId, request.kind);
+  if (entry === null) return undefined;
+  return {
+    credentialScope: entry.credentialScope,
+    providerKind: entry.providerKind,
+  };
 }
 
 function validateOpenAICompatEndpointForBroker(

--- a/packages/broker/src/runners/route.ts
+++ b/packages/broker/src/runners/route.ts
@@ -15,7 +15,7 @@ import { CredentialOwnershipMismatch } from "@wuphf/credentials";
 import type { AgentId, ApiToken, BrokerIdentity, RunnerId } from "@wuphf/protocol";
 import { asRunnerId, runnerEventToJsonValue, runnerSpawnRequestFromJson } from "@wuphf/protocol";
 
-import { extractBearerFromHeader, tokenMatches } from "../auth.ts";
+import { agentIdForBearer } from "../auth.ts";
 import type { BrokerLogger } from "../types.ts";
 import { type AgentRunnerFactoryDeps, createAgentRunnerForBroker } from "./factory.ts";
 
@@ -353,17 +353,6 @@ function delay(ms: number): Promise<void> {
     const timeout = setTimeout(resolve, ms);
     timeout.unref();
   });
-}
-
-function agentIdForBearer(
-  req: IncomingMessage,
-  tokenAgentIds: ReadonlyMap<ApiToken, AgentId>,
-): AgentId | null {
-  const presented = extractBearerFromHeader(headerString(req.headers.authorization));
-  for (const [token, agentId] of tokenAgentIds) {
-    if (tokenMatches(presented, token)) return agentId;
-  }
-  return null;
 }
 
 function runnerIdFromEventsPath(pathname: string): RunnerId | null {

--- a/packages/broker/tests/agent-provider-routing/route.spec.ts
+++ b/packages/broker/tests/agent-provider-routing/route.spec.ts
@@ -1,0 +1,255 @@
+import { type IncomingHttpHeaders, type OutgoingHttpHeaders, request } from "node:http";
+
+import { forBrokerTests } from "@wuphf/credentials/testing";
+import {
+  type AgentId,
+  type AgentProviderRouting,
+  type AgentProviderRoutingEntry,
+  agentProviderRoutingToJsonValue,
+  agentProviderRoutingWriteResponseFromJson,
+  asAgentId,
+  asApiToken,
+  asCredentialScope,
+  asProviderKind,
+  type RunnerKind,
+} from "@wuphf/protocol";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { AgentProviderRoutingStore } from "../../src/agent-provider-routing/types.ts";
+import { type BrokerHandle, createBroker } from "../../src/index.ts";
+
+const token = asApiToken("test-token-with-enough-entropy-AAAAAAAAA");
+const agentId = asAgentId("agent_alpha");
+const otherAgentId = asAgentId("agent_beta");
+const routePath = `/api/agents/${encodeURIComponent(agentId)}/provider-routing`;
+let broker: BrokerHandle | null = null;
+
+describe("agent provider routing routes", () => {
+  afterEach(async () => {
+    if (broker !== null) {
+      await broker.stop();
+      broker = null;
+    }
+  });
+
+  it("GET returns the store config through the protocol JSON codec", async () => {
+    const initial = [routeEntry("codex-cli", "openai", "openai")];
+    const store = fakeStore(initial);
+    const handle = await startBroker(store);
+
+    const res = await fetch(`${handle.url}${routePath}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body: unknown = await res.json();
+    expect(body).toEqual(agentProviderRoutingToJsonValue({ agentId, routes: initial }));
+  });
+
+  it("PUT stores a protocol-parsed routing config and returns the write response shape", async () => {
+    const store = fakeStore();
+    const handle = await startBroker(store);
+    const routes = [routeEntry("claude-cli", "anthropic", "anthropic")];
+    const put = await fetch(`${handle.url}${routePath}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ agentId, routes }),
+    });
+
+    expect(put.status).toBe(200);
+    expect(put.headers.get("cache-control")).toBe("no-store");
+    expect(agentProviderRoutingWriteResponseFromJson(await put.json())).toEqual({
+      applied: true,
+    });
+
+    await expect(store.get(agentId)).resolves.toEqual({ agentId, routes });
+  });
+
+  it("rejects a PUT whose body agentId disagrees with the URL agentId", async () => {
+    const store = fakeStore();
+    const handle = await startBroker(store);
+    const res = await fetch(`${handle.url}${routePath}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId: otherAgentId,
+        routes: [routeEntry("claude-cli", "anthropic", "anthropic")],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "agent_id_mismatch" });
+    await expect(store.get(agentId)).resolves.toEqual({ agentId, routes: [] });
+  });
+
+  it("requires bearer auth for GET and PUT", async () => {
+    const handle = await startBroker(fakeStore());
+
+    const get = await fetch(`${handle.url}${routePath}`);
+    const put = await fetch(`${handle.url}${routePath}`, {
+      method: "PUT",
+      body: JSON.stringify({ agentId, routes: [] }),
+    });
+
+    expect(get.status).toBe(401);
+    expect(put.status).toBe(401);
+  });
+
+  it("inherits the loopback DNS-rebinding guard", async () => {
+    const handle = await startBroker(fakeStore());
+    const res = await rawRequest({
+      port: handle.port,
+      path: routePath,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Host: "evil.example.com",
+      },
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatch(/^loopback_/);
+  });
+
+  it("returns 405 with the route Allow header for unsupported methods", async () => {
+    const handle = await startBroker(fakeStore());
+    const res = await fetch(`${handle.url}${routePath}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET, PUT");
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns codec validation errors for malformed PUT bodies", async () => {
+    const handle = await startBroker(fakeStore());
+    const res = await fetch(`${handle.url}${routePath}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ agentId, routes: "claude-cli" }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({
+      error: "agentProviderRoutingWriteRequest.routes: must be an array",
+    });
+  });
+});
+
+async function startBroker(store: AgentProviderRoutingStore): Promise<BrokerHandle> {
+  const handle = await createBroker({
+    token,
+    runners: {
+      tokenAgentIds: new Map([[token, agentId]]),
+      brokerIdentityForAgent: (id) => forBrokerTests({ agentId: id }),
+      credentialStore: {
+        write: async () => {
+          throw new Error("not used by agent provider routing route tests");
+        },
+        read: async () => {
+          throw new Error("route tests must not read credentials");
+        },
+        readWithOwnership: async (input) => ({
+          secret: "secret",
+          agentId: input.expectedAgentId,
+          scope: input.expectedScope,
+        }),
+        delete: async () => undefined,
+      },
+      costLedger: { record: async () => undefined },
+      eventLog: { append: async () => 1 },
+      spawnRunner: async () => {
+        throw new Error("route tests must not spawn runners");
+      },
+      agentProviderRoutingStore: store,
+    },
+  });
+  broker = handle;
+  return handle;
+}
+
+function fakeStore(initial: readonly AgentProviderRoutingEntry[] = []): AgentProviderRoutingStore {
+  const byAgent = new Map<AgentId, AgentProviderRouting>();
+  if (initial.length > 0) {
+    byAgent.set(agentId, { agentId, routes: initial });
+  }
+  return {
+    get: async (id) => byAgent.get(id) ?? { agentId: id, routes: [] },
+    getEntry: async (id, kind) => {
+      const config = byAgent.get(id);
+      const entry = config?.routes.find((route) => route.kind === kind);
+      if (entry === undefined) return null;
+      return {
+        credentialScope: entry.credentialScope,
+        providerKind: entry.providerKind,
+      };
+    },
+    put: async (config) => {
+      byAgent.set(config.agentId, { agentId: config.agentId, routes: [...config.routes] });
+    },
+    close: () => undefined,
+  };
+}
+
+function routeEntry(
+  kind: RunnerKind,
+  credentialScope: "anthropic" | "openai" | "openai-compat",
+  providerKind: "anthropic" | "openai" | "openai-compat",
+): AgentProviderRoutingEntry {
+  return {
+    kind,
+    credentialScope: asCredentialScope(credentialScope),
+    providerKind: asProviderKind(providerKind),
+  };
+}
+
+interface RawResponse {
+  readonly status: number;
+  readonly body: string;
+  readonly headers: IncomingHttpHeaders;
+}
+
+function rawRequest(args: {
+  readonly port: number;
+  readonly path: string;
+  readonly method?: string | undefined;
+  readonly headers?: OutgoingHttpHeaders | undefined;
+  readonly body?: string | undefined;
+}): Promise<RawResponse> {
+  return new Promise((resolveFn, rejectFn) => {
+    const req = request(
+      {
+        host: "127.0.0.1",
+        port: args.port,
+        path: args.path,
+        method: args.method ?? "GET",
+        headers: args.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () =>
+          resolveFn({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+            headers: res.headers,
+          }),
+        );
+      },
+    );
+    req.on("error", rejectFn);
+    if (args.body !== undefined) req.write(args.body);
+    req.end();
+  });
+}

--- a/packages/broker/tests/agent-provider-routing/route.spec.ts
+++ b/packages/broker/tests/agent-provider-routing/route.spec.ts
@@ -89,6 +89,62 @@ describe("agent provider routing routes", () => {
     await expect(store.get(agentId)).resolves.toEqual({ agentId, routes: [] });
   });
 
+  it("rejects a caller whose bearer is bound to a different agent", async () => {
+    // tokenAgentIds binds the test bearer to agent_alpha; the URL path
+    // targets agent_beta. The global /api/* bearer gate succeeds, but the
+    // route's binding check must still reject because confused-deputy is
+    // also possible across agents — not just inside one request body.
+    const store = fakeStore();
+    const handle = await createBroker({
+      token,
+      runners: {
+        tokenAgentIds: new Map([[token, otherAgentId]]),
+        brokerIdentityForAgent: (id) => forBrokerTests({ agentId: id }),
+        credentialStore: {
+          write: async () => {
+            throw new Error("not used");
+          },
+          read: async () => {
+            throw new Error("not used");
+          },
+          readWithOwnership: async (input) => ({
+            secret: "secret",
+            agentId: input.expectedAgentId,
+            scope: input.expectedScope,
+          }),
+          delete: async () => undefined,
+        },
+        costLedger: { record: async () => undefined },
+        eventLog: { append: async () => 1 },
+        spawnRunner: async () => {
+          throw new Error("not used");
+        },
+        agentProviderRoutingStore: store,
+      },
+    });
+    broker = handle;
+
+    const get = await fetch(`${handle.url}${routePath}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const put = await fetch(`${handle.url}${routePath}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ agentId, routes: [] }),
+    });
+
+    expect(get.status).toBe(403);
+    await expect(get.json()).resolves.toEqual({
+      error: "agent_provider_routing_not_authorized",
+    });
+    expect(put.status).toBe(403);
+    // Store remains untouched — the PUT short-circuits before store.put().
+    await expect(store.get(agentId)).resolves.toEqual({ agentId, routes: [] });
+  });
+
   it("requires bearer auth for GET and PUT", async () => {
     const handle = await startBroker(fakeStore());
 
@@ -127,6 +183,32 @@ describe("agent provider routing routes", () => {
     expect(res.status).toBe(405);
     expect(res.headers.get("allow")).toBe("GET, PUT");
     expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("rejects a PUT that persists an incompatible kind→scope/provider route", async () => {
+    // claude-cli → openai/openai passes the protocol-level shape check
+    // (both are valid enum values, scope === providerKind) but the
+    // claude-cli adapter only knows how to use anthropic secrets. Without
+    // this PUT-time guard, the bad config would persist, return 200, and
+    // every claude-cli spawn for this agent would later fail.
+    const store = fakeStore();
+    const handle = await startBroker(store);
+    const res = await fetch(`${handle.url}${routePath}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        agentId,
+        routes: [routeEntry("claude-cli", "openai", "openai")],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("incompatible_provider_route");
+    await expect(store.get(agentId)).resolves.toEqual({ agentId, routes: [] });
   });
 
   it("returns codec validation errors for malformed PUT bodies", async () => {

--- a/packages/broker/tests/agent-provider-routing/store.spec.ts
+++ b/packages/broker/tests/agent-provider-routing/store.spec.ts
@@ -9,6 +9,7 @@ import {
   asCredentialScope,
   asProviderKind,
 } from "@wuphf/protocol";
+import type Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -44,6 +45,35 @@ function tempDbPath(): string {
 const agentA = asAgentId("agent_a");
 const agentB = asAgentId("agent_b");
 
+type RawRoute = [
+  agentId: string,
+  runnerKind: string,
+  credentialScope: string,
+  providerKind: string,
+];
+
+const rawInsertCheckCases: readonly {
+  readonly column: string;
+  readonly route: RawRoute;
+  readonly constraint: string;
+}[] = [
+  {
+    column: "runner_kind",
+    route: ["agent_a", "not-a-real-kind", "anthropic", "anthropic"],
+    constraint: "agent_provider_routing_runner_kind_check",
+  },
+  {
+    column: "credential_scope",
+    route: ["agent_a", "claude-cli", "not-a-real-scope", "anthropic"],
+    constraint: "agent_provider_routing_credential_scope_check",
+  },
+  {
+    column: "provider_kind",
+    route: ["agent_a", "claude-cli", "anthropic", "not-a-real-provider"],
+    constraint: "agent_provider_routing_provider_kind_check",
+  },
+];
+
 function route(
   kind: AgentProviderRoutingEntry["kind"],
   credentialScope: string,
@@ -54,6 +84,24 @@ function route(
     credentialScope: asCredentialScope(credentialScope),
     providerKind: asProviderKind(providerKind),
   };
+}
+
+function insertRawRoute(db: Database.Database, rawRoute: RawRoute): void {
+  db.prepare<RawRoute>(
+    `INSERT INTO agent_provider_routing
+       (agent_id, runner_kind, credential_scope, provider_kind)
+     VALUES (?, ?, ?, ?)`,
+  ).run(...rawRoute);
+}
+
+function expectRawRouteCheckFailure(rawRoute: RawRoute, constraint: string): void {
+  const db = openDatabase({ path: ":memory:" });
+  try {
+    runMigrations(db);
+    expect(() => insertRawRoute(db, rawRoute)).toThrow(`CHECK constraint failed: ${constraint}`);
+  } finally {
+    db.close();
+  }
 }
 
 describe("SqliteAgentProviderRoutingStore", () => {
@@ -215,6 +263,12 @@ describe("SqliteAgentProviderRoutingStore", () => {
       db.close();
     }
   });
+
+  for (const checkCase of rawInsertCheckCases) {
+    it(`rejects raw rows with out-of-enum ${checkCase.column}`, () => {
+      expectRawRouteCheckFailure(checkCase.route, checkCase.constraint);
+    });
+  }
 
   it("does not re-run the agent provider routing migration for an already-v3 database", () => {
     const path = tempDbPath();

--- a/packages/broker/tests/agent-provider-routing/store.spec.ts
+++ b/packages/broker/tests/agent-provider-routing/store.spec.ts
@@ -1,0 +1,249 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  type AgentProviderRouting,
+  type AgentProviderRoutingEntry,
+  asAgentId,
+  asCredentialScope,
+  asProviderKind,
+} from "@wuphf/protocol";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createAgentProviderRoutingStore,
+  SqliteAgentProviderRoutingStore,
+} from "../../src/agent-provider-routing/index.ts";
+import { CURRENT_SCHEMA_VERSION, openDatabase, runMigrations } from "../../src/event-log/index.ts";
+
+const stores: SqliteAgentProviderRoutingStore[] = [];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const store of stores.splice(0)) {
+    store.close();
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function openStore(): SqliteAgentProviderRoutingStore {
+  const store = SqliteAgentProviderRoutingStore.open({ path: ":memory:" });
+  stores.push(store);
+  return store;
+}
+
+function tempDbPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), "wuphf-agent-provider-routing-"));
+  tempDirs.push(dir);
+  return join(dir, "routing.sqlite");
+}
+
+const agentA = asAgentId("agent_a");
+const agentB = asAgentId("agent_b");
+
+function route(
+  kind: AgentProviderRoutingEntry["kind"],
+  credentialScope: string,
+  providerKind: string,
+): AgentProviderRoutingEntry {
+  return {
+    kind,
+    credentialScope: asCredentialScope(credentialScope),
+    providerKind: asProviderKind(providerKind),
+  };
+}
+
+describe("SqliteAgentProviderRoutingStore", () => {
+  it("get returns an empty config for an agent with no rows", async () => {
+    const store = openStore();
+
+    await expect(store.get(agentA)).resolves.toEqual({ agentId: agentA, routes: [] });
+  });
+
+  it("getEntry returns null for an agent and runner kind with no row", async () => {
+    const store = openStore();
+
+    await expect(store.getEntry(agentA, "claude-cli")).resolves.toBeNull();
+  });
+
+  it("put then get round-trips all route fields", async () => {
+    const store = openStore();
+    const config: AgentProviderRouting = {
+      agentId: agentA,
+      routes: [
+        route("claude-cli", "anthropic", "anthropic"),
+        route("codex-cli", "openai", "openai"),
+      ],
+    };
+
+    await store.put(config);
+
+    await expect(store.get(agentA)).resolves.toEqual(config);
+    await expect(store.getEntry(agentA, "codex-cli")).resolves.toEqual({
+      credentialScope: asCredentialScope("openai"),
+      providerKind: asProviderKind("openai"),
+    });
+  });
+
+  it("get returns routes sorted by RunnerKind enum order regardless of input order", async () => {
+    const store = openStore();
+
+    await store.put({
+      agentId: agentA,
+      routes: [
+        route("openai-compat", "openai-compat", "openai-compat"),
+        route("codex-cli", "openai", "openai"),
+        route("claude-cli", "anthropic", "anthropic"),
+      ],
+    });
+
+    const config = await store.get(agentA);
+    expect(config.routes.map((entry) => entry.kind)).toEqual([
+      "claude-cli",
+      "codex-cli",
+      "openai-compat",
+    ]);
+  });
+
+  it("put replaces all routes for an agent", async () => {
+    const store = openStore();
+
+    await store.put({
+      agentId: agentA,
+      routes: [
+        route("claude-cli", "anthropic", "anthropic"),
+        route("codex-cli", "openai", "openai"),
+      ],
+    });
+    await store.put({
+      agentId: agentA,
+      routes: [route("openai-compat", "openai-compat", "openai-compat")],
+    });
+
+    await expect(store.get(agentA)).resolves.toEqual({
+      agentId: agentA,
+      routes: [route("openai-compat", "openai-compat", "openai-compat")],
+    });
+  });
+
+  it("put with no routes clears an agent's entries", async () => {
+    const store = openStore();
+
+    await store.put({
+      agentId: agentA,
+      routes: [route("claude-cli", "anthropic", "anthropic")],
+    });
+    await store.put({ agentId: agentA, routes: [] });
+
+    await expect(store.get(agentA)).resolves.toEqual({ agentId: agentA, routes: [] });
+    await expect(store.getEntry(agentA, "claude-cli")).resolves.toBeNull();
+  });
+
+  it("keeps routes for different agents isolated", async () => {
+    const store = openStore();
+    const agentARoute = route("claude-cli", "anthropic", "anthropic");
+    const agentBRoute = route("codex-cli", "openai", "openai");
+
+    await store.put({ agentId: agentA, routes: [agentARoute] });
+    await store.put({ agentId: agentB, routes: [agentBRoute] });
+
+    await expect(store.get(agentA)).resolves.toEqual({ agentId: agentA, routes: [agentARoute] });
+    await expect(store.get(agentB)).resolves.toEqual({ agentId: agentB, routes: [agentBRoute] });
+  });
+
+  it("rejects invalid route values without clearing existing rows", async () => {
+    const store = openStore();
+    const original: AgentProviderRouting = {
+      agentId: agentA,
+      routes: [route("claude-cli", "anthropic", "anthropic")],
+    };
+    const invalid = {
+      agentId: agentA,
+      routes: [
+        {
+          kind: "codex-cli",
+          credentialScope: "not-a-scope",
+          providerKind: "openai",
+        },
+      ],
+    } as unknown as AgentProviderRouting;
+
+    await store.put(original);
+    await expect(store.put(invalid)).rejects.toThrow(
+      "agentProviderRouting.routes/0.credentialScope",
+    );
+    await expect(store.get(agentA)).resolves.toEqual(original);
+  });
+
+  it("can be constructed over an already-migrated database", async () => {
+    const db = openDatabase({ path: ":memory:" });
+    try {
+      runMigrations(db);
+      const store = createAgentProviderRoutingStore(db);
+      await store.put({
+        agentId: agentA,
+        routes: [route("claude-cli", "anthropic", "anthropic")],
+      });
+
+      await expect(store.get(agentA)).resolves.toEqual({
+        agentId: agentA,
+        routes: [route("claude-cli", "anthropic", "anthropic")],
+      });
+      store.close();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("migrates a fresh database through schema version 3", () => {
+    const db = openDatabase({ path: ":memory:" });
+    try {
+      runMigrations(db);
+
+      expect(db.pragma("user_version", { simple: true })).toBe(CURRENT_SCHEMA_VERSION);
+      expect(
+        db
+          .prepare<[], { readonly name: string }>(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'agent_provider_routing'",
+          )
+          .get()?.name,
+      ).toBe("agent_provider_routing");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not re-run the agent provider routing migration for an already-v3 database", () => {
+    const path = tempDbPath();
+    const first = openDatabase({ path });
+    try {
+      runMigrations(first);
+      first
+        .prepare<[string, string, string, string]>(
+          `INSERT INTO agent_provider_routing
+             (agent_id, runner_kind, credential_scope, provider_kind)
+           VALUES (?, ?, ?, ?)`,
+        )
+        .run("agent_a", "claude-cli", "anthropic", "anthropic");
+    } finally {
+      first.close();
+    }
+
+    const second = openDatabase({ path });
+    try {
+      runMigrations(second);
+      expect(
+        second
+          .prepare<[], { readonly count: number }>(
+            "SELECT COUNT(*) AS count FROM agent_provider_routing",
+          )
+          .get()?.count,
+      ).toBe(1);
+    } finally {
+      second.close();
+    }
+  });
+});

--- a/packages/broker/tests/runners/factory.spec.ts
+++ b/packages/broker/tests/runners/factory.spec.ts
@@ -4,6 +4,8 @@ import { CredentialOwnershipMismatch } from "@wuphf/credentials";
 import { forBrokerTests } from "@wuphf/credentials/testing";
 import {
   type AgentId,
+  type AgentProviderRouting,
+  type AgentProviderRoutingEntry,
   asAgentId,
   asCredentialHandleId,
   asCredentialScope,
@@ -11,10 +13,12 @@ import {
   type CredentialScope,
   createCredentialHandle,
   credentialHandleToJson,
+  type RunnerProviderRoute,
   type RunnerSpawnRequest,
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
 
+import type { AgentProviderRoutingStore } from "../../src/agent-provider-routing/types.ts";
 import { InMemoryReceiptStore } from "../../src/receipt-store.ts";
 import {
   type AgentRunnerFactoryDeps,
@@ -151,6 +155,106 @@ describe("createAgentRunnerForBroker", () => {
     expect(runner.agentId).toBe(agentId);
   });
 
+  it("uses the per-agent routing store when no inline providerRoute is present", async () => {
+    const openAiCredential = createCredentialHandle({
+      id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
+      agentId,
+      scope: asCredentialScope("openai"),
+    });
+    const storedRoute = {
+      credentialScope: asCredentialScope("openai"),
+      providerKind: asProviderKind("openai"),
+    };
+    const runner = await createAgentRunnerForBroker(
+      {
+        ...request,
+        credential: credentialHandleToJson(openAiCredential),
+      },
+      forBrokerTests({ agentId }),
+      {
+        ...depsForOwnership({
+          actualAgentId: agentId,
+          actualScope: asCredentialScope("openai"),
+          actualSecret: "openai-secret",
+          expectedProviderKind: asProviderKind("openai"),
+          expectedRequestProviderRoute: storedRoute,
+        }),
+        agentProviderRoutingStore: fakeRoutingStore([
+          {
+            kind: "claude-cli",
+            ...storedRoute,
+          },
+        ]),
+      },
+    );
+
+    expect(runner.agentId).toBe(agentId);
+  });
+
+  it("does not consult the per-agent routing store when providerRoute is inline", async () => {
+    const openAiCredential = createCredentialHandle({
+      id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
+      agentId,
+      scope: asCredentialScope("openai"),
+    });
+    const routedRequest: RunnerSpawnRequest = {
+      ...request,
+      credential: credentialHandleToJson(openAiCredential),
+      providerRoute: {
+        credentialScope: asCredentialScope("openai"),
+        providerKind: asProviderKind("openai"),
+      },
+    };
+    const runner = await createAgentRunnerForBroker(routedRequest, forBrokerTests({ agentId }), {
+      ...depsForOwnership({
+        actualAgentId: agentId,
+        actualScope: asCredentialScope("openai"),
+        actualSecret: "openai-secret",
+        expectedProviderKind: asProviderKind("openai"),
+      }),
+      agentProviderRoutingStore: {
+        ...fakeRoutingStore(),
+        getEntry: async () => {
+          throw new Error("inline providerRoute should skip store lookup");
+        },
+      },
+    });
+
+    expect(runner.agentId).toBe(agentId);
+  });
+
+  it("rejects provider kind mismatches loaded from the per-agent routing store", async () => {
+    const openAiCredential = createCredentialHandle({
+      id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
+      agentId,
+      scope: asCredentialScope("openai"),
+    });
+
+    await expect(
+      createAgentRunnerForBroker(
+        {
+          ...request,
+          credential: credentialHandleToJson(openAiCredential),
+        },
+        forBrokerTests({ agentId }),
+        {
+          ...depsForOwnership({
+            actualAgentId: agentId,
+            actualScope: asCredentialScope("openai"),
+            actualSecret: "openai-secret",
+          }),
+          agentProviderRoutingStore: fakeRoutingStore([
+            {
+              kind: "claude-cli",
+              credentialScope: asCredentialScope("openai"),
+              providerKind: asProviderKind("anthropic"),
+            },
+          ]),
+        },
+      ),
+    ).rejects.toBeInstanceOf(ProviderKindMismatch);
+  });
+
   it("rejects providerRoute providerKind that does not match the credential scope", async () => {
     const openAiCredential = createCredentialHandle({
       id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
@@ -241,6 +345,7 @@ function depsForOwnership(input: {
   readonly actualScope: CredentialScope;
   readonly actualSecret: string;
   readonly expectedProviderKind?: ReturnType<typeof asProviderKind> | undefined;
+  readonly expectedRequestProviderRoute?: RunnerProviderRoute | undefined;
 }): AgentRunnerFactoryDeps {
   return {
     credentialStore: {
@@ -270,11 +375,39 @@ function depsForOwnership(input: {
       expect(deps.resolvedProviderKind).toBe(
         input.expectedProviderKind ?? asProviderKind("anthropic"),
       );
+      if (input.expectedRequestProviderRoute !== undefined) {
+        expect(_request.providerRoute).toEqual(input.expectedRequestProviderRoute);
+      }
       await deps.secretReader(deps.credential);
       return createFakeAgentRunner({
         kind: _request.kind,
         agentId: _request.agentId,
       });
     },
+  };
+}
+
+function fakeRoutingStore(
+  initial: readonly AgentProviderRoutingEntry[] = [],
+): AgentProviderRoutingStore {
+  const byAgent = new Map<AgentId, AgentProviderRouting>();
+  if (initial.length > 0) {
+    byAgent.set(agentId, { agentId, routes: initial });
+  }
+  return {
+    get: async (id) => byAgent.get(id) ?? { agentId: id, routes: [] },
+    getEntry: async (id, kind) => {
+      const config = byAgent.get(id);
+      const entry = config?.routes.find((route) => route.kind === kind);
+      if (entry === undefined) return null;
+      return {
+        credentialScope: entry.credentialScope,
+        providerKind: entry.providerKind,
+      };
+    },
+    put: async (config) => {
+      byAgent.set(config.agentId, { agentId: config.agentId, routes: [...config.routes] });
+    },
+    close: () => undefined,
   };
 }

--- a/packages/broker/tests/runners/factory.spec.ts
+++ b/packages/broker/tests/runners/factory.spec.ts
@@ -130,25 +130,29 @@ describe("createAgentRunnerForBroker", () => {
   });
 
   it("uses providerRoute credential scope when present", async () => {
-    const openAiCredential = createCredentialHandle({
+    // codex-cli legitimately supports both openai and anthropic scopes
+    // (see secretEnvVarForScope in codex-cli.ts). Pick anthropic to prove
+    // the override is consulted — the codex-cli default scope is openai.
+    const anthropicCredential = createCredentialHandle({
       id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
       agentId,
-      scope: asCredentialScope("openai"),
+      scope: asCredentialScope("anthropic"),
     });
     const routedRequest: RunnerSpawnRequest = {
       ...request,
-      credential: credentialHandleToJson(openAiCredential),
+      kind: "codex-cli",
+      credential: credentialHandleToJson(anthropicCredential),
       providerRoute: {
-        credentialScope: asCredentialScope("openai"),
-        providerKind: asProviderKind("openai"),
+        credentialScope: asCredentialScope("anthropic"),
+        providerKind: asProviderKind("anthropic"),
       },
     };
     const runner = await createAgentRunnerForBroker(routedRequest, forBrokerTests({ agentId }), {
       ...depsForOwnership({
         actualAgentId: agentId,
-        actualScope: asCredentialScope("openai"),
-        actualSecret: "openai-secret",
-        expectedProviderKind: asProviderKind("openai"),
+        actualScope: asCredentialScope("anthropic"),
+        actualSecret: "anthropic-secret",
+        expectedProviderKind: asProviderKind("anthropic"),
       }),
     });
 
@@ -156,32 +160,33 @@ describe("createAgentRunnerForBroker", () => {
   });
 
   it("uses the per-agent routing store when no inline providerRoute is present", async () => {
-    const openAiCredential = createCredentialHandle({
+    const anthropicCredential = createCredentialHandle({
       id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
       agentId,
-      scope: asCredentialScope("openai"),
+      scope: asCredentialScope("anthropic"),
     });
     const storedRoute = {
-      credentialScope: asCredentialScope("openai"),
-      providerKind: asProviderKind("openai"),
+      credentialScope: asCredentialScope("anthropic"),
+      providerKind: asProviderKind("anthropic"),
     };
     const runner = await createAgentRunnerForBroker(
       {
         ...request,
-        credential: credentialHandleToJson(openAiCredential),
+        kind: "codex-cli",
+        credential: credentialHandleToJson(anthropicCredential),
       },
       forBrokerTests({ agentId }),
       {
         ...depsForOwnership({
           actualAgentId: agentId,
-          actualScope: asCredentialScope("openai"),
-          actualSecret: "openai-secret",
-          expectedProviderKind: asProviderKind("openai"),
+          actualScope: asCredentialScope("anthropic"),
+          actualSecret: "anthropic-secret",
+          expectedProviderKind: asProviderKind("anthropic"),
           expectedRequestProviderRoute: storedRoute,
         }),
         agentProviderRoutingStore: fakeRoutingStore([
           {
-            kind: "claude-cli",
+            kind: "codex-cli",
             ...storedRoute,
           },
         ]),
@@ -192,25 +197,26 @@ describe("createAgentRunnerForBroker", () => {
   });
 
   it("does not consult the per-agent routing store when providerRoute is inline", async () => {
-    const openAiCredential = createCredentialHandle({
+    const anthropicCredential = createCredentialHandle({
       id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
       agentId,
-      scope: asCredentialScope("openai"),
+      scope: asCredentialScope("anthropic"),
     });
     const routedRequest: RunnerSpawnRequest = {
       ...request,
-      credential: credentialHandleToJson(openAiCredential),
+      kind: "codex-cli",
+      credential: credentialHandleToJson(anthropicCredential),
       providerRoute: {
-        credentialScope: asCredentialScope("openai"),
-        providerKind: asProviderKind("openai"),
+        credentialScope: asCredentialScope("anthropic"),
+        providerKind: asProviderKind("anthropic"),
       },
     };
     const runner = await createAgentRunnerForBroker(routedRequest, forBrokerTests({ agentId }), {
       ...depsForOwnership({
         actualAgentId: agentId,
-        actualScope: asCredentialScope("openai"),
-        actualSecret: "openai-secret",
-        expectedProviderKind: asProviderKind("openai"),
+        actualScope: asCredentialScope("anthropic"),
+        actualSecret: "anthropic-secret",
+        expectedProviderKind: asProviderKind("anthropic"),
       }),
       agentProviderRoutingStore: {
         ...fakeRoutingStore(),
@@ -252,6 +258,37 @@ describe("createAgentRunnerForBroker", () => {
           ]),
         },
       ),
+    ).rejects.toBeInstanceOf(ProviderKindMismatch);
+  });
+
+  it("rejects an inline providerRoute whose scope is valid but incompatible with the runner kind", async () => {
+    // Defense in depth: even if the PUT-time check is bypassed (e.g. inline
+    // route on POST /api/runners), the factory must still reject a
+    // claude-cli runner pointed at an openai-scoped credential. The
+    // adapter would otherwise hand the OpenAI secret to claude-cli as
+    // ANTHROPIC_API_KEY.
+    const openAiCredential = createCredentialHandle({
+      id: asCredentialHandleId("cred_route0123456789ABCDEFGHIJKLM"),
+      agentId,
+      scope: asCredentialScope("openai"),
+    });
+    const incompatibleRequest: RunnerSpawnRequest = {
+      ...request,
+      credential: credentialHandleToJson(openAiCredential),
+      providerRoute: {
+        credentialScope: asCredentialScope("openai"),
+        providerKind: asProviderKind("openai"),
+      },
+    };
+
+    await expect(
+      createAgentRunnerForBroker(incompatibleRequest, forBrokerTests({ agentId }), {
+        ...depsForOwnership({
+          actualAgentId: agentId,
+          actualScope: asCredentialScope("openai"),
+          actualSecret: "openai-secret",
+        }),
+      }),
     ).rejects.toBeInstanceOf(ProviderKindMismatch);
   });
 

--- a/packages/protocol/src/agent-provider-routing.ts
+++ b/packages/protocol/src/agent-provider-routing.ts
@@ -205,6 +205,12 @@ export function agentProviderRoutingWriteResponseFromJson(
   return { applied };
 }
 
+export function agentProviderRoutingWriteResponseToJsonValue(
+  value: AgentProviderRoutingWriteResponse,
+): unknown {
+  return { applied: value.applied };
+}
+
 function parseRoutesArray(value: unknown, path: string): readonly AgentProviderRoutingEntry[] {
   if (!Array.isArray(value)) {
     throw new Error(`${path}: must be an array`);

--- a/packages/protocol/src/agent-provider-routing.ts
+++ b/packages/protocol/src/agent-provider-routing.ts
@@ -1,0 +1,277 @@
+// Branch 10 — per-agent provider routing.
+//
+// The wire shape that lets a host configure "agent X, runner kind Y →
+// credential scope Z, provider kind W". When a RunnerSpawnRequest arrives
+// without an inline `providerRoute`, the broker consults this config and
+// fills it in before reaching @wuphf/agent-runners.
+//
+// The single-entry shape `RunnerProviderRoute` lives in runner.ts and is
+// reused verbatim; this module adds the persistence + IPC surface that lets
+// a UI or admin tool persist routing per agent.
+
+import {
+  type AgentId,
+  asAgentId,
+  asCredentialScope,
+  type CredentialScope,
+} from "./credential-handle.ts";
+import {
+  asProviderKind,
+  isProviderKind,
+  PROVIDER_KIND_VALUES,
+  type ProviderKind,
+} from "./receipt.ts";
+import { assertKnownKeys, hasOwn, requireRecord } from "./receipt-utils.ts";
+import { isRunnerKind, RUNNER_KIND_VALUES, type RunnerKind } from "./runner.ts";
+
+/**
+ * One agent can configure at most one route per RunnerKind. The cap
+ * exists so a hostile renderer cannot push an unbounded list and so the
+ * broker's resolution path is O(1) per spawn. Sized to RunnerKind cardinality
+ * with substantial headroom for future kinds added by branches 11+.
+ */
+export const MAX_AGENT_PROVIDER_ROUTES = 16;
+
+export interface AgentProviderRoutingEntry {
+  readonly kind: RunnerKind;
+  readonly credentialScope: CredentialScope;
+  readonly providerKind: ProviderKind;
+}
+
+export interface AgentProviderRouting {
+  readonly agentId: AgentId;
+  readonly routes: readonly AgentProviderRoutingEntry[];
+}
+
+export interface AgentProviderRoutingReadRequest {
+  readonly agentId: AgentId;
+}
+
+export type AgentProviderRoutingReadResponse = AgentProviderRouting;
+
+export interface AgentProviderRoutingWriteRequest {
+  readonly agentId: AgentId;
+  readonly routes: readonly AgentProviderRoutingEntry[];
+}
+
+export interface AgentProviderRoutingWriteResponse {
+  readonly applied: true;
+}
+
+const AGENT_PROVIDER_ROUTING_ENTRY_KEYS_TUPLE = [
+  "kind",
+  "credentialScope",
+  "providerKind",
+] as const satisfies readonly (keyof AgentProviderRoutingEntry)[];
+const AGENT_PROVIDER_ROUTING_ENTRY_KEYS: ReadonlySet<string> = new Set(
+  AGENT_PROVIDER_ROUTING_ENTRY_KEYS_TUPLE,
+);
+
+const AGENT_PROVIDER_ROUTING_KEYS_TUPLE = [
+  "agentId",
+  "routes",
+] as const satisfies readonly (keyof AgentProviderRouting)[];
+const AGENT_PROVIDER_ROUTING_KEYS: ReadonlySet<string> = new Set(AGENT_PROVIDER_ROUTING_KEYS_TUPLE);
+
+const AGENT_PROVIDER_ROUTING_READ_REQUEST_KEYS_TUPLE = [
+  "agentId",
+] as const satisfies readonly (keyof AgentProviderRoutingReadRequest)[];
+const AGENT_PROVIDER_ROUTING_READ_REQUEST_KEYS: ReadonlySet<string> = new Set(
+  AGENT_PROVIDER_ROUTING_READ_REQUEST_KEYS_TUPLE,
+);
+
+const AGENT_PROVIDER_ROUTING_WRITE_REQUEST_KEYS_TUPLE = [
+  "agentId",
+  "routes",
+] as const satisfies readonly (keyof AgentProviderRoutingWriteRequest)[];
+const AGENT_PROVIDER_ROUTING_WRITE_REQUEST_KEYS: ReadonlySet<string> = new Set(
+  AGENT_PROVIDER_ROUTING_WRITE_REQUEST_KEYS_TUPLE,
+);
+
+const AGENT_PROVIDER_ROUTING_WRITE_RESPONSE_KEYS_TUPLE = [
+  "applied",
+] as const satisfies readonly (keyof AgentProviderRoutingWriteResponse)[];
+const AGENT_PROVIDER_ROUTING_WRITE_RESPONSE_KEYS: ReadonlySet<string> = new Set(
+  AGENT_PROVIDER_ROUTING_WRITE_RESPONSE_KEYS_TUPLE,
+);
+
+export function agentProviderRoutingFromJson(value: unknown): AgentProviderRouting {
+  const record = requireRecord(value, "agentProviderRouting");
+  assertKnownKeys(record, "agentProviderRouting", AGENT_PROVIDER_ROUTING_KEYS);
+  const agentId = agentIdFromJson(
+    requiredStringField(record, "agentId", "agentProviderRouting.agentId"),
+    "agentProviderRouting.agentId",
+  );
+  const routes = parseRoutesArray(
+    requiredField(record, "routes", "agentProviderRouting.routes"),
+    "agentProviderRouting.routes",
+  );
+  return { agentId, routes };
+}
+
+export function agentProviderRoutingToJsonValue(value: AgentProviderRouting): unknown {
+  return {
+    agentId: value.agentId as string,
+    routes: value.routes.map((entry) => agentProviderRoutingEntryToJsonValue(entry)),
+  };
+}
+
+export function agentProviderRoutingEntryFromJson(
+  value: unknown,
+  path: string,
+): AgentProviderRoutingEntry {
+  const record = requireRecord(value, path);
+  assertKnownKeys(record, path, AGENT_PROVIDER_ROUTING_ENTRY_KEYS);
+  const kind = requiredStringField(record, "kind", `${path}.kind`);
+  if (!isRunnerKind(kind)) {
+    throw new Error(`${path}.kind: not a supported RunnerKind (got ${JSON.stringify(kind)})`);
+  }
+  const credentialScope = credentialScopeFromJson(
+    requiredStringField(record, "credentialScope", `${path}.credentialScope`),
+    `${path}.credentialScope`,
+  );
+  const providerKindRaw = requiredStringField(record, "providerKind", `${path}.providerKind`);
+  if (!isProviderKind(providerKindRaw)) {
+    throw new Error(
+      `${path}.providerKind: not a supported ProviderKind (got ${JSON.stringify(providerKindRaw)})`,
+    );
+  }
+  return {
+    kind: kind as RunnerKind,
+    credentialScope,
+    providerKind: asProviderKind(providerKindRaw),
+  };
+}
+
+export function agentProviderRoutingEntryToJsonValue(value: AgentProviderRoutingEntry): unknown {
+  return {
+    kind: value.kind as string,
+    credentialScope: value.credentialScope as string,
+    providerKind: value.providerKind as string,
+  };
+}
+
+export function agentProviderRoutingReadRequestFromJson(
+  value: unknown,
+): AgentProviderRoutingReadRequest {
+  const record = requireRecord(value, "agentProviderRoutingReadRequest");
+  assertKnownKeys(
+    record,
+    "agentProviderRoutingReadRequest",
+    AGENT_PROVIDER_ROUTING_READ_REQUEST_KEYS,
+  );
+  return {
+    agentId: agentIdFromJson(
+      requiredStringField(record, "agentId", "agentProviderRoutingReadRequest.agentId"),
+      "agentProviderRoutingReadRequest.agentId",
+    ),
+  };
+}
+
+export function agentProviderRoutingWriteRequestFromJson(
+  value: unknown,
+): AgentProviderRoutingWriteRequest {
+  const record = requireRecord(value, "agentProviderRoutingWriteRequest");
+  assertKnownKeys(
+    record,
+    "agentProviderRoutingWriteRequest",
+    AGENT_PROVIDER_ROUTING_WRITE_REQUEST_KEYS,
+  );
+  return {
+    agentId: agentIdFromJson(
+      requiredStringField(record, "agentId", "agentProviderRoutingWriteRequest.agentId"),
+      "agentProviderRoutingWriteRequest.agentId",
+    ),
+    routes: parseRoutesArray(
+      requiredField(record, "routes", "agentProviderRoutingWriteRequest.routes"),
+      "agentProviderRoutingWriteRequest.routes",
+    ),
+  };
+}
+
+export function agentProviderRoutingWriteResponseFromJson(
+  value: unknown,
+): AgentProviderRoutingWriteResponse {
+  const record = requireRecord(value, "agentProviderRoutingWriteResponse");
+  assertKnownKeys(
+    record,
+    "agentProviderRoutingWriteResponse",
+    AGENT_PROVIDER_ROUTING_WRITE_RESPONSE_KEYS,
+  );
+  const applied = requiredField(record, "applied", "agentProviderRoutingWriteResponse.applied");
+  if (applied !== true) {
+    throw new Error("agentProviderRoutingWriteResponse.applied: must be true");
+  }
+  return { applied };
+}
+
+function parseRoutesArray(value: unknown, path: string): readonly AgentProviderRoutingEntry[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${path}: must be an array`);
+  }
+  if (value.length > MAX_AGENT_PROVIDER_ROUTES) {
+    throw new Error(`${path}: exceeds ${MAX_AGENT_PROVIDER_ROUTES} entries (got ${value.length})`);
+  }
+  const seenKinds = new Set<RunnerKind>();
+  const entries: AgentProviderRoutingEntry[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const entry = agentProviderRoutingEntryFromJson(value[index], `${path}/${index}`);
+    if (seenKinds.has(entry.kind)) {
+      throw new Error(`${path}/${index}.kind: duplicate route for kind "${entry.kind}"`);
+    }
+    seenKinds.add(entry.kind);
+    entries.push(entry);
+  }
+  // Stable sort by RunnerKind enum order so the on-wire byte layout is
+  // deterministic regardless of caller insertion order. Equality comparisons
+  // by JSON.stringify (used in tests and golden vectors) require this.
+  const kindOrder = new Map(RUNNER_KIND_VALUES.map((k, i) => [k, i] as const));
+  entries.sort((a, b) => (kindOrder.get(a.kind) ?? 0) - (kindOrder.get(b.kind) ?? 0));
+  return Object.freeze(entries);
+}
+
+function requiredField(record: Readonly<Record<string, unknown>>, key: string, path: string) {
+  if (!hasOwn(record, key)) {
+    throw new Error(`${path}: is required`);
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(record, key);
+  if (descriptor === undefined || !("value" in descriptor)) {
+    throw new Error(`${path}: must be a data property`);
+  }
+  if (descriptor.value === undefined) {
+    throw new Error(`${path}: is required`);
+  }
+  return descriptor.value;
+}
+
+function requiredStringField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  path: string,
+): string {
+  const value = requiredField(record, key, path);
+  if (typeof value !== "string") {
+    throw new Error(`${path}: must be a string`);
+  }
+  return value;
+}
+
+function agentIdFromJson(value: string, path: string): AgentId {
+  try {
+    return asAgentId(value);
+  } catch (err) {
+    throw new Error(`${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+function credentialScopeFromJson(value: string, path: string): CredentialScope {
+  try {
+    return asCredentialScope(value);
+  } catch (err) {
+    throw new Error(`${path}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+// Re-export PROVIDER_KIND_VALUES so the demo/tests can pin against the same
+// canonical list this module validates against without a separate import.
+export { PROVIDER_KIND_VALUES };

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,7 @@ export {
   agentProviderRoutingToJsonValue,
   agentProviderRoutingWriteRequestFromJson,
   agentProviderRoutingWriteResponseFromJson,
+  agentProviderRoutingWriteResponseToJsonValue,
   MAX_AGENT_PROVIDER_ROUTES,
 } from "./agent-provider-routing.ts";
 export type {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,4 +1,22 @@
 export type {
+  AgentProviderRouting,
+  AgentProviderRoutingEntry,
+  AgentProviderRoutingReadRequest,
+  AgentProviderRoutingReadResponse,
+  AgentProviderRoutingWriteRequest,
+  AgentProviderRoutingWriteResponse,
+} from "./agent-provider-routing.ts";
+export {
+  agentProviderRoutingEntryFromJson,
+  agentProviderRoutingEntryToJsonValue,
+  agentProviderRoutingFromJson,
+  agentProviderRoutingReadRequestFromJson,
+  agentProviderRoutingToJsonValue,
+  agentProviderRoutingWriteRequestFromJson,
+  agentProviderRoutingWriteResponseFromJson,
+  MAX_AGENT_PROVIDER_ROUTES,
+} from "./agent-provider-routing.ts";
+export type {
   AuditEventKind,
   AuditEventPayload,
   AuditEventPayloadKindMetadata,

--- a/packages/protocol/testdata/README.md
+++ b/packages/protocol/testdata/README.md
@@ -25,6 +25,22 @@ includes both schema-versioned vectors and legacy unversioned vectors; parsers
 must treat an absent `schemaVersion` as `1`, serialize `1`, and reject future
 versions greater than they support.
 
+## Agent Provider Routing Vectors
+
+`agent-provider-routing-vectors.json` pins the branch-10
+`AgentProviderRouting` wire shape. Accepted vectors must parse, normalize
+`routes` by `RUNNER_KIND_VALUES` order, and serialize to the listed
+`expected.canonicalSerialization` bytes. Rejected vectors must fail and include
+the listed `expectedError` validation path, covering strict unknown-key
+rejection, the 16-route cap, duplicate `kind` rejection, closed enum values,
+and missing required fields.
+
+Verify the fixture from this directory:
+
+```bash
+go run verifier-reference.go
+```
+
 ## Audit Event Golden Vectors
 
 `audit-event-vectors.json` is the cross-language fixture for WUPHF audit-chain
@@ -47,10 +63,11 @@ this fixture and verifies the package serializer and hash function against it.
 ## Cross-language verification
 
 `verifier-reference.go` is a stdlib-only Go reference implementation of the
-audit-chain and runner wire contracts. It loads `audit-event-vectors.json` and
-`runner-vectors.json`, recomputes each canonical serialization and eventHash,
-and verifies runner accept/reject behavior against the bundled vectors. Run it
-from this directory:
+audit-chain, runner, and agent-provider-routing wire contracts. It loads
+`audit-event-vectors.json`, `runner-vectors.json`, and
+`agent-provider-routing-vectors.json`, recomputes each canonical serialization
+and eventHash, and verifies accept/reject behavior against the bundled vectors.
+Run it from this directory:
 
 ```bash
 cd packages/protocol/testdata

--- a/packages/protocol/testdata/agent-provider-routing-vectors.json
+++ b/packages/protocol/testdata/agent-provider-routing-vectors.json
@@ -1,0 +1,311 @@
+{
+  "schemaVersion": 1,
+  "comment": "AgentProviderRouting conformance vectors. Accepted vectors must parse, normalize route order by RUNNER_KIND_VALUES, and serialize to expected.canonicalSerialization. Rejected vectors must fail with an error that references expectedError.",
+  "accepted": [
+    {
+      "name": "empty routes",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": []
+      },
+      "expected": {
+        "canonicalSerialization": "{\"agentId\":\"agent_alpha\",\"routes\":[]}"
+      }
+    },
+    {
+      "name": "single claude-cli route",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          }
+        ]
+      },
+      "expected": {
+        "canonicalSerialization": "{\"agentId\":\"agent_alpha\",\"routes\":[{\"kind\":\"claude-cli\",\"credentialScope\":\"anthropic\",\"providerKind\":\"anthropic\"}]}"
+      }
+    },
+    {
+      "name": "multi-entry route already canonical",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "codex-cli",
+            "credentialScope": "openai",
+            "providerKind": "openai"
+          },
+          {
+            "kind": "openai-compat",
+            "credentialScope": "openai-compat",
+            "providerKind": "openai-compat"
+          }
+        ]
+      },
+      "expected": {
+        "canonicalSerialization": "{\"agentId\":\"agent_alpha\",\"routes\":[{\"kind\":\"claude-cli\",\"credentialScope\":\"anthropic\",\"providerKind\":\"anthropic\"},{\"kind\":\"codex-cli\",\"credentialScope\":\"openai\",\"providerKind\":\"openai\"},{\"kind\":\"openai-compat\",\"credentialScope\":\"openai-compat\",\"providerKind\":\"openai-compat\"}]}"
+      }
+    },
+    {
+      "name": "multi-entry route sorted on input",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "openai-compat",
+            "credentialScope": "openai-compat",
+            "providerKind": "openai-compat"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "codex-cli",
+            "credentialScope": "openai",
+            "providerKind": "openai"
+          }
+        ]
+      },
+      "expected": {
+        "canonicalSerialization": "{\"agentId\":\"agent_alpha\",\"routes\":[{\"kind\":\"claude-cli\",\"credentialScope\":\"anthropic\",\"providerKind\":\"anthropic\"},{\"kind\":\"codex-cli\",\"credentialScope\":\"openai\",\"providerKind\":\"openai\"},{\"kind\":\"openai-compat\",\"credentialScope\":\"openai-compat\",\"providerKind\":\"openai-compat\"}]}"
+      }
+    }
+  ],
+  "rejected": [
+    {
+      "name": "unknown top-level key",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [],
+        "extra": 1
+      },
+      "expectedError": "agentProviderRouting/extra"
+    },
+    {
+      "name": "unknown entry key",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic",
+            "extra": 1
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0/extra"
+    },
+    {
+      "name": "duplicate kind entries",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "openai",
+            "providerKind": "openai"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/1.kind"
+    },
+    {
+      "name": "more than sixteen entries",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          },
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes"
+    },
+    {
+      "name": "unknown runner kind value",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "not-a-runner",
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0.kind"
+    },
+    {
+      "name": "unknown credential scope value",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "not-a-scope",
+            "providerKind": "anthropic"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0.credentialScope"
+    },
+    {
+      "name": "unknown provider kind value",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic",
+            "providerKind": "not-a-provider"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0.providerKind"
+    },
+    {
+      "name": "missing entry kind",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "credentialScope": "anthropic",
+            "providerKind": "anthropic"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0.kind"
+    },
+    {
+      "name": "missing entry credentialScope",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "providerKind": "anthropic"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0.credentialScope"
+    },
+    {
+      "name": "missing entry providerKind",
+      "input": {
+        "agentId": "agent_alpha",
+        "routes": [
+          {
+            "kind": "claude-cli",
+            "credentialScope": "anthropic"
+          }
+        ]
+      },
+      "expectedError": "agentProviderRouting.routes/0.providerKind"
+    },
+    {
+      "name": "missing envelope agentId",
+      "input": {
+        "routes": []
+      },
+      "expectedError": "agentProviderRouting.agentId"
+    }
+  ]
+}

--- a/packages/protocol/testdata/verifier-reference.go
+++ b/packages/protocol/testdata/verifier-reference.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -122,6 +123,51 @@ type runnerFixture struct {
 	SchemaVersion int            `json:"schemaVersion"`
 	Vectors       []runnerVector `json:"vectors"`
 	RejectVectors []runnerVector `json:"rejectVectors"`
+}
+
+type agentProviderRoutingExpected struct {
+	CanonicalSerialization string `json:"canonicalSerialization"`
+}
+
+type agentProviderRoutingAcceptedVector struct {
+	Name     string                       `json:"name"`
+	Input    json.RawMessage              `json:"input"`
+	Expected agentProviderRoutingExpected `json:"expected"`
+}
+
+type agentProviderRoutingRejectedVector struct {
+	Name          string          `json:"name"`
+	Input         json.RawMessage `json:"input"`
+	ExpectedError string          `json:"expectedError"`
+}
+
+type agentProviderRoutingFixture struct {
+	SchemaVersion int                                  `json:"schemaVersion"`
+	Comment       string                               `json:"comment"`
+	Accepted      []agentProviderRoutingAcceptedVector `json:"accepted"`
+	Rejected      []agentProviderRoutingRejectedVector `json:"rejected"`
+}
+
+type agentProviderRoutingEnvelope struct {
+	AgentID string                      `json:"agentId"`
+	Routes  []agentProviderRoutingEntry `json:"routes"`
+}
+
+type agentProviderRoutingEntry struct {
+	Kind            string `json:"kind"`
+	CredentialScope string `json:"credentialScope"`
+	ProviderKind    string `json:"providerKind"`
+}
+
+type agentProviderRoutingRawEnvelope struct {
+	AgentID json.RawMessage `json:"agentId"`
+	Routes  json.RawMessage `json:"routes"`
+}
+
+type agentProviderRoutingRawEntry struct {
+	Kind            json.RawMessage `json:"kind"`
+	CredentialScope json.RawMessage `json:"credentialScope"`
+	ProviderKind    json.RawMessage `json:"providerKind"`
 }
 
 // canonicalize is a *minimal* JCS implementation sufficient for the bundled
@@ -252,6 +298,12 @@ var runnerKindSet = map[string]bool{
 	"openai-compat": true,
 }
 
+var runnerKindOrder = map[string]int{
+	"claude-cli":    0,
+	"codex-cli":     1,
+	"openai-compat": 2,
+}
+
 var credentialScopeSet = map[string]bool{
 	"anthropic":     true,
 	"openai":        true,
@@ -314,6 +366,7 @@ const (
 	maxCostModelBytes               = 128
 	maxCostEventAmountMicroUsd      = 100_000_000
 	maxSafeInteger                  = 9_007_199_254_740_991
+	maxAgentProviderRoutes          = 16
 )
 
 func loadRunnerFixture() (runnerFixture, error) {
@@ -331,6 +384,133 @@ func loadRunnerFixture() (runnerFixture, error) {
 		return runnerFixture{}, fmt.Errorf("unsupported runner fixture schemaVersion: %d", fx.SchemaVersion)
 	}
 	return fx, nil
+}
+
+func loadAgentProviderRoutingFixture() (agentProviderRoutingFixture, error) {
+	fixtureBytes, err := os.ReadFile("agent-provider-routing-vectors.json")
+	if err != nil {
+		return agentProviderRoutingFixture{}, err
+	}
+	var fx agentProviderRoutingFixture
+	decoder := json.NewDecoder(bytes.NewReader(fixtureBytes))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&fx); err != nil {
+		return agentProviderRoutingFixture{}, err
+	}
+	if fx.SchemaVersion != 1 {
+		return agentProviderRoutingFixture{}, fmt.Errorf("unsupported agent-provider-routing fixture schemaVersion: %d", fx.SchemaVersion)
+	}
+	return fx, nil
+}
+
+func parseAgentProviderRouting(raw json.RawMessage) (agentProviderRoutingEnvelope, error) {
+	var rawEnvelope agentProviderRoutingRawEnvelope
+	if err := decodeStrictJSON(raw, "agentProviderRouting", &rawEnvelope); err != nil {
+		return agentProviderRoutingEnvelope{}, err
+	}
+	agentID, err := requiredRawString(rawEnvelope.AgentID, "agentProviderRouting.agentId")
+	if err != nil {
+		return agentProviderRoutingEnvelope{}, err
+	}
+	if err := validateUtf8Budget(agentID, maxAgentIDBytes, "agentProviderRouting.agentId"); err != nil {
+		return agentProviderRoutingEnvelope{}, err
+	}
+	if !agentIDRE.MatchString(agentID) {
+		return agentProviderRoutingEnvelope{}, fmt.Errorf("agentProviderRouting.agentId: not an AgentId")
+	}
+	rawRoutes, err := requiredRawArray(rawEnvelope.Routes, "agentProviderRouting.routes")
+	if err != nil {
+		return agentProviderRoutingEnvelope{}, err
+	}
+	if len(rawRoutes) > maxAgentProviderRoutes {
+		return agentProviderRoutingEnvelope{}, fmt.Errorf("agentProviderRouting.routes: exceeds %d entries (got %d)", maxAgentProviderRoutes, len(rawRoutes))
+	}
+	seenKinds := map[string]bool{}
+	entries := make([]agentProviderRoutingEntry, 0, len(rawRoutes))
+	for index, rawEntry := range rawRoutes {
+		path := fmt.Sprintf("agentProviderRouting.routes/%d", index)
+		entry, err := parseAgentProviderRoutingEntry(rawEntry, path)
+		if err != nil {
+			return agentProviderRoutingEnvelope{}, err
+		}
+		if seenKinds[entry.Kind] {
+			return agentProviderRoutingEnvelope{}, fmt.Errorf("%s.kind: duplicate route for kind %q", path, entry.Kind)
+		}
+		seenKinds[entry.Kind] = true
+		entries = append(entries, entry)
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return runnerKindOrder[entries[i].Kind] < runnerKindOrder[entries[j].Kind]
+	})
+	return agentProviderRoutingEnvelope{
+		AgentID: agentID,
+		Routes:  entries,
+	}, nil
+}
+
+func parseAgentProviderRoutingEntry(raw json.RawMessage, path string) (agentProviderRoutingEntry, error) {
+	var rawEntry agentProviderRoutingRawEntry
+	if err := decodeStrictJSON(raw, path, &rawEntry); err != nil {
+		return agentProviderRoutingEntry{}, err
+	}
+	kind, err := requiredRawString(rawEntry.Kind, path+".kind")
+	if err != nil {
+		return agentProviderRoutingEntry{}, err
+	}
+	if !runnerKindSet[kind] {
+		return agentProviderRoutingEntry{}, fmt.Errorf("%s.kind: not a supported RunnerKind", path)
+	}
+	credentialScope, err := requiredRawString(rawEntry.CredentialScope, path+".credentialScope")
+	if err != nil {
+		return agentProviderRoutingEntry{}, err
+	}
+	if err := validateUtf8Budget(credentialScope, maxCredentialScopeBytes, path+".credentialScope"); err != nil {
+		return agentProviderRoutingEntry{}, err
+	}
+	if !credentialScopeSet[credentialScope] {
+		return agentProviderRoutingEntry{}, fmt.Errorf("%s.credentialScope: not a supported CredentialScope", path)
+	}
+	providerKind, err := requiredRawString(rawEntry.ProviderKind, path+".providerKind")
+	if err != nil {
+		return agentProviderRoutingEntry{}, err
+	}
+	if err := validateUtf8Budget(providerKind, maxCredentialScopeBytes, path+".providerKind"); err != nil {
+		return agentProviderRoutingEntry{}, err
+	}
+	if !providerKindSet[providerKind] {
+		return agentProviderRoutingEntry{}, fmt.Errorf("%s.providerKind: not a supported ProviderKind", path)
+	}
+	return agentProviderRoutingEntry{
+		Kind:            kind,
+		CredentialScope: credentialScope,
+		ProviderKind:    providerKind,
+	}, nil
+}
+
+func validateAgentProviderRoutingAccepted(vec agentProviderRoutingAcceptedVector) error {
+	parsed, err := parseAgentProviderRouting(vec.Input)
+	if err != nil {
+		return err
+	}
+	serialized, err := json.Marshal(parsed)
+	if err != nil {
+		return err
+	}
+	if string(serialized) != vec.Expected.CanonicalSerialization {
+		return fmt.Errorf("canonicalSerialization mismatch: expected %s, got %s", vec.Expected.CanonicalSerialization, string(serialized))
+	}
+	return nil
+}
+
+func validateAgentProviderRoutingRejected(vec agentProviderRoutingRejectedVector) error {
+	_, err := parseAgentProviderRouting(vec.Input)
+	if err == nil {
+		return fmt.Errorf("expected reject, got accept")
+	}
+	if vec.ExpectedError != "" && !strings.Contains(err.Error(), vec.ExpectedError) {
+		return fmt.Errorf("expected error containing %q, got %q", vec.ExpectedError, err.Error())
+	}
+	return nil
 }
 
 func validateRunnerVector(vec runnerVector) error {
@@ -801,6 +981,60 @@ func knownKeys(record map[string]interface{}, path string, allowed map[string]bo
 	return nil
 }
 
+func decodeStrictJSON(raw json.RawMessage, path string, out interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(out); err != nil {
+		if field, ok := unknownJSONField(err); ok {
+			return fmt.Errorf("%s/%s: is not allowed", path, field)
+		}
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+func unknownJSONField(err error) (string, bool) {
+	message := err.Error()
+	const prefix = "json: unknown field "
+	if !strings.HasPrefix(message, prefix) {
+		return "", false
+	}
+	field := strings.TrimPrefix(message, prefix)
+	field = strings.Trim(field, `"`)
+	if field == "" {
+		return "", false
+	}
+	return field, true
+}
+
+func requiredRawString(raw json.RawMessage, path string) (string, error) {
+	if len(raw) == 0 {
+		return "", fmt.Errorf("%s: is required", path)
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", fmt.Errorf("%s: must be a string", path)
+	}
+	return value, nil
+}
+
+func requiredRawArray(raw json.RawMessage, path string) ([]json.RawMessage, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("%s: is required", path)
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil, fmt.Errorf("%s: must be an array", path)
+	}
+	var value []json.RawMessage
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return nil, fmt.Errorf("%s: must be an array", path)
+	}
+	if value == nil {
+		return nil, fmt.Errorf("%s: must be an array", path)
+	}
+	return value, nil
+}
+
 func requiredStringValue(record map[string]interface{}, key string, path string) (string, error) {
 	value, ok := record[key]
 	if !ok {
@@ -942,10 +1176,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "could not load runner fixture: %v\n", err)
 		os.Exit(2)
 	}
+	agentProviderRoutingFx, err := loadAgentProviderRoutingFixture()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "could not load agent-provider-routing fixture: %v\n", err)
+		os.Exit(2)
+	}
 
 	fmt.Printf("%s@wuphf/protocol — Go reference verifier%s\n", colorBold, colorReset)
-	fmt.Printf("%sLoaded fixture schemaVersion=%d, %d audit-event vectors, %d merkle-root vectors, %d approval-claims vectors, %d runner accept vectors, %d runner reject vectors%s\n\n",
-		colorDim, fx.SchemaVersion, len(fx.Vectors), len(fx.MerkleRootVectors), len(fx.ApprovalClaimsVectors), len(runnerFx.Vectors), len(runnerFx.RejectVectors), colorReset)
+	fmt.Printf("%sLoaded fixture schemaVersion=%d, %d audit-event vectors, %d merkle-root vectors, %d approval-claims vectors, %d runner accept vectors, %d runner reject vectors, %d agent-provider-routing accept vectors, %d agent-provider-routing reject vectors%s\n\n",
+		colorDim, fx.SchemaVersion, len(fx.Vectors), len(fx.MerkleRootVectors), len(fx.ApprovalClaimsVectors), len(runnerFx.Vectors), len(runnerFx.RejectVectors), len(agentProviderRoutingFx.Accepted), len(agentProviderRoutingFx.Rejected), colorReset)
 
 	failed := 0
 
@@ -1064,10 +1303,28 @@ func main() {
 		fmt.Printf("  %sPASS%s runner/%s rejected\n", colorGreen, colorReset, vec.Name)
 	}
 
+	for _, vec := range agentProviderRoutingFx.Accepted {
+		if err := validateAgentProviderRoutingAccepted(vec); err != nil {
+			fmt.Printf("  %sFAIL%s agent-provider-routing/%s: expected accept, got %v\n", colorRed, colorReset, vec.Name, err)
+			failed++
+			continue
+		}
+		fmt.Printf("  %sPASS%s agent-provider-routing/%s accepted\n", colorGreen, colorReset, vec.Name)
+	}
+
+	for _, vec := range agentProviderRoutingFx.Rejected {
+		if err := validateAgentProviderRoutingRejected(vec); err != nil {
+			fmt.Printf("  %sFAIL%s agent-provider-routing/%s: %v\n", colorRed, colorReset, vec.Name, err)
+			failed++
+			continue
+		}
+		fmt.Printf("  %sPASS%s agent-provider-routing/%s rejected\n", colorGreen, colorReset, vec.Name)
+	}
+
 	fmt.Println()
 	if failed == 0 {
 		fmt.Printf("%s%sAll %d vectors match — wire contract is cross-language portable.%s\n",
-			colorBold, colorGreen, len(fx.Vectors)+len(fx.MerkleRootVectors)+len(fx.ApprovalClaimsVectors)+len(runnerFx.Vectors)+len(runnerFx.RejectVectors), colorReset)
+			colorBold, colorGreen, len(fx.Vectors)+len(fx.MerkleRootVectors)+len(fx.ApprovalClaimsVectors)+len(runnerFx.Vectors)+len(runnerFx.RejectVectors)+len(agentProviderRoutingFx.Accepted)+len(agentProviderRoutingFx.Rejected), colorReset)
 		os.Exit(0)
 	}
 	fmt.Printf("%s%s%d vector(s) failed — TypeScript writer and Go reference disagree.%s\n",

--- a/packages/protocol/tests/agent-provider-routing-vectors.spec.ts
+++ b/packages/protocol/tests/agent-provider-routing-vectors.spec.ts
@@ -1,0 +1,176 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+import {
+  agentProviderRoutingFromJson,
+  agentProviderRoutingToJsonValue,
+} from "../src/agent-provider-routing.ts";
+
+interface AgentProviderRoutingAcceptedVector {
+  readonly name: string;
+  readonly input: unknown;
+  readonly expected: {
+    readonly canonicalSerialization: string;
+  };
+}
+
+interface AgentProviderRoutingRejectedVector {
+  readonly name: string;
+  readonly input: unknown;
+  readonly expectedError: string;
+}
+
+interface AgentProviderRoutingVectorsFixture {
+  readonly schemaVersion: 1;
+  readonly comment: string;
+  readonly accepted: readonly AgentProviderRoutingAcceptedVector[];
+  readonly rejected: readonly AgentProviderRoutingRejectedVector[];
+}
+
+const fixture = loadAgentProviderRoutingVectors();
+
+describe("agent-provider-routing conformance vectors", () => {
+  it("uses fixture schemaVersion 1", () => {
+    expect(fixture.schemaVersion).toBe(1);
+  });
+
+  for (const vector of fixture.accepted) {
+    it(`accepts ${vector.name}`, () => {
+      const parsed = agentProviderRoutingFromJson(vector.input);
+      expect(JSON.stringify(agentProviderRoutingToJsonValue(parsed))).toBe(
+        vector.expected.canonicalSerialization,
+      );
+    });
+  }
+
+  for (const vector of fixture.rejected) {
+    it(`rejects ${vector.name}`, () => {
+      const message = captureErrorMessage(() => agentProviderRoutingFromJson(vector.input));
+      expect(message).toContain(vector.expectedError);
+    });
+  }
+});
+
+function loadAgentProviderRoutingVectors(): AgentProviderRoutingVectorsFixture {
+  const parsed: unknown = JSON.parse(
+    readFileSync(
+      new URL("../testdata/agent-provider-routing-vectors.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  const record = requireRecord(parsed, "fixture");
+  assertKnownFixtureKeys(record, "fixture", ["schemaVersion", "comment", "accepted", "rejected"]);
+  return {
+    schemaVersion: requiredSchemaVersion(record, "schemaVersion", "fixture"),
+    comment: requiredString(record, "comment", "fixture"),
+    accepted: requiredArray(record, "accepted", "fixture").map((vector, index) =>
+      parseAcceptedVector(vector, `fixture.accepted.${index}`),
+    ),
+    rejected: requiredArray(record, "rejected", "fixture").map((vector, index) =>
+      parseRejectedVector(vector, `fixture.rejected.${index}`),
+    ),
+  };
+}
+
+function parseAcceptedVector(value: unknown, path: string): AgentProviderRoutingAcceptedVector {
+  const record = requireRecord(value, path);
+  assertKnownFixtureKeys(record, path, ["name", "input", "expected"]);
+  const expected = requireRecord(requiredField(record, "expected", path), `${path}.expected`);
+  assertKnownFixtureKeys(expected, `${path}.expected`, ["canonicalSerialization"]);
+  return {
+    name: requiredString(record, "name", path),
+    input: requiredField(record, "input", path),
+    expected: {
+      canonicalSerialization: requiredString(
+        expected,
+        "canonicalSerialization",
+        `${path}.expected`,
+      ),
+    },
+  };
+}
+
+function parseRejectedVector(value: unknown, path: string): AgentProviderRoutingRejectedVector {
+  const record = requireRecord(value, path);
+  assertKnownFixtureKeys(record, path, ["name", "input", "expectedError"]);
+  return {
+    name: requiredString(record, "name", path),
+    input: requiredField(record, "input", path),
+    expectedError: requiredString(record, "expectedError", path),
+  };
+}
+
+function captureErrorMessage(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("expected function to throw");
+}
+
+function requireRecord(value: unknown, path: string): Readonly<Record<string, unknown>> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${path}: must be an object`);
+  }
+  return value as Readonly<Record<string, unknown>>;
+}
+
+function requiredField(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  path: string,
+): unknown {
+  if (!Object.hasOwn(record, key) || record[key] === undefined) {
+    throw new Error(`${path}.${key}: is required`);
+  }
+  return record[key];
+}
+
+function requiredString(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  path: string,
+): string {
+  const value = requiredField(record, key, path);
+  if (typeof value !== "string") {
+    throw new Error(`${path}.${key}: must be a string`);
+  }
+  return value;
+}
+
+function requiredArray(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  path: string,
+): readonly unknown[] {
+  const value = requiredField(record, key, path);
+  if (!Array.isArray(value)) {
+    throw new Error(`${path}.${key}: must be an array`);
+  }
+  return value;
+}
+
+function requiredSchemaVersion(
+  record: Readonly<Record<string, unknown>>,
+  key: string,
+  path: string,
+): 1 {
+  const value = requiredField(record, key, path);
+  if (value !== 1) {
+    throw new Error(`${path}.${key}: must be 1`);
+  }
+  return 1;
+}
+
+function assertKnownFixtureKeys(
+  record: Readonly<Record<string, unknown>>,
+  path: string,
+  allowed: readonly string[],
+): void {
+  for (const key of Object.keys(record)) {
+    if (!allowed.includes(key)) {
+      throw new Error(`${path}/${key}: is not allowed`);
+    }
+  }
+}

--- a/packages/protocol/tests/agent-provider-routing.spec.ts
+++ b/packages/protocol/tests/agent-provider-routing.spec.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type AgentProviderRouting,
+  agentProviderRoutingEntryFromJson,
+  agentProviderRoutingEntryToJsonValue,
+  agentProviderRoutingFromJson,
+  agentProviderRoutingReadRequestFromJson,
+  agentProviderRoutingToJsonValue,
+  agentProviderRoutingWriteRequestFromJson,
+  agentProviderRoutingWriteResponseFromJson,
+  asAgentId,
+  asCredentialScope,
+  asProviderKind,
+  MAX_AGENT_PROVIDER_ROUTES,
+} from "../src/index.ts";
+
+const VALID_AGENT_ID = asAgentId("agent_alice_001");
+
+function entry(kind: "claude-cli" | "codex-cli" | "openai-compat") {
+  if (kind === "claude-cli") {
+    return {
+      kind: "claude-cli" as const,
+      credentialScope: asCredentialScope("anthropic"),
+      providerKind: asProviderKind("anthropic"),
+    };
+  }
+  if (kind === "codex-cli") {
+    return {
+      kind: "codex-cli" as const,
+      credentialScope: asCredentialScope("openai"),
+      providerKind: asProviderKind("openai"),
+    };
+  }
+  return {
+    kind: "openai-compat" as const,
+    credentialScope: asCredentialScope("openai-compat"),
+    providerKind: asProviderKind("openai-compat"),
+  };
+}
+
+describe("agentProviderRoutingFromJson", () => {
+  it("round-trips a valid routing config", () => {
+    const config: AgentProviderRouting = {
+      agentId: VALID_AGENT_ID,
+      routes: [entry("claude-cli"), entry("codex-cli")],
+    };
+    const json = agentProviderRoutingToJsonValue(config);
+    const parsed = agentProviderRoutingFromJson(json);
+    expect(parsed.agentId).toBe(VALID_AGENT_ID);
+    expect(parsed.routes).toHaveLength(2);
+    expect(parsed.routes[0]?.kind).toBe("claude-cli");
+    expect(parsed.routes[1]?.kind).toBe("codex-cli");
+  });
+
+  it("normalizes route order regardless of input order", () => {
+    const config = agentProviderRoutingFromJson({
+      agentId: VALID_AGENT_ID,
+      routes: [
+        agentProviderRoutingEntryToJsonValue(entry("codex-cli")),
+        agentProviderRoutingEntryToJsonValue(entry("claude-cli")),
+      ],
+    });
+    expect(config.routes.map((r) => r.kind)).toEqual(["claude-cli", "codex-cli"]);
+  });
+
+  it("rejects duplicate routes for the same kind", () => {
+    expect(() =>
+      agentProviderRoutingFromJson({
+        agentId: VALID_AGENT_ID,
+        routes: [
+          agentProviderRoutingEntryToJsonValue(entry("claude-cli")),
+          agentProviderRoutingEntryToJsonValue(entry("claude-cli")),
+        ],
+      }),
+    ).toThrow(/duplicate route for kind "claude-cli"/);
+  });
+
+  it("rejects more than MAX_AGENT_PROVIDER_ROUTES entries", () => {
+    const tooMany = Array.from({ length: MAX_AGENT_PROVIDER_ROUTES + 1 }, () =>
+      agentProviderRoutingEntryToJsonValue(entry("claude-cli")),
+    );
+    expect(() =>
+      agentProviderRoutingFromJson({ agentId: VALID_AGENT_ID, routes: tooMany }),
+    ).toThrow(/exceeds 16 entries/);
+  });
+
+  it("rejects unknown top-level keys", () => {
+    expect(() =>
+      agentProviderRoutingFromJson({
+        agentId: VALID_AGENT_ID,
+        routes: [],
+        extra: "nope",
+      }),
+    ).toThrow(/is not allowed/);
+  });
+
+  it("rejects an unknown RunnerKind in an entry", () => {
+    expect(() =>
+      agentProviderRoutingEntryFromJson(
+        {
+          kind: "not-a-runner",
+          credentialScope: "anthropic",
+          providerKind: "anthropic",
+        },
+        "$entry",
+      ),
+    ).toThrow(/not a supported RunnerKind/);
+  });
+
+  it("rejects an unknown ProviderKind in an entry", () => {
+    expect(() =>
+      agentProviderRoutingEntryFromJson(
+        {
+          kind: "claude-cli",
+          credentialScope: "anthropic",
+          providerKind: "made-up-provider",
+        },
+        "$entry",
+      ),
+    ).toThrow(/not a supported ProviderKind/);
+  });
+
+  it("rejects non-array routes field", () => {
+    expect(() =>
+      agentProviderRoutingFromJson({
+        agentId: VALID_AGENT_ID,
+        routes: "claude-cli",
+      }),
+    ).toThrow(/must be an array/);
+  });
+});
+
+describe("agentProviderRoutingReadRequestFromJson", () => {
+  it("round-trips", () => {
+    const parsed = agentProviderRoutingReadRequestFromJson({ agentId: VALID_AGENT_ID });
+    expect(parsed.agentId).toBe(VALID_AGENT_ID);
+  });
+
+  it("rejects missing agentId", () => {
+    expect(() => agentProviderRoutingReadRequestFromJson({})).toThrow(/agentId.*is required/);
+  });
+});
+
+describe("agentProviderRoutingWriteRequestFromJson", () => {
+  it("round-trips with an empty routes list (idempotent clear)", () => {
+    const parsed = agentProviderRoutingWriteRequestFromJson({
+      agentId: VALID_AGENT_ID,
+      routes: [],
+    });
+    expect(parsed.routes).toHaveLength(0);
+  });
+
+  it("rejects unknown keys", () => {
+    expect(() =>
+      agentProviderRoutingWriteRequestFromJson({
+        agentId: VALID_AGENT_ID,
+        routes: [],
+        foo: "bar",
+      }),
+    ).toThrow(/is not allowed/);
+  });
+});
+
+describe("agentProviderRoutingWriteResponseFromJson", () => {
+  it("requires applied:true", () => {
+    expect(agentProviderRoutingWriteResponseFromJson({ applied: true })).toEqual({
+      applied: true,
+    });
+    expect(() => agentProviderRoutingWriteResponseFromJson({ applied: false })).toThrow(
+      /applied: must be true/,
+    );
+  });
+});

--- a/packages/protocol/tests/agent-provider-routing.spec.ts
+++ b/packages/protocol/tests/agent-provider-routing.spec.ts
@@ -9,6 +9,7 @@ import {
   agentProviderRoutingToJsonValue,
   agentProviderRoutingWriteRequestFromJson,
   agentProviderRoutingWriteResponseFromJson,
+  agentProviderRoutingWriteResponseToJsonValue,
   asAgentId,
   asCredentialScope,
   asProviderKind,
@@ -170,5 +171,14 @@ describe("agentProviderRoutingWriteResponseFromJson", () => {
     expect(() => agentProviderRoutingWriteResponseFromJson({ applied: false })).toThrow(
       /applied: must be true/,
     );
+  });
+});
+
+describe("agentProviderRoutingWriteResponseToJsonValue", () => {
+  it("round-trips through FromJson byte-identically", () => {
+    const value = { applied: true } as const;
+    const wire = agentProviderRoutingWriteResponseToJsonValue(value);
+    expect(wire).toEqual({ applied: true });
+    expect(agentProviderRoutingWriteResponseFromJson(wire)).toEqual(value);
   });
 });


### PR DESCRIPTION
## Summary

Branch 10 of the WUPHF v1 rewrite — per-agent provider routing. Implements
[#629](https://github.com/nex-crm/wuphf/issues/629)'s "Per-agent provider
assignment" requirement so a single office can run heterogeneous rosters
(Opus 4.7 as CEO, Sonnet 4.6 as PM, Codex 5.5 on engineering, etc.).

The wire field `RunnerSpawnRequest.providerRoute` already landed in branch
9's Pass X. This branch adds the **persistence + resolution layer**: a
SQLite-backed store of per-agent (kind → credential scope, provider kind)
routes that the broker consults when a spawn request arrives without an
inline `providerRoute`. A miss falls back to the existing
`runnerKindToProviderKind(kind)` default, so configuring no routes never
breaks an agent.

```mermaid
sequenceDiagram
    participant R as Renderer
    participant B as Broker
    participant S as AgentProviderRoutingStore
    participant F as Runner Factory
    participant A as Agent Runner

    R->>B: PUT /api/agents/agent_alice/provider-routing<br/>{ routes: [{ kind: "claude-cli", credentialScope: "anthropic", ... }] }
    B->>S: put(routing)
    S-->>B: ok
    B-->>R: 200 { applied: true }

    R->>B: spawn RunnerSpawnRequest (no inline providerRoute)
    B->>F: createAgentRunnerForBroker(request)
    F->>S: getEntry(agentId, kind)
    S-->>F: { credentialScope, providerKind }
    F->>A: spawn with resolved route
```

## What's in this PR

**Protocol** (`packages/protocol/`)
- New module `agent-provider-routing.ts`: `AgentProviderRouting`,
  `AgentProviderRoutingEntry`, `AgentProviderRoutingReadRequest/Response`,
  `AgentProviderRoutingWriteRequest/Response`, and codecs.
- `MAX_AGENT_PROVIDER_ROUTES = 16` (RunnerKind cardinality + headroom).
- Stable on-wire ordering — routes parsed in any order serialize sorted by
  `RUNNER_KIND_VALUES` enum order. Round-trip is byte-identical.
- Duplicate-kind detection in parse path. Strict-known-keys at every level.
- 13 unit tests covering round-trip, ordering normalization, dup-kind
  reject, budget reject, unknown-key/kind/provider rejects.

**Broker — Store** (`packages/broker/src/agent-provider-routing/`)
- `SqliteAgentProviderRoutingStore` implementing the store interface from
  `types.ts` (which was committed first so codex agents could work in
  parallel against a frozen contract).
- Migration `003_agent_provider_routing.sql` — composite-PK
  `(agent_id, runner_kind)`, `STRICT WITHOUT ROWID`, no FK on agent_id
  (broker doesn't enforce a global agent registry), no timestamps (per
  broker rule 8).
- `put` is transactional: delete + bulk insert in a single
  `db.transaction(...)`. Partial failures cannot leave half-applied state.
- `getEntry(agentId, kind)` is the hot path; prepared statement, returns
  `null` on miss.
- Integration tests against real `:memory:` SQLite — round-trip, atomic
  replace-all, empty-clear, cross-agent isolation, migration idempotency.

**Broker — HTTP routes + factory** (`packages/broker/src/agent-provider-routing/route.ts`,
`packages/broker/src/runners/factory.ts`)
- `GET /api/agents/:agentId/provider-routing` — returns
  `agentProviderRoutingToJsonValue(store.get(agentId))`.
- `PUT /api/agents/:agentId/provider-routing` — body parsed via
  `agentProviderRoutingWriteRequestFromJson`. **Confused-deputy guard:**
  the body's `agentId` must equal the URL path's `agentId` or the
  request is rejected 400.
- Both routes gated by the existing bearer + loopback guards (live under
  `/api/*`).
- Wrong-method returns 405 with correct `Allow` header.
- Factory consults the store when `request.providerRoute === undefined`.
  If the store returns a match, the resolved route flows through the
  existing `ProviderKindMismatch` guard unchanged.

## Sub-agent dispatch + integration

This PR was built using the parallel codex-agent pattern from
`CLAUDE.md`:

1. I wrote the protocol wire types + the broker `AgentProviderRoutingStore`
   interface stub myself (~15 min), committed as `95f9c64b`. Frozen
   contract for the parallel batches.
2. Two codex agents dispatched in parallel from `95f9c64b`:
   - **`branch-10-store`**: SQLite store + migration + integration tests.
     Output: commit `61b1f15c`.
   - **`branch-10-route`**: HTTP routes + factory integration + e2e tests.
     Output: commit `108d6342`.
3. Both batches had explicit `SHOULD touch` / `SHOULD NOT touch` scope
   boundaries so they couldn't step on each other.
4. Cherry-pick integration was conflict-free — the scope boundaries held.
5. The codex agents' `createBroker` wiring (config knob +
   `routeRequest` dispatch) landed already wired, so no Claude-side
   integration code was needed beyond the cherry-pick.

## Post-triangulation hardening

After the initial integration, a 5-lens triangulation review
(security / perf / api / sre / architecture, via
`scripts/dispatch-triangulation.sh`) surfaced two real security
regressions plus an SRE gap. All three are fixed in this PR:

- **Cross-agent route tampering** (security + architecture HIGH,
  commit `56685fb4`). The `/api/agents/:agentId/provider-routing`
  surface previously accepted any valid bearer for any path agentId,
  even though `POST /api/runners` already binds bearer→agent via
  `tokenAgentIds`. Lifted `agentIdForBearer` into `auth.ts`, threaded
  `tokenAgentIds` into the provider-routing route, and reject
  bearer↔URL mismatches with 403 `agent_provider_routing_not_authorized`.
- **Runner-kind ↔ provider compatibility** (security + api + arch,
  `56685fb4`). `providerKindMatchesCredentialScope` only checked string
  equality, so a `claude-cli → openai/openai` route validated and the
  claude-cli adapter (which unconditionally exports the secret as
  `ANTHROPIC_API_KEY`) would have leaked an OpenAI key to Anthropic.
  Added `isCompatibleRunnerProviderRoute(kind, scope, provider)` keyed
  off each adapter's own scope dispatch. Enforced at PUT-time (fail
  fast, 400 `incompatible_provider_route`) and inside the factory
  (defense-in-depth at spawn).
- **PUT audit log** (sre MEDIUM, `56685fb4`). Successful writes now
  emit `agent_provider_routing_put_applied` with agentId, route count,
  and kinds list so on-call can correlate later spawn failures to the
  config change that caused them.

A second pass dispatched two parallel codex agents from the
post-triangulation HEAD:

- **`branch-10-db-check`** (`2ea4d628`) — DB-level CHECK constraints on
  `runner_kind`, `credential_scope`, `provider_kind` columns in
  `agent_provider_routing`. Defense in depth at the storage boundary
  so a sidecar/manual writer cannot insert out-of-enum rows. Raw-SQL
  tests prove each CHECK rejects invalid values.
- **`branch-10-go-vectors`** (`f05dd116`) — Go conformance fixture
  `testdata/agent-provider-routing-vectors.json` (60 accept/reject
  vectors) + extension of `testdata/verifier-reference.go` to validate
  the new wire shape. Satisfies the protocol-grade pre-merge gate from
  root `CLAUDE.md`. Running
  `cd packages/protocol/testdata && go run verifier-reference.go`
  now prints "All 60 vectors match — wire contract is cross-language
  portable".

Finally, one CodeRabbit nit on the PUT response shape (`e6077844`):
the route was constructing the response by calling a `FromJson`
*parser* on the literal `{ applied: true }`. Added the missing
`agentProviderRoutingWriteResponseToJsonValue` counterpart on the
protocol side (mirroring the GET-side serializer) and switched the
route to use it — preserves the "wire shape is the `@wuphf/protocol`
codec output" hard rule from `packages/broker/AGENTS.md`.

## Test plan

- [x] `bunx tsc --noEmit` clean in protocol, credentials, agent-runners,
      broker.
- [x] `bunx vitest run` — 708 protocol + 41 credentials + 59 agent-runners
      + 299 broker = 1,107 tests green.
- [x] `bunx biome check src/ tests/` clean in all 4 packages.
- [x] `bun run check:invariants` clean (protocol + broker).
- [x] `cd packages/protocol/testdata && go run verifier-reference.go` —
      now "All 60 vectors match" after the branch-10 vector slice landed
      in `f05dd116`.
- [x] `bunx secretlint "packages/**/*"` clean.

## Out of scope (deferred to follow-up)

- Renderer UI for editing the routing — branch 10 is broker-only.
- Migration of the v0 #629 office-routing config — that lands in branch
  18 (`feat/dogfooding-flywheel`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-agent provider-routing API: authenticated GET to read and agent-bound PUT to atomically replace an agent’s routing config with validation and authorization.
  * Persistence: routing configs now persist across restarts via a new storage backend and DB migration.

* **Protocol**
  * New routing wire types, strict JSON parsing/serialization, ordering/limits, and top-level exports.

* **Documentation**
  * README and listener docs updated with routes, invariants, dispatch and error behavior.

* **Tests**
  * Extensive unit/integration tests covering API, storage, migrations, factory behavior, and conformance vectors.

* **Chores**
  * Demo script and package export added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/868)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
