### PR TITLE
docs: add rich artifact tutorial scenarios

### DIFF
--- a/docs/tutorials/rich-html-artifacts/README.md
+++ b/docs/tutorials/rich-html-artifacts/README.md
@@ -1,0 +1,33 @@
+# Rich HTML Artifact Tutorial Scenarios
+
+These fixtures model the first WUPHF workflows where agent output should be HTML first:
+
+1. Notebook exploration: an agent creates a dense, interactive HTML artifact next to its working notes.
+2. Wiki promotion: the artifact is promoted into a durable wiki article with provenance.
+3. Chat handoff: the agent references the artifact with a terse `visual-artifact:<id>` marker so the UI renders a preview card instead of a plain link.
+
+The goal is to keep the viral article's lesson concrete: when the output is a plan, explainer, review packet, incident report, or tuning surface, markdown should carry the summary and provenance while HTML carries the visual, interactive representation.
+
+## Scenarios
+
+- `revops-launch-risk`: a RevOps operator comparing launch blockers, tradeoffs, and owner load before committing a GTM plan.
+- `support-incident-room`: a customer/support ops lead turning an incident timeline into a readable command-room artifact.
+- `sales-review-brief`: a sales engineer or reviewer explaining a technical change with annotated diff, risks, and reviewer prompts.
+
+Each scenario has:
+
+- `source.md`: the notebook note the agent would write while exploring.
+- `artifact.html`: the HTML artifact the agent should create from the note.
+- `wiki.md`: the markdown summary used when promoting the artifact to the team wiki.
+- `chat.txt`: the agent chat message that should become a rich artifact card in chat.
+
+## Validation
+
+These examples are executable fixtures, not just documentation.
+
+```bash
+bash scripts/test-go.sh ./internal/team
+bash scripts/test-web.sh web/src/lib/richArtifactTutorialFixtures.test.ts web/src/lib/richArtifactReferences.test.ts
+```
+
+The Go test creates and promotes every HTML artifact through the wiki repo API. The web test parses the same chat fixtures through the chat artifact reference parser.

--- a/docs/tutorials/rich-html-artifacts/README.md
+++ b/docs/tutorials/rich-html-artifacts/README.md
@@ -21,6 +21,8 @@ Each scenario has:
 - `wiki.md`: the markdown summary used when promoting the artifact to the team wiki.
 - `chat.txt`: the agent chat message that should become a rich artifact card in chat.
 
+The `scenarios.json` manifest separates intended deployment paths from local fixture files. `sourceMarkdownPath` and `targetWikiPath` describe where the agent-created source note and promoted wiki article should live in a real workspace; `sourcePath`, `wikiPath`, `htmlPath`, and `chatPath` point at fixture files under this tutorial directory for tests and examples.
+
 ## Validation
 
 These examples are executable fixtures, not just documentation.

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
@@ -30,7 +30,8 @@
     .risk.med { color: #9a640c; }
     .risk.low { color: #26724e; }
     .controls { display: grid; gap: 12px; }
-    label { display: grid; gap: 6px; font-size: 13px; color: #48556a; }
+    .control { display: grid; gap: 6px; }
+    label { font-size: 13px; color: #48556a; }
     input[type="range"] { width: 100%; accent-color: #2764d8; }
     .score { display: grid; grid-template-columns: auto 1fr; gap: 14px; align-items: center; margin: 16px 0; }
     .dial { width: 92px; height: 92px; border-radius: 50%; display: grid; place-items: center; background: conic-gradient(#2764d8 var(--score, 56%), #e8edf5 0); color: #13213b; font-size: 26px; font-weight: 800; }
@@ -98,15 +99,24 @@
       <section>
         <h2>Risk Tuning</h2>
         <div class="controls">
-          <label for="pricing">Pricing severity <input id="pricing" type="range" min="0" max="100" value="82"></label>
-          <label for="support">Support readiness <input id="support" type="range" min="0" max="100" value="58"></label>
-          <label for="sales">Sales confidence <input id="sales" type="range" min="0" max="100" value="64"></label>
+          <div class="control">
+            <label for="pricing">Pricing severity</label>
+            <input id="pricing" type="range" min="0" max="100" value="82">
+          </div>
+          <div class="control">
+            <label for="support">Support readiness</label>
+            <input id="support" type="range" min="0" max="100" value="58">
+          </div>
+          <div class="control">
+            <label for="sales">Sales confidence</label>
+            <input id="sales" type="range" min="0" max="100" value="64">
+          </div>
         </div>
         <div class="score">
-          <div id="dial" class="dial" style="--score: 68%">68</div>
+          <div id="dial" class="dial" style="--score: 68%" aria-live="polite" aria-atomic="true">68</div>
           <div class="decision">
-            <strong id="decisionTitle">Hold for mitigation</strong>
-            <p id="decisionCopy">Launch can proceed only after pricing has an approved fallback.</p>
+            <strong id="decisionTitle" aria-live="polite">Hold for mitigation</strong>
+            <p id="decisionCopy" aria-live="polite">Launch can proceed only after pricing has an approved fallback.</p>
           </div>
         </div>
         <button type="button" id="copy">Copy mitigation prompt</button>

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
@@ -128,7 +128,7 @@
       const salesGap = 100 - Number(fields[2].value);
       const score = Math.round((pricing + supportGap + salesGap) / 3);
       dial.textContent = String(score);
-      dial.style.setProperty("--score", score + "%");
+      dial.style.setProperty("--score", `${score}%`);
       if (score >= 67) {
         decisionTitle.textContent = "Hold for mitigation";
         decisionCopy.textContent = "Launch needs an explicit fallback owner before the team commits.";
@@ -139,13 +139,17 @@
         decisionTitle.textContent = "Launch is ready";
         decisionCopy.textContent = "Remaining risk is low enough for the planned launch window.";
       }
-      prompt.textContent = "Launch risk score " + score + ". Assign Finance to close pricing fallback, Support to refresh screenshots, and Sales to prepare the enterprise confidence story.";
+      prompt.textContent = `Launch risk score ${score}. Assign Finance to close pricing fallback, Support to refresh screenshots, and Sales to prepare the enterprise confidence story.`;
     }
 
     for (const field of fields) field.addEventListener("input", render);
     copy.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(prompt.textContent);
-      copy.textContent = "Copied";
+      try {
+        await navigator.clipboard.writeText(prompt.textContent);
+        copy.textContent = "Copied";
+      } catch {
+        copy.textContent = "Clipboard unavailable";
+      }
       window.setTimeout(() => { copy.textContent = "Copy mitigation prompt"; }, 1200);
     });
     render();

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RevOps Launch Risk Room</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f7f8fb;
+      color: #18202f;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #f7f8fb; }
+    main { max-width: 1120px; margin: 0 auto; padding: 28px; }
+    header { display: grid; grid-template-columns: 1fr auto; gap: 20px; align-items: end; margin-bottom: 22px; }
+    h1 { margin: 0 0 8px; font-size: 30px; letter-spacing: 0; }
+    p { margin: 0; color: #566176; line-height: 1.5; }
+    .badge { display: inline-flex; align-items: center; min-height: 28px; padding: 4px 10px; border-radius: 6px; background: #e6f2ef; color: #1d6b5a; font-weight: 700; font-size: 13px; }
+    .grid { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(280px, .9fr); gap: 16px; }
+    section { background: #ffffff; border: 1px solid #dfe5ef; border-radius: 8px; padding: 18px; box-shadow: 0 1px 2px rgba(16, 24, 40, .04); }
+    h2 { margin: 0 0 14px; font-size: 17px; }
+    table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    th { text-align: left; color: #606b80; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; border-bottom: 1px solid #e6ebf2; padding: 8px; }
+    td { border-bottom: 1px solid #eef2f7; padding: 10px 8px; vertical-align: top; }
+    tr:last-child td { border-bottom: 0; }
+    .risk { font-weight: 700; }
+    .risk.high { color: #a33a2b; }
+    .risk.med { color: #9a640c; }
+    .risk.low { color: #26724e; }
+    .controls { display: grid; gap: 12px; }
+    label { display: grid; gap: 6px; font-size: 13px; color: #48556a; }
+    input[type="range"] { width: 100%; accent-color: #2764d8; }
+    .score { display: grid; grid-template-columns: auto 1fr; gap: 14px; align-items: center; margin: 16px 0; }
+    .dial { width: 92px; height: 92px; border-radius: 50%; display: grid; place-items: center; background: conic-gradient(#2764d8 var(--score, 56%), #e8edf5 0); color: #13213b; font-size: 26px; font-weight: 800; }
+    .decision { border-left: 4px solid #2764d8; padding: 10px 12px; background: #f2f6ff; border-radius: 6px; }
+    .owner-load { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
+    .owner { min-height: 86px; border: 1px solid #dfe5ef; border-radius: 7px; padding: 10px; background: #fbfcfe; }
+    .owner strong { display: block; margin-bottom: 8px; }
+    .bar { height: 8px; border-radius: 999px; background: #e9edf4; overflow: hidden; }
+    .bar span { display: block; height: 100%; background: #2764d8; }
+    button { border: 1px solid #1f56b3; background: #2764d8; color: white; border-radius: 6px; min-height: 36px; padding: 8px 12px; font-weight: 700; cursor: pointer; }
+    pre { white-space: pre-wrap; background: #101828; color: #eef4ff; border-radius: 8px; padding: 14px; font-size: 13px; line-height: 1.45; overflow: auto; }
+    @media (max-width: 820px) {
+      main { padding: 18px; }
+      header, .grid { grid-template-columns: 1fr; }
+      .owner-load { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>Launch Risk Room</h1>
+        <p>Compare blockers, owner load, and mitigation options before moving the GTM plan from planning into execution.</p>
+      </div>
+      <span class="badge">HTML first artifact</span>
+    </header>
+
+    <div class="grid">
+      <section>
+        <h2>Blocker Matrix</h2>
+        <table>
+          <thead>
+            <tr><th>Blocker</th><th>Owner</th><th>Risk</th><th>Mitigation</th></tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Pricing approval</td>
+              <td>Finance</td>
+              <td class="risk high">High</td>
+              <td>Lock fallback packaging by EOD.</td>
+            </tr>
+            <tr>
+              <td>Support screenshots</td>
+              <td>Support</td>
+              <td class="risk med">Medium</td>
+              <td>Refresh the checkout playbook with new states.</td>
+            </tr>
+            <tr>
+              <td>Enterprise confidence story</td>
+              <td>Sales</td>
+              <td class="risk med">Medium</td>
+              <td>Draft the account-specific objection narrative.</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <div class="owner-load" aria-label="Owner load">
+          <div class="owner"><strong>Finance</strong><div class="bar"><span style="width: 78%"></span></div><p>Approval path is the launch gate.</p></div>
+          <div class="owner"><strong>Support</strong><div class="bar"><span style="width: 44%"></span></div><p>Visual refresh is bounded.</p></div>
+          <div class="owner"><strong>Sales</strong><div class="bar"><span style="width: 63%"></span></div><p>Buyer narrative still needs proof.</p></div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Risk Tuning</h2>
+        <div class="controls">
+          <label>Pricing severity <input id="pricing" type="range" min="0" max="100" value="82"></label>
+          <label>Support readiness <input id="support" type="range" min="0" max="100" value="58"></label>
+          <label>Sales confidence <input id="sales" type="range" min="0" max="100" value="64"></label>
+        </div>
+        <div class="score">
+          <div id="dial" class="dial" style="--score: 68%">68</div>
+          <div class="decision">
+            <strong id="decisionTitle">Hold for mitigation</strong>
+            <p id="decisionCopy">Launch can proceed only after pricing has an approved fallback.</p>
+          </div>
+        </div>
+        <button type="button" id="copy">Copy mitigation prompt</button>
+        <pre id="prompt">Assign Finance to close pricing fallback, Support to refresh screenshots, and Sales to prepare the enterprise confidence story.</pre>
+      </section>
+    </div>
+  </main>
+  <script>
+    const fields = ["pricing", "support", "sales"].map((id) => document.getElementById(id));
+    const dial = document.getElementById("dial");
+    const decisionTitle = document.getElementById("decisionTitle");
+    const decisionCopy = document.getElementById("decisionCopy");
+    const prompt = document.getElementById("prompt");
+    const copy = document.getElementById("copy");
+
+    function render() {
+      const pricing = Number(fields[0].value);
+      const supportGap = 100 - Number(fields[1].value);
+      const salesGap = 100 - Number(fields[2].value);
+      const score = Math.round((pricing + supportGap + salesGap) / 3);
+      dial.textContent = String(score);
+      dial.style.setProperty("--score", score + "%");
+      if (score >= 67) {
+        decisionTitle.textContent = "Hold for mitigation";
+        decisionCopy.textContent = "Launch needs an explicit fallback owner before the team commits.";
+      } else if (score >= 40) {
+        decisionTitle.textContent = "Launch with watchpoints";
+        decisionCopy.textContent = "Proceed only with same-day owner check-ins and a rollback message.";
+      } else {
+        decisionTitle.textContent = "Launch is ready";
+        decisionCopy.textContent = "Remaining risk is low enough for the planned launch window.";
+      }
+      prompt.textContent = "Launch risk score " + score + ". Assign Finance to close pricing fallback, Support to refresh screenshots, and Sales to prepare the enterprise confidence story.";
+    }
+
+    for (const field of fields) field.addEventListener("input", render);
+    copy.addEventListener("click", async () => {
+      await navigator.clipboard.writeText(prompt.textContent);
+      copy.textContent = "Copied";
+      window.setTimeout(() => { copy.textContent = "Copy mitigation prompt"; }, 1200);
+    });
+    render();
+  </script>
+</body>
+</html>

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/artifact.html
@@ -98,9 +98,9 @@
       <section>
         <h2>Risk Tuning</h2>
         <div class="controls">
-          <label>Pricing severity <input id="pricing" type="range" min="0" max="100" value="82"></label>
-          <label>Support readiness <input id="support" type="range" min="0" max="100" value="58"></label>
-          <label>Sales confidence <input id="sales" type="range" min="0" max="100" value="64"></label>
+          <label for="pricing">Pricing severity <input id="pricing" type="range" min="0" max="100" value="82"></label>
+          <label for="support">Support readiness <input id="support" type="range" min="0" max="100" value="58"></label>
+          <label for="sales">Sales confidence <input id="sales" type="range" min="0" max="100" value="64"></label>
         </div>
         <div class="score">
           <div id="dial" class="dial" style="--score: 68%">68</div>

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/chat.txt
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/chat.txt
@@ -1,0 +1,5 @@
+I created the launch risk room as an HTML artifact so you can compare owner load, blocker severity, and next-step prompts without scanning a long checklist.
+
+visual-artifact:ra_0123456789abcdef
+
+Promote the markdown summary to the wiki once the launch owner agrees with the risk posture.

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/source.md
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/source.md
@@ -1,0 +1,9 @@
+# RevOps launch risk notebook
+
+The launch plan needs a richer representation than a markdown checklist. The team has three blockers:
+
+- Pricing approval is still pending with finance.
+- The support playbook has screenshots from an old checkout flow.
+- Sales wants a confidence story for two enterprise accounts.
+
+The useful artifact should let the operator compare owner load, risk severity, and mitigation options on one screen. It should also export a short prompt that can be pasted back into WUPHF to assign the next work items.

--- a/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/wiki.md
+++ b/docs/tutorials/rich-html-artifacts/fixtures/revops-launch-risk/wiki.md
@@ -1,0 +1,9 @@
+# RevOps Launch Risk Room
+
+Use the visual artifact when deciding whether a product launch is ready to move from planning into execution. The HTML view carries the owner-load matrix, risk severity controls, and a prompt exporter for follow-up assignment.
+
+Recommended operating rhythm:
+
+- Review blocker severity with the launch owner.
+- Update owner load before assigning mitigation work.
+- Copy the mitigation prompt into chat after the team chooses the final launch posture.

--- a/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/artifact.html
@@ -92,8 +92,12 @@
   <script>
     const copy = document.getElementById("copy");
     copy.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(document.getElementById("prompt").value);
-      copy.textContent = "Copied";
+      try {
+        await navigator.clipboard.writeText(document.getElementById("prompt").value);
+        copy.textContent = "Copied";
+      } catch {
+        copy.textContent = "Clipboard unavailable";
+      }
       window.setTimeout(() => { copy.textContent = "Copy reviewer prompt"; }, 1200);
     });
   </script>

--- a/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/artifact.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sales Engineering Review Brief</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f6f7fb;
+      color: #141b2d;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+    main { max-width: 1120px; margin: 0 auto; padding: 28px; }
+    header { margin-bottom: 18px; }
+    h1 { margin: 0 0 8px; font-size: 30px; letter-spacing: 0; }
+    p { margin: 0; color: #5c6576; line-height: 1.5; }
+    .layout { display: grid; grid-template-columns: minmax(0, .95fr) minmax(0, 1.05fr); gap: 16px; }
+    section { background: #ffffff; border: 1px solid #dfe4ed; border-radius: 8px; padding: 18px; }
+    h2 { margin: 0 0 14px; font-size: 18px; }
+    .summary { display: grid; gap: 10px; }
+    .chiprow { display: flex; flex-wrap: wrap; gap: 8px; }
+    .chip { border-radius: 999px; padding: 5px 10px; background: #eef5ff; color: #20549d; font-weight: 700; font-size: 13px; }
+    .risk { display: grid; grid-template-columns: 82px 1fr; gap: 10px; padding: 10px; border: 1px solid #e4e9f1; border-radius: 7px; margin-bottom: 8px; }
+    .sev { display: grid; place-items: center; border-radius: 6px; color: #ffffff; font-weight: 800; }
+    .sev.high { background: #a93f32; }
+    .sev.med { background: #9a6a1f; }
+    .sev.low { background: #2d7551; }
+    pre { margin: 0; overflow: auto; background: #101828; color: #ecf3ff; border-radius: 8px; padding: 14px; font-size: 13px; line-height: 1.5; }
+    .add { color: #88dfa5; }
+    .del { color: #ffac9f; }
+    .note { color: #9ec2ff; }
+    button { border: 1px solid #20549d; background: #2364bf; color: #ffffff; border-radius: 6px; min-height: 36px; padding: 8px 12px; font-weight: 700; cursor: pointer; }
+    textarea { width: 100%; min-height: 128px; border: 1px solid #cbd5e1; border-radius: 8px; padding: 12px; font: inherit; line-height: 1.5; margin-bottom: 10px; }
+    details { border: 1px solid #e1e7ef; border-radius: 7px; padding: 10px 12px; background: #fbfcfe; }
+    details + details { margin-top: 8px; }
+    summary { cursor: pointer; font-weight: 800; }
+    @media (max-width: 860px) {
+      main { padding: 18px; }
+      .layout { grid-template-columns: 1fr; }
+      .risk { grid-template-columns: 1fr; }
+      .sev { min-height: 34px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Reviewer Brief</h1>
+      <p>Explain a technical change through the reviewer, field, and buyer-risk lenses in one pass.</p>
+    </header>
+    <div class="layout">
+      <section class="summary">
+        <h2>Buyer outcome</h2>
+        <p>This change makes artifact handoffs easier to inspect in chat, reducing the chance that a customer-facing reviewer misses the visual context behind a recommendation.</p>
+        <div class="chiprow">
+          <span class="chip">ICP: sales engineering</span>
+          <span class="chip">Surface: chat</span>
+          <span class="chip">Mode: review</span>
+        </div>
+
+        <h2>Review asks</h2>
+        <div class="risk"><div class="sev high">High</div><div><strong>Trust boundary</strong><p>Confirm sandboxed HTML cannot execute external scripts or navigate the host page.</p></div></div>
+        <div class="risk"><div class="sev med">Med</div><div><strong>Diff focus</strong><p>Verify artifact markers render as cards without stripping useful prose.</p></div></div>
+        <div class="risk"><div class="sev low">Low</div><div><strong>Buyer story</strong><p>Check whether the artifact summary is clear enough for a non-engineer.</p></div></div>
+
+        <details open>
+          <summary>Why HTML here</summary>
+          <p>The diff, buyer story, and reviewer prompts occupy different mental tracks. HTML lets the reader scan all three without expanding a long markdown file.</p>
+        </details>
+      </section>
+
+      <section>
+        <h2>Annotated diff focus</h2>
+        <pre><span class="note">web/src/components/messages/MessageBubble.tsx</span>
+<span class="del">- renderMarkdown(content)</span>
+<span class="add">+ const artifactIds = extractRichArtifactIds(content)</span>
+<span class="add">+ renderArtifactCards(artifactIds)</span>
+
+<span class="note">web/src/lib/richArtifactReferences.ts</span>
+<span class="add">+ strip standalone visual-artifact markers</span>
+<span class="add">+ ignore markers inside fenced code blocks</span></pre>
+
+        <h2>Copy reviewer prompt</h2>
+        <textarea id="prompt">Review the rich artifact chat rendering. Focus on sandbox trust boundaries, marker parsing, whitespace preservation, and whether a sales engineer can explain the buyer value from the artifact card alone.</textarea>
+        <button id="copy" type="button">Copy reviewer prompt</button>
+      </section>
+    </div>
+  </main>
+  <script>
+    const copy = document.getElementById("copy");
+    copy.addEventListener("click", async () => {
+      await navigator.clipboard.writeText(document.getElementById("prompt").value);
+      copy.textContent = "Copied";
+      window.setTimeout(() => { copy.textContent = "Copy reviewer prompt"; }, 1200);
+    });
+  </script>
+</body>
+</html>

--- a/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/artifact.html
@@ -84,7 +84,7 @@
 <span class="add">+ ignore markers inside fenced code blocks</span></pre>
 
         <h2>Copy reviewer prompt</h2>
-        <textarea id="prompt">Review the rich artifact chat rendering. Focus on sandbox trust boundaries, marker parsing, whitespace preservation, and whether a sales engineer can explain the buyer value from the artifact card alone.</textarea>
+        <textarea id="prompt" aria-label="Copy reviewer prompt">Review the rich artifact chat rendering. Focus on sandbox trust boundaries, marker parsing, whitespace preservation, and whether a sales engineer can explain the buyer value from the artifact card alone.</textarea>
         <button id="copy" type="button">Copy reviewer prompt</button>
       </section>
     </div>

--- a/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/chat.txt
+++ b/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/chat.txt
@@ -1,0 +1,5 @@
+I built the reviewer brief as an HTML artifact so engineering and sales can inspect the diff focus, buyer risk, and review prompt side by side.
+
+visual-artifact:ra_aaaaaaaaaaaaaaaa
+
+Use this in chat for the review handoff, then promote the summary if the pattern becomes reusable.

--- a/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/source.md
+++ b/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/source.md
@@ -1,0 +1,10 @@
+# Sales engineering review notebook
+
+The field team needs a reviewer brief for a technical change before sharing it with a design partner. A markdown-only diff summary is too flat because reviewers need:
+
+- A short buyer-facing reason the change matters.
+- The code path that changed.
+- Risks that could affect an enterprise proof of concept.
+- A copyable prompt for a focused engineering review.
+
+The artifact should make the diff and reviewer asks scannable in one pass.

--- a/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/wiki.md
+++ b/docs/tutorials/rich-html-artifacts/fixtures/sales-review-brief/wiki.md
@@ -1,0 +1,10 @@
+# Sales Engineering Review Brief
+
+Use this artifact when a technical change needs to be reviewed through both engineering and buyer-risk lenses before customer discussion.
+
+The visual view includes:
+
+- Buyer outcome summary.
+- Annotated diff focus.
+- Severity-coded review asks.
+- A copyable reviewer prompt.

--- a/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/artifact.html
@@ -33,13 +33,12 @@
     .event { border-left: 3px solid #245b4f; padding: 0 0 16px 14px; }
     .event strong { display: block; margin-bottom: 4px; }
     .impact { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
-    .impact div, .owner { background: #f8fafc; border: 1px solid #e4e9f0; border-radius: 7px; padding: 12px; }
-    .owners { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+    .impact div { background: #f8fafc; border: 1px solid #e4e9f0; border-radius: 7px; padding: 12px; }
     textarea { width: 100%; min-height: 136px; resize: vertical; border: 1px solid #cbd5e1; border-radius: 8px; padding: 12px; font: inherit; line-height: 1.5; }
     svg { width: 100%; height: auto; display: block; }
     @media (max-width: 800px) {
       main { padding: 18px; }
-      header, .status, .impact, .owners { display: grid; grid-template-columns: 1fr; }
+      header, .status, .impact { display: grid; grid-template-columns: 1fr; }
       .timeline { grid-template-columns: 1fr; }
       .event { border-left: 0; border-top: 3px solid #245b4f; padding: 10px 0 14px; }
     }

--- a/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/artifact.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Support Incident Command Room</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f5f7f9;
+      color: #17212f;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; }
+    main { max-width: 1100px; margin: 0 auto; padding: 28px; }
+    header { display: flex; align-items: flex-end; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+    h1 { margin: 0 0 8px; font-size: 30px; letter-spacing: 0; }
+    p { margin: 0; color: #5b6575; line-height: 1.5; }
+    .status { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; margin-bottom: 16px; }
+    .metric { background: #ffffff; border: 1px solid #dfe5ed; border-radius: 8px; padding: 14px; }
+    .metric span { color: #647084; font-size: 12px; text-transform: uppercase; letter-spacing: .04em; }
+    .metric strong { display: block; margin-top: 6px; font-size: 22px; }
+    .tabs { display: flex; flex-wrap: wrap; gap: 8px; margin: 0 0 14px; }
+    button { border: 1px solid #ccd5e0; background: #ffffff; color: #17212f; border-radius: 6px; min-height: 36px; padding: 8px 12px; font-weight: 700; cursor: pointer; }
+    button[aria-selected="true"], #copy { background: #245b4f; border-color: #245b4f; color: #ffffff; }
+    section { background: #ffffff; border: 1px solid #dfe5ed; border-radius: 8px; padding: 18px; }
+    h2 { margin: 0 0 14px; font-size: 18px; }
+    .panel { display: none; }
+    .panel.active { display: grid; gap: 14px; }
+    .timeline { display: grid; grid-template-columns: 96px 1fr; gap: 12px; }
+    .time { color: #647084; font-weight: 700; }
+    .event { border-left: 3px solid #245b4f; padding: 0 0 16px 14px; }
+    .event strong { display: block; margin-bottom: 4px; }
+    .impact { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+    .impact div, .owner { background: #f8fafc; border: 1px solid #e4e9f0; border-radius: 7px; padding: 12px; }
+    .owners { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+    textarea { width: 100%; min-height: 136px; resize: vertical; border: 1px solid #cbd5e1; border-radius: 8px; padding: 12px; font: inherit; line-height: 1.5; }
+    svg { width: 100%; height: auto; display: block; }
+    @media (max-width: 800px) {
+      main { padding: 18px; }
+      header, .status, .impact, .owners { display: grid; grid-template-columns: 1fr; }
+      .timeline { grid-template-columns: 1fr; }
+      .event { border-left: 0; border-top: 3px solid #245b4f; padding: 10px 0 14px; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div>
+        <h1>Incident Command Room</h1>
+        <p>A single visual packet for impact, recovery timeline, owners, and the next customer-facing update.</p>
+      </div>
+    </header>
+
+    <div class="status">
+      <div class="metric"><span>State</span><strong>Mitigated</strong></div>
+      <div class="metric"><span>Customers</span><strong>14</strong></div>
+      <div class="metric"><span>Open owners</span><strong>3</strong></div>
+      <div class="metric"><span>Next update</span><strong>30m</strong></div>
+    </div>
+
+    <div class="tabs" role="tablist" aria-label="Incident views">
+      <button type="button" role="tab" aria-selected="true" data-view="impact">Customer impact</button>
+      <button type="button" role="tab" aria-selected="false" data-view="timeline">Timeline</button>
+      <button type="button" role="tab" aria-selected="false" data-view="update">Copy update</button>
+    </div>
+
+    <section>
+      <div id="impact" class="panel active">
+        <h2>Customer impact</h2>
+        <div class="impact">
+          <div><strong>Enterprise</strong><p>Seven accounts saw delayed sync status for 19 minutes.</p></div>
+          <div><strong>Growth</strong><p>Five accounts retried import jobs successfully after mitigation.</p></div>
+          <div><strong>Internal</strong><p>Support triage queue held two manual follow-ups.</p></div>
+        </div>
+        <svg viewBox="0 0 720 150" role="img" aria-label="Impact by segment">
+          <rect x="30" y="28" width="210" height="34" rx="4" fill="#245b4f"></rect>
+          <rect x="30" y="78" width="150" height="34" rx="4" fill="#3b82a0"></rect>
+          <rect x="30" y="122" width="60" height="18" rx="4" fill="#b87932"></rect>
+          <text x="256" y="51" fill="#17212f" font-size="16">Enterprise: 7 affected</text>
+          <text x="196" y="101" fill="#17212f" font-size="16">Growth: 5 affected</text>
+          <text x="104" y="137" fill="#17212f" font-size="14">Internal: 2 follow-ups</text>
+        </svg>
+      </div>
+
+      <div id="timeline" class="panel">
+        <h2>Timeline</h2>
+        <div class="timeline">
+          <div class="time">09:12</div><div class="event"><strong>Detection</strong><p>Support saw repeated import sync questions in the inbox.</p></div>
+          <div class="time">09:19</div><div class="event"><strong>Mitigation</strong><p>Engineering disabled the stale cache path and forced refresh.</p></div>
+          <div class="time">09:31</div><div class="event"><strong>Recovery</strong><p>Retry jobs completed and customer statuses normalized.</p></div>
+        </div>
+      </div>
+
+      <div id="update" class="panel">
+        <h2>Copy update</h2>
+        <textarea id="message">We mitigated the sync delay at 09:19 PT and all retry jobs completed by 09:31 PT. We are reviewing cache invalidation coverage and will send a final postmortem after the owner review.</textarea>
+        <button id="copy" type="button">Copy update</button>
+      </div>
+    </section>
+  </main>
+  <script>
+    const tabs = Array.from(document.querySelectorAll("[data-view]"));
+    const panels = Array.from(document.querySelectorAll(".panel"));
+    for (const tab of tabs) {
+      tab.addEventListener("click", () => {
+        const target = tab.getAttribute("data-view");
+        for (const next of tabs) next.setAttribute("aria-selected", String(next === tab));
+        for (const panel of panels) panel.classList.toggle("active", panel.id === target);
+      });
+    }
+    const copy = document.getElementById("copy");
+    copy.addEventListener("click", async () => {
+      await navigator.clipboard.writeText(document.getElementById("message").value);
+      copy.textContent = "Copied";
+      window.setTimeout(() => { copy.textContent = "Copy update"; }, 1200);
+    });
+  </script>
+</body>
+</html>

--- a/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/artifact.html
+++ b/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/artifact.html
@@ -62,13 +62,13 @@
     </div>
 
     <div class="tabs" role="tablist" aria-label="Incident views">
-      <button type="button" role="tab" aria-selected="true" data-view="impact">Customer impact</button>
-      <button type="button" role="tab" aria-selected="false" data-view="timeline">Timeline</button>
-      <button type="button" role="tab" aria-selected="false" data-view="update">Copy update</button>
+      <button id="tab-impact" type="button" role="tab" aria-selected="true" aria-controls="impact" data-view="impact">Customer impact</button>
+      <button id="tab-timeline" type="button" role="tab" aria-selected="false" aria-controls="timeline" data-view="timeline">Timeline</button>
+      <button id="tab-update" type="button" role="tab" aria-selected="false" aria-controls="update" data-view="update">Copy update</button>
     </div>
 
     <section>
-      <div id="impact" class="panel active">
+      <div id="impact" class="panel active" role="tabpanel" aria-labelledby="tab-impact">
         <h2>Customer impact</h2>
         <div class="impact">
           <div><strong>Enterprise</strong><p>Seven accounts saw delayed sync status for 19 minutes.</p></div>
@@ -85,7 +85,7 @@
         </svg>
       </div>
 
-      <div id="timeline" class="panel">
+      <div id="timeline" class="panel" role="tabpanel" aria-labelledby="tab-timeline" hidden>
         <h2>Timeline</h2>
         <div class="timeline">
           <div class="time">09:12</div><div class="event"><strong>Detection</strong><p>Support saw repeated import sync questions in the inbox.</p></div>
@@ -94,7 +94,7 @@
         </div>
       </div>
 
-      <div id="update" class="panel">
+      <div id="update" class="panel" role="tabpanel" aria-labelledby="tab-update" hidden>
         <h2>Copy update</h2>
         <textarea id="message">We mitigated the sync delay at 09:19 PT and all retry jobs completed by 09:31 PT. We are reviewing cache invalidation coverage and will send a final postmortem after the owner review.</textarea>
         <button id="copy" type="button">Copy update</button>
@@ -108,13 +108,21 @@
       tab.addEventListener("click", () => {
         const target = tab.getAttribute("data-view");
         for (const next of tabs) next.setAttribute("aria-selected", String(next === tab));
-        for (const panel of panels) panel.classList.toggle("active", panel.id === target);
+        for (const panel of panels) {
+          const selected = panel.id === target;
+          panel.classList.toggle("active", selected);
+          panel.hidden = !selected;
+        }
       });
     }
     const copy = document.getElementById("copy");
     copy.addEventListener("click", async () => {
-      await navigator.clipboard.writeText(document.getElementById("message").value);
-      copy.textContent = "Copied";
+      try {
+        await navigator.clipboard.writeText(document.getElementById("message").value);
+        copy.textContent = "Copied";
+      } catch {
+        copy.textContent = "Clipboard unavailable";
+      }
       window.setTimeout(() => { copy.textContent = "Copy update"; }, 1200);
     });
   </script>

--- a/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/chat.txt
+++ b/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/chat.txt
@@ -1,0 +1,5 @@
+I turned the incident notes into an HTML command-room artifact with impact, timeline, owners, and a copyable customer update.
+
+visual-artifact:ra_fedcba9876543210
+
+Use the artifact for the customer update, then promote the summary to the incident playbook once the postmortem is complete.

--- a/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/source.md
+++ b/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/source.md
@@ -1,0 +1,5 @@
+# Support incident command notebook
+
+A customer impact report is hard to read as a wall of markdown because readers need timeline, blast radius, status, and ownership at once.
+
+The agent should produce an HTML command-room artifact that lets the support lead move between customer impact, engineering timeline, and next actions. The final artifact should export a concise customer update that can be pasted into the unified inbox or back into chat.

--- a/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/wiki.md
+++ b/docs/tutorials/rich-html-artifacts/fixtures/support-incident-room/wiki.md
@@ -1,0 +1,10 @@
+# Support Incident Command Room
+
+Use this artifact for customer-facing incidents where leadership needs a readable status packet and support needs a copyable customer update.
+
+The visual view contains:
+
+- Customer impact by segment.
+- A timeline that separates detection, mitigation, and recovery.
+- Owner assignments for follow-up.
+- A copyable update for the next customer message.

--- a/docs/tutorials/rich-html-artifacts/scenarios.json
+++ b/docs/tutorials/rich-html-artifacts/scenarios.json
@@ -1,5 +1,13 @@
 {
   "version": 1,
+  "fieldPurpose": {
+    "sourceMarkdownPath": "Intended notebook path where the agent would write the source note.",
+    "targetWikiPath": "Intended wiki path where the promoted article should live.",
+    "sourcePath": "Local fixture file path for the source notebook note.",
+    "wikiPath": "Local fixture file path for the promoted wiki markdown.",
+    "htmlPath": "Local fixture file path for the HTML artifact.",
+    "chatPath": "Local fixture file path for the chat handoff message."
+  },
   "scenarios": [
     {
       "slug": "revops-launch-risk",
@@ -49,11 +57,7 @@
       "wikiPath": "fixtures/sales-review-brief/wiki.md",
       "chatPath": "fixtures/sales-review-brief/chat.txt",
       "expectedChatArtifactId": "ra_aaaaaaaaaaaaaaaa",
-      "expectedTerms": [
-        "Reviewer Brief",
-        "Diff focus",
-        "Copy reviewer prompt"
-      ]
+      "expectedTerms": ["Reviewer Brief", "Diff focus", "Copy reviewer prompt"]
     }
   ]
 }

--- a/docs/tutorials/rich-html-artifacts/scenarios.json
+++ b/docs/tutorials/rich-html-artifacts/scenarios.json
@@ -1,0 +1,59 @@
+{
+  "version": 1,
+  "scenarios": [
+    {
+      "slug": "revops-launch-risk",
+      "title": "RevOps Launch Risk Room",
+      "summary": "Interactive launch risk room for comparing blockers, owner load, and mitigation tradeoffs.",
+      "actorSlug": "revops-agent",
+      "sourceMarkdownPath": "agents/revops-agent/notebook/revops-launch-risk.md",
+      "targetWikiPath": "team/playbooks/revops-launch-risk-room.md",
+      "htmlPath": "fixtures/revops-launch-risk/artifact.html",
+      "sourcePath": "fixtures/revops-launch-risk/source.md",
+      "wikiPath": "fixtures/revops-launch-risk/wiki.md",
+      "chatPath": "fixtures/revops-launch-risk/chat.txt",
+      "expectedChatArtifactId": "ra_0123456789abcdef",
+      "expectedTerms": [
+        "Launch Risk Room",
+        "Owner load",
+        "Copy mitigation prompt"
+      ]
+    },
+    {
+      "slug": "support-incident-room",
+      "title": "Support Incident Command Room",
+      "summary": "Interactive incident report for customer impact, timeline, owners, and next actions.",
+      "actorSlug": "support-agent",
+      "sourceMarkdownPath": "agents/support-agent/notebook/support-incident-room.md",
+      "targetWikiPath": "team/playbooks/support-incident-command-room.md",
+      "htmlPath": "fixtures/support-incident-room/artifact.html",
+      "sourcePath": "fixtures/support-incident-room/source.md",
+      "wikiPath": "fixtures/support-incident-room/wiki.md",
+      "chatPath": "fixtures/support-incident-room/chat.txt",
+      "expectedChatArtifactId": "ra_fedcba9876543210",
+      "expectedTerms": [
+        "Incident Command Room",
+        "Customer impact",
+        "Copy update"
+      ]
+    },
+    {
+      "slug": "sales-review-brief",
+      "title": "Sales Engineering Review Brief",
+      "summary": "Interactive reviewer brief with annotated diff, buyer-risk lens, and copyable review prompt.",
+      "actorSlug": "saleseng-agent",
+      "sourceMarkdownPath": "agents/saleseng-agent/notebook/sales-review-brief.md",
+      "targetWikiPath": "team/playbooks/sales-engineering-review-brief.md",
+      "htmlPath": "fixtures/sales-review-brief/artifact.html",
+      "sourcePath": "fixtures/sales-review-brief/source.md",
+      "wikiPath": "fixtures/sales-review-brief/wiki.md",
+      "chatPath": "fixtures/sales-review-brief/chat.txt",
+      "expectedChatArtifactId": "ra_aaaaaaaaaaaaaaaa",
+      "expectedTerms": [
+        "Reviewer Brief",
+        "Diff focus",
+        "Copy reviewer prompt"
+      ]
+    }
+  ]
+}

--- a/internal/team/rich_artifact_tutorial_fixtures_test.go
+++ b/internal/team/rich_artifact_tutorial_fixtures_test.go
@@ -1,0 +1,178 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type richArtifactTutorialManifest struct {
+	Version   int                            `json:"version"`
+	Scenarios []richArtifactTutorialScenario `json:"scenarios"`
+}
+
+type richArtifactTutorialScenario struct {
+	Slug                   string   `json:"slug"`
+	Title                  string   `json:"title"`
+	Summary                string   `json:"summary"`
+	ActorSlug              string   `json:"actorSlug"`
+	SourceMarkdownPath     string   `json:"sourceMarkdownPath"`
+	TargetWikiPath         string   `json:"targetWikiPath"`
+	HTMLPath               string   `json:"htmlPath"`
+	SourcePath             string   `json:"sourcePath"`
+	WikiPath               string   `json:"wikiPath"`
+	ChatPath               string   `json:"chatPath"`
+	ExpectedChatArtifactID string   `json:"expectedChatArtifactId"`
+	ExpectedTerms          []string `json:"expectedTerms"`
+}
+
+func TestRichArtifactTutorialFixturesExerciseWikiFlow(t *testing.T) {
+	repoRoot := findTutorialRepoRoot(t)
+	manifest := readRichArtifactTutorialManifest(t, repoRoot)
+	if manifest.Version != 1 {
+		t.Fatalf("manifest version = %d, want 1", manifest.Version)
+	}
+	if len(manifest.Scenarios) < 2 {
+		t.Fatalf("expected at least 2 tutorial scenarios, got %d", len(manifest.Scenarios))
+	}
+
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+
+	baseTime := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	for i, scenario := range manifest.Scenarios {
+		scenario := scenario
+		now := baseTime.Add(time.Duration(i) * time.Minute)
+		t.Run(scenario.Slug, func(t *testing.T) {
+			source := readRichArtifactTutorialFile(t, repoRoot, scenario.SourcePath)
+			wiki := readRichArtifactTutorialFile(t, repoRoot, scenario.WikiPath)
+			html := readRichArtifactTutorialFile(t, repoRoot, scenario.HTMLPath)
+
+			if !strings.Contains(html, "<script>") {
+				t.Fatalf("%s: expected interactive HTML with a script tag", scenario.Slug)
+			}
+			for _, term := range scenario.ExpectedTerms {
+				if !strings.Contains(html, term) {
+					t.Fatalf("%s: html missing expected term %q", scenario.Slug, term)
+				}
+			}
+
+			if _, _, err := repo.CommitNotebook(ctx, scenario.ActorSlug, scenario.SourceMarkdownPath, source, "create", "tutorial: capture source "+scenario.Slug); err != nil {
+				t.Fatalf("commit notebook source: %v", err)
+			}
+
+			artifact, sanitizedHTML, err := newRichArtifact(RichArtifactCreateRequest{
+				Slug:               scenario.ActorSlug,
+				Title:              scenario.Title,
+				Summary:            scenario.Summary,
+				HTML:               html,
+				SourceMarkdownPath: scenario.SourceMarkdownPath,
+				RelatedTaskID:      "tutorial-" + scenario.Slug,
+				RelatedReceiptIDs:  []string{"receipt-" + scenario.Slug},
+			}, now)
+			if err != nil {
+				t.Fatalf("new rich artifact: %v", err)
+			}
+			if sanitizedHTML != html {
+				t.Fatal("newRichArtifact changed fixture HTML")
+			}
+
+			if _, bytesWritten, err := repo.CommitRichArtifact(ctx, scenario.ActorSlug, artifact, sanitizedHTML, "artifact: create tutorial "+scenario.Slug); err != nil {
+				t.Fatalf("commit rich artifact: %v", err)
+			} else if bytesWritten == 0 {
+				t.Fatal("expected artifact bytes to be written")
+			}
+
+			promoted, _, _, err := repo.PromoteRichArtifact(ctx, scenario.ActorSlug, artifact.ID, scenario.TargetWikiPath, wiki, "create", "wiki: promote tutorial "+scenario.Slug, now.Add(30*time.Second))
+			if err != nil {
+				t.Fatalf("promote rich artifact: %v", err)
+			}
+			if promoted.Kind != richArtifactKindWikiVisual {
+				t.Fatalf("promoted kind = %q, want %q", promoted.Kind, richArtifactKindWikiVisual)
+			}
+			if promoted.TrustLevel != richArtifactTrustPromoted {
+				t.Fatalf("promoted trust = %q, want %q", promoted.TrustLevel, richArtifactTrustPromoted)
+			}
+			if promoted.PromotedWikiPath != scenario.TargetWikiPath {
+				t.Fatalf("promoted path = %q, want %q", promoted.PromotedWikiPath, scenario.TargetWikiPath)
+			}
+
+			got, gotHTML, err := repo.RichArtifact(artifact.ID)
+			if err != nil {
+				t.Fatalf("read rich artifact: %v", err)
+			}
+			if got.ID != promoted.ID || got.SourceMarkdownPath != scenario.SourceMarkdownPath {
+				t.Fatalf("read artifact provenance = (%q, %q), want (%q, %q)", got.ID, got.SourceMarkdownPath, promoted.ID, scenario.SourceMarkdownPath)
+			}
+			if gotHTML != html {
+				t.Fatal("persisted HTML did not round trip")
+			}
+
+			wikiOnDisk, err := os.ReadFile(filepath.Join(repo.Root(), filepath.FromSlash(scenario.TargetWikiPath)))
+			if err != nil {
+				t.Fatalf("read promoted wiki article: %v", err)
+			}
+			wikiText := string(wikiOnDisk)
+			for _, want := range []string{"Visual Artifact Provenance", artifact.ID, artifact.HTMLPath, scenario.SourceMarkdownPath} {
+				if !strings.Contains(wikiText, want) {
+					t.Fatalf("promoted wiki article missing %q", want)
+				}
+			}
+
+			listed, err := repo.ListRichArtifacts(RichArtifactFilter{SourceMarkdownPath: scenario.SourceMarkdownPath})
+			if err != nil {
+				t.Fatalf("list rich artifacts: %v", err)
+			}
+			if len(listed) != 1 || listed[0].ID != artifact.ID {
+				t.Fatalf("listed artifacts = %+v, want only %s", listed, artifact.ID)
+			}
+		})
+	}
+}
+
+func readRichArtifactTutorialManifest(t *testing.T, repoRoot string) richArtifactTutorialManifest {
+	t.Helper()
+	raw := readRichArtifactTutorialFile(t, repoRoot, "scenarios.json")
+	var manifest richArtifactTutorialManifest
+	if err := json.Unmarshal([]byte(raw), &manifest); err != nil {
+		t.Fatalf("decode tutorial manifest: %v", err)
+	}
+	return manifest
+}
+
+func readRichArtifactTutorialFile(t *testing.T, repoRoot, relPath string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot, "docs", "tutorials", "rich-html-artifacts", filepath.FromSlash(relPath)))
+	if err != nil {
+		t.Fatalf("read tutorial fixture %s: %v", relPath, err)
+	}
+	if strings.TrimSpace(string(raw)) == "" {
+		t.Fatalf("tutorial fixture %s is empty", relPath)
+	}
+	return string(raw)
+}
+
+func findTutorialRepoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root with go.mod")
+		}
+		dir = parent
+	}
+}

--- a/internal/team/rich_artifact_tutorial_fixtures_test.go
+++ b/internal/team/rich_artifact_tutorial_fixtures_test.go
@@ -36,8 +36,8 @@ func TestRichArtifactTutorialFixturesExerciseWikiFlow(t *testing.T) {
 	if manifest.Version != 1 {
 		t.Fatalf("manifest version = %d, want 1", manifest.Version)
 	}
-	if len(manifest.Scenarios) < 2 {
-		t.Fatalf("expected at least 2 tutorial scenarios, got %d", len(manifest.Scenarios))
+	if len(manifest.Scenarios) < 3 {
+		t.Fatalf("expected at least 3 tutorial scenarios, got %d", len(manifest.Scenarios))
 	}
 
 	repo := newTestRepo(t)

--- a/web/src/lib/richArtifactTutorialFixtures.test.ts
+++ b/web/src/lib/richArtifactTutorialFixtures.test.ts
@@ -47,10 +47,14 @@ const manifest = JSON.parse(
   readTutorialFile("scenarios.json"),
 ) as TutorialManifest;
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 describe("rich artifact tutorial fixtures", () => {
   it("ships multiple ICP scenarios", () => {
     expect(manifest.version).toBe(1);
-    expect(manifest.scenarios.length).toBeGreaterThanOrEqual(2);
+    expect(manifest.scenarios.length).toBeGreaterThanOrEqual(3);
   });
 
   for (const scenario of manifest.scenarios) {
@@ -62,7 +66,7 @@ describe("rich artifact tutorial fixtures", () => {
       ]);
       expect(chat).toMatch(
         new RegExp(
-          `^\\s*visual-artifact:${scenario.expectedChatArtifactId}\\s*$`,
+          `^\\s*visual-artifact:${escapeRegExp(scenario.expectedChatArtifactId)}\\s*$`,
           "m",
         ),
       );

--- a/web/src/lib/richArtifactTutorialFixtures.test.ts
+++ b/web/src/lib/richArtifactTutorialFixtures.test.ts
@@ -1,0 +1,86 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+
+import {
+  extractRichArtifactIds,
+  stripStandaloneRichArtifactReferenceLines,
+} from "./richArtifactReferences";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface TutorialManifest {
+  version: number;
+  scenarios: TutorialScenario[];
+}
+
+interface TutorialScenario {
+  slug: string;
+  title: string;
+  summary: string;
+  actorSlug: string;
+  sourceMarkdownPath: string;
+  targetWikiPath: string;
+  htmlPath: string;
+  sourcePath: string;
+  wikiPath: string;
+  chatPath: string;
+  expectedChatArtifactId: string;
+  expectedTerms: string[];
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const TUTORIAL_ROOT = path.join(
+  REPO_ROOT,
+  "docs",
+  "tutorials",
+  "rich-html-artifacts",
+);
+
+function readTutorialFile(relPath: string): string {
+  return readFileSync(path.join(TUTORIAL_ROOT, relPath), "utf8");
+}
+
+const manifest = JSON.parse(
+  readTutorialFile("scenarios.json"),
+) as TutorialManifest;
+
+describe("rich artifact tutorial fixtures", () => {
+  it("ships multiple ICP scenarios", () => {
+    expect(manifest.version).toBe(1);
+    expect(manifest.scenarios.length).toBeGreaterThanOrEqual(2);
+  });
+
+  for (const scenario of manifest.scenarios) {
+    it(`${scenario.slug}: chat marker renders as a rich artifact reference`, () => {
+      const chat = readTutorialFile(scenario.chatPath);
+
+      expect(extractRichArtifactIds(chat)).toEqual([
+        scenario.expectedChatArtifactId,
+      ]);
+      expect(chat).toMatch(
+        new RegExp(
+          `^\\s*visual-artifact:${scenario.expectedChatArtifactId}\\s*$`,
+          "m",
+        ),
+      );
+
+      const stripped = stripStandaloneRichArtifactReferenceLines(chat);
+      expect(stripped).not.toContain(scenario.expectedChatArtifactId);
+      expect(extractRichArtifactIds(stripped)).toEqual([]);
+      expect(stripped).toContain("HTML");
+    });
+
+    it(`${scenario.slug}: HTML artifact is interactive and keeps expected review cues`, () => {
+      const html = readTutorialFile(scenario.htmlPath);
+
+      expect(html).toContain("<script>");
+      expect(html).toContain("addEventListener");
+      for (const term of scenario.expectedTerms) {
+        expect(html).toContain(term);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add rich HTML artifact tutorial fixtures for RevOps launch risk, support incident command, and sales engineering review scenarios
- validate the fixtures through the wiki rich artifact create/promote flow
- validate the same chat handoff fixtures through the rich artifact reference parser

## Stack
- Stacked on #873 / `codex/rich-agent-artifact-phase-2`. Retarget to `main` after #873 merges.

## Validation
- `go test -race ./internal/team -run TestRichArtifactTutorialFixturesExerciseWikiFlow -count=1`
- `bash scripts/test-web.sh web/src/lib/richArtifactTutorialFixtures.test.ts web/src/lib/richArtifactReferences.test.ts`
- `bunx tsc --noEmit`
- `bunx biome check src/lib/richArtifactTutorialFixtures.test.ts`
- `bash scripts/test-go.sh ./internal/team`
- `git diff --check`

Screenshots skipped: docs/test fixture change only; no app UI delta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Rich HTML Artifacts tutorial with three interactive scenarios (RevOps Launch Risk, Support Incident Command Room, Sales Review Brief), example fixtures (markdown, HTML, wiki, chat), guidance on markdown vs HTML split, expected outputs, and validation/run instructions. Interactive artifacts include sliders, risk dial, tabs, reviewer/mitigation prompts, and copy-to-clipboard controls.

* **Tests**
  * Added end-to-end and frontend validation tests that exercise the tutorial scenarios, verify HTML interactivity and copy/prompt behaviors, and confirm promotion/workflow outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->