### PR TITLE
feat(launcher): pane-backed tmux is default for claude-code; headless is the fallback

### DIFF
--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -134,15 +134,25 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)
 	}
 
-	// Default path: headless `claude --print` per turn. Anthropic re-sanctioned
-	// this invocation (OpenClaw policy note, 2026-04), so it runs on the user's
-	// normal subscription quota — no separate extra-usage quota is charged on
-	// top. The legacy interactive pane-per-agent mode remains reachable via
-	// trySpawnWebAgentPanes as an internal fallback primitive, but is not
-	// invoked at startup.
+	// Default for claude-code: spawn an interactive tmux pane per agent so
+	// the user can attach and watch the real Claude TUI (tools, thinking,
+	// confirmations) for any agent at any time. TrySpawnWebAgentPanes
+	// self-guards on UsesPaneRuntime() (Codex/OpenCode/MLX runtimes skip
+	// this entirely), on visible-member count (blank-slate launches skip
+	// until onboarding adds members), and on tmux availability. Any failure
+	// (tmux missing, terminal too small, dead pane on spawn) flips the agent
+	// back to headless `claude --print` dispatch via the failedPaneSlugs /
+	// paneBackedAgents=false fallback paths already wired into the targeter.
+	//
+	// Anthropic re-sanctioned the `claude --print` invocation (OpenClaw
+	// policy note, 2026-04), so the headless fallback still runs on the
+	// user's normal subscription quota with no extra-usage charge.
+	l.panes().TrySpawnWebAgentPanes()
 
 	// Headless context is used for codex runtime, default dispatch, and
-	// per-turn operations that don't fit a long-lived pane session.
+	// per-turn operations that don't fit a long-lived pane session — and
+	// for every claude-code agent when the pane spawn above failed or
+	// declined.
 	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
 	l.resumeInFlightWork()
 

--- a/internal/team/pane_lifecycle_orchestration_test.go
+++ b/internal/team/pane_lifecycle_orchestration_test.go
@@ -238,6 +238,74 @@ func TestTrySpawnWebAgentPanes_HeadlessRuntimeNoOp(t *testing.T) {
 	}
 }
 
+// TestTrySpawnWebAgentPanes_BlankSlateNoOp guards the early-return that
+// prevents an empty tmux session (only the placeholder pane, no agent
+// panes) on blank-slate web launches where the broker has zero members
+// yet. Before this guard, LaunchWeb's pane-default call would create a
+// half-built session and flip paneBackedFlag=true, breaking subsequent
+// reconfigure paths and the capture loops.
+func TestTrySpawnWebAgentPanes_BlankSlateNoOp(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	flag := false
+	posted := 0
+	pl := newPaneLifecycleWithDeps("wuphf-team", paneLifecycleDeps{
+		postSystemMessage:    func(channel, body, kind string) { posted++ },
+		usesPaneRuntime:      func() bool { return true },
+		visibleOfficeMembers: func() []officeMember { return nil },
+		paneBackedFlag:       &flag,
+	})
+	pl.TrySpawnWebAgentPanes()
+
+	if got := len(fake.calls); got != 0 {
+		t.Errorf("expected zero tmux calls when there are no visible members, got %d (calls=%v)", got, fake.calls)
+	}
+	if flag {
+		t.Errorf("paneBackedFlag should stay false when blank-slate; got true")
+	}
+	if posted != 0 {
+		t.Errorf("expected zero broker posts on blank-slate skip, got %d", posted)
+	}
+}
+
+// TestTrySpawnWebAgentPanes_HappyPathFlipsFlag is the new default's
+// load-bearing contract: with claude-code + at least one visible
+// member + a working tmux runner, TrySpawnWebAgentPanes flips
+// paneBackedFlag=true so subsequent dispatch routes through the live
+// panes instead of falling through to headless `claude --print`. Before
+// the LaunchWeb wiring change this code path was reachable only via the
+// reconfigure flow.
+func TestTrySpawnWebAgentPanes_HappyPathFlipsFlag(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["split-window"] = []byte("ok")
+	setTmuxRunnerForTest(t, fake)
+
+	flag := false
+	pl := newPaneLifecycleWithDeps("wuphf-team", paneLifecycleDeps{
+		cwd:                   "/repo",
+		postSystemMessage:     func(channel, body, kind string) {},
+		usesPaneRuntime:       func() bool { return true },
+		visibleOfficeMembers:  func() []officeMember { return []officeMember{{Slug: "ceo"}} },
+		overflowOfficeMembers: func() []officeMember { return nil },
+		agentPaneTargets:      func() map[string]notificationTarget { return nil },
+		isOneOnOne:            func() bool { return false },
+		claudeCommand:         func(slug, prompt string) (string, error) { return "claude --slug=" + slug, nil },
+		buildPrompt:           func(slug string) string { return "" },
+		agentName:             func(slug string) string { return slug },
+		recordFailure:         func(slug, reason string) { t.Fatalf("unexpected recordFailure for %s: %s", slug, reason) },
+		paneBackedFlag:        &flag,
+	})
+	pl.TrySpawnWebAgentPanes()
+
+	if !flag {
+		t.Errorf("paneBackedFlag = false after successful spawn, want true (dispatch would stay headless)")
+	}
+	if len(fake.callsFor("new-session")) == 0 {
+		t.Errorf("expected at least one new-session call on happy path; calls = %v", fake.calls)
+	}
+}
+
 // countingRunner wraps a fakeTmuxRunner to inject a one-shot failure on
 // the Nth call to a specific tmux subcommand. Used by the
 // "additional split failure" test where we need success on the first

--- a/internal/team/pane_lifecycle_spawn.go
+++ b/internal/team/pane_lifecycle_spawn.go
@@ -200,11 +200,17 @@ func (p *paneLifecycle) DetectDeadPanesAfterSpawn(members []officeMember) {
 	}
 }
 
-// TrySpawnWebAgentPanes attempts to spawn the full pane-backed
-// fallback session (PLAN.md §C5e). On success flips the
-// paneBackedFlag *bool true so the targeter routes through pane
-// dispatch. On failure, calls reportPaneFallback which prints the
-// stderr banner and posts the broker-side advisory.
+// TrySpawnWebAgentPanes attempts to spawn the pane-backed session
+// (PLAN.md §C5e). On success flips the paneBackedFlag *bool true so
+// the targeter routes through pane dispatch. On failure, calls
+// reportPaneFallback which prints the stderr banner and posts the
+// broker-side advisory — the launcher continues in headless
+// `claude --print` mode for that agent (or for every agent, when the
+// failure was session-wide).
+//
+// No-op when there are zero visible members (blank-slate web launches
+// before onboarding finishes); reconfiguration after the user adds
+// agents picks up the panes via launcher_reconfigure.go.
 func (p *paneLifecycle) TrySpawnWebAgentPanes() {
 	if p.deps.postSystemMessage == nil {
 		// Production wires postSystemMessage from a non-nil broker;
@@ -212,6 +218,11 @@ func (p *paneLifecycle) TrySpawnWebAgentPanes() {
 		return
 	}
 	if p.deps.usesPaneRuntime != nil && !p.deps.usesPaneRuntime() {
+		return
+	}
+	if p.deps.visibleOfficeMembers != nil && len(p.deps.visibleOfficeMembers()) == 0 {
+		// Blank-slate launch: no agents to host yet. Skip rather than
+		// open an empty tmux session with only the placeholder pane.
 		return
 	}
 	if err := p.TmuxAvailable(); err != nil {
@@ -239,7 +250,7 @@ func (p *paneLifecycle) TrySpawnWebAgentPanes() {
 		*p.deps.paneBackedFlag = true
 	}
 	go p.DetectDeadPanesAfterSpawn(append(p.deps.visibleOfficeMembers(), p.deps.overflowOfficeMembers()...))
-	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (pane-backed fallback active)\n", p.sessionName)
+	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (pane-backed mode active)\n", p.sessionName)
 }
 
 // PrimeVisibleAgents waits for visible agent panes to clear claude's


### PR DESCRIPTION
## Summary

- `LaunchWeb` now calls `TrySpawnWebAgentPanes` after broker boot, so the default web-mode runtime for claude-code is interactive tmux panes per agent (real Claude TUI: thinking, tool calls, confirmations the user can watch).
- The existing fallback machinery stays load-bearing: a non-pane-eligible provider (Codex / OpenCode / MLX), a missing `tmux` binary, a failed pane spawn, or a pane that dies on launch each route the affected agent back to `claude --print` headless dispatch via `failedPaneSlugs` / `paneBackedAgents=false`. No behavioral change to the headless code path.
- `TrySpawnWebAgentPanes` gains an explicit empty-members guard so a blank-slate web launch (broker has zero visible members) does not open an orphan tmux session containing only the placeholder pane.

## Why now

The legacy interactive pane-per-agent path was described in the comments as a "fallback primitive, but not invoked at startup." For claude-code installs that is now the wrong default — the live pane is the most valuable feedback surface we have for watching an agent reason. This flip makes the default match the most-useful state without taking anything away from the headless dispatch path, because the fallback is what runs whenever pane spawn declines or fails.

## Test plan

- [x] `bash scripts/test-go.sh` — all 38 packages green (incl. `internal/team` + `internal/team/transport`)
- [x] New unit pin `TestTrySpawnWebAgentPanes_BlankSlateNoOp` — verifies the empty-members guard fires (zero tmux calls, `paneBackedFlag` stays false, zero broker advisories)
- [x] New unit pin `TestTrySpawnWebAgentPanes_HappyPathFlipsFlag` — verifies the new default's load-bearing contract: a successful spawn flips `paneBackedFlag=true` so dispatch routes through panes
- [x] **Real Chrome — happy path**: 4 pack agents on broker 17890 / web 17891. Banner `Agents: interactive Claude panes in tmux session "wuphf-team" (pane-backed mode active)`. `tmux -L wuphf list-panes -t wuphf-team:team` shows 5 panes (channel + Builder + Reviewer + Operator + Founder). Chrome tab loads `http://127.0.0.1:17891/`, title `WUPHF - Slack for AI employees with a shared brain`, routes to `/#/channels/general`.
- [x] **Real Chrome — tmux-missing fallback**: relaunched with `PATH` stripped of `/opt/homebrew/bin` and `/usr/local/bin`. Banner: `Agents: pane-backed fallback attempted but tmux not found (...). Continuing with the default headless path (\`claude --print\` per turn on your normal subscription). Install tmux if you want the fallback to be available.` No tmux session exists. Same SPA renders in Chrome identically.

## Fallback contract (unchanged, just newly default-active)

| Trigger | Result |
| --- | --- |
| `usesPaneRuntime()` is false (Codex / OpenCode / MLX) | Skip pane spawn, stay headless |
| `tmux` not on `PATH` | `ReportPaneFallback` advisory, `paneBackedAgents=false`, headless |
| First-agent split fails (terminal too small, etc.) | Kill session, advisory, headless for everyone |
| Individual additional split fails | `recordPaneSpawnFailure` flags that slug; other agents stay pane-backed; the failed slug goes headless via `failedPaneSlugs` |
| Pane dies within 1.5s of spawn | Per-slug fallback via `DetectDeadPanesAfterSpawn` |
| Zero visible members (new) | Skip entirely; reconfigure picks up panes after onboarding adds agents |

## Notes

- No `web/` changes, so the project screenshot rule does not apply.
- Comment updates in `launcher_web.go` and `pane_lifecycle_spawn.go` reflect the new "default = panes, headless is the fallback" framing; the success banner now reads "pane-backed mode active" instead of "pane-backed fallback active."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web launcher now automatically attempts to initialize interactive per-agent pane sessions at startup.

* **Bug Fixes**
  * Improved handling when no agents are present, preventing unnecessary empty pane sessions.

* **Documentation**
  * Updated success messaging for pane-backed mode activation.

* **Tests**
  * Added coverage for pane initialization scenarios, including edge cases and successful initialization paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->