### PR TITLE
feat: render rich artifact references in chat

### DIFF
--- a/internal/teammcp/notebook_tools_test.go
+++ b/internal/teammcp/notebook_tools_test.go
@@ -73,7 +73,7 @@ func TestNotebookVisualArtifactToolsTeachHTMLGuidance(t *testing.T) {
 	if tool == nil {
 		t.Fatalf("notebook_visual_artifact_create was not registered; tools=%v", tools)
 	}
-	for _, want := range []string{"after notebook_write", "self-contained", "inline CSS/JS", "no network fetches", "interactive tuning surfaces"} {
+	for _, want := range []string{"after notebook_write", "self-contained", "inline CSS/JS", "no network fetches", "interactive tuning surfaces", "visual-artifact:ra_0123456789abcdef"} {
 		if !strings.Contains(tool.Description, want) {
 			t.Fatalf("description missing %q:\n%s", want, tool.Description)
 		}

--- a/internal/teammcp/rich_artifact_tools.go
+++ b/internal/teammcp/rich_artifact_tools.go
@@ -10,7 +10,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const notebookVisualArtifactGuidance = "Use this after notebook_write when the work would be clearer as a rich visual artifact: complex specs, implementation plans, code explainers, PR reviews, comparison grids, diagrams, mockups, reports, or interactive tuning surfaces. HTML must be self-contained: inline CSS/JS only, no network fetches, no external images/scripts/fonts, responsive layout, readable copy, and copy/export controls when the artifact is interactive. The paired markdown notebook entry remains the durable source note; this HTML is the visual companion users review in notebooks and the wiki."
+const notebookVisualArtifactGuidance = "Use this after notebook_write when the work would be clearer as a rich visual artifact: complex specs, implementation plans, code explainers, PR reviews, comparison grids, diagrams, mockups, reports, or interactive tuning surfaces. HTML must be self-contained: inline CSS/JS only, no network fetches, no external images/scripts/fonts, responsive layout, readable copy, and copy/export controls when the artifact is interactive. The paired markdown notebook entry remains the durable source note; this HTML is the visual companion users review in notebooks and the wiki. After creating an artifact, include visual-artifact:ra_0123456789abcdef on its own line in the channel summary so chat renders a compact artifact card."
 
 // TeamNotebookVisualArtifactCreateArgs is the contract for
 // notebook_visual_artifact_create.

--- a/internal/teammcp/server_types.go
+++ b/internal/teammcp/server_types.go
@@ -153,7 +153,7 @@ type conversationContext struct {
 
 type TeamBroadcastArgs struct {
 	Channel   string   `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
-	Content   string   `json:"content" jsonschema:"Message to post to the shared team channel"`
+	Content   string   `json:"content" jsonschema:"Message to post to the shared team channel. If you created an HTML visual artifact, include visual-artifact:ra_0123456789abcdef on its own line so chat renders a compact artifact card."`
 	MySlug    string   `json:"my_slug,omitempty" jsonschema:"Agent slug sending the message. Defaults to WUPHF_AGENT_SLUG."`
 	Tagged    []string `json:"tagged,omitempty" jsonschema:"Optional list of tagged agent slugs who should respond"`
 	ReplyToID string   `json:"reply_to_id,omitempty" jsonschema:"Reply in-thread to a specific message ID when continuing a narrow discussion"`

--- a/web/e2e/screenshots/rich-artifact-chat.mjs
+++ b/web/e2e/screenshots/rich-artifact-chat.mjs
@@ -1,0 +1,246 @@
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const artifact = {
+  id: "ra_0123456789abcdef",
+  kind: "notebook_html",
+  title: "ICP onboarding walkthrough",
+  summary:
+    "Interactive HTML plan comparing founder, operator, and reviewer onboarding paths.",
+  trustLevel: "draft",
+  representation: "html",
+  htmlPath: "wiki/visual-artifacts/ra_0123456789abcdef.html",
+  sourceMarkdownPath: "agents/pm/notebook/icp-onboarding-walkthrough.md",
+  createdBy: "pm",
+  createdAt: "2026-05-16T12:00:00Z",
+  updatedAt: "2026-05-16T12:00:00Z",
+  contentHash: "hash",
+  sanitizerVersion: "sandbox-v1",
+};
+
+const artifactHtml = `<!doctype html>
+<html>
+  <head>
+    <style>
+      body { margin: 0; font-family: Inter, system-ui, sans-serif; color: #1f2937; background: #f8fafc; }
+      main { padding: 28px; display: grid; gap: 18px; }
+      h1 { margin: 0; font-size: 26px; }
+      .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+      .lane { background: white; border: 1px solid #d7dde8; border-radius: 8px; padding: 14px; }
+      .lane strong { display: block; margin-bottom: 8px; color: #0f766e; }
+      .meter { height: 10px; border-radius: 99px; background: #e5e7eb; overflow: hidden; margin-top: 12px; }
+      .meter span { display: block; height: 100%; background: #2563eb; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>ICP onboarding walkthrough</h1>
+      <p>Use the cards to compare what each WUPHF user needs from the first rich-artifact experience.</p>
+      <section class="grid">
+        <div class="lane"><strong>Founder</strong>Scan the product strategy, ask for tradeoffs, and promote the winning plan.<div class="meter"><span style="width: 82%"></span></div></div>
+        <div class="lane"><strong>Operator</strong>Review the weekly status report, copy the next actions, and send it to the team.<div class="meter"><span style="width: 68%"></span></div></div>
+        <div class="lane"><strong>Reviewer</strong>Open the code explainer, inspect annotated diffs, and approve with context.<div class="meter"><span style="width: 74%"></span></div></div>
+      </section>
+    </main>
+  </body>
+</html>`;
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1280, height: 850 },
+});
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/config", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          llm_provider: "claude-code",
+          llm_provider_configured: true,
+          memory_backend: "markdown",
+          team_lead_slug: "ceo",
+        }),
+      }),
+    );
+    const memberPayload = {
+      members: [
+        {
+          slug: "pm",
+          name: "Mara",
+          role: "Product",
+          provider: "claude-code",
+          built_in: true,
+          online: true,
+        },
+      ],
+      meta: { humanHasPosted: true },
+    };
+    await ctx.route("**/api/office-members", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(memberPayload),
+      }),
+    );
+    await ctx.route("**/api/members*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(memberPayload),
+      }),
+    );
+    await ctx.route("**/api/channels", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          channels: [
+            {
+              slug: "general",
+              name: "General",
+              description: "Shared office channel",
+            },
+          ],
+        }),
+      }),
+    );
+    await ctx.route("**/api/messages*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "msg-rich-artifact",
+              from: "pm",
+              channel: "general",
+              content:
+                "I made the interactive onboarding walkthrough for our ICP review.\n\nvisual-artifact:ra_0123456789abcdef",
+              timestamp: "2026-05-16T12:00:00Z",
+            },
+          ],
+        }),
+      }),
+    );
+    await ctx.route("**/api/workspaces/list", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ workspaces: [] }),
+      }),
+    );
+    await ctx.route("**/api/requests*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ requests: [] }),
+      }),
+    );
+    await ctx.route("**/api/review/list*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ reviews: [] }),
+      }),
+    );
+    await ctx.route("**/api/tasks/inbox", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          rows: [],
+          counts: {
+            decisionRequired: 0,
+            running: 0,
+            blocked: 0,
+            mergedToday: 0,
+          },
+          refreshedAt: "2026-05-16T12:00:00Z",
+        }),
+      }),
+    );
+    await ctx.route("**/api/tasks?*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ tasks: [] }),
+      }),
+    );
+    await ctx.route("**/api/usage", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          total: {
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            total_tokens: 0,
+            cost_usd: 0,
+            requests: 0,
+          },
+        }),
+      }),
+    );
+    await ctx.route("**/api/commands", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      }),
+    );
+    await ctx.route("**/api/upgrade-check", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          current: "0.83.5",
+          latest: "0.83.5",
+          upgrade_available: false,
+          is_dev_build: false,
+        }),
+      }),
+    );
+    await ctx.route("**/api/notebook/visual-artifacts/ra_0123456789abcdef", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ artifact, html: artifactHtml }),
+      }),
+    );
+  },
+});
+
+await page.goto(`${DEFAULT_BASE}/#/channels/general`, { waitUntil: "load" });
+await page.waitForSelector(".status-bar", { timeout: 15_000 });
+await flipStore(page);
+try {
+  await page.waitForSelector(".message-artifact-reference", { timeout: 10_000 });
+} catch (err) {
+  console.error(await page.locator("body").innerText());
+  throw err;
+}
+await page.waitForTimeout(700);
+await shotElement(
+  page,
+  ".thread-group:has(.message-artifact-reference)",
+  OUT,
+  "01-chat-artifact-card",
+);
+
+await page.getByRole("button", { name: "Open", exact: true }).click();
+await page
+  .getByRole("dialog", { name: "ICP onboarding walkthrough" })
+  .waitFor({ timeout: 10_000 });
+await shotPage(page, OUT, "02-chat-artifact-modal");
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  await browser.close();
+  process.exit(1);
+}
+
+console.log(`captured 2 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/messages/MessageArtifactReferences.tsx
+++ b/web/src/components/messages/MessageArtifactReferences.tsx
@@ -1,0 +1,227 @@
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+
+import {
+  fetchRichArtifact,
+  type RichArtifact,
+  type RichArtifactDetail,
+} from "../../api/richArtifacts";
+import RichArtifactFrame from "../rich-artifacts/RichArtifactFrame";
+
+const MODAL_FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+interface MessageArtifactReferencesProps {
+  artifactIds: string[];
+}
+
+interface ArtifactReferenceItem {
+  id: string;
+  detail?: RichArtifactDetail;
+  error?: string;
+}
+
+export default function MessageArtifactReferences({
+  artifactIds,
+}: MessageArtifactReferencesProps) {
+  const [activeDetail, setActiveDetail] = useState<RichArtifactDetail | null>(
+    null,
+  );
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const artifactQueries = useQueries({
+    queries: artifactIds.map((id) => ({
+      queryKey: ["rich-artifact-reference", id],
+      queryFn: () => fetchRichArtifact(id),
+      staleTime: 60_000,
+    })),
+  });
+
+  useEffect(() => {
+    if (!activeDetail) return;
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    closeButtonRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus();
+      previousFocusRef.current = null;
+    };
+  }, [activeDetail]);
+
+  if (artifactIds.length === 0) return null;
+
+  function closeDialog() {
+    setActiveDetail(null);
+  }
+
+  function handleDialogKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeDialog();
+      return;
+    }
+    if (event.key === "Tab") trapModalFocus(event, dialogRef.current);
+  }
+
+  return (
+    <section
+      className="message-artifact-references"
+      aria-label="Rich artifacts"
+    >
+      {artifactIds.map((id, index) => {
+        const result = artifactQueries[index];
+        return (
+          <MessageArtifactReference
+            key={id}
+            item={{
+              id,
+              detail: result?.data,
+              error: queryErrorMessage(result?.error),
+            }}
+            onOpen={(detail) => setActiveDetail(detail)}
+          />
+        );
+      })}
+      {activeDetail ? (
+        <div
+          ref={dialogRef}
+          className="rich-artifact-modal message-artifact-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={`message-artifact-modal-title-${activeDetail.artifact.id}`}
+          onKeyDown={handleDialogKeyDown}
+        >
+          <div className="rich-artifact-modal-bar">
+            <div>
+              <h2
+                id={`message-artifact-modal-title-${activeDetail.artifact.id}`}
+              >
+                {activeDetail.artifact.title}
+              </h2>
+              <div className="rich-artifact-meta">
+                <span>{activeDetail.artifact.trustLevel}</span>
+                <span>{activeDetail.artifact.htmlPath}</span>
+              </div>
+            </div>
+            <div className="rich-artifact-modal-actions">
+              {activeDetail.artifact.promotedWikiPath ? (
+                <a href={wikiHref(activeDetail.artifact.promotedWikiPath)}>
+                  Open wiki
+                </a>
+              ) : null}
+              <button ref={closeButtonRef} type="button" onClick={closeDialog}>
+                Close
+              </button>
+            </div>
+          </div>
+          <RichArtifactFrame
+            title={activeDetail.artifact.title}
+            html={activeDetail.html}
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function MessageArtifactReference({
+  item,
+  onOpen,
+}: {
+  item: ArtifactReferenceItem;
+  onOpen: (detail: RichArtifactDetail) => void;
+}) {
+  if (item.error) {
+    return (
+      <article className="message-artifact-reference message-artifact-error">
+        <div>
+          <span className="message-artifact-kicker">HTML artifact</span>
+          <h4>{item.id}</h4>
+          <p>{item.error}</p>
+        </div>
+      </article>
+    );
+  }
+  const { detail } = item;
+  if (!detail) {
+    return (
+      <article className="message-artifact-reference" aria-busy="true">
+        <div>
+          <span className="message-artifact-kicker">HTML artifact</span>
+          <h4>{item.id}</h4>
+          <p>Loading artifact...</p>
+        </div>
+      </article>
+    );
+  }
+
+  const { artifact } = detail;
+  return (
+    <article
+      className="message-artifact-reference"
+      aria-label={`Rich artifact: ${artifact.title}`}
+    >
+      <div className="message-artifact-main">
+        <span className="message-artifact-kicker">
+          {artifact.kind === "wiki_visual" ? "Wiki visual" : "Notebook visual"}
+        </span>
+        <h4>{artifact.title}</h4>
+        {artifact.summary ? <p>{artifact.summary}</p> : null}
+        <div className="message-artifact-meta">
+          <span>{artifact.trustLevel}</span>
+          <span>{artifactSource(artifact)}</span>
+        </div>
+      </div>
+      <div className="message-artifact-actions">
+        {artifact.promotedWikiPath ? (
+          <a href={wikiHref(artifact.promotedWikiPath)}>Open wiki</a>
+        ) : null}
+        <button type="button" onClick={() => onOpen(detail)}>
+          Open
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function artifactSource(artifact: RichArtifact): string {
+  if (artifact.promotedWikiPath) return artifact.promotedWikiPath;
+  if (artifact.sourceMarkdownPath) return artifact.sourceMarkdownPath;
+  return `@${artifact.createdBy}`;
+}
+
+function queryErrorMessage(error: unknown): string | undefined {
+  if (!error) return undefined;
+  return error instanceof Error ? error.message : "Failed to load artifact";
+}
+
+function wikiHref(path: string): string {
+  return `#/wiki/${encodeURI(path)}`;
+}
+
+function trapModalFocus(
+  event: KeyboardEvent<HTMLDivElement>,
+  dialog: HTMLDivElement | null,
+) {
+  const focusables = Array.from(
+    dialog?.querySelectorAll<HTMLElement>(MODAL_FOCUSABLE_SELECTOR) ?? [],
+  ).filter((element) => !element.hasAttribute("disabled"));
+  if (focusables.length === 0) {
+    event.preventDefault();
+    return;
+  }
+  const [first] = focusables;
+  const last = focusables.at(-1);
+  if (!(first && last)) return;
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault();
+    first.focus();
+  }
+}

--- a/web/src/components/messages/MessageBubble.test.tsx
+++ b/web/src/components/messages/MessageBubble.test.tsx
@@ -1,0 +1,138 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Message, OfficeMember } from "../../api/client";
+import * as richApi from "../../api/richArtifacts";
+import { MessageBubble } from "./MessageBubble";
+
+const officeMembers: OfficeMember[] = [
+  {
+    slug: "pm",
+    name: "Mara",
+    role: "Product",
+    built_in: false,
+  } as OfficeMember,
+];
+
+const MESSAGE: Message = {
+  id: "msg-1",
+  from: "pm",
+  channel: "general",
+  content:
+    "I made the interactive strategy map.\n\nvisual-artifact:ra_0123456789abcdef",
+  timestamp: "2026-05-16T12:00:00Z",
+};
+
+const ARTIFACT_DETAIL: richApi.RichArtifactDetail = {
+  artifact: {
+    id: "ra_0123456789abcdef",
+    kind: "notebook_html",
+    title: "Product strategy map",
+    summary: "A richer artifact for reviewing the WUPHF rollout.",
+    trustLevel: "draft",
+    representation: "html",
+    htmlPath: "wiki/visual-artifacts/ra_0123456789abcdef.html",
+    sourceMarkdownPath: "agents/pm/notebook/product-strategy.md",
+    createdBy: "pm",
+    createdAt: "2026-05-16T12:00:00Z",
+    updatedAt: "2026-05-16T12:00:00Z",
+    contentHash: "hash",
+    sanitizerVersion: "sandbox-v1",
+  },
+  html: "<h1>Artifact body</h1>",
+};
+
+function renderWithQueryClient(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+vi.mock("../../hooks/useMembers", () => ({
+  useOfficeMembers: () => ({ data: officeMembers, isLoading: false }),
+}));
+
+vi.mock("../../hooks/useConfig", () => ({
+  useDefaultHarness: () => null,
+}));
+
+vi.mock("../../routes/useCurrentRoute", () => ({
+  useChannelSlug: () => "general",
+}));
+
+describe("<MessageBubble> rich artifact references", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(richApi, "fetchRichArtifact").mockResolvedValue(ARTIFACT_DETAIL);
+  });
+
+  it("renders a compact artifact card and hides the raw marker line", async () => {
+    renderWithQueryClient(<MessageBubble message={MESSAGE} />);
+
+    expect(
+      screen.getByText("I made the interactive strategy map."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/visual-artifact:/)).toBeNull();
+
+    const card = await screen.findByLabelText(
+      "Rich artifact: Product strategy map",
+    );
+    expect(within(card).getByText("Notebook visual")).toBeInTheDocument();
+    expect(within(card).getByText("draft")).toBeInTheDocument();
+    expect(
+      within(card).getByText("agents/pm/notebook/product-strategy.md"),
+    ).toBeInTheDocument();
+    expect(richApi.fetchRichArtifact).toHaveBeenCalledWith(
+      "ra_0123456789abcdef",
+    );
+  });
+
+  it("opens artifact HTML only inside the sandboxed modal frame", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<MessageBubble message={MESSAGE} />);
+
+    const card = await screen.findByLabelText(
+      "Rich artifact: Product strategy map",
+    );
+    expect(screen.queryByText("Artifact body")).toBeNull();
+
+    await user.click(within(card).getByRole("button", { name: "Open" }));
+
+    const dialog = screen.getByRole("dialog", {
+      name: "Product strategy map",
+    });
+    const frame = within(dialog).getByTitle("Product strategy map");
+    expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+    expect(frame).toHaveAttribute(
+      "srcdoc",
+      expect.stringContaining("<h1>Artifact body</h1>"),
+    );
+  });
+
+  it("closes the artifact modal with Escape", async () => {
+    const user = userEvent.setup();
+    renderWithQueryClient(<MessageBubble message={MESSAGE} />);
+
+    const card = await screen.findByLabelText(
+      "Rich artifact: Product strategy map",
+    );
+    await user.click(within(card).getByRole("button", { name: "Open" }));
+    expect(
+      screen.getByRole("dialog", { name: "Product strategy map" }),
+    ).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Product strategy map" }),
+      ).toBeNull();
+    });
+  });
+});

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 
 import type { Message } from "../../api/client";
@@ -12,12 +12,17 @@ import {
   messageMarkdownComponents,
   messageRemarkPlugins,
 } from "../../lib/messageMarkdown";
+import {
+  extractRichArtifactIds,
+  stripStandaloneRichArtifactReferenceLines,
+} from "../../lib/richArtifactReferences";
 import { useChannelSlug } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
 import { RedactedBadge } from "../ui/RedactedBadge";
 import { showNotice } from "../ui/Toast";
+import MessageArtifactReferences from "./MessageArtifactReferences";
 
 interface MessageBubbleProps {
   message: Message;
@@ -86,14 +91,23 @@ export function MessageBubble({
   // HTML. Local-LLM agent content (mlx-lm, ollama, exo) flows through the
   // same path so the XSS posture applies uniformly. Human input takes the
   // safe ReactNode path via renderMentions.
+  const messageText = message.content || "";
+  const richArtifactIds = useMemo(
+    () => extractRichArtifactIds(messageText),
+    [messageText],
+  );
+  const renderedText = useMemo(
+    () => stripStandaloneRichArtifactReferenceLines(messageText),
+    [messageText],
+  );
 
   // Turn human text like "@pm when are you free?" into mention chips for
   // registered agent slugs. Non-agent @-references stay plain text. The
   // memo keys on content + the slug list so rapid renders don't re-parse.
   const knownSlugs = useMemo(() => members.map((m) => m.slug), [members]);
   const humanRendered = useMemo(
-    () => (isHuman ? renderMentions(message.content || "", knownSlugs) : null),
-    [isHuman, message.content, knownSlugs],
+    () => (isHuman ? renderMentions(renderedText, knownSlugs) : null),
+    [isHuman, renderedText, knownSlugs],
   );
 
   // Status messages — compact
@@ -184,19 +198,15 @@ export function MessageBubble({
 
         {/* Text — humans render mention chips via safe ReactNode children;
             agent messages render through ReactMarkdown (no raw HTML). */}
-        {isHuman ? (
-          <div className="message-text">{humanRendered}</div>
-        ) : (
-          <div className="message-text">
-            <ReactMarkdown
-              remarkPlugins={messageRemarkPlugins}
-              components={messageMarkdownComponents}
-              skipHtml={true}
-            >
-              {message.content || ""}
-            </ReactMarkdown>
-          </div>
-        )}
+        <MessageBodyText
+          isHuman={isHuman}
+          renderedText={renderedText}
+          humanRendered={humanRendered}
+        />
+
+        {richArtifactIds.length > 0 ? (
+          <MessageArtifactReferences artifactIds={richArtifactIds} />
+        ) : null}
 
         {/* Reactions */}
         {reactions.length > 0 && (
@@ -332,6 +342,30 @@ export function MessageBubble({
           ) : null}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function MessageBodyText({
+  isHuman,
+  renderedText,
+  humanRendered,
+}: {
+  isHuman: boolean;
+  renderedText: string;
+  humanRendered: ReactNode;
+}) {
+  if (!renderedText) return null;
+  if (isHuman) return <div className="message-text">{humanRendered}</div>;
+  return (
+    <div className="message-text">
+      <ReactMarkdown
+        remarkPlugins={messageRemarkPlugins}
+        components={messageMarkdownComponents}
+        skipHtml={true}
+      >
+        {renderedText}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/web/src/lib/richArtifactReferences.test.ts
+++ b/web/src/lib/richArtifactReferences.test.ts
@@ -41,6 +41,18 @@ describe("rich artifact references", () => {
     expect(extractRichArtifactIds(content)).toEqual(["ra_bbbbbbbbbbbbbbbb"]);
   });
 
+  it("does not close fences with a mismatched delimiter", () => {
+    const content = [
+      "```",
+      "~~~",
+      "visual-artifact:ra_aaaaaaaaaaaaaaaa",
+      "```",
+      "visual-artifact:ra_bbbbbbbbbbbbbbbb",
+    ].join("\n");
+
+    expect(extractRichArtifactIds(content)).toEqual(["ra_bbbbbbbbbbbbbbbb"]);
+  });
+
   it("strips standalone marker lines but preserves prose", () => {
     const content = [
       "Here is the review.",
@@ -64,6 +76,17 @@ describe("rich artifact references", () => {
 
   it("preserves non-artifact message whitespace exactly", () => {
     const content = "  Keep leading space\n\n\nand trailing blanks.  \n";
+
+    expect(stripStandaloneRichArtifactReferenceLines(content)).toBe(content);
+  });
+
+  it("preserves artifact-looking lines inside mismatched fences", () => {
+    const content = [
+      "~~~",
+      "```",
+      "visual-artifact:ra_0123456789abcdef",
+      "~~~",
+    ].join("\n");
 
     expect(stripStandaloneRichArtifactReferenceLines(content)).toBe(content);
   });

--- a/web/src/lib/richArtifactReferences.test.ts
+++ b/web/src/lib/richArtifactReferences.test.ts
@@ -61,4 +61,10 @@ describe("rich artifact references", () => {
 
     expect(stripStandaloneRichArtifactReferenceLines(content)).toBe(content);
   });
+
+  it("preserves non-artifact message whitespace exactly", () => {
+    const content = "  Keep leading space\n\n\nand trailing blanks.  \n";
+
+    expect(stripStandaloneRichArtifactReferenceLines(content)).toBe(content);
+  });
 });

--- a/web/src/lib/richArtifactReferences.test.ts
+++ b/web/src/lib/richArtifactReferences.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractRichArtifactIds,
+  stripStandaloneRichArtifactReferenceLines,
+} from "./richArtifactReferences";
+
+describe("rich artifact references", () => {
+  it("extracts explicit visual artifact markers in first-seen order", () => {
+    const content = [
+      "I made the HTML companion.",
+      "visual-artifact:ra_0123456789abcdef",
+      "rich artifact id: ra_fedcba9876543210",
+      "visual-artifact:ra_0123456789abcdef",
+    ].join("\n");
+
+    expect(extractRichArtifactIds(content)).toEqual([
+      "ra_0123456789abcdef",
+      "ra_fedcba9876543210",
+    ]);
+  });
+
+  it("extracts notebook and wiki visual artifact paths", () => {
+    const content =
+      "[open](/notebook/visual-artifacts/ra_aaaaaaaaaaaaaaaa) and wiki/visual-artifacts/ra_bbbbbbbbbbbbbbbb.html";
+
+    expect(extractRichArtifactIds(content)).toEqual([
+      "ra_aaaaaaaaaaaaaaaa",
+      "ra_bbbbbbbbbbbbbbbb",
+    ]);
+  });
+
+  it("does not extract references from fenced code blocks", () => {
+    const content = [
+      "```",
+      "visual-artifact:ra_aaaaaaaaaaaaaaaa",
+      "```",
+      "visual-artifact:ra_bbbbbbbbbbbbbbbb",
+    ].join("\n");
+
+    expect(extractRichArtifactIds(content)).toEqual(["ra_bbbbbbbbbbbbbbbb"]);
+  });
+
+  it("strips standalone marker lines but preserves prose", () => {
+    const content = [
+      "Here is the review.",
+      "",
+      "- visual artifact: ra_0123456789abcdef",
+      "",
+      "Use it for the implementation pass.",
+    ].join("\n");
+
+    expect(stripStandaloneRichArtifactReferenceLines(content)).toBe(
+      "Here is the review.\n\nUse it for the implementation pass.",
+    );
+  });
+
+  it("does not strip a sentence that merely links to an artifact", () => {
+    const content =
+      "Open [the artifact](/notebook/visual-artifacts/ra_0123456789abcdef) when ready.";
+
+    expect(stripStandaloneRichArtifactReferenceLines(content)).toBe(content);
+  });
+});

--- a/web/src/lib/richArtifactReferences.ts
+++ b/web/src/lib/richArtifactReferences.ts
@@ -1,0 +1,76 @@
+const RICH_ARTIFACT_ID = "ra_[0-9a-f]{16}";
+
+const EXPLICIT_REFERENCE_PATTERN =
+  "(?:\\b(?:visual|rich|html|notebook)[\\s_-]*artifact(?:[\\s_-]*(?:ref|reference|id))?\\b\\s*[:=#-]?\\s*|#?/?(?:notebook|wiki)/visual-artifacts/)(" +
+  RICH_ARTIFACT_ID +
+  ")(?:\\.html)?";
+
+const REFERENCE_LINE_FILLER_RE =
+  /\b(?:visual|rich|html|notebook|wiki|artifact|artifacts|reference|ref|id|open|view|see|link)\b/gi;
+
+function referenceRegex(): RegExp {
+  return new RegExp(EXPLICIT_REFERENCE_PATTERN, "gi");
+}
+
+export function extractRichArtifactIds(content: string): string[] {
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  forEachNonFenceLine(content, (line) => {
+    for (const match of line.matchAll(referenceRegex())) {
+      const id = match[1]?.toLowerCase();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+  });
+  return ids;
+}
+
+export function stripStandaloneRichArtifactReferenceLines(
+  content: string,
+): string {
+  const lines = content.split(/\r?\n/);
+  let inFence = false;
+  const kept: string[] = [];
+  for (const line of lines) {
+    if (isFenceBoundary(line)) {
+      inFence = !inFence;
+      kept.push(line);
+      continue;
+    }
+    if (!inFence && isStandaloneReferenceLine(line)) continue;
+    kept.push(line);
+  }
+  return kept
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function forEachNonFenceLine(
+  content: string,
+  visit: (line: string) => void,
+): void {
+  let inFence = false;
+  for (const line of content.split(/\r?\n/)) {
+    if (isFenceBoundary(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (!inFence) visit(line);
+  }
+}
+
+function isFenceBoundary(line: string): boolean {
+  const trimmed = line.trimStart();
+  return trimmed.startsWith("```") || trimmed.startsWith("~~~");
+}
+
+function isStandaloneReferenceLine(line: string): boolean {
+  if (!referenceRegex().test(line)) return false;
+  const withoutReferences = line.replace(referenceRegex(), "");
+  const remaining = withoutReferences
+    .replace(REFERENCE_LINE_FILLER_RE, "")
+    .replace(/[\s()[\]{}<>`*_~|:;,.!?#="'/-]+/g, "");
+  return remaining.length === 0;
+}

--- a/web/src/lib/richArtifactReferences.ts
+++ b/web/src/lib/richArtifactReferences.ts
@@ -8,6 +8,8 @@ const EXPLICIT_REFERENCE_PATTERN =
 const REFERENCE_LINE_FILLER_RE =
   /\b(?:visual|rich|html|notebook|wiki|artifact|artifacts|reference|ref|id|open|view|see|link)\b/gi;
 
+type FenceToken = "`" | "~";
+
 function referenceRegex(): RegExp {
   return new RegExp(EXPLICIT_REFERENCE_PATTERN, "gi");
 }
@@ -30,12 +32,17 @@ export function stripStandaloneRichArtifactReferenceLines(
   content: string,
 ): string {
   const lines = content.split(/\r?\n/);
-  let inFence = false;
+  let inFence: FenceToken | null = null;
   let removedReferenceLine = false;
   const kept: string[] = [];
   for (const line of lines) {
-    if (isFenceBoundary(line)) {
-      inFence = !inFence;
+    const token = fenceToken(line);
+    if (token) {
+      if (!inFence) {
+        inFence = token;
+      } else if (inFence === token) {
+        inFence = null;
+      }
       kept.push(line);
       continue;
     }
@@ -53,19 +60,26 @@ function forEachNonFenceLine(
   content: string,
   visit: (line: string) => void,
 ): void {
-  let inFence = false;
+  let inFence: FenceToken | null = null;
   for (const line of content.split(/\r?\n/)) {
-    if (isFenceBoundary(line)) {
-      inFence = !inFence;
+    const token = fenceToken(line);
+    if (token) {
+      if (!inFence) {
+        inFence = token;
+      } else if (inFence === token) {
+        inFence = null;
+      }
       continue;
     }
     if (!inFence) visit(line);
   }
 }
 
-function isFenceBoundary(line: string): boolean {
+function fenceToken(line: string): FenceToken | null {
   const trimmed = line.trimStart();
-  return trimmed.startsWith("```") || trimmed.startsWith("~~~");
+  if (trimmed.startsWith("```")) return "`";
+  if (trimmed.startsWith("~~~")) return "~";
+  return null;
 }
 
 function isStandaloneReferenceLine(line: string): boolean {

--- a/web/src/lib/richArtifactReferences.ts
+++ b/web/src/lib/richArtifactReferences.ts
@@ -31,6 +31,7 @@ export function stripStandaloneRichArtifactReferenceLines(
 ): string {
   const lines = content.split(/\r?\n/);
   let inFence = false;
+  let removedReferenceLine = false;
   const kept: string[] = [];
   for (const line of lines) {
     if (isFenceBoundary(line)) {
@@ -38,13 +39,14 @@ export function stripStandaloneRichArtifactReferenceLines(
       kept.push(line);
       continue;
     }
-    if (!inFence && isStandaloneReferenceLine(line)) continue;
+    if (!inFence && isStandaloneReferenceLine(line)) {
+      removedReferenceLine = true;
+      continue;
+    }
     kept.push(line);
   }
-  return kept
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
+  if (!removedReferenceLine) return content;
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
 }
 
 function forEachNonFenceLine(

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -298,6 +298,115 @@
   color: var(--accent-warm);
 }
 
+/* ─── Rich artifact references ─── */
+.message-artifact-references {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.message-artifact-reference {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text-secondary);
+}
+
+.message-artifact-reference h4 {
+  margin: 1px 0 3px;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.message-artifact-reference p {
+  margin: 0 0 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.message-artifact-kicker {
+  display: block;
+  color: var(--text-tertiary);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.message-artifact-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.message-artifact-meta span {
+  max-width: min(100%, 360px);
+  overflow-wrap: anywhere;
+}
+
+.message-artifact-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.message-artifact-actions button,
+.message-artifact-actions a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--border-dark);
+  border-radius: 6px;
+  background: var(--bg-warm);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.message-artifact-actions button:hover,
+.message-artifact-actions a:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.message-artifact-error {
+  border-left-color: var(--red, #b3261e);
+}
+
+.message-artifact-modal {
+  z-index: 95;
+}
+
+@media (max-width: 640px) {
+  .message-artifact-reference {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .message-artifact-actions {
+    justify-content: flex-start;
+  }
+}
+
 /* ─── @mention ─── */
 .mention {
   display: inline-block;

--- a/web/src/styles/rich-artifacts.css
+++ b/web/src/styles/rich-artifacts.css
@@ -57,7 +57,11 @@
 }
 
 .rich-artifact-modal-actions button,
+.rich-artifact-modal-actions a,
 .nb-visual-artifact-actions button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 32px;
   padding: 0 12px;
   border: 1px solid rgba(31, 41, 55, 0.18);
@@ -65,10 +69,12 @@
   background: #fff;
   color: #172033;
   font: inherit;
+  text-decoration: none;
   cursor: pointer;
 }
 
 .rich-artifact-modal-actions button:hover,
+.rich-artifact-modal-actions a:hover,
 .nb-visual-artifact-actions button:hover {
   background: #f5f7fa;
 }


### PR DESCRIPTION
## Summary
- renders compact rich artifact cards in chat when agents include `visual-artifact:ra_...` references
- opens referenced HTML artifacts in the existing sandboxed iframe modal instead of inline-rendering agent HTML
- teaches MCP notebook artifact and broadcast tools to include the chat marker after creating visual artifacts

## Verification
- `bash scripts/test-web.sh`
- `cd web && bunx tsc --noEmit`
- `bash scripts/test-go.sh ./internal/team ./internal/teammcp`
- `bash scripts/test-web.sh web/src/lib/richArtifactReferences.test.ts web/src/components/messages/MessageBubble.test.tsx web/src/components/rich-artifacts/RichArtifactFrame.test.tsx`
- `bash scripts/test-go.sh ./internal/teammcp`
- `bash scripts/check-file-size.sh`
- `git diff --check`



## Screenshots

![01-chat-artifact-card](https://github.com/nex-crm/wuphf/raw/screenshots/pr-873/01-chat-artifact-card.png)

![02-chat-artifact-modal](https://github.com/nex-crm/wuphf/raw/screenshots/pr-873/02-chat-artifact-modal.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat messages show compact rich-artifact cards with an "Open" action to view artifacts in a sandboxed modal; Escape closes the modal.

* **New Components / Parsing**
  * Client parsing extracts rich-artifact IDs, hides standalone artifact marker lines, and surfaces artifact previews alongside message text.

* **Tests**
  * Added unit and e2e tests and screenshot checks for extraction, rendering, and modal behavior.

* **Style**
  * Updated styles for artifact cards, modal actions, and responsive layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->