### PR TITLE
fix(web): persist AI-generated channels to backend before navigating

### DIFF
--- a/web/src/components/channels/ChannelWizard.tsx
+++ b/web/src/components/channels/ChannelWizard.tsx
@@ -94,6 +94,7 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
           return;
         }
         const channel = await generateChannel(prompt.trim());
+        await createChannel(channel.slug, channel.name || channel.slug, channel.description || "");
         newSlug = channel.slug;
       } else {
         if (!(manual.slug.trim() && manual.name.trim())) {


### PR DESCRIPTION
## Summary

Fix channel creation in "Describe" (AI) mode — the generated channel was never persisted to the backend, causing it to disappear on the next SSE refetch.

## Problem

In `ChannelWizard.tsx`, the "describe" mode called `generateChannel(prompt)` to get a channel template but **never called `createChannel()`** to persist it. The channel existed only in frontend state temporarily. When SSE fired `office_changed` and React Query refetched from `GET /channels`, the backend had no record of it.

The manual mode (line 104) correctly called `createChannel()` first.

## Fix

One-line addition: `await createChannel(channel.slug, channel.name, channel.description)` after `generateChannel()`, matching the manual mode path.

## Test plan
- [ ] Create channel via "Describe" mode → channel persists after clicking away
- [ ] Create channel via "Manual" mode → still works (unchanged)
- [ ] Messages can be sent to AI-generated channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed channel creation in describe mode to properly initialize and save new channels with generated details and sensible default values for missing information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/870)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->