### PR TITLE
fix(web): restore conversation-shell layout CSS lost in inbox refactor

### DIFF
--- a/web/e2e/screenshots/conversation-scroll-fix.mjs
+++ b/web/e2e/screenshots/conversation-scroll-fix.mjs
@@ -1,0 +1,97 @@
+// Capture the conversation view with a long message list to verify the
+// scrolling fix. Without the .conversation-shell / .conversation-chat
+// CSS, the message feed overflows below the viewport, the composer is
+// pushed off-screen, and ChannelParticipants stacks below the composer.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh conversation-scroll-fix <pr-number>
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+import process from "node:process";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const MEMBERS = [
+  { slug: "ceo", name: "CEO", role: "Lead agent", online: true },
+  { slug: "builder", name: "Builder", role: "Engineering", online: true },
+  { slug: "design", name: "Designer", role: "Product design", online: false },
+  { slug: "research", name: "Researcher", role: "Research", online: false },
+  { slug: "human", name: "Human", role: "Viewer" },
+];
+
+const messages = Array.from({ length: 30 }, (_, i) => ({
+  id: `msg-${i + 1}`,
+  from: i % 3 === 0 ? "ceo" : i % 3 === 1 ? "builder" : "design",
+  channel: "general",
+  content: `Message ${i + 1}: lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`,
+  timestamp: `2026-05-${String((i % 28) + 1).padStart(2, "0")}T12:00:00Z`,
+}));
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 900 },
+});
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/channels", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          channels: [
+            {
+              slug: "general",
+              name: "general",
+              description: "Team discussion",
+              members: ["human", "ceo", "builder", "design"],
+            },
+          ],
+        }),
+      }),
+    );
+    await ctx.route("**/api/office-members", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          members: MEMBERS,
+          meta: { humanHasPosted: true },
+        }),
+      }),
+    );
+    await ctx.route("**/api/members*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ members: MEMBERS }),
+      }),
+    );
+    await ctx.route("**/api/messages*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ messages }),
+      }),
+    );
+    await ctx.route("**/api/requests*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ requests: [] }),
+      }),
+    );
+  },
+});
+
+await bootShell(page, {
+  afterFlipSelector: ".conversation-shell",
+  settleMs: 700,
+});
+await shotPage(page, OUT, "01-conversation-scroll-fix");
+
+console.log(`captured conversation-scroll-fix screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -1274,6 +1274,19 @@ html[data-theme="nex"]
 }
 
 /* ─── Messages ─── */
+.conversation-shell {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  background: var(--bg);
+}
+.conversation-chat {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
 .messages {
   flex: 1;
   overflow-y: auto;
@@ -1281,6 +1294,246 @@ html[data-theme="nex"]
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+.channel-participants {
+  min-height: 0;
+  border-left: 1px solid var(--border);
+  background: var(--bg-card);
+  display: flex;
+  flex-direction: column;
+}
+.channel-participants-header {
+  min-height: 58px;
+  padding: 14px 16px 12px;
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.channel-participants-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+.channel-participants-subtitle {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.channel-participants-add {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+.channel-participants-add:hover,
+.channel-participants-add:focus-visible {
+  background: var(--bg-warm);
+  color: var(--text);
+}
+.channel-participants-add:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+.channel-participants-add-menu {
+  border-bottom: 1px solid var(--border-light);
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.channel-participants-list {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.channel-participant {
+  width: 100%;
+  min-height: 42px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  border-radius: 6px;
+}
+.channel-participant-main,
+.channel-participant-add-option {
+  min-width: 0;
+  min-height: 42px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) 8px;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 8px;
+  text-align: left;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+.channel-participant-add-option {
+  width: 100%;
+}
+.channel-participant-main:hover,
+.channel-participant-main:focus-visible,
+.channel-participant-add-option:hover,
+.channel-participant-add-option:focus-visible {
+  background: var(--bg-warm);
+  color: var(--text);
+}
+.channel-participant-main:focus-visible,
+.channel-participant-add-option:focus-visible,
+.channel-participant-toggle:focus-visible,
+.channel-participant-remove:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+.channel-participant.is-disabled {
+  opacity: 0.58;
+}
+.channel-participant-avatar {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.channel-participant-avatar .pixel-avatar {
+  width: 24px;
+  height: 24px;
+}
+.channel-participant-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.channel-participant-name,
+.channel-participant-role {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.channel-participant-name {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+}
+.channel-participant-role {
+  font-size: 11px;
+  color: var(--text-tertiary);
+}
+.channel-participant-presence {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--border-strong);
+}
+.channel-participant-presence.is-active {
+  background: var(--green);
+}
+.channel-participant-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding-right: 4px;
+}
+.channel-participant-toggle,
+.channel-participant-remove {
+  min-width: 58px;
+  height: 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text-tertiary);
+  padding: 0 8px;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  cursor: pointer;
+}
+.channel-participant-remove {
+  min-width: 24px;
+  width: 24px;
+  padding: 0;
+  overflow: hidden;
+  text-indent: 100%;
+  white-space: nowrap;
+  position: relative;
+}
+.channel-participant-remove::before {
+  content: "×";
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-indent: 0;
+  color: var(--text-tertiary);
+}
+.channel-participant-remove.is-pending {
+  min-width: 34px;
+  width: 34px;
+  text-indent: 0;
+}
+.channel-participant-remove.is-pending::before {
+  content: none;
+}
+.channel-participant-toggle:hover:not(:disabled),
+.channel-participant-remove:hover:not(:disabled) {
+  border-color: var(--border-dark);
+  color: var(--text);
+  background: var(--bg-warm);
+}
+.channel-participant-remove:hover:not(:disabled)::before {
+  color: var(--red);
+}
+.channel-participant-toggle:disabled,
+.channel-participant-remove:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.channel-participant-add-glyph {
+  font-size: 16px;
+  color: var(--text-tertiary);
+  text-align: center;
+}
+.channel-participants-empty {
+  padding: 14px 8px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+@media (max-width: 1100px) {
+  .conversation-shell {
+    grid-template-columns: minmax(0, 1fr) 224px;
+  }
+}
+
+@media (max-width: 860px) {
+  .conversation-shell {
+    display: flex;
+  }
+  .conversation-chat {
+    flex: 1;
+  }
+  .channel-participants {
+    display: none;
+  }
 }
 
 /* ─── App panels ─── */


### PR DESCRIPTION
## Summary

After PR #802 (unified Gmail two-pane Inbox) merged, the conversation surface could no longer scroll and the channel participants rail rendered *below* the composer ("random agents under the textbox").

**Root cause:** `e55d377` deleted ~250 lines of CSS from `web/src/styles/layout.css` — the `.conversation-shell` grid container, `.conversation-chat` flex column, and the `.channel-participants*` rail rules. But `web/src/routes/RootRoute.tsx` (`ConversationView`) and `web/src/components/messages/ChannelParticipants.tsx` still render those exact classes. With no CSS backing them:

- the grid collapsed, so the `<ChannelParticipants>` aside fell beneath the chat column instead of beside it
- `min-height: 0` on the flex children was gone, so the message feed grew to its content height, pushing the composer off-screen
- ancestor `overflow: hidden` then prevented page-level scrolling, so the user saw a stuck viewport with no way to reach the composer

## Fix

Restore the deleted rules verbatim from `e55d377^`:

- `.conversation-shell` — 1fr | 280px grid with `min-height: 0`
- `.conversation-chat` — flex column with `min-width: 0`, `min-height: 0`
- `.channel-participants` + `.channel-participant-*` visual rules
- `@media (max-width: 1100px)` narrows the rail to 224px
- `@media (max-width: 860px)` collapses to single column and hides the rail

Also adds `web/e2e/screenshots/conversation-scroll-fix.mjs` driving a 30-message feed so a future regression where the composer is pushed off-screen would be visually obvious.

## Test plan

- [x] `bash scripts/test-web.sh` — 1535 pass, 2 skipped
- [x] `bunx biome check web/src/styles/layout.css` — clean
- [x] Visual verification via screenshot harness — composer pinned at bottom, participant rail visible in its 280px column, message feed scrolls to message 30
- [ ] Reviewer: pull branch, `bun run dev`, open `/`, confirm chat scrolls and the right-hand participants rail is visible

## Screenshots

To reproduce the before/after locally:

```bash
# After (current branch) — feed scrolled to message 30, composer pinned, rail visible
bash web/e2e/screenshots/publish.sh --dry-run conversation-scroll-fix 881

# Before — checkout this branch, run `git revert <fix sha>` in a worktree, repeat
```

(Inline image embeds omitted: the remote-environment signing infra used by this session rejects commits made from orphan worktrees, so the standard `publish.sh` flow can't push the screenshot branch. A maintainer with a normal local checkout can run `publish.sh conversation-scroll-fix 881` to attach images to this PR.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated conversation layout styling with an enhanced channel participants panel, including responsive design adjustments for smaller viewports.

* **Tests**
  * Added end-to-end screenshot test to validate conversation scrolling functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/881?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->