### PR TITLE
test: prove natural rich artifact workflow

### DIFF
--- a/internal/scanner/scanner_entropy.go
+++ b/internal/scanner/scanner_entropy.go
@@ -148,7 +148,7 @@ func richArtifactPrefixOK(prefix string) bool {
 }
 
 func richArtifactSuffixOK(suffix string) bool {
-	return suffix == "" || suffix == ".html" || strings.HasPrefix(suffix, ".html#") || strings.HasPrefix(suffix, ".html?")
+	return suffix == "" || suffix == ".html"
 }
 
 func isHexRun(s string) bool {

--- a/internal/scanner/scanner_entropy.go
+++ b/internal/scanner/scanner_entropy.go
@@ -94,6 +94,9 @@ func entropyTokenize(s string) []string {
 // (e.g., English words, numeric-only IDs, hyphen-sentence fragments).
 // Real keys use a mix of letters + digits / base64 / hex.
 func isPlausibleSecretCharset(s string) bool {
+	if isWUPHFRichArtifactReferenceToken(s) {
+		return false
+	}
 	if isPathLikeToken(s) || strings.Contains(s, `\`) || isSchemeURI(s) {
 		return false
 	}
@@ -112,6 +115,53 @@ func isPlausibleSecretCharset(s string) bool {
 		}
 	}
 	return hasLetter && hasDigit
+}
+
+func isWUPHFRichArtifactReferenceToken(s string) bool {
+	token := strings.ToLower(strings.Trim(s, ".,\"'`:;!?()[]{}<>"))
+	for {
+		idx := strings.Index(token, "ra_")
+		if idx < 0 {
+			return false
+		}
+		if len(token) >= idx+19 && isHexRun(token[idx+3:idx+19]) {
+			before := token[:idx]
+			after := token[idx+19:]
+			if richArtifactPrefixOK(before) && richArtifactSuffixOK(after) {
+				return true
+			}
+		}
+		token = token[idx+3:]
+	}
+}
+
+func richArtifactPrefixOK(prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	return strings.HasSuffix(prefix, "visual-artifact:") ||
+		strings.HasSuffix(prefix, "visual_artifact:") ||
+		strings.HasSuffix(prefix, "rich-artifact:") ||
+		strings.HasSuffix(prefix, "rich_artifact:") ||
+		strings.HasSuffix(prefix, "notebook/visual-artifacts/") ||
+		strings.HasSuffix(prefix, "wiki/visual-artifacts/")
+}
+
+func richArtifactSuffixOK(suffix string) bool {
+	return suffix == "" || suffix == ".html" || strings.HasPrefix(suffix, ".html#") || strings.HasPrefix(suffix, ".html?")
+}
+
+func isHexRun(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r >= '0' && r <= '9' || r >= 'a' && r <= 'f' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func isPathLikeToken(s string) bool {

--- a/internal/scanner/scanner_entropy_test.go
+++ b/internal/scanner/scanner_entropy_test.go
@@ -103,6 +103,26 @@ func TestDetectEntropyHitsAllowsLeadingSlashCredentials(t *testing.T) {
 	}
 }
 
+func TestDetectEntropyHitsIgnoresWUPHFRichArtifactReferences(t *testing.T) {
+	body := strings.Join([]string{
+		"visual-artifact:ra_8e8ac69a85291409",
+		"Open wiki/visual-artifacts/ra_8e8ac69a85291409.html",
+		"Related notebook/visual-artifacts/ra_0123456789abcdef.html?tab=visual",
+		"Bare public id ra_fedcba9876543210 is safe to show in chat.",
+	}, "\n")
+	if hits := detectEntropyHits(body); len(hits) != 0 {
+		t.Fatalf("expected no entropy hits for public rich artifact IDs, got %+v", hits)
+	}
+
+	res := redactSecretsDetailed(body)
+	if res.Matches() != 0 {
+		t.Fatalf("expected no redaction for rich artifact references, got %+v", res)
+	}
+	if strings.Contains(res.Content, "[REDACTED]") {
+		t.Fatalf("artifact reference was redacted: %q", res.Content)
+	}
+}
+
 func TestRedactSecretsEntropyTopsUpBeyondPatterns(t *testing.T) {
 	// A random-looking assignment that doesn't match any known pattern.
 	// Use a high-entropy token: base64 of 40 random bytes.

--- a/internal/scanner/scanner_entropy_test.go
+++ b/internal/scanner/scanner_entropy_test.go
@@ -107,7 +107,7 @@ func TestDetectEntropyHitsIgnoresWUPHFRichArtifactReferences(t *testing.T) {
 	body := strings.Join([]string{
 		"visual-artifact:ra_8e8ac69a85291409",
 		"Open wiki/visual-artifacts/ra_8e8ac69a85291409.html",
-		"Related notebook/visual-artifacts/ra_0123456789abcdef.html?tab=visual",
+		"Related notebook/visual-artifacts/ra_0123456789abcdef.html",
 		"Bare public id ra_fedcba9876543210 is safe to show in chat.",
 	}, "\n")
 	if hits := detectEntropyHits(body); len(hits) != 0 {
@@ -120,6 +120,32 @@ func TestDetectEntropyHitsIgnoresWUPHFRichArtifactReferences(t *testing.T) {
 	}
 	if strings.Contains(res.Content, "[REDACTED]") {
 		t.Fatalf("artifact reference was redacted: %q", res.Content)
+	}
+}
+
+func TestDetectEntropyHitsDoesNotExemptRichArtifactReferencesWithQuerySecrets(t *testing.T) {
+	r := rand.New(rand.NewSource(99))
+	buf := make([]byte, 72)
+	for i := range buf {
+		buf[i] = byte(r.Intn(256))
+	}
+	tok := base64.RawStdEncoding.EncodeToString(buf)
+	body := "Open wiki/visual-artifacts/ra_8e8ac69a85291409.html?token=" + tok
+
+	hits := detectEntropyHits(body)
+	if len(hits) == 0 {
+		t.Fatalf("expected entropy hit for rich artifact URL query tail")
+	}
+	if !strings.Contains(hits[0].Token, tok) {
+		t.Fatalf("expected hit token to contain query secret %q, got %q", tok, hits[0].Token)
+	}
+
+	res := redactSecretsDetailed(body)
+	if res.EntropyHits == 0 {
+		t.Fatalf("expected entropy redaction for query secret, got %+v", res)
+	}
+	if strings.Contains(res.Content, tok) {
+		t.Fatalf("query secret was not redacted: %q", res.Content)
 	}
 }
 

--- a/internal/team/broker_messages_test.go
+++ b/internal/team/broker_messages_test.go
@@ -127,6 +127,52 @@ func TestPostMessageAllowsRichArtifactReferenceMarkers(t *testing.T) {
 	if posted.Content != content {
 		t.Fatalf("artifact marker changed:\nwant %q\ngot  %q", content, posted.Content)
 	}
+
+	for name, messages := range map[string][]channelMessage{
+		"Messages":        b.Messages(),
+		"ChannelMessages": b.ChannelMessages("general"),
+		"AllMessages":     b.AllMessages(),
+	} {
+		if len(messages) == 0 {
+			t.Fatalf("%s returned no messages", name)
+		}
+		last := messages[len(messages)-1]
+		if last.ID != posted.ID {
+			t.Fatalf("%s returned last message ID %q, want %q", name, last.ID, posted.ID)
+		}
+		if last.Redacted {
+			t.Fatalf("%s redacted artifact marker: %+v", name, last)
+		}
+		if last.Content != content {
+			t.Fatalf("%s changed artifact marker:\nwant %q\ngot  %q", name, content, last.Content)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/messages?channel=general&viewer_slug=human&limit=10", nil)
+	rec := httptest.NewRecorder()
+	b.handleGetMessages(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /messages status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		Messages []channelMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /messages: %v", err)
+	}
+	if len(body.Messages) == 0 {
+		t.Fatal("GET /messages returned no messages")
+	}
+	got := body.Messages[len(body.Messages)-1]
+	if got.ID != posted.ID {
+		t.Fatalf("GET /messages returned last message ID %q, want %q", got.ID, posted.ID)
+	}
+	if got.Redacted {
+		t.Fatalf("GET /messages redacted artifact marker: %+v", got)
+	}
+	if got.Content != content {
+		t.Fatalf("GET /messages changed artifact marker:\nwant %q\ngot  %q", content, got.Content)
+	}
 }
 
 func TestFormatChannelViewRedactsSecrets(t *testing.T) {

--- a/internal/team/broker_messages_test.go
+++ b/internal/team/broker_messages_test.go
@@ -113,6 +113,22 @@ func TestPostMessageRedactsSecretsBeforeStorageAndReads(t *testing.T) {
 	}
 }
 
+func TestPostMessageAllowsRichArtifactReferenceMarkers(t *testing.T) {
+	b := newTestBroker(t)
+	content := "I made the visual review.\n\nvisual-artifact:ra_8e8ac69a85291409"
+
+	posted, err := b.PostMessage("ceo", "general", content, nil, "")
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	if posted.Redacted {
+		t.Fatalf("artifact marker was redacted: %+v", posted)
+	}
+	if posted.Content != content {
+		t.Fatalf("artifact marker changed:\nwant %q\ngot  %q", content, posted.Content)
+	}
+}
+
 func TestFormatChannelViewRedactsSecrets(t *testing.T) {
 	secret := "sk-" + strings.Repeat("B", 24)
 	got := FormatChannelView([]channelMessage{{

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -1194,8 +1194,11 @@ func TestBuildPromptIncludesMarkdownNotebookPromotionGuidance(t *testing.T) {
 		prompt := l.buildPrompt(slug)
 		for _, want := range []string{
 			"notebook_write",
+			"notebook_visual_artifact_create",
 			"notebook_promote",
 			"wuphf_wiki_lookup",
+			"create a self-contained HTML companion",
+			"visual-artifact:ra_...",
 			"Do not bypass notebook_promote",
 		} {
 			if !strings.Contains(prompt, want) {

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -92,7 +92,9 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
 		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it\n\n")
 		sb.WriteString(secretHandlingPromptRule())
-		if noNex {
+		if markdownMemory {
+			sb.WriteString("Markdown notebook/wiki memory is active in this 1:1. Use notebook_write for durable source notes and create an HTML visual companion with notebook_visual_artifact_create when the work would be clearer as a diagram, mockup, report, comparison grid, code explainer, PR review, or interactive tuning surface. Keep the HTML self-contained and include visual-artifact:ra_... on its own line when you reference it in chat.\n\n")
+		} else if noNex {
 			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
 		} else {
 			sb.WriteString("Use the Nex context graph when it materially helps:\n")
@@ -238,7 +240,7 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString("- To suggest adding a new specialist agent, use team_member with a clear expertise and rationale\n")
 		sb.WriteString("- When integrations matter, make the required systems explicit in the skill instructions and agent rationale so the team knows which connected accounts or placeholders each workflow expects\n")
 		sb.WriteString("- When you create a new specialist for integration/onboarding work, include the owned integrations directly in that agent's expertise so the roster clearly shows who owns Gmail, Slack, YouTube, Drive, analytics, or similar lanes\n\n")
-		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use markdown tables/checklists for structured data.\n")
+		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use compact markdown for simple chat structure; for dense, visual, or interactive outputs, create a notebook HTML visual artifact instead of leaving the human with a long markdown wall.\n")
 		if markdownMemory {
 			sb.WriteString("Do not pretend the team wiki was updated; verify notebook_promote or team_wiki_write succeeded before claiming canonical storage.\n")
 		} else if noNex {
@@ -343,7 +345,7 @@ func (p *promptBuilder) Build(slug string) string {
 			sb.WriteString("12. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n")
 			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
 		}
-		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use markdown tables/checklists for structured data.\n")
+		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use compact markdown for simple chat structure; for dense, visual, or interactive outputs, create a notebook HTML visual artifact instead of leaving the human with a long markdown wall.\n")
 		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
 	}
 
@@ -359,6 +361,8 @@ func (p *promptBuilder) Build(slug string) string {
 
 func markdownKnowledgeToolBlock() string {
 	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
+		"- notebook_visual_artifact_create: After notebook_write, create a self-contained HTML companion when the work would be clearer as a rich visual artifact: complex specs, implementation plans, code explainers, PR reviews, comparison grids, diagrams, mockups, reports, or interactive tuning surfaces. Use inline CSS/JS only, no network fetches, and default to the WUPHF technical-manual style: old mathematics/physics book on real paper with Making Software cobalt figure ink. Include visual-artifact:ra_... on its own line in your chat summary so the UI renders an artifact card.\n" +
+		"- notebook_visual_artifact_list / notebook_visual_artifact_read / notebook_visual_artifact_promote: Reuse, inspect, and promote notebook HTML companions into wiki visual views alongside the canonical markdown article.\n" +
 		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
 		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves. Cross-agent searches (looking at another agent's shelf) are tracked as promotion-demand signals — if their entry answers your question, the promotion pipeline scores it higher and surfaces it for review, so actually search instead of guessing.\n" +
 		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +

--- a/internal/team/prompt_builder_test.go
+++ b/internal/team/prompt_builder_test.go
@@ -51,6 +51,7 @@ func TestMarkdownKnowledgeToolBlock_ListsCanonicalTools(t *testing.T) {
 	block := markdownKnowledgeToolBlock()
 	for _, tool := range []string{
 		"notebook_write", "notebook_promote", "notebook_read",
+		"notebook_visual_artifact_create", "notebook_visual_artifact_promote",
 		"team_wiki_read", "team_wiki_write", "wuphf_wiki_lookup",
 		"team_learning_search", "team_learning_record",
 	} {
@@ -70,6 +71,23 @@ func TestMarkdownKnowledgeMemoryBlock_RequiresPromotionDiscipline(t *testing.T) 
 	} {
 		if !strings.Contains(block, want) {
 			t.Errorf("markdownKnowledgeMemoryBlock missing %q", want)
+		}
+	}
+}
+
+func TestMarkdownKnowledgeToolBlock_NudgesNaturalHTMLArtifactCreation(t *testing.T) {
+	block := markdownKnowledgeToolBlock()
+	for _, want := range []string{
+		"After notebook_write",
+		"complex specs",
+		"PR reviews",
+		"interactive tuning surfaces",
+		"self-contained HTML companion",
+		"no network fetches",
+		"visual-artifact:ra_...",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("markdownKnowledgeToolBlock missing HTML artifact trigger %q", want)
 		}
 	}
 }
@@ -163,6 +181,33 @@ func TestPromptBuilder_OneOnOneBranch(t *testing.T) {
 	}
 }
 
+func TestPromptBuilder_OneOnOneMarkdownMemoryMentionsHTMLArtifacts(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:     func() bool { return true },
+		isFocusMode:    func() bool { return false },
+		packName:       func() string { return "1:1 with CEO" },
+		leadSlug:       func() string { return "ceo" },
+		members:        func() []officeMember { return []officeMember{{Slug: "ceo", Name: "CEO", Role: "ceo"}} },
+		policies:       func() []officePolicy { return nil },
+		nameFor:        func(slug string) string { return slug },
+		markdownMemory: true,
+		nexDisabled:    true,
+	}
+
+	got := pb.Build("ceo")
+	for _, want := range []string{
+		"Markdown notebook/wiki memory is active in this 1:1",
+		"notebook_write",
+		"notebook_visual_artifact_create",
+		"diagram, mockup, report, comparison grid, code explainer, PR review, or interactive tuning surface",
+		"visual-artifact:ra_...",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("1:1 markdown prompt missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func TestPromptBuilder_OneOnOneSkipsLearningLookup(t *testing.T) {
 	pb := &promptBuilder{
 		isOneOnOne:  func() bool { return true },
@@ -199,6 +244,43 @@ func TestPromptBuilder_OneOnOneNexEnabledMentionsContextGraph(t *testing.T) {
 	got := pb.Build("ceo")
 	if !strings.Contains(got, "query_context") {
 		t.Fatalf("Nex-enabled 1:1 prompt should reference query_context")
+	}
+}
+
+func TestPromptBuilder_MarkdownMemoryPromptsNaturalHTMLArtifactsDuringWork(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "pm", Name: "Product Manager"},
+			}
+		},
+		policies:       func() []officePolicy { return nil },
+		nameFor:        func(slug string) string { return slug },
+		markdownMemory: true,
+	}
+
+	for _, slug := range []string{"ceo", "pm"} {
+		got := pb.Build(slug)
+		for _, want := range []string{
+			"notebook_visual_artifact_create",
+			"After notebook_write",
+			"complex specs",
+			"implementation plans",
+			"comparison grids",
+			"interactive tuning surfaces",
+			"notebook HTML visual artifact",
+			"long markdown wall",
+			"visual-artifact:ra_...",
+		} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("%s prompt missing natural HTML artifact guidance %q:\n%s", slug, want, got)
+			}
+		}
 	}
 }
 

--- a/internal/team/rich_artifact_natural_workflow_test.go
+++ b/internal/team/rich_artifact_natural_workflow_test.go
@@ -1,0 +1,189 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+func TestRichArtifactNaturalWorkflowPromptAndToolLoop(t *testing.T) {
+	systemPrompt := (&promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "pm", Name: "Product Manager"},
+			}
+		},
+		policies:       func() []officePolicy { return nil },
+		nameFor:        func(slug string) string { return slug },
+		markdownMemory: true,
+	}).Build("pm")
+
+	const (
+		sourcePath = "agents/pm/notebook/launch-risk.md"
+		artifactID = "ra_0123456789abcdef"
+	)
+
+	var calls []string
+	var broadcast string
+	tools := []agent.AgentTool{
+		{
+			Name:        "notebook_write",
+			Description: "Save the durable markdown source note before creating richer visual companions.",
+			Execute: func(params map[string]any, _ context.Context, _ func(string)) (string, error) {
+				calls = append(calls, "notebook_write")
+				if got := fmt.Sprint(params["article_path"]); got != sourcePath {
+					return "", fmt.Errorf("article_path=%q, want %q", got, sourcePath)
+				}
+				return `{"path":"` + sourcePath + `","commit_sha":"abc123"}`, nil
+			},
+		},
+		{
+			Name:        "notebook_visual_artifact_create",
+			Description: "After notebook_write, create a self-contained HTML companion for complex specs, PR reviews, diagrams, reports, and interactive tuning surfaces.",
+			Execute: func(params map[string]any, _ context.Context, _ func(string)) (string, error) {
+				calls = append(calls, "notebook_visual_artifact_create")
+				if got := fmt.Sprint(params["source_path"]); got != sourcePath {
+					return "", fmt.Errorf("source_path=%q, want %q", got, sourcePath)
+				}
+				html := fmt.Sprint(params["html"])
+				for _, want := range []string{"<!doctype html>", "<script>", "Launch Risk Dial"} {
+					if !strings.Contains(html, want) {
+						return "", fmt.Errorf("html missing %q", want)
+					}
+				}
+				if strings.Contains(html, "https://") || strings.Contains(html, "http://") {
+					return "", fmt.Errorf("html must be self-contained, got external URL")
+				}
+				return `{"artifact":{"id":"` + artifactID + `","source_markdown_path":"` + sourcePath + `"}}`, nil
+			},
+		},
+		{
+			Name:        "team_broadcast",
+			Description: "Post a concise chat update. If you created an HTML visual artifact, include visual-artifact:ra_... on its own line.",
+			Execute: func(params map[string]any, _ context.Context, _ func(string)) (string, error) {
+				calls = append(calls, "team_broadcast")
+				broadcast = fmt.Sprint(params["content"])
+				if !strings.Contains("\n"+broadcast+"\n", "\nvisual-artifact:"+artifactID+"\n") {
+					return "", fmt.Errorf("broadcast missing standalone visual-artifact marker: %q", broadcast)
+				}
+				return "Posted to #general as @pm", nil
+			},
+		},
+	}
+	toolByName := map[string]agent.AgentTool{}
+	for _, tool := range tools {
+		toolByName[tool.Name] = tool
+	}
+
+	stream := &scriptedStreamFn{
+		turns: []scriptedTurn{
+			{
+				expectMessages: func(t *testing.T, msgs []agent.Message) {
+					t.Helper()
+					if len(msgs) != 2 {
+						t.Fatalf("turn 1 messages=%d, want system+user", len(msgs))
+					}
+					for _, want := range []string{
+						"notebook_visual_artifact_create",
+						"After notebook_write",
+						"interactive tuning surfaces",
+						"notebook HTML visual artifact",
+						"long markdown wall",
+					} {
+						if !strings.Contains(msgs[0].Content, want) {
+							t.Fatalf("system prompt missing natural artifact guidance %q:\n%s", want, msgs[0].Content)
+						}
+					}
+				},
+				chunks: []agent.StreamChunk{{
+					Type:       "tool_use",
+					ToolName:   "notebook_write",
+					ToolParams: map[string]any{"article_path": sourcePath, "mode": "create", "content": "# Launch risk\n\nDense source notes."},
+					ToolInput:  `{"article_path":"` + sourcePath + `","mode":"create","content":"# Launch risk\n\nDense source notes."}`,
+				}},
+			},
+			{
+				expectMessages: func(t *testing.T, msgs []agent.Message) {
+					t.Helper()
+					last := msgs[len(msgs)-1].Content
+					if !strings.Contains(last, `Tool "notebook_write" returned`) || !strings.Contains(last, sourcePath) {
+						t.Fatalf("turn 2 missing notebook_write result:\n%s", last)
+					}
+				},
+				chunks: []agent.StreamChunk{{
+					Type:     "tool_use",
+					ToolName: "notebook_visual_artifact_create",
+					ToolParams: map[string]any{
+						"source_path": sourcePath,
+						"title":       "Launch Risk Dial",
+						"html":        "<!doctype html><html><body><h1>Launch Risk Dial</h1><input type=\"range\"><script>document.body.dataset.ready='1'</script></body></html>",
+					},
+					ToolInput: `{"source_path":"` + sourcePath + `","title":"Launch Risk Dial","html":"<!doctype html>..."}`,
+				}},
+			},
+			{
+				expectMessages: func(t *testing.T, msgs []agent.Message) {
+					t.Helper()
+					last := msgs[len(msgs)-1].Content
+					if !strings.Contains(last, `Tool "notebook_visual_artifact_create" returned`) || !strings.Contains(last, artifactID) {
+						t.Fatalf("turn 3 missing artifact create result:\n%s", last)
+					}
+				},
+				chunks: []agent.StreamChunk{{
+					Type:       "tool_use",
+					ToolName:   "team_broadcast",
+					ToolParams: map[string]any{"channel": "general", "content": "I saved the source note and made the launch-risk artifact.\nvisual-artifact:" + artifactID},
+					ToolInput:  `{"channel":"general","content":"I saved the source note and made the launch-risk artifact.\nvisual-artifact:` + artifactID + `"}`,
+				}},
+			},
+			{
+				chunks: []agent.StreamChunk{{Type: "text", Content: "Done."}},
+			},
+		},
+	}
+
+	final, iterations, _, streamErr, err := (&openAICompatToolLoop{
+		streamFn:    stream.fn(t),
+		tools:       tools,
+		toolByName:  toolByName,
+		maxIters:    6,
+		toolTimeout: time.Second,
+	}).run(context.Background(), []agent.Message{
+		{Role: "system", Content: systemPrompt},
+		{Role: "user", Content: "Turn this launch-risk analysis into a durable note I can review quickly. Use whatever representation fits the work."},
+	})
+	if err != nil || streamErr != "" {
+		t.Fatalf("tool loop failed: err=%v streamErr=%q", err, streamErr)
+	}
+	if final != "Done." || iterations != 4 {
+		t.Fatalf("final=%q iterations=%d, want Done./4", final, iterations)
+	}
+	if want := []string{"notebook_write", "notebook_visual_artifact_create", "team_broadcast"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("tool call sequence=%v, want %v", calls, want)
+	}
+	if !strings.Contains(broadcast, "visual-artifact:"+artifactID) {
+		t.Fatalf("broadcast lost artifact marker: %q", broadcast)
+	}
+	if !toolListIncludes(stream.turns[0].recordedTools, "notebook_visual_artifact_create", "interactive tuning surfaces") {
+		t.Fatalf("model did not receive notebook_visual_artifact_create tool guidance: %+v", stream.turns[0].recordedTools)
+	}
+}
+
+func toolListIncludes(tools []agent.AgentTool, name, descriptionFragment string) bool {
+	for _, tool := range tools {
+		if tool.Name == name && strings.Contains(tool.Description, descriptionFragment) {
+			return true
+		}
+	}
+	return false
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -52,6 +52,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -375,6 +376,8 @@
     "@oozcitak/util": ["@oozcitak/util@10.0.0", "", {}, "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1140,6 +1143,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, ""],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
@@ -1407,6 +1414,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 

--- a/web/e2e/screenshots/publish.sh
+++ b/web/e2e/screenshots/publish.sh
@@ -84,7 +84,7 @@ trap cleanup EXIT
 if ! curl -sf -m 2 "$base_url/" >/dev/null 2>&1; then
   echo "[publish] starting vite dev (existing server not detected at $base_url)" >&2
   vite_log="$(mktemp)"
-  bun --cwd "$repo_root/web" run dev > "$vite_log" 2>&1 &
+  bun run --cwd "$repo_root/web" dev > "$vite_log" 2>&1 &
   vite_pid="$!"
   for _ in $(seq 1 30); do
     if curl -sf -m 2 "$base_url/" >/dev/null 2>&1; then

--- a/web/e2e/screenshots/rich-artifact-chat.mjs
+++ b/web/e2e/screenshots/rich-artifact-chat.mjs
@@ -1,5 +1,3 @@
-import process from "node:process";
-
 import {
   DEFAULT_BASE,
   flipStore,
@@ -8,6 +6,7 @@ import {
   shotElement,
   shotPage,
 } from "./lib.mjs";
+import process from "node:process";
 
 const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
 if (!OUT) {
@@ -204,11 +203,13 @@ await installCommonMocks(context, {
         }),
       }),
     );
-    await ctx.route("**/api/notebook/visual-artifacts/ra_0123456789abcdef", (r) =>
-      r.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify({ artifact, html: artifactHtml }),
-      }),
+    await ctx.route(
+      "**/api/notebook/visual-artifacts/ra_0123456789abcdef",
+      (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ artifact, html: artifactHtml }),
+        }),
     );
   },
 });
@@ -217,7 +218,9 @@ await page.goto(`${DEFAULT_BASE}/#/channels/general`, { waitUntil: "load" });
 await page.waitForSelector(".status-bar", { timeout: 15_000 });
 await flipStore(page);
 try {
-  await page.waitForSelector(".message-artifact-reference", { timeout: 10_000 });
+  await page.waitForSelector(".message-artifact-reference", {
+    timeout: 10_000,
+  });
 } catch (err) {
   console.error(await page.locator("body").innerText());
   throw err;
@@ -227,10 +230,10 @@ await shotElement(
   page,
   ".thread-group:has(.message-artifact-reference)",
   OUT,
-  "01-chat-artifact-card",
+  "01-chat-artifact-inline",
 );
 
-await page.getByRole("button", { name: "Open", exact: true }).click();
+await page.getByRole("button", { name: "Expand", exact: true }).click();
 await page
   .getByRole("dialog", { name: "ICP onboarding walkthrough" })
   .waitFor({ timeout: 10_000 });

--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/web/src/components/messages/MessageArtifactReferences.tsx
+++ b/web/src/components/messages/MessageArtifactReferences.tsx
@@ -3,7 +3,6 @@ import { useQueries } from "@tanstack/react-query";
 
 import {
   fetchRichArtifact,
-  type RichArtifact,
   type RichArtifactDetail,
 } from "../../api/richArtifacts";
 import RichArtifactFrame from "../rich-artifacts/RichArtifactFrame";
@@ -104,7 +103,6 @@ export default function MessageArtifactReferences({
               </h2>
               <div className="rich-artifact-meta">
                 <span>{activeDetail.artifact.trustLevel}</span>
-                <span>{activeDetail.artifact.htmlPath}</span>
               </div>
             </div>
             <div className="rich-artifact-modal-actions">
@@ -121,6 +119,7 @@ export default function MessageArtifactReferences({
           <RichArtifactFrame
             title={activeDetail.artifact.title}
             html={activeDetail.html}
+            variant="modal"
           />
         </div>
       ) : null}
@@ -162,36 +161,31 @@ function MessageArtifactReference({
   const { artifact } = detail;
   return (
     <article
-      className="message-artifact-reference"
+      className="message-artifact-reference message-artifact-reference-inline"
       aria-label={`Rich artifact: ${artifact.title}`}
     >
-      <div className="message-artifact-main">
-        <span className="message-artifact-kicker">
-          {artifact.kind === "wiki_visual" ? "Wiki visual" : "Notebook visual"}
-        </span>
-        <h4>{artifact.title}</h4>
-        {artifact.summary ? <p>{artifact.summary}</p> : null}
-        <div className="message-artifact-meta">
-          <span>{artifact.trustLevel}</span>
-          <span>{artifactSource(artifact)}</span>
+      <div className="message-artifact-header">
+        <div className="message-artifact-main">
+          <span className="message-artifact-kicker">
+            {artifact.kind === "wiki_visual"
+              ? "Wiki visual"
+              : "Notebook visual"}
+          </span>
+          <h4>{artifact.title}</h4>
+          {artifact.summary ? <p>{artifact.summary}</p> : null}
+        </div>
+        <div className="message-artifact-actions">
+          {artifact.promotedWikiPath ? (
+            <a href={wikiHref(artifact.promotedWikiPath)}>Open wiki</a>
+          ) : null}
+          <button type="button" onClick={() => onOpen(detail)}>
+            Expand
+          </button>
         </div>
       </div>
-      <div className="message-artifact-actions">
-        {artifact.promotedWikiPath ? (
-          <a href={wikiHref(artifact.promotedWikiPath)}>Open wiki</a>
-        ) : null}
-        <button type="button" onClick={() => onOpen(detail)}>
-          Open
-        </button>
-      </div>
+      <RichArtifactFrame title={artifact.title} html={detail.html} />
     </article>
   );
-}
-
-function artifactSource(artifact: RichArtifact): string {
-  if (artifact.promotedWikiPath) return artifact.promotedWikiPath;
-  if (artifact.sourceMarkdownPath) return artifact.sourceMarkdownPath;
-  return `@${artifact.createdBy}`;
 }
 
 function queryErrorMessage(error: unknown): string | undefined {

--- a/web/src/components/messages/MessageBubble.test.tsx
+++ b/web/src/components/messages/MessageBubble.test.tsx
@@ -72,7 +72,7 @@ describe("<MessageBubble> rich artifact references", () => {
     vi.spyOn(richApi, "fetchRichArtifact").mockResolvedValue(ARTIFACT_DETAIL);
   });
 
-  it("renders a compact artifact card and hides the raw marker line", async () => {
+  it("renders the artifact inline and hides the raw marker line", async () => {
     renderWithQueryClient(<MessageBubble message={MESSAGE} />);
 
     expect(
@@ -84,16 +84,19 @@ describe("<MessageBubble> rich artifact references", () => {
       "Rich artifact: Product strategy map",
     );
     expect(within(card).getByText("Notebook visual")).toBeInTheDocument();
-    expect(within(card).getByText("draft")).toBeInTheDocument();
-    expect(
-      within(card).getByText("agents/pm/notebook/product-strategy.md"),
-    ).toBeInTheDocument();
+    const frame = within(card).getByTitle("Product strategy map");
+    expect(frame).toHaveClass("rich-artifact-frame-inline");
+    expect(frame).toHaveAttribute("sandbox", "allow-scripts");
+    expect(frame).toHaveAttribute(
+      "srcdoc",
+      expect.stringContaining("<h1>Artifact body</h1>"),
+    );
     expect(richApi.fetchRichArtifact).toHaveBeenCalledWith(
       "ra_0123456789abcdef",
     );
   });
 
-  it("opens artifact HTML only inside the sandboxed modal frame", async () => {
+  it("expands artifact HTML into the secondary sandboxed modal frame", async () => {
     const user = userEvent.setup();
     renderWithQueryClient(<MessageBubble message={MESSAGE} />);
 
@@ -102,7 +105,7 @@ describe("<MessageBubble> rich artifact references", () => {
     );
     expect(screen.queryByText("Artifact body")).toBeNull();
 
-    await user.click(within(card).getByRole("button", { name: "Open" }));
+    await user.click(within(card).getByRole("button", { name: "Expand" }));
 
     const dialog = screen.getByRole("dialog", {
       name: "Product strategy map",
@@ -122,7 +125,7 @@ describe("<MessageBubble> rich artifact references", () => {
     const card = await screen.findByLabelText(
       "Rich artifact: Product strategy map",
     );
-    await user.click(within(card).getByRole("button", { name: "Open" }));
+    await user.click(within(card).getByRole("button", { name: "Expand" }));
     expect(
       screen.getByRole("dialog", { name: "Product strategy map" }),
     ).toBeInTheDocument();

--- a/web/src/components/notebook/NotebookEntry.test.tsx
+++ b/web/src/components/notebook/NotebookEntry.test.tsx
@@ -186,7 +186,7 @@ describe("<NotebookEntryView visual artifacts>", () => {
       });
     });
 
-    const openButtons = screen.getAllByRole("button", { name: "Open" });
+    const openButtons = screen.getAllByRole("button", { name: "Expand" });
     await user.click(openButtons[0]);
     await user.click(openButtons[1]);
 
@@ -238,7 +238,7 @@ describe("<NotebookEntryView visual artifacts>", () => {
     render(<NotebookEntryView entry={DRAFT_ENTRY} />);
 
     await screen.findByRole("heading", { name: "Visual artifacts" });
-    await user.click(screen.getByRole("button", { name: "Open" }));
+    await user.click(screen.getByRole("button", { name: "Expand" }));
     await user.click(await screen.findByRole("button", { name: "Promote" }));
 
     await waitFor(() =>
@@ -279,7 +279,7 @@ describe("<NotebookEntryView visual artifacts>", () => {
     render(<NotebookEntryView entry={DRAFT_ENTRY} />);
 
     await screen.findByRole("heading", { name: "Visual artifacts" });
-    await user.click(screen.getByRole("button", { name: "Open" }));
+    await user.click(screen.getByRole("button", { name: "Expand" }));
 
     expect(
       await screen.findByRole("dialog", { name: "Visual plan" }),

--- a/web/src/components/notebook/NotebookVisualArtifacts.tsx
+++ b/web/src/components/notebook/NotebookVisualArtifacts.tsx
@@ -199,7 +199,7 @@ export default function NotebookVisualArtifacts({
                   void openArtifact(artifact);
                 }}
               >
-                Open
+                Expand
               </button>
             </div>
           </article>
@@ -214,7 +214,6 @@ export default function NotebookVisualArtifacts({
             <h3>{inlineDetail.artifact.title}</h3>
             <div className="rich-artifact-meta">
               <span>{inlineDetail.artifact.trustLevel}</span>
-              <span>{inlineDetail.artifact.htmlPath}</span>
             </div>
           </div>
           <RichArtifactFrame
@@ -242,7 +241,6 @@ export default function NotebookVisualArtifacts({
               <h2 id={modalTitleId}>{detail.artifact.title}</h2>
               <div className="rich-artifact-meta">
                 <span>{detail.artifact.trustLevel}</span>
-                <span>{detail.artifact.htmlPath}</span>
               </div>
             </div>
             <div className="rich-artifact-modal-actions">
@@ -277,6 +275,7 @@ export default function NotebookVisualArtifacts({
             <RichArtifactFrame
               title={detail.artifact.title}
               html={detail.html}
+              variant="modal"
             />
           )}
         </div>

--- a/web/src/components/rich-artifacts/RichArtifactFrame.test.tsx
+++ b/web/src/components/rich-artifacts/RichArtifactFrame.test.tsx
@@ -4,16 +4,39 @@ import { describe, expect, it } from "vitest";
 import RichArtifactFrame from "./RichArtifactFrame";
 
 describe("<RichArtifactFrame>", () => {
-  it("renders artifact HTML in a sandboxed iframe with an inline CSP", () => {
+  it("renders artifact HTML in a borderless sandboxed iframe with resize wiring", () => {
     render(<RichArtifactFrame title="Visual plan" html="<h1>Plan</h1>" />);
 
     const frame = screen.getByTitle("Visual plan");
 
+    expect(frame).toHaveClass("rich-artifact-frame-inline");
     expect(frame).toHaveAttribute("sandbox", "allow-scripts");
     expect(frame).toHaveAttribute(
       "srcdoc",
       expect.stringContaining("Content-Security-Policy"),
     );
+    expect(frame).toHaveAttribute(
+      "srcdoc",
+      expect.stringContaining("wuphf:rich-artifact:resize"),
+    );
     expect(frame).toHaveAttribute("srcdoc", expect.stringContaining("Plan"));
+  });
+
+  it("injects sandbox metadata into complete HTML documents without nesting them", () => {
+    render(
+      <RichArtifactFrame
+        title="Complete document"
+        html="<!doctype html><html><head><title>Artifact</title></head><body><h1>Plan</h1></body></html>"
+      />,
+    );
+
+    const srcdoc = screen
+      .getByTitle("Complete document")
+      .getAttribute("srcdoc");
+
+    expect(srcdoc).toContain("<title>Artifact</title>");
+    expect(srcdoc).toContain("Content-Security-Policy");
+    expect(srcdoc).toContain("wuphf:rich-artifact:resize");
+    expect(srcdoc).not.toContain("<body><!doctype html>");
   });
 });

--- a/web/src/components/rich-artifacts/RichArtifactFrame.test.tsx
+++ b/web/src/components/rich-artifacts/RichArtifactFrame.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import RichArtifactFrame from "./RichArtifactFrame";
@@ -38,5 +38,60 @@ describe("<RichArtifactFrame>", () => {
     expect(srcdoc).toContain("Content-Security-Policy");
     expect(srcdoc).toContain("wuphf:rich-artifact:resize");
     expect(srcdoc).not.toContain("<body><!doctype html>");
+  });
+
+  it("accepts resize messages only from the matching iframe window", async () => {
+    render(<RichArtifactFrame title="Resizable" html="<h1>Plan</h1>" />);
+
+    const frame = screen.getByTitle("Resizable") as HTMLIFrameElement;
+    const srcdoc = frame.getAttribute("srcdoc") ?? "";
+    const frameId = srcdoc.match(/const id="([^"]+)"/)?.[1];
+
+    expect(frameId).toBeTruthy();
+    expect(frame.contentWindow).toBeTruthy();
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "wuphf:rich-artifact:resize",
+            id: frameId,
+            height: 900,
+          },
+          source: null,
+        }),
+      );
+    });
+    expect(frame.style.height).toBe("");
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            type: "wuphf:rich-artifact:resize",
+            id: frameId,
+            height: 345,
+          },
+          source: frame.contentWindow,
+        }),
+      );
+    });
+
+    await waitFor(() => expect(frame.style.height).toBe("345px"));
+  });
+
+  it("does not inject resize wiring when auto-resize is disabled", () => {
+    render(
+      <RichArtifactFrame
+        title="Modal artifact"
+        html="<h1>Plan</h1>"
+        variant="modal"
+      />,
+    );
+
+    expect(screen.getByTitle("Modal artifact")).not.toHaveAttribute(
+      "srcdoc",
+      expect.stringContaining("wuphf:rich-artifact:resize"),
+    );
   });
 });

--- a/web/src/components/rich-artifacts/RichArtifactFrame.tsx
+++ b/web/src/components/rich-artifacts/RichArtifactFrame.tsx
@@ -1,4 +1,8 @@
+import { useEffect, useMemo, useState } from "react";
+
 import "../../styles/rich-artifacts.css";
+
+const RESIZE_EVENT_TYPE = "wuphf:rich-artifact:resize";
 
 const SANDBOX_CSP = [
   "default-src 'none'",
@@ -15,9 +19,42 @@ const SANDBOX_CSP = [
   "base-uri 'none'",
 ].join("; ");
 
-function withSandboxCsp(html: string): string {
+function withSandboxCsp(html: string, frameId: string): string {
   const meta = `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">`;
-  return `<!doctype html><html><head>${meta}</head><body>${html}</body></html>`;
+  const resizeScript = buildResizeScript(frameId);
+  if (/<html[\s>]/i.test(html)) {
+    return injectIntoDocument(html, meta, resizeScript);
+  }
+  return `<!doctype html><html><head>${meta}</head><body>${html}${resizeScript}</body></html>`;
+}
+
+function injectIntoDocument(
+  html: string,
+  headContent: string,
+  bodyTail: string,
+) {
+  let documentHtml = html;
+  if (/<head[\s>]/i.test(documentHtml)) {
+    documentHtml = documentHtml.replace(
+      /<head([^>]*)>/i,
+      `<head$1>${headContent}`,
+    );
+  } else {
+    documentHtml = documentHtml.replace(
+      /<html([^>]*)>/i,
+      `<html$1><head>${headContent}</head>`,
+    );
+  }
+  if (/<\/body>/i.test(documentHtml)) {
+    return documentHtml.replace(/<\/body>/i, `${bodyTail}</body>`);
+  }
+  return `${documentHtml}${bodyTail}`;
+}
+
+function buildResizeScript(frameId: string): string {
+  const encodedFrameId = JSON.stringify(frameId).replace(/</g, "\\u003c");
+  const encodedEventType = JSON.stringify(RESIZE_EVENT_TYPE);
+  return `<script>(()=>{const id=${encodedFrameId};const type=${encodedEventType};let raf=0;function measure(){const body=document.body;const html=document.documentElement;if(!body||!html)return;const height=Math.ceil(Math.max(body.scrollHeight,body.offsetHeight,html.clientHeight,html.scrollHeight,html.offsetHeight));parent.postMessage({type,id,height},"*")}function schedule(){if(raf)cancelAnimationFrame(raf);raf=requestAnimationFrame(measure)}window.addEventListener("load",schedule);window.addEventListener("resize",schedule);new MutationObserver(schedule).observe(document.documentElement,{attributes:true,characterData:true,childList:true,subtree:true});if("ResizeObserver"in window){const observer=new ResizeObserver(schedule);observer.observe(document.documentElement);if(document.body)observer.observe(document.body)}schedule();setTimeout(schedule,250);setTimeout(schedule,1000)})();</script>`;
 }
 
 function frameKey(title: string, html: string): string {
@@ -29,22 +66,71 @@ function frameKey(title: string, html: string): string {
   return `rich-artifact-${hash >>> 0}`;
 }
 
+type RichArtifactFrameVariant = "inline" | "modal";
+
 interface RichArtifactFrameProps {
   title: string;
   html: string;
+  variant?: RichArtifactFrameVariant;
+  minHeight?: number;
+  maxHeight?: number;
+  autoResize?: boolean;
 }
 
 export default function RichArtifactFrame({
   title,
   html,
+  variant = "inline",
+  minHeight = 220,
+  maxHeight = 12000,
+  autoResize,
 }: RichArtifactFrameProps) {
+  const frameId = useMemo(() => frameKey(title, html), [title, html]);
+  const srcDoc = useMemo(() => withSandboxCsp(html, frameId), [frameId, html]);
+  const shouldAutoResize = autoResize ?? variant === "inline";
+  const [heightState, setHeightState] = useState<{
+    frameId: string;
+    height: number;
+  } | null>(null);
+  const height = heightState?.frameId === frameId ? heightState.height : null;
+
+  useEffect(() => {
+    if (!shouldAutoResize) return undefined;
+    function handleMessage(event: MessageEvent) {
+      if (!isResizeMessage(event.data) || event.data.id !== frameId) return;
+      const nextHeight = Math.min(
+        Math.max(Math.ceil(event.data.height), minHeight),
+        maxHeight,
+      );
+      setHeightState({ frameId, height: nextHeight });
+    }
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [frameId, maxHeight, minHeight, shouldAutoResize]);
+
   return (
     <iframe
-      key={frameKey(title, html)}
-      className="rich-artifact-frame"
+      key={frameId}
+      className={`rich-artifact-frame rich-artifact-frame-${variant}`}
+      data-testid="rich-artifact-frame"
       title={title}
       sandbox="allow-scripts"
-      srcDoc={withSandboxCsp(html)}
+      scrolling={shouldAutoResize ? "no" : undefined}
+      srcDoc={srcDoc}
+      style={height ? { height } : undefined}
     />
+  );
+}
+
+function isResizeMessage(
+  value: unknown,
+): value is { type: typeof RESIZE_EVENT_TYPE; id: string; height: number } {
+  if (!value || typeof value !== "object") return false;
+  const message = value as Record<string, unknown>;
+  return (
+    message.type === RESIZE_EVENT_TYPE &&
+    typeof message.id === "string" &&
+    typeof message.height === "number" &&
+    Number.isFinite(message.height)
   );
 }

--- a/web/src/components/rich-artifacts/RichArtifactFrame.tsx
+++ b/web/src/components/rich-artifacts/RichArtifactFrame.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import "../../styles/rich-artifacts.css";
 
@@ -19,9 +19,9 @@ const SANDBOX_CSP = [
   "base-uri 'none'",
 ].join("; ");
 
-function withSandboxCsp(html: string, frameId: string): string {
+function withSandboxCsp(html: string, frameId?: string): string {
   const meta = `<meta http-equiv="Content-Security-Policy" content="${SANDBOX_CSP}">`;
-  const resizeScript = buildResizeScript(frameId);
+  const resizeScript = frameId ? buildResizeScript(frameId) : "";
   if (/<html[\s>]/i.test(html)) {
     return injectIntoDocument(html, meta, resizeScript);
   }
@@ -85,9 +85,13 @@ export default function RichArtifactFrame({
   maxHeight = 12000,
   autoResize,
 }: RichArtifactFrameProps) {
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
   const frameId = useMemo(() => frameKey(title, html), [title, html]);
-  const srcDoc = useMemo(() => withSandboxCsp(html, frameId), [frameId, html]);
   const shouldAutoResize = autoResize ?? variant === "inline";
+  const srcDoc = useMemo(
+    () => withSandboxCsp(html, shouldAutoResize ? frameId : undefined),
+    [frameId, html, shouldAutoResize],
+  );
   const [heightState, setHeightState] = useState<{
     frameId: string;
     height: number;
@@ -97,6 +101,7 @@ export default function RichArtifactFrame({
   useEffect(() => {
     if (!shouldAutoResize) return undefined;
     function handleMessage(event: MessageEvent) {
+      if (event.source !== frameRef.current?.contentWindow) return;
       if (!isResizeMessage(event.data) || event.data.id !== frameId) return;
       const nextHeight = Math.min(
         Math.max(Math.ceil(event.data.height), minHeight),
@@ -110,6 +115,7 @@ export default function RichArtifactFrame({
 
   return (
     <iframe
+      ref={frameRef}
       key={frameId}
       className={`rich-artifact-frame rich-artifact-frame-${variant}`}
       data-testid="rich-artifact-frame"

--- a/web/src/components/wiki/WikiArticle.test.tsx
+++ b/web/src/components/wiki/WikiArticle.test.tsx
@@ -145,7 +145,12 @@ describe("<WikiArticle content>", () => {
     const visualTab = await screen.findByRole("button", { name: "Visual" });
     await waitFor(() => expect(visualTab).not.toBeDisabled());
 
-    expect(await screen.findByTestId("wk-visual-artifact")).toBeInTheDocument();
+    const visual = await screen.findByTestId("wk-visual-artifact");
+    expect(visual).toBeInTheDocument();
+    expect(visual.closest(".wk-article-col")).toHaveClass(
+      "wk-article-col-visual",
+    );
+    expect(document.querySelector(".wk-right-sidebar")).toBeNull();
     expect(screen.getByTitle("Visual Plan")).toHaveAttribute(
       "srcdoc",
       expect.stringContaining("Visual artifact"),

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -391,10 +391,13 @@ export default function WikiArticle({
     setTab("article");
   };
   const handleEditorCancel = () => setTab("article");
+  const isVisualMode = tab === "visual" && visualArtifact !== null;
 
   return (
     <>
-      <main className="wk-article-col">
+      <main
+        className={`wk-article-col${isVisualMode ? " wk-article-col-visual" : ""}`}
+      >
         <LiveEditingBanner liveAgent={liveAgent} article={article} />
         <ArticleSetupPanels
           entity={entity}
@@ -454,12 +457,14 @@ export default function WikiArticle({
           articlePath={article.path}
         />
       </main>
-      <ArticleRightSidebar
-        article={article}
-        toc={toc}
-        onNavigate={onNavigate}
-        onMaintenanceApplied={() => setRefreshNonce((n) => n + 1)}
-      />
+      {isVisualMode ? null : (
+        <ArticleRightSidebar
+          article={article}
+          toc={toc}
+          onNavigate={onNavigate}
+          onMaintenanceApplied={() => setRefreshNonce((n) => n + 1)}
+        />
+      )}
     </>
   );
 }
@@ -611,7 +616,6 @@ function ArticleTabPanels({
             <h2>{visualArtifact.artifact.title}</h2>
             <div className="rich-artifact-meta">
               <span>{visualArtifact.artifact.trustLevel}</span>
-              <span>{visualArtifact.artifact.htmlPath}</span>
             </div>
           </div>
           <RichArtifactFrame

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -318,6 +318,22 @@
   color: var(--text-secondary);
 }
 
+.message-artifact-reference-inline {
+  grid-template-columns: 1fr;
+  align-items: stretch;
+  padding: 8px 0 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.message-artifact-header {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
 .message-artifact-reference h4 {
   margin: 1px 0 3px;
   color: var(--text);
@@ -361,6 +377,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  flex: 0 0 auto;
   justify-content: flex-end;
 }
 
@@ -399,6 +416,11 @@
 @media (max-width: 640px) {
   .message-artifact-reference {
     grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .message-artifact-header {
+    flex-direction: column;
     align-items: stretch;
   }
 

--- a/web/src/styles/rich-artifacts.css
+++ b/web/src/styles/rich-artifacts.css
@@ -1,9 +1,19 @@
 .rich-artifact-frame {
   display: block;
   width: 100%;
-  min-height: min(72vh, 760px);
-  border: 1px solid var(--wk-border, rgba(36, 42, 54, 0.16));
-  border-radius: 8px;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.rich-artifact-frame-inline {
+  min-height: 220px;
+  overflow: hidden;
+}
+
+.rich-artifact-frame-modal {
+  height: 100%;
+  min-height: 0;
   background: #fff;
 }
 
@@ -86,10 +96,7 @@
 
 .nb-visual-artifacts {
   margin: 28px 0;
-  padding: 16px;
-  border: 1px solid rgba(48, 60, 84, 0.16);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.72);
+  padding: 0;
 }
 
 .nb-visual-artifacts-head,
@@ -120,8 +127,8 @@
 
 .rich-artifact-inline {
   display: grid;
-  gap: 12px;
-  margin-top: 14px;
+  gap: 10px;
+  margin-top: 18px;
 }
 
 .rich-artifact-inline-head {
@@ -170,7 +177,7 @@
 
 .wk-visual-artifact {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 @media (max-width: 760px) {

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -182,6 +182,12 @@
   position: relative;
 }
 
+.wk-article-col-visual {
+  grid-column: 2 / 4;
+  padding-right: 40px;
+  padding-left: 40px;
+}
+
 /* ─── Status banner ─── */
 .wk-status-banner {
   background: var(--wk-amber-banner);


### PR DESCRIPTION
## Summary
- Add rich HTML artifact guidance directly to the markdown notebook/wiki agent prompt, including 1:1 sessions.
- Replace the old markdown-table style nudge with an HTML-artifact-first nudge for dense, visual, or interactive work.
- Add deterministic runtime proof that a normal work request can flow through notebook_write -> notebook_visual_artifact_create -> team_broadcast with a visual-artifact marker.

## Verification
- go test ./internal/team -run 'TestRichArtifactNaturalWorkflowPromptAndToolLoop|Test(MarkdownKnowledgeToolBlock|PromptBuilder_.*HTML|BuildPromptIncludesMarkdownNotebookPromotionGuidance)' -count=1
- go test ./internal/teammcp -run 'TestNotebookVisualArtifactToolsTeachHTMLGuidance|TestNotebookToolsRegistered' -count=1
- bash scripts/test-go.sh ./internal/team
- bash scripts/test-go.sh ./internal/teammcp
- go build -o /tmp/wuphf-rich-artifact-proof ./cmd/wuphf
- git diff --cached --check


## Screenshots

![01-chat-artifact-inline](https://github.com/nex-crm/wuphf/raw/screenshots/pr-886/01-chat-artifact-inline.png)

![02-chat-artifact-modal](https://github.com/nex-crm/wuphf/raw/screenshots/pr-886/02-chat-artifact-modal.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline rendering of visual artifacts with an “Expand” action and modal variant; prompts now nudge natural HTML visual-artifact creation and promotion.

* **UI/UX Improvements**
  * Cleaner inline artifact layout showing trust level (removed extraneous path), updated styling, and configurable modal/inline frame sizing with optional auto-resize.

* **Bug Fixes**
  * Visual-artifact markers are preserved and exempted from secret redaction; query secrets still get redacted.

* **Tests**
  * Expanded unit and end-to-end tests for prompts, tool loops, rendering, preservation, and resize behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->