### PR TITLE
fix(inbox): wire Phase 2 inbox routes into broker mux

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -511,6 +511,16 @@ func (b *Broker) StartOnPort(port int) error {
 	// /tasks/memory-workflow exact paths win for their literals.
 	mux.HandleFunc("/tasks/inbox", b.requireAuth(b.handleTasksInbox))
 	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
+	// Phase 2 unified inbox: fan-out merge across tasks + requests +
+	// reviews. Additive — the legacy /tasks/inbox stays in place so
+	// the existing frontend keeps working through the transition.
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	mux.HandleFunc("/inbox/cursor", b.requireAuth(b.handleInboxCursor))
+	// Phase 3 agent-thread inbox: per-agent thread grouping +
+	// chat-style detail (messages interleaved with action cards).
+	// /inbox/threads composes on top of /inbox/items.
+	mux.HandleFunc("/inbox/threads", b.requireAuth(b.handleInboxThreads))
+	mux.HandleFunc("/inbox/threads/", b.requireAuth(b.handleInboxThreadDetail))
 	mux.HandleFunc("/session-mode", b.requireAuth(b.handleSessionMode))
 	mux.HandleFunc("/focus-mode", b.requireAuth(b.handleFocusMode))
 	mux.HandleFunc("/messages", b.requireAuth(b.handleMessages))


### PR DESCRIPTION
## Summary

#802 shipped four new handlers (handleInboxItems, handleInboxCursor, handleInboxThreads, handleInboxThreadDetail) but the four \`mux.HandleFunc\` registrations dropped during the rebase squash.

Result: the new Gmail two-pane Inbox UI on main calls \`GET /inbox/items?filter=all\`, hits the broker mux catch-all 404, and silently renders empty. The entire Phase 2 backend is currently dead code in main.

## Repro

\`\`\`bash
WUPHF_RUNTIME_HOME=~/.wuphf-test/.wuphf wuphf --broker-port 7899 --web-port 7900 --no-open &
curl -s -o /dev/null -w \"%{http_code}\\n\" 'http://localhost:7899/inbox/items?filter=all'
# → 404
\`\`\`

## Fix

Add the four \`HandleFunc\` lines next to \`/tasks/inbox\` in \`broker.go\`. No new logic — only registration.

## Test plan
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test -count=1 -timeout 120s ./internal/team/\` green
- [ ] CI green
- [ ] Manual: \`curl /inbox/items?filter=all\` returns 200 after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified inbox endpoints providing consolidated access to tasks, requests, and reviews.
  * Enabled thread-based organization and grouping for improved message management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->