### PR TITLE
feat(onboarding): Phase 1 — pre-office provider picker + empty-shell entry

### DIFF
--- a/web/e2e/screenshots/onboarding-phase1.mjs
+++ b/web/e2e/screenshots/onboarding-phase1.mjs
@@ -1,0 +1,108 @@
+// Capture the Phase 1 pre-office provider picker in two states:
+// all runtimes detected, and no runtimes detected (the evaluator path).
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh onboarding-phase1 <pr-number>
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const PREREQS_ALL_DETECTED = [
+  { name: "claude", required: false, found: true, version: "v1.2.3" },
+  { name: "codex", required: false, found: true, version: "v0.8.1" },
+  { name: "opencode", required: false, found: true, version: "v0.4.0" },
+];
+
+const PREREQS_NONE = [
+  { name: "claude", required: false, found: false },
+  { name: "codex", required: false, found: false },
+  { name: "opencode", required: false, found: false },
+];
+
+async function installPrePickMocks(context, prereqs) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      // Override the default onboarded:true stub so RootRoute renders
+      // the pre-office picker instead of the Shell.
+      await ctx.route("**/api/onboarding/state", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ onboarded: false }),
+        }),
+      );
+      await ctx.route("**/api/onboarding/prereqs", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(prereqs),
+        }),
+      );
+    },
+  });
+}
+
+async function bootPrePick(page) {
+  // Phase 1 ships behind a localStorage flag (lib/featureFlags.ts).
+  // Seed the flag BEFORE the first React render so RootRoute picks up
+  // the V2 surface on its initial mount.
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("wuphf:onboarding-v2", "1");
+    } catch {
+      // private-mode tabs can throw; the picker falls back to the
+      // ?onboardingV2=1 query param in that case.
+    }
+  });
+  // Set up the prereqs-response wait BEFORE navigation so a fast fetch
+  // doesn't race the listener. Deterministic replacement for the old
+  // fixed-400ms sleep (PR #889 CodeRabbit feedback).
+  const prereqsResponse = page.waitForResponse(
+    (res) =>
+      res.url().includes("/api/onboarding/prereqs") &&
+      res.request().method() === "GET" &&
+      res.ok(),
+    { timeout: 15_000 },
+  );
+  await page.goto(`${DEFAULT_BASE}/?onboardingV2=1`, { waitUntil: "load" });
+  await prereqsResponse;
+  await page.waitForSelector('[data-testid="pre-pick-screen"]', {
+    timeout: 15_000,
+  });
+  // Wait for the resolved status labels to land (either "Detected" with
+  // a version, or "Not installed"). The card subtree starts in
+  // "Checking…" and re-renders once prereqs resolve; capturing during
+  // that transient leaks an empty-state into screenshots.
+  await page.waitForFunction(
+    () => {
+      const txt = document.body?.textContent ?? "";
+      return /Detected|Not installed/.test(txt);
+    },
+    null,
+    { timeout: 5_000 },
+  );
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1200, height: 800 },
+});
+
+await installPrePickMocks(context, PREREQS_ALL_DETECTED);
+await bootPrePick(page);
+await shotPage(page, OUT, "01-pre-pick-all-detected");
+
+await installPrePickMocks(context, PREREQS_NONE);
+await bootPrePick(page);
+await shotPage(page, OUT, "02-pre-pick-none-detected");
+
+console.log(`captured 2 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -1,0 +1,180 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PrePickScreen } from "./PrePickScreen";
+
+// The pre-pick screen reads /onboarding/prereqs and POSTs /config +
+// /onboarding/complete. Stub both so tests stay focused on the screen's
+// own behavior — no broker contract is exercised here.
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    get: vi.fn(),
+    post: vi.fn(),
+  };
+});
+
+import { get, post } from "../../api/client";
+
+const getMock = vi.mocked(get);
+const postMock = vi.mocked(post);
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  postMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function mockPrereqs(found: Record<string, boolean>) {
+  getMock.mockResolvedValue([
+    {
+      name: "claude",
+      required: false,
+      found: found.claude ?? false,
+      version: "v1.2.3",
+    },
+    {
+      name: "codex",
+      required: false,
+      found: found.codex ?? false,
+      version: "v0.8.1",
+    },
+    { name: "opencode", required: false, found: found.opencode ?? false },
+  ]);
+}
+
+describe("PrePickScreen", () => {
+  it("renders the three dispatchable runtime cards plus a skip affordance", async () => {
+    mockPrereqs({ claude: true, codex: true });
+    render(<PrePickScreen onComplete={vi.fn()} />);
+
+    expect(
+      await screen.findByTestId("pre-pick-card-claude-code"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("pre-pick-card-codex")).toBeInTheDocument();
+    expect(screen.getByTestId("pre-pick-card-opencode")).toBeInTheDocument();
+    expect(screen.getByTestId("pre-pick-skip")).toBeInTheDocument();
+  });
+
+  it("posts /config and /onboarding/complete when a detected runtime is picked", async () => {
+    mockPrereqs({ claude: true });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/config",
+      expect.objectContaining({
+        llm_provider: "claude-code",
+        llm_provider_priority: ["claude-code"],
+        memory_backend: "markdown",
+      }),
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      "/onboarding/complete",
+      expect.objectContaining({
+        skip_task: true,
+        blueprint: "",
+        agents: [],
+        runtime: "claude-code",
+      }),
+    );
+  });
+
+  it("posts /onboarding/complete with no runtime when the user picks the skip affordance", async () => {
+    mockPrereqs({});
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const skip = await screen.findByTestId("pre-pick-skip");
+    fireEvent.click(skip);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+
+    // /config must NOT be called for sandbox mode — that's the path that
+    // distinguishes evaluators ("look around first" via Marcus) from
+    // committed runtime pickers in Phase 2.
+    expect(
+      postMock.mock.calls.find((call) => call[0] === "/config"),
+    ).toBeUndefined();
+    expect(postMock).toHaveBeenCalledWith(
+      "/onboarding/complete",
+      expect.objectContaining({
+        skip_task: true,
+        runtime: "",
+        runtime_priority: [],
+      }),
+    );
+  });
+
+  it("opens the install URL in a new tab when a missing runtime card is clicked", async () => {
+    mockPrereqs({});
+    const open = vi.fn();
+    const originalOpen = window.open;
+    Object.defineProperty(window, "open", {
+      configurable: true,
+      writable: true,
+      value: open,
+    });
+    try {
+      render(<PrePickScreen onComplete={vi.fn()} />);
+      const card = await screen.findByTestId("pre-pick-card-opencode");
+      // Wait for prereqs fetch so the status text settles on "Not installed".
+      await waitFor(() => expect(card.textContent).toMatch(/Not installed/));
+      fireEvent.click(card);
+      expect(open).toHaveBeenCalledWith(
+        "https://opencode.ai",
+        "_blank",
+        "noopener,noreferrer",
+      );
+      // No backend writes should fire from an install-link click.
+      expect(postMock).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "open", {
+        configurable: true,
+        writable: true,
+        value: originalOpen,
+      });
+    }
+  });
+
+  it("surfaces an error if /onboarding/complete fails and does not invoke onComplete", async () => {
+    mockPrereqs({ codex: true });
+    postMock.mockImplementation(async (path: string) => {
+      if (path === "/onboarding/complete") {
+        throw new Error("broker unreachable");
+      }
+      return {};
+    });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-codex");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /broker unreachable/i,
+    );
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { get, post } from "../../api/client";
+import { RUNTIMES } from "./wizard/constants";
+import { RuntimeLogo } from "./wizard/RuntimeLogos";
+import type { PrereqResult, RuntimeSpec } from "./wizard/types";
+
+// Phase 1 of the onboarding-into-office redesign
+// (docs/specs/onboarding-into-office.md). The 9-step wizard collapses
+// into one pre-office screen — runtime selection. Everything else
+// (company name, blueprint pick, team trim, first task) moves into a
+// CEO DM inside the real Shell in Phase 2 and later.
+//
+// The user picks a detected runtime OR opts into sandbox mode. Either
+// path posts /onboarding/complete with skip_task:true so the broker
+// runs its existing scratch-path setup; deeper changes to the broker
+// (seedMinimalScratchLocked, deterministic phase machine) are Phase 2.
+//
+// `onComplete` is invoked after both the /config and /onboarding/complete
+// requests succeed. RootRoute then flips onboardingComplete and routes the
+// user to the Shell.
+
+interface PrePickScreenProps {
+  onComplete: () => void;
+}
+
+interface RuntimeCardState {
+  spec: RuntimeSpec;
+  detected: PrereqResult | undefined;
+  available: boolean;
+}
+
+interface RuntimeCardProps {
+  state: RuntimeCardState;
+  prereqsLoaded: boolean;
+  isSubmitting: boolean;
+  anySubmitting: boolean;
+  onPick: (spec: RuntimeSpec) => void;
+  onInstall: (url: string) => void;
+}
+
+function cardStatusLabel({
+  prereqsLoaded,
+  available,
+  version,
+}: {
+  prereqsLoaded: boolean;
+  available: boolean;
+  version: string | undefined;
+}): string {
+  if (!prereqsLoaded) return "Checking…";
+  if (!available) return "Not installed";
+  return version ? `Detected · ${version}` : "Detected";
+}
+
+function RuntimeCard({
+  state,
+  prereqsLoaded,
+  isSubmitting,
+  anySubmitting,
+  onPick,
+  onInstall,
+}: RuntimeCardProps) {
+  const { spec, detected, available } = state;
+  const statusLabel = isSubmitting
+    ? "Starting your office…"
+    : cardStatusLabel({
+        prereqsLoaded,
+        available,
+        version: detected?.version,
+      });
+  const installHint =
+    !available && prereqsLoaded ? (
+      <div className="pre-pick-card-install">Install →</div>
+    ) : null;
+  return (
+    <button
+      key={spec.label}
+      type="button"
+      className={`pre-pick-card${available ? " available" : " missing"}`}
+      data-testid={`pre-pick-card-${spec.provider}`}
+      disabled={anySubmitting}
+      onClick={() => {
+        if (!available) {
+          onInstall(spec.installUrl);
+          return;
+        }
+        onPick(spec);
+      }}
+    >
+      <div className="pre-pick-card-head">
+        <RuntimeLogo label={spec.label} />
+        <span className="pre-pick-card-name">{spec.label}</span>
+      </div>
+      <div className="pre-pick-card-status">{statusLabel}</div>
+      {installHint}
+    </button>
+  );
+}
+
+type PrereqsPayload = { prereqs?: PrereqResult[] } | PrereqResult[];
+
+function prereqsFromPayload(data: PrereqsPayload): PrereqResult[] {
+  if (Array.isArray(data)) return data;
+  return data.prereqs ?? [];
+}
+
+// Phase 1 ships the three runtimes the broker can dispatch to: Claude
+// Code, Codex, Opencode. Cursor and Windsurf (provider:null in RUNTIMES)
+// have no dispatch path so we omit them here — they would land the user
+// in sandbox mode anyway.
+const DISPATCHABLE_RUNTIMES = RUNTIMES.filter((r) => r.provider !== null);
+
+export function PrePickScreen({ onComplete }: PrePickScreenProps) {
+  const [prereqs, setPrereqs] = useState<PrereqResult[]>([]);
+  const [prereqsLoaded, setPrereqsLoaded] = useState(false);
+  const [submitting, setSubmitting] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string>("");
+
+  useEffect(() => {
+    let cancelled = false;
+    get<PrereqsPayload>("/onboarding/prereqs")
+      .then((data) => {
+        if (cancelled) return;
+        setPrereqs(prereqsFromPayload(data));
+      })
+      .catch(() => {
+        // Prereqs unreachable — render runtime cards as "Install" so the
+        // user can still proceed. The wizard takes the same posture.
+      })
+      .finally(() => {
+        if (!cancelled) setPrereqsLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const runtimes = useMemo<RuntimeCardState[]>(
+    () =>
+      DISPATCHABLE_RUNTIMES.map((spec) => {
+        const detected = prereqs.find((p) => p.name === spec.binary);
+        return {
+          spec,
+          detected,
+          available: Boolean(detected?.found),
+        };
+      }),
+    [prereqs],
+  );
+
+  async function commitChoice(
+    provider: RuntimeSpec["provider"],
+    runtimeLabel: string,
+  ): Promise<void> {
+    setSubmitError("");
+    setSubmitting(runtimeLabel);
+    try {
+      // /config persists runtime selection. Skip when the user opts into
+      // sandbox mode (provider === null) — they'll wire one up later via
+      // Settings → Runtimes and the broker treats missing llm_provider as
+      // "no dispatch capability."
+      if (provider) {
+        await post("/config", {
+          memory_backend: "markdown",
+          llm_provider: provider,
+          llm_provider_priority: [provider],
+        });
+      }
+      // Phase 1 sends only the minimum the existing /onboarding/complete
+      // handler needs. Company name, blueprint, team trim, and first task
+      // all move into the in-office CEO conversation (Phase 2+).
+      await post("/onboarding/complete", {
+        company: "",
+        description: "",
+        priority: "",
+        website: "",
+        owner_name: "",
+        owner_role: "",
+        scan_completed: false,
+        runtime: provider ?? "",
+        runtime_priority: provider ? [provider] : [],
+        memory_backend: "markdown",
+        blueprint: "",
+        agents: [],
+        api_keys: {},
+        task: "",
+        skip_task: true,
+      });
+      onComplete();
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to start the office";
+      setSubmitError(msg);
+      setSubmitting(null);
+    }
+  }
+
+  function openInstallPage(url: string): void {
+    if (typeof window === "undefined") return;
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  return (
+    <div className="pre-pick-screen" data-testid="pre-pick-screen">
+      <div className="pre-pick-body">
+        <div className="pre-pick-hero">
+          <div className="pre-pick-eyebrow">WUPHF</div>
+          <h1 className="pre-pick-headline">Pick a runtime.</h1>
+          <p className="pre-pick-subhead">
+            Your office needs an AI runtime. Pick one of the three below, or
+            skip to look around first.
+          </p>
+        </div>
+
+        <div className="pre-pick-card-grid">
+          {runtimes.map((state) => (
+            <RuntimeCard
+              key={state.spec.label}
+              state={state}
+              prereqsLoaded={prereqsLoaded}
+              isSubmitting={submitting === state.spec.label}
+              anySubmitting={Boolean(submitting)}
+              onPick={(spec) => void commitChoice(spec.provider, spec.label)}
+              onInstall={openInstallPage}
+            />
+          ))}
+        </div>
+
+        <div className="pre-pick-secondary-row">
+          <button
+            type="button"
+            className="pre-pick-secondary-button"
+            data-testid="pre-pick-skip"
+            disabled={Boolean(submitting)}
+            onClick={() => void commitChoice(null, "skip")}
+          >
+            {submitting === "skip"
+              ? "Opening your office…"
+              : "I’ll add one later  →"}
+          </button>
+        </div>
+
+        <p className="pre-pick-helper">
+          You can change this any time in <strong>Settings → Runtimes</strong>.
+        </p>
+
+        {submitError ? (
+          <div role="alert" className="pre-pick-error">
+            {submitError}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/featureFlags.test.ts
+++ b/web/src/lib/featureFlags.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetOnboardingV2FlagForTests,
+  isOnboardingV2Enabled,
+} from "./featureFlags";
+
+function setSearch(search: string) {
+  window.history.replaceState({}, "", `/${search}`);
+}
+
+beforeEach(() => {
+  __resetOnboardingV2FlagForTests();
+  setSearch("");
+});
+
+afterEach(() => {
+  __resetOnboardingV2FlagForTests();
+  setSearch("");
+});
+
+describe("isOnboardingV2Enabled", () => {
+  it("defaults to false without any opt-in signal", () => {
+    expect(isOnboardingV2Enabled()).toBe(false);
+  });
+
+  it("returns true when the URL carries ?onboardingV2=1", () => {
+    setSearch("?onboardingV2=1");
+    expect(isOnboardingV2Enabled()).toBe(true);
+  });
+
+  it("persists the URL choice so subsequent calls return the same value", () => {
+    setSearch("?onboardingV2=1");
+    expect(isOnboardingV2Enabled()).toBe(true);
+    setSearch("");
+    expect(isOnboardingV2Enabled()).toBe(true);
+  });
+
+  it("lets ?onboardingV2=0 explicitly disable an earlier opt-in", () => {
+    setSearch("?onboardingV2=1");
+    isOnboardingV2Enabled();
+    setSearch("?onboardingV2=0");
+    expect(isOnboardingV2Enabled()).toBe(false);
+    setSearch("");
+    expect(isOnboardingV2Enabled()).toBe(false);
+  });
+});

--- a/web/src/lib/featureFlags.ts
+++ b/web/src/lib/featureFlags.ts
@@ -1,0 +1,74 @@
+// Feature flag plumbing for staged onboarding rollouts.
+//
+// Phase 1 of the onboarding-into-office redesign (docs/specs/
+// onboarding-into-office.md) replaces the 9-step wizard with a single
+// pre-office provider picker plus an empty-shell office entry. The
+// existing wizard stays mounted behind this flag so we can roll back
+// without redeploying.
+//
+// Resolution order:
+//   1. URL search param (?onboardingV2=1 enables, =0 disables). Persisted
+//      to localStorage so subsequent visits respect the explicit choice.
+//   2. localStorage value from a prior URL toggle.
+//   3. Default: false (OFF) — the wizard stays the live path until we
+//      flip the default in a follow-up.
+
+const STORAGE_KEY = "wuphf:onboarding-v2";
+
+function readStorage(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "1" || raw === "true") return true;
+    if (raw === "0" || raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    // Ignore quota / privacy-mode storage errors. The flag falls back
+    // to per-load query-param resolution in that case.
+  }
+}
+
+function readSearchParamOverride(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get("onboardingV2");
+    if (raw === null) return null;
+    if (raw === "1" || raw === "true") return true;
+    if (raw === "0" || raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function isOnboardingV2Enabled(): boolean {
+  const fromParam = readSearchParamOverride();
+  if (fromParam !== null) {
+    writeStorage(fromParam);
+    return fromParam;
+  }
+  const fromStorage = readStorage();
+  if (fromStorage !== null) return fromStorage;
+  return false;
+}
+
+// Test-only helper. Call between tests to keep the localStorage-backed
+// flag from leaking state across cases.
+export function __resetOnboardingV2FlagForTests(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -24,6 +24,7 @@ import { DMView } from "../components/messages/DMView";
 import { InterviewBar } from "../components/messages/InterviewBar";
 import { MessageFeed } from "../components/messages/MessageFeed";
 import { TypingIndicator } from "../components/messages/TypingIndicator";
+import { PrePickScreen } from "../components/onboarding/PrePickScreen";
 import { SplashScreen } from "../components/onboarding/SplashScreen";
 import { Wizard } from "../components/onboarding/Wizard";
 import { ConfirmHost } from "../components/ui/ConfirmDialog";
@@ -33,6 +34,7 @@ import type { WikiTab } from "../components/wiki/WikiTabs";
 import WikiTabs from "../components/wiki/WikiTabs";
 import { useBrokerEvents } from "../hooks/useBrokerEvents";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { isOnboardingV2Enabled } from "../lib/featureFlags";
 import { rootRoute, router } from "../lib/router";
 import { getTheme } from "../lib/themes";
 import { useAppStore } from "../stores/app";
@@ -599,6 +601,9 @@ function RoutedBody() {
 export default function RootRoute() {
   const [apiReady, setApiReady] = useState(false);
   const [showSplash, setShowSplash] = useState(false);
+  // The flag is resolved once at mount. Switching it mid-session would
+  // require a reload anyway — onboarding state is loaded once at boot.
+  const [onboardingV2] = useState<boolean>(() => isOnboardingV2Enabled());
   const theme = useAppStore((s) => s.theme);
   const onboardingComplete = useAppStore((s) => s.onboardingComplete);
   const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
@@ -668,7 +673,16 @@ export default function RootRoute() {
   } else if (showSplash) {
     body = <SplashScreen onDone={() => setShowSplash(false)} />;
   } else if (!onboardingComplete) {
-    body = (
+    body = onboardingV2 ? (
+      <PrePickScreen
+        onComplete={() => {
+          // Phase 1 enters the office immediately. SplashScreen is the
+          // wizard's celebration screen; we skip it for the new flow so
+          // the user lands in the Shell without an intervening modal.
+          setOnboardingComplete(true);
+        }}
+      />
+    ) : (
       <Wizard
         onComplete={() => {
           setShowSplash(true);

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2002,3 +2002,180 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Phase 1: Pre-office provider picker (onboarding-into-office spec)
+   Single full-bleed screen — no modal chrome, no progress dots.
+   ═══════════════════════════════════════════════════════════════ */
+
+.pre-pick-screen {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  background: radial-gradient(circle at center, #f9f9fb 0%, #ffffff 70%);
+}
+
+.pre-pick-body {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: center;
+}
+
+.pre-pick-hero {
+  text-align: center;
+}
+
+.pre-pick-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+}
+
+.pre-pick-headline {
+  font-family: var(--font-logo);
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 12px 0;
+}
+
+.pre-pick-subhead {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 480px;
+  margin: 0 auto;
+  text-wrap: balance;
+}
+
+.pre-pick-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  width: 100%;
+}
+
+@media (max-width: 720px) {
+  .pre-pick-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pre-pick-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-card);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.pre-pick-card:hover:not(:disabled) {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.pre-pick-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.pre-pick-card:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.pre-pick-card.missing {
+  background: transparent;
+}
+
+.pre-pick-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pre-pick-card-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.pre-pick-card-status {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.pre-pick-card.available .pre-pick-card-status {
+  color: var(--green-600, #16a34a);
+}
+
+.pre-pick-card-install {
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.pre-pick-secondary-row {
+  display: flex;
+  justify-content: center;
+}
+
+.pre-pick-secondary-button {
+  font-size: 13px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.pre-pick-secondary-button:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.pre-pick-secondary-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.pre-pick-secondary-button:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.pre-pick-helper {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+.pre-pick-error {
+  font-size: 13px;
+  color: var(--red-600, #dc2626);
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(220, 38, 38, 0.06);
+  border: 1px solid rgba(220, 38, 38, 0.18);
+}


### PR DESCRIPTION
## Summary

First implementation slice of the onboarding-into-office redesign
(see sibling PR with \`docs/specs/onboarding-into-office.md\`). The
9-step modal wizard collapses into one full-bleed pre-office screen —
runtime selection only. Everything else (company name, blueprint
pick, team trim, first task) moves into a CEO DM inside the real
Shell in Phase 2.

The new flow ships behind a localStorage / URL feature flag so we
can roll back without redeploying. The existing wizard is preserved
verbatim and stays the live path until the flag default flips.

## What's in

- \`PrePickScreen\` with three runtime cards (Claude Code, Codex,
  Opencode) backed by \`/onboarding/prereqs\` detection, an "I'll add
  one later" secondary affordance for sandbox mode, and a helper
  line pointing at Settings → Runtimes.
- Sandbox path: skips \`/config\` so the broker keeps no
  \`llm_provider\` persisted, but still completes onboarding so the
  user lands in the Shell.
- Feature flag (\`web/src/lib/featureFlags.ts\`) with URL-param
  toggling that persists to localStorage for follow-up visits.
- Styles bound to existing \`global.css\` tokens; no new design system
  additions.

## How to try it

- Opt in: visit \`/?onboardingV2=1\` once (persisted to localStorage).
- Opt out: visit \`/?onboardingV2=0\` once.
- Default: OFF. Existing wizard is unchanged.

## Tests

- 5 component tests covering each runtime card click, the sandbox
  "skip" affordance, the install-link path for missing runtimes, and
  the error surface when \`/onboarding/complete\` fails.
- 4 unit tests for the feature flag (URL → localStorage persistence,
  explicit-disable case).
- Full web suite green: 170 files / 1543 tests.
- \`bunx biome check\` clean on all touched files.
- \`bunx tsc --noEmit\` clean.

## What's deferred to later phases

- CEO DM auto-open + the deterministic phase machine (Phase 2).
- \`seedMinimalScratchLocked\` (CEO-only office). For now the broker's
  existing scratch path runs, so the office is created with the
  default founding team (Phase 2 narrows this).
- The dogfood-default flag flip (follow-up).

## Test plan

- [ ] Manually verify \`/?onboardingV2=1\` shows the picker on a fresh
      onboarding state
- [ ] Manually verify \`/?onboardingV2=0\` restores the legacy wizard
- [ ] Confirm picking each detected runtime lands the user in the
      Shell with the runtime persisted to \`/config\`
- [ ] Confirm "I'll add one later" lands the user in the Shell with
      no \`llm_provider\` persisted
- [ ] Confirm an already-onboarded user lands directly in Shell
      regardless of the flag
- [ ] Re-run \`bash scripts/test-web.sh\` end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-pre-pick-all-detected](https://github.com/nex-crm/wuphf/raw/screenshots/pr-889/01-pre-pick-all-detected.png)

![02-pre-pick-none-detected](https://github.com/nex-crm/wuphf/raw/screenshots/pr-889/02-pre-pick-none-detected.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase 1 onboarding pre-pick screen for runtime/provider selection with skip-to-sandbox; selection persists configuration and completes onboarding.
  * Onboarding V2 opt-in flag to conditionally show the pre-pick flow.

* **Style**
  * New full-screen pre-pick layout, responsive provider card grid, card states, secondary actions, and error banner.

* **Tests**
  * Unit tests covering pre-pick UI, interactions, and feature-flag behavior.
  * E2E screenshot flow capturing pre-pick states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->