### PR TITLE
feat(team,web): cross-provider parity for Hermes + OpenClaw HTTP — real tool calls, real logos

### DIFF
--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -94,6 +95,26 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	toolByName := make(map[string]agent.AgentTool, len(tools))
 	for _, t := range tools {
 		toolByName[t.Name] = t
+	}
+
+	// Some OpenAI-compat upstreams (Hermes api_server, OpenClaw HTTP) ignore
+	// the caller's tools[] field and run their own agent loop. We can still
+	// make tool calls work by prompting the model to emit
+	// `<tools>{"name":"X","arguments":{...}}</tools>` in its text — WUPHF's
+	// existing parseJSONInContentToolCall parser picks those up and the loop
+	// dispatches them through toolByName the same way a native tool_call
+	// would. The bridge tools are still registered for dispatch even though
+	// the upstream never sees them in the tools[] field.
+	if kind == provider.KindHermesAgent || kind == provider.KindOpenclawHTTP {
+		if len(tools) > 0 {
+			systemPrompt = openAICompatPromptedToolsPrompt(slug, systemPrompt, tools)
+		} else {
+			systemPrompt = openAICompatTextOnlyPrompt(slug, systemPrompt)
+		}
+	} else if len(tools) == 0 {
+		// Native OpenAI-compat (mlx-lm, ollama, exo) with no tools — bridge
+		// failed; degrade to text-only with the same preamble.
+		systemPrompt = openAICompatTextOnlyPrompt(slug, systemPrompt)
 	}
 
 	msgs := make([]agent.Message, 0, 4)
@@ -301,6 +322,14 @@ func isUserVisiblePostTool(name string) bool {
 // with `{` and contains both `"name"` and `"arguments"` substrings.
 func looksUnparsedToolCall(text string) bool {
 	t := strings.TrimSpace(text)
+	// `<tools>{...}</tools>` is the prompted-tools dialect emitted by
+	// Hermes/OpenClaw-HTTP when they use the schema-in-prompt protocol.
+	// It's structurally a tool invocation, never legitimate prose, and we
+	// don't want the live-chat-relay leaking the raw JSON into the channel
+	// before the openAICompatToolLoop dispatches it.
+	if strings.HasPrefix(t, "<tools>") && strings.Contains(t, "</tools>") {
+		return true
+	}
 	if !strings.HasPrefix(t, "{") {
 		return false
 	}
@@ -318,4 +347,79 @@ func isOpenAICompatKind(kind string) bool {
 	default:
 		return false
 	}
+}
+
+// openAICompatTextOnlyPrompt wraps the standard system prompt with a leading
+// directive telling the model that no tools are callable in this session and
+// that its reply text will be posted to the channel verbatim by WUPHF. We do
+// not strip the existing prompt body — its persona / team / voice content is
+// still useful — we just override the parts that promise team_broadcast,
+// team_task, human_message, etc. are dispatchable.
+func openAICompatTextOnlyPrompt(slug, originalPrompt string) string {
+	header := strings.Builder{}
+	header.WriteString("== TOOL-LESS REPLY MODE ==\n")
+	header.WriteString("This API session does NOT support tool calls. Tools like team_broadcast, team_task, team_skill_run, human_message, mcp__wuphf-office__*, query_context, etc. are NOT callable here, even if the section below mentions them.\n")
+	header.WriteString("Reply with plain assistant text ONLY. WUPHF will automatically post that text to the channel for you — no tool invocation is needed or possible.\n")
+	header.WriteString("Do NOT say things like \"I can't execute team_broadcast\" or \"the tool isn't available\" — just answer in prose as if you were replying in chat. Do NOT propose creating tasks, channels, skills, or wiki entries unless the human explicitly asked for narrative-only suggestions.\n")
+	if slug != "" {
+		header.WriteString(fmt.Sprintf("You are @%s. Speak in first person and stay in role.\n", slug))
+	}
+	header.WriteString("\n--- background context (treat tool sections below as descriptive, not callable) ---\n\n")
+	header.WriteString(originalPrompt)
+	return header.String()
+}
+
+// openAICompatPromptedToolsPrompt wraps the standard system prompt with a
+// tool-calling preamble that teaches the model to emit text-encoded tool
+// invocations as `<tools>{...}</tools>` blocks. WUPHF's existing
+// parseJSONInContentToolCall (internal/provider/openai_compat.go) parses
+// those blocks back into tool_use stream chunks, and openAICompatToolLoop
+// dispatches them through the registered tool map and feeds results back
+// as the next user turn — the same multi-turn flow native tool_calls take.
+//
+// This path exists for OpenAI-compat upstreams that ignore the request's
+// tools[] field (Hermes api_server runs its own internal agent loop;
+// OpenClaw HTTP behaves similarly). For those backends, sending tools in
+// the request body is a no-op — the prompt is the only place we can teach
+// the model what's callable.
+func openAICompatPromptedToolsPrompt(slug, originalPrompt string, tools []agent.AgentTool) string {
+	header := strings.Builder{}
+	header.WriteString("== TOOL CALLING (PROMPT-ENCODED) ==\n")
+	header.WriteString("This API session does NOT deliver tools through the OpenAI `tool_calls` field. Instead, you invoke tools by emitting a `<tools>{...}</tools>` block in your reply text. WUPHF parses these blocks, executes the tool, and feeds the result back into the conversation as the next user turn.\n\n")
+	header.WriteString("To call a tool, emit exactly:\n")
+	header.WriteString("    <tools>{\"name\":\"<tool-name>\",\"arguments\":{...}}</tools>\n")
+	header.WriteString("Rules:\n")
+	header.WriteString("- The block must be the ENTIRE reply (with optional surrounding whitespace). Do NOT mix prose and a tools block in the same turn — the parser only fires when the JSON dominates the message.\n")
+	header.WriteString("- Use exactly one tools block per turn. If you need a second tool, wait for the result and call it next turn.\n")
+	header.WriteString("- `arguments` must be a JSON object matching the tool's schema. Strings must be JSON-escaped; do NOT wrap arguments in extra quotes.\n")
+	header.WriteString("- If you do NOT need to call a tool this turn, reply with plain prose — WUPHF will post it to the channel automatically.\n")
+	header.WriteString("- Tool RESULTS arrive as the next user message prefixed with `Tool \"<name>\" returned:`. Read them and decide whether to call another tool or write a final user-facing reply.\n")
+	header.WriteString("- Do NOT mention this protocol to the human (no \"let me call team_broadcast\" narration). Either emit the block or write the reply directly.\n\n")
+	if slug != "" {
+		header.WriteString(fmt.Sprintf("You are @%s. Speak in first person and stay in role.\n\n", slug))
+	}
+	header.WriteString("Available tools (name, description, JSON schema):\n")
+	for _, t := range tools {
+		schemaBytes, err := json.Marshal(t.Schema)
+		schemaStr := "{}"
+		if err == nil && len(schemaBytes) > 0 {
+			schemaStr = string(schemaBytes)
+		}
+		desc := strings.TrimSpace(t.Description)
+		if desc == "" {
+			desc = "(no description)"
+		}
+		// Single-line description keeps the prompt compact; schemas are
+		// already JSON. Tools without schemas get an empty object so the
+		// model emits `"arguments":{}` rather than guessing.
+		header.WriteString(fmt.Sprintf("- %s: %s\n  schema: %s\n", t.Name, desc, schemaStr))
+	}
+	header.WriteString("\nExamples:\n")
+	header.WriteString("To post to #general:\n")
+	header.WriteString("    <tools>{\"name\":\"team_broadcast\",\"arguments\":{\"channel\":\"general\",\"content\":\"Hello team\",\"tagged\":[]}}</tools>\n")
+	header.WriteString("To answer the human without calling any tool:\n")
+	header.WriteString("    Just reply in plain prose. No tools block.\n\n")
+	header.WriteString("--- background context (the section below describes tool names + intent; ignore any language that implies tool_calls are dispatched natively — use the <tools>{...}</tools> protocol above instead) ---\n\n")
+	header.WriteString(originalPrompt)
+	return header.String()
 }

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -400,18 +400,23 @@ func openAICompatPromptedToolsPrompt(slug, originalPrompt string, tools []agent.
 	}
 	header.WriteString("Available tools (name, description, JSON schema):\n")
 	for _, t := range tools {
-		schemaBytes, err := json.Marshal(t.Schema)
+		// Tools without schemas get an empty object so the model emits
+		// `"arguments":{}` rather than guessing. Note `json.Marshal(nil)`
+		// returns `[]byte("null"), nil` — checking only `err == nil` would
+		// emit `schema: null` for nil-schema tools, which is confusing to the
+		// model. Detect nil first.
 		schemaStr := "{}"
-		if err == nil && len(schemaBytes) > 0 {
-			schemaStr = string(schemaBytes)
+		if t.Schema != nil {
+			if schemaBytes, err := json.Marshal(t.Schema); err == nil && len(schemaBytes) > 0 {
+				schemaStr = string(schemaBytes)
+			}
 		}
 		desc := strings.TrimSpace(t.Description)
 		if desc == "" {
 			desc = "(no description)"
 		}
 		// Single-line description keeps the prompt compact; schemas are
-		// already JSON. Tools without schemas get an empty object so the
-		// model emits `"arguments":{}` rather than guessing.
+		// already JSON.
 		header.WriteString(fmt.Sprintf("- %s: %s\n  schema: %s\n", t.Name, desc, schemaStr))
 	}
 	header.WriteString("\nExamples:\n")

--- a/internal/team/headless_openai_compat_test.go
+++ b/internal/team/headless_openai_compat_test.go
@@ -71,6 +71,30 @@ func TestLooksUnparsedToolCall(t *testing.T) {
 			in:   "```json\n{\"name\":\"team_broadcast\",\"arguments\":{\"channel\":\"general\"}}\n```",
 			want: false, // doesn't START with { (leads with the fence) — caller already strips fences
 		},
+		// `<tools>...</tools>` is the prompted-tools dialect emitted by
+		// Hermes / OpenClaw-HTTP when the backend ignores the request's
+		// tools[] field. The live-chat-relay must NOT post the raw JSON
+		// to the channel; the openAICompatToolLoop dispatches it instead.
+		{
+			name: "tools-tag basic",
+			in:   `<tools>{"name":"team_broadcast","arguments":{"channel":"general","content":"hi"}}</tools>`,
+			want: true,
+		},
+		{
+			name: "tools-tag with surrounding whitespace",
+			in:   "   <tools>{\"name\":\"x\",\"arguments\":{}}</tools>\n",
+			want: true,
+		},
+		{
+			name: "tools-tag closed but empty body",
+			in:   `<tools></tools>`,
+			want: true, // structurally a tools-block; should not leak to chat
+		},
+		{
+			name: "prose mentioning the tag name without closer",
+			in:   `I would call the <tools> block but won't here.`,
+			want: false, // no </tools> closer; legitimate prose
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/team/headless_openai_compat_test.go
+++ b/internal/team/headless_openai_compat_test.go
@@ -3,6 +3,7 @@ package team
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,6 +103,35 @@ func TestLooksUnparsedToolCall(t *testing.T) {
 				t.Errorf("looksUnparsedToolCall(%q) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestOpenAICompatPromptedToolsPrompt_NilSchema pins the nil-schema
+// fallback for the schema-in-prompt protocol. json.Marshal(nil) yields
+// `"null"` (4 bytes, no error), so the historic check `err == nil && len > 0`
+// silently emitted `schema: null` for tools that registered no schema —
+// that confused the model and CodeRabbit flagged it. The contract: nil
+// schemas render as `{}`, matching the prompt's stated intent and
+// matching what the parser dispatches when the model leaves arguments
+// off (`"arguments":{}`).
+func TestOpenAICompatPromptedToolsPrompt_NilSchema(t *testing.T) {
+	tools := []agent.AgentTool{
+		{Name: "no_schema_tool", Description: "A tool that has no schema.", Schema: nil},
+		{Name: "with_schema_tool", Description: "A tool with a real schema.", Schema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"x": map[string]any{"type": "string"}},
+		}},
+	}
+	out := openAICompatPromptedToolsPrompt("ceo", "ORIGINAL", tools)
+
+	if !strings.Contains(out, "- no_schema_tool: A tool that has no schema.\n  schema: {}\n") {
+		t.Errorf("nil-schema tool should render `schema: {}`; got:\n%s", out)
+	}
+	if strings.Contains(out, "schema: null") {
+		t.Errorf("prompt must NOT render `schema: null` for nil-schema tools; got:\n%s", out)
+	}
+	if !strings.Contains(out, `"type":"object"`) {
+		t.Errorf("real-schema tool should render its JSON schema verbatim; got:\n%s", out)
 	}
 }
 

--- a/web/e2e/screenshots/harness-badges.mjs
+++ b/web/e2e/screenshots/harness-badges.mjs
@@ -1,0 +1,224 @@
+// Capture the harness badges that show which LLM runtime each agent is on.
+// PR #890 fixes two regressions:
+//   1. `hermes-agent` and `openclaw-http` kinds fell through to the Claude
+//      icon — now Hermes shows the caduceus on indigo, OpenClaw shows the
+//      lobster on white.
+//   2. The badges now use the projects' actual SVGs (favicon.svg /
+//      acp_registry/icon.svg) embedded verbatim, not hand-redrawn glyphs.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh harness-badges <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+// One agent per provider kind so each badge variation is visible in the
+// participant rail. Includes the existing claude-code/codex/opencode/openclaw
+// kinds for visual comparison alongside the new hermes-agent and the
+// openclaw-http alias.
+const OFFICE_MEMBERS = [
+  {
+    slug: "ceo",
+    name: "CEO",
+    role: "Lead agent on claude-code",
+    expertise: ["coordination"],
+    status: "active",
+    liveActivity: "Reviewing the launch plan",
+    built_in: true,
+    online: true,
+    provider: { kind: "claude-code" },
+  },
+  {
+    slug: "codex-test",
+    name: "Codex Test",
+    role: "Test agent on codex",
+    expertise: ["test"],
+    status: "idle",
+    online: true,
+    provider: { kind: "codex" },
+  },
+  {
+    slug: "opencode-test",
+    name: "Opencode Test",
+    role: "Test agent on opencode",
+    expertise: ["test"],
+    status: "idle",
+    online: true,
+    provider: { kind: "opencode" },
+  },
+  {
+    slug: "openclaw-test",
+    name: "OpenClaw Test",
+    role: "Test agent on openclaw-http",
+    expertise: ["test"],
+    status: "idle",
+    online: true,
+    provider: { kind: "openclaw-http" },
+  },
+  {
+    slug: "hermes-test",
+    name: "Hermes Test",
+    role: "Test agent on hermes-agent",
+    expertise: ["test"],
+    status: "idle",
+    online: true,
+    provider: { kind: "hermes-agent" },
+  },
+];
+
+const CHANNEL_MEMBERS = [
+  ...OFFICE_MEMBERS,
+  { slug: "human", name: "Human", role: "Viewer" },
+];
+
+const MESSAGES = [
+  {
+    id: "msg-1",
+    from: "human",
+    channel: "general",
+    content:
+      "Roll call — each of you, one sentence: which runtime are you on?",
+    timestamp: "2026-05-17T20:00:00Z",
+  },
+  {
+    id: "msg-2",
+    from: "ceo",
+    channel: "general",
+    content: "CEO here, running on **Claude Sonnet 4.6**.",
+    timestamp: "2026-05-17T20:00:30Z",
+    reply_to: "msg-1",
+  },
+  {
+    id: "msg-3",
+    from: "codex-test",
+    channel: "general",
+    content: "@codex-test: I'm running on **GPT-5**.",
+    timestamp: "2026-05-17T20:00:35Z",
+    reply_to: "msg-1",
+  },
+  {
+    id: "msg-4",
+    from: "opencode-test",
+    channel: "general",
+    content: "@opencode-test: running through **Opencode**.",
+    timestamp: "2026-05-17T20:00:40Z",
+    reply_to: "msg-1",
+  },
+  {
+    id: "msg-5",
+    from: "openclaw-test",
+    channel: "general",
+    content:
+      "@openclaw-test: I'm openclaw-test, running on **openai-codex/gpt-5** via the OpenClaw HTTP gateway.",
+    timestamp: "2026-05-17T20:00:45Z",
+    reply_to: "msg-1",
+  },
+  {
+    id: "msg-6",
+    from: "hermes-test",
+    channel: "general",
+    content:
+      "@hermes-test here — running on **gpt-5.5** via Hermes Agent's OpenAI-compatible api_server.",
+    timestamp: "2026-05-17T20:00:50Z",
+    reply_to: "msg-1",
+  },
+];
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 940 },
+});
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/channels", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          channels: [
+            {
+              slug: "general",
+              name: "general",
+              description: "Primary coordination channel.",
+              members: OFFICE_MEMBERS.map((m) => m.slug).concat("human"),
+            },
+          ],
+        }),
+      }),
+    );
+    await ctx.route("**/api/office-members", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          members: OFFICE_MEMBERS,
+          meta: { humanHasPosted: true },
+        }),
+      }),
+    );
+    await ctx.route("**/api/members*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ members: CHANNEL_MEMBERS }),
+      }),
+    );
+    await ctx.route("**/api/messages*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ messages: MESSAGES }),
+      }),
+    );
+    await ctx.route("**/api/requests*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ requests: [] }),
+      }),
+    );
+  },
+});
+
+await bootShell(page, {
+  afterFlipSelector: ".sidebar-agent-avatar",
+  settleMs: 800,
+});
+
+// 1. Full channel view — sidebar avatars + message bubbles, each with its
+//    own harness badge. This is the headline "all five kinds at once" shot.
+await shotPage(page, OUT, "01-cross-provider-channel");
+
+// 2. Sidebar zoom — agents-rail only, so the badge differences are easy to
+//    compare at the resolution the reviewer sees them in the app.
+await shotElement(
+  page,
+  ".sidebar-agents, .agents-rail, nav.sidebar",
+  OUT,
+  "02-sidebar-harness-badges",
+).catch(async () => {
+  // Selectors evolved across refactors; fall back to whichever container
+  // actually wraps the agent avatars so the spec doesn't fail-stop here.
+  await shotElement(page, "aside, .left-sidebar", OUT, "02-sidebar-harness-badges");
+});
+
+// 3. Message bubble zoom — the badge attaches to the avatar at message-
+//    bubble scale too. Capture the cluster of bubble avatars so reviewers
+//    can see the same badge on a different surface.
+await shotElement(
+  page,
+  ".messages-list, .channel-messages, main",
+  OUT,
+  "03-message-bubble-badges",
+);
+
+console.log(`captured cross-provider harness badge screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/ui/HarnessBadge.tsx
+++ b/web/src/components/ui/HarnessBadge.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { HarnessKind } from "../../lib/harness";
 import { harnessLabel } from "../../lib/harness";
 
@@ -7,65 +9,173 @@ interface HarnessBadgeProps {
   className?: string;
 }
 
-const PALETTE: Record<HarnessKind, { bg: string; fg: string }> = {
-  "claude-code": { bg: "#D97757", fg: "#FFFFFF" },
-  codex: { bg: "#10A37F", fg: "#FFFFFF" },
-  opencode: { bg: "#2563EB", fg: "#FFFFFF" },
-  openclaw: { bg: "#8B5CF6", fg: "#FFFFFF" },
+// Per-kind rendering record. Each entry describes the badge's background
+// color, a viewBox for the embedded SVG (so each brand's native coordinate
+// system survives), and an SVG body. We use the projects' OWN SVG sources
+// verbatim where they exist:
+//   - openclaw — http://127.0.0.1:18789/favicon.svg (gradient lobster)
+//   - hermes-agent — ~/.hermes/hermes-agent/acp_registry/icon.svg (caduceus)
+// The other three (claude-code, codex, opencode) have no permissively-shippable
+// SVG inside this repo; they keep minimal monogram-style glyphs in brand colors.
+type GlyphDef = {
+  bg: string;
+  viewBox: string;
+  body: ReactNode;
 };
 
-function Glyph({ kind, color }: { kind: HarnessKind; color: string }) {
-  switch (kind) {
-    case "claude-code":
-      return (
+const GLYPHS: Record<HarnessKind, GlyphDef> = {
+  "claude-code": {
+    bg: "#D97757",
+    viewBox: "0 0 24 24",
+    body: (
+      <path
+        d="M12 3v18M3 12h18M5.6 5.6l12.8 12.8M18.4 5.6L5.6 18.4"
+        stroke="#FFFFFF"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+      />
+    ),
+  },
+  codex: {
+    bg: "#10A37F",
+    viewBox: "0 0 24 24",
+    body: (
+      <path
+        d="M6 8l5 4-5 4M13 16h6"
+        stroke="#FFFFFF"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    ),
+  },
+  opencode: {
+    bg: "#2563EB",
+    viewBox: "0 0 24 24",
+    body: (
+      <path
+        d="M9 8l-4 4 4 4M15 8l4 4-4 4"
+        stroke="#FFFFFF"
+        strokeWidth="2.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    ),
+  },
+  // OpenClaw lobster — exact copy of the project's favicon.svg served from
+  // their gateway at /favicon.svg. White badge background lets the native
+  // red gradient + dark eyes read clearly even at 12px.
+  openclaw: {
+    bg: "#FFFFFF",
+    viewBox: "0 0 120 120",
+    body: (
+      <>
+        <defs>
+          <linearGradient
+            id="harness-openclaw-gradient"
+            x1="0%"
+            y1="0%"
+            x2="100%"
+            y2="100%"
+          >
+            <stop offset="0%" stopColor="#ff4d4d" />
+            <stop offset="100%" stopColor="#991b1b" />
+          </linearGradient>
+        </defs>
+        {/* body */}
         <path
-          d="M12 3v18M3 12h18M5.6 5.6l12.8 12.8M18.4 5.6L5.6 18.4"
-          stroke={color}
-          strokeWidth="2.4"
+          d="M60 10 C30 10 15 35 15 55 C15 75 30 95 45 100 L45 110 L55 110 L55 100 C55 100 60 102 65 100 L65 110 L75 110 L75 100 C90 95 105 75 105 55 C105 35 90 10 60 10Z"
+          fill="url(#harness-openclaw-gradient)"
+        />
+        {/* left claw */}
+        <path
+          d="M20 45 C5 40 0 50 5 60 C10 70 20 65 25 55 C28 48 25 45 20 45Z"
+          fill="url(#harness-openclaw-gradient)"
+        />
+        {/* right claw */}
+        <path
+          d="M100 45 C115 40 120 50 115 60 C110 70 100 65 95 55 C92 48 95 45 100 45Z"
+          fill="url(#harness-openclaw-gradient)"
+        />
+        {/* antennae */}
+        <path
+          d="M45 15 Q35 5 30 8"
+          stroke="#ff4d4d"
+          strokeWidth="3"
+          strokeLinecap="round"
+          fill="none"
+        />
+        <path
+          d="M75 15 Q85 5 90 8"
+          stroke="#ff4d4d"
+          strokeWidth="3"
+          strokeLinecap="round"
+          fill="none"
+        />
+        {/* eyes */}
+        <circle cx="45" cy="35" r="6" fill="#050810" />
+        <circle cx="75" cy="35" r="6" fill="#050810" />
+        <circle cx="46" cy="34" r="2.5" fill="#00e5cc" />
+        <circle cx="76" cy="34" r="2.5" fill="#00e5cc" />
+      </>
+    ),
+  },
+  // Hermes caduceus — exact copy of ~/.hermes/hermes-agent/acp_registry/icon.svg.
+  // Original uses `currentColor`, so we set `color` on the wrapper and the paths
+  // inherit it. White-on-indigo for visibility on the indigo Hermes badge.
+  "hermes-agent": {
+    bg: "#3730A3",
+    viewBox: "0 0 16 16",
+    body: (
+      <>
+        <path
+          d="M8 1.5v13"
+          stroke="currentColor"
+          strokeWidth="1.5"
           strokeLinecap="round"
         />
-      );
-    case "codex":
-      return (
         <path
-          d="M6 8l5 4-5 4M13 16h6"
-          stroke={color}
-          strokeWidth="2.4"
+          d="M8 3.25c-2.35-1.4-4.7-.95-6.25.35 1.85-.2 3.8.2 5.55 1.55"
+          stroke="currentColor"
+          strokeWidth="1.1"
           strokeLinecap="round"
           strokeLinejoin="round"
-          fill="none"
         />
-      );
-    case "opencode":
-      return (
         <path
-          d="M9 8l-4 4 4 4M15 8l4 4-4 4"
-          stroke={color}
-          strokeWidth="2.4"
+          d="M8 3.25c2.35-1.4 4.7-.95 6.25.35-1.85-.2-3.8.2-5.55 1.55"
+          stroke="currentColor"
+          strokeWidth="1.1"
           strokeLinecap="round"
           strokeLinejoin="round"
-          fill="none"
         />
-      );
-    case "openclaw":
-      return (
         <path
-          d="M7 5v10M12 3v12M17 5v10M6 15c0 3 3 5 6 5s6-2 6-5"
-          stroke={color}
-          strokeWidth="2.2"
+          d="M8 13.25c-2.3-1-3.05-2.65-1.35-4.15-2 .8-2.35 2.95-.35 4"
+          stroke="currentColor"
+          strokeWidth="1.1"
           strokeLinecap="round"
-          fill="none"
+          strokeLinejoin="round"
         />
-      );
-  }
-}
+        <path
+          d="M8 13.25c2.3-1 3.05-2.65 1.35-4.15 2 .8 2.35 2.95.35 4"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <circle cx="8" cy="1.8" r="1.1" fill="currentColor" />
+      </>
+    ),
+  },
+};
 
 export function HarnessBadge({
   kind,
   size = 12,
   className,
 }: HarnessBadgeProps) {
-  const { bg, fg } = PALETTE[kind];
+  const glyph = GLYPHS[kind];
   const classes = ["harness-badge", className].filter(Boolean).join(" ");
   return (
     <span
@@ -73,10 +183,21 @@ export function HarnessBadge({
       role="img"
       aria-label={`${harnessLabel(kind)} harness`}
       title={harnessLabel(kind)}
-      style={{ width: size, height: size, background: bg }}
+      style={{
+        width: size,
+        height: size,
+        background: glyph.bg,
+        color: "#FFFFFF",
+      }}
     >
-      <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true">
-        <Glyph kind={kind} color={fg} />
+      <svg
+        viewBox={glyph.viewBox}
+        width={size}
+        height={size}
+        fill="none"
+        aria-hidden="true"
+      >
+        {glyph.body}
       </svg>
     </span>
   );

--- a/web/src/lib/harness.ts
+++ b/web/src/lib/harness.ts
@@ -1,13 +1,24 @@
 import type { OfficeMember } from "../api/client";
 
-export type HarnessKind = "claude-code" | "codex" | "opencode" | "openclaw";
+export type HarnessKind =
+  | "claude-code"
+  | "codex"
+  | "opencode"
+  | "openclaw"
+  | "hermes-agent";
 
+// `openclaw-http` is the OpenAI-compat transport for OpenClaw; treat it as the
+// same harness visually as the WebSocket bridge so users see one OpenClaw
+// identity. Hermes is its own harness.
 const VALID_KINDS: Record<string, HarnessKind> = {
   "claude-code": "claude-code",
   claude: "claude-code",
   codex: "codex",
   opencode: "opencode",
   openclaw: "openclaw",
+  "openclaw-http": "openclaw",
+  "hermes-agent": "hermes-agent",
+  hermes: "hermes-agent",
 };
 
 function normalize(raw: string | undefined | null): HarnessKind | null {
@@ -38,5 +49,7 @@ export function harnessLabel(kind: HarnessKind): string {
       return "Opencode";
     case "openclaw":
       return "OpenClaw";
+    case "hermes-agent":
+      return "Hermes";
   }
 }


### PR DESCRIPTION
## Summary

Makes `hermes-agent` and `openclaw-http` first-class providers in WUPHF on two axes that were broken: their agents couldn't actually call broker tools, and their UI badges fell back to the Claude icon.

**Backend** (`internal/team/headless_openai_compat.go`)

Hermes's `api_server` adapter and OpenClaw's `/v1/chat/completions` handler both **ignore the caller's `tools[]` field** — they run their own internal agent loops with their own toolsets. That meant WUPHF agents bound to those backends couldn't dispatch `team_broadcast`, `team_task`, or any other broker MCP tool. The model would type prose, or literally apologize for the missing tool ("I can't execute team_broadcast because that tool isn't available in this API session" — observed in `headless-codex-hermes-test.log`).

Fix: when an OpenAI-compat turn targets one of those kinds, the system prompt now teaches the model to emit `<tools>{"name":"X","arguments":{...}}</tools>` blocks. That form is already understood by `provider.parseJSONInContentToolCall` (one of three dialects the parser supports), and the existing `openAICompatToolLoop` dispatches it through the registered tool map and feeds results back via the standard multi-turn flow — same behavior native OpenAI `tool_calls` would get.

Two supporting changes:
- `openAICompatTextOnlyPrompt` fallback for when the MCP bridge fails to register tools at all (degrades gracefully, suppresses the apology language).
- `looksUnparsedToolCall` now recognizes the `<tools>...</tools>` form so the live-chat-relay doesn't leak raw JSON into channels before the loop dispatches the tool. New test cases pin the expanded predicate.

**Frontend** (`web/src/lib/harness.ts`, `web/src/components/ui/HarnessBadge.tsx`)

PR #796 added `hermes-agent` and `openclaw-http` as provider kinds, but the frontend `harness.ts` map never learned about them — both fell through `normalize()` and rendered as the orange Claude badge. Hard to tell which agent was on which runtime.

Now:
- `HarnessKind` includes `hermes-agent`. `VALID_KINDS` aliases `openclaw-http` → `openclaw` (same identity, different transport) and accepts both `hermes-agent` and `hermes`.
- `HarnessBadge` restructured to a `GLYPHS` record keyed on kind, each entry carrying its own background, native viewBox, and SVG body.
- **OpenClaw** embeds the project's `favicon.svg` verbatim — red gradient lobster, antennae, teal-pupil eyes — on a white badge background so the native colors read at 12px.
- **Hermes** embeds `acp_registry/icon.svg` verbatim — caduceus paths use `currentColor` and tint white on a Nous-indigo (`#3730A3`) background.
- `claude-code` / `codex` / `opencode` keep their existing monogram glyphs (no permissively-shippable upstream SVGs to embed for those yet).

## End-to-end verification

Local test office with 4 hires (one per provider):

| Agent | Provider | Outcome |
|---|---|---|
| `claude-test` | `claude-code` | Tool-calls via native MCP (unchanged) |
| `codex-test` | `codex` | Tool-calls via native MCP (unchanged) |
| `openclaw-test` | `openclaw-http` | **NEW**: `team_broadcast` dispatched via `<tools>` block |
| `hermes-test` | `hermes-agent` | **NEW**: `team_broadcast` dispatched via `<tools>` block |

Log evidence (`~/.wuphf/logs/headless-codex-hermes-test.log`):
```
openai_compat_tool_ok: team_broadcast -> Posted to #general as @hermes-test (msg-101).
openai_compat_tool_ok: team_broadcast -> Posted to #general as @hermes-test (msg-106) in reply to msg-101.
openai_compat_tool_ok: team_broadcast -> Posted to #general as @hermes-test (msg-112) in reply to msg-110.
```

## Test plan

- [x] `go test ./internal/team` — full team package, all pass (including the extended `TestLooksUnparsedToolCall` cases for the `<tools>` form)
- [x] `gofmt -l` clean
- [x] `go vet ./internal/team` clean
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check --write` clean
- [x] `go build -o wuphf ./cmd/wuphf` succeeds
- [x] `bun run build` (web) succeeds
- [x] Manual: spawn an office, hire 4 agents (one per provider), DM each to confirm streaming works, post a 4-way `@`-tag to #general and confirm all 4 reply (claude-code/codex via native tool_calls, hermes/openclaw via prompted `<tools>`)
- [ ] Screenshots (web/) — pending; reviewer can spin up a 4-provider office to verify the badges render. UI delta is described above; the existing screenshot harness at `web/e2e/screenshots/` would need a new spec that mocks a 4-provider roster.

## Caveats reviewers should weigh

- The prompted-tools approach is fragile against very small models or models that ignore formatting instructions. It works well on gpt-5.4 / gpt-5.5-grade backends (verified here) but may regress if the user swaps Hermes's inference provider to something weaker. The text-only fallback catches the case where the model fails to emit a parseable `<tools>` block — the reply still lands in the channel as prose.
- Multi-step tool sequences on prompted-tools backends are noticeably slower than native tool_calls because each turn through Hermes runs Hermes's own internal agent loop.
- The OpenClaw / Hermes brand SVGs are embedded verbatim from the projects' own asset files. If those upstream assets are licensed restrictively (haven't audited), we may need to switch to clean-room redraws before public release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-cross-provider-channel](https://github.com/nex-crm/wuphf/raw/screenshots/pr-890/01-cross-provider-channel.png)

![02-sidebar-harness-badges](https://github.com/nex-crm/wuphf/raw/screenshots/pr-890/02-sidebar-harness-badges.png)

![03-message-bubble-badges](https://github.com/nex-crm/wuphf/raw/screenshots/pr-890/03-message-bubble-badges.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now use a tool-aware or tool-less prompt so tool calls are only used when available; unparsed tool-call blocks are suppressed from chat output.
  * Added explicit support and labeling for the Hermes agent kind alongside existing providers.
  * Redesigned harness provider badges with unique SVG visuals per provider.

* **Tests**
  * Extended unit tests for tool-call detection and prompt rendering.
  * Added cross-provider E2E screenshot harness for badge rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->