### PR TITLE
feat(onboarding): Phase 2 — deterministic CEO conversation UI

### DIFF
--- a/docs/specs/onboarding-into-office.md
+++ b/docs/specs/onboarding-into-office.md
@@ -1,0 +1,1108 @@
+# Design — Onboarding into the Office
+
+**Branch:** `design/onboarding-into-office`
+**Status:** Draft for review
+**Author:** Design consultation, 2026-05-17
+**Replaces:** `web/src/components/onboarding/Wizard.tsx` (9-step modal) and the
+hard-cut transition into `Shell` after `/onboarding/complete`.
+
+---
+
+## TL;DR
+
+The current onboarding is a 9-step modal wizard that hard-cuts to an office the
+user has not yet seen. New users get all the questions front-loaded, the office
+appears fully formed in one frame, and agents start running on the first task
+before the user has any trust calibration. We replace it with:
+
+1. **One pre-office screen** — provider selection (Claude Code / Codex /
+   Opencode). Everything else moves into the office.
+2. **An empty office shell with a DM open to CEO.** The user sees their office
+   from frame 1, but it is quiet. The CEO greets them and asks the first
+   question. The shell **populates live** as decisions are made: channels
+   fade in, agents slide into the sidebar, the workspace label updates.
+   The early turns are pure form-fills (workspace name, description, website
+   URL, blueprint pick, team trim) plus a deterministic website scan that
+   seeds the wiki. **No LLM tokens spent in this phase.** The LLM only
+   starts speaking once the user describes a first issue.
+3. **An issue-first planning loop.** Tasks are upgraded to **Issues** — proper
+   spec documents with comments, sub-issues, and an explicit human approval
+   gate. CEO drafts the issue with the user; CEO can suggest pulling other
+   agents in to comment during drafting. **Nothing executes until the user
+   approves the issue.** This is the trust-building beat the current product
+   does not have.
+4. **One agent cast across two stages.** No separate "planner" role. The same
+   Engineer, Designer, PM, etc. comment during drafting and then execute after
+   approval. Stages are a property of the issue, not the agents.
+
+Result: the office feels like it is forming around the user as they decide what
+to do, and they get to plan before anything runs. Activation goes from
+*see → trust*: the user sees a coherent office and gets one trustworthy first
+output (an approved issue) before any execution happens.
+
+---
+
+## Eng review decisions (2026-05-17)
+
+`/plan-eng-review` locked these decisions and folded the scope reductions back
+into the implementation phases. Each line is a load-bearing decision that
+should not be revisited without going through the same review.
+
+### Scope reduction
+- **Sub-issues + wiki mirror deferred to Phase 6.** Phase 4 v1 ships the issue
+  document, comments timeline, Approve & Start gate, and execution lineup
+  dispatch. Sub-issue semantics (parent-child, dispatch order, cascading
+  completion) and wiki mirror on approval move to a Phase 6 follow-up. Cuts
+  ~3 dev-days off v1 with no loss to the trust-calibration goal.
+
+### Architecture
+- **Approval gate: server-side enforcement in the broker.** Adds
+  `isExecutableTeamTaskStatus` (true only for `LifecycleStateRunning` and
+  `LifecycleStateApproved`). Every dispatch entry point goes through the
+  guard: `PamDispatcher`, `headless codex`, self-heal, agent-to-agent
+  dispatch, external triggers. Comments allowed in any lifecycle state.
+- **Issue surface reuses existing lifecycle states.** No new "Issue" primitive.
+  An issue IS a lifecycle task with a richer presentation. Status pill maps
+  to existing `LifecycleState`; `Approve & Start` = existing `approve`
+  action; comments use the existing comment infrastructure (already wired
+  per `broker_inbox_handler.go:229`). Adds one new state
+  `LifecycleStateDrafting` for the pre-Intake "agents can comment, not
+  dispatch" mode. Cuts ~40% off Phase 3 scope.
+- **CEO transcript lives in `b.messages`, not in onboarding state.** The CEO
+  DM is a real DM (`dm:ceo:onboarding` reserved slug). Inherits SSE,
+  persistence, replay, search for free. `state.CEOTranscript` is NOT
+  introduced.
+- **Staged form answers + atomic seed at `seed` phase.** User answers update
+  `state.FormAnswers`. Sidebar "office forming" is a frontend overlay
+  rendering preview rows from `state.FormAnswers`. The atomic
+  `seedFromBlueprintLocked` (existing) runs once at the `seed` phase
+  boundary. No broker mutation refactor required.
+- **Onboarding completes at end of `bridge` phase regardless of first issue.**
+  `state.CompletedAt` is set when the user picks "Start an issue" OR
+  "Look around first" at `bridge`. Adds separate
+  `state.FirstIssueApprovedAt *time.Time` for activation-depth tracking.
+  Marcus path (look around first) is a fully onboarded user.
+- **Explicit phase cursor + `PendingSuggestion` for resumption.** No
+  transcript replay. State has `Phase string` + `PendingSuggestion
+  *Suggestion`. On reopen, if `PendingSuggestion != nil`, re-emit it
+  (idempotent by `Suggestion.ID`). Transcript is for users to read, not
+  for the machine to interpret.
+- **Scratch path uses `seedMinimalScratchLocked` (new), not
+  `synthesizeBlueprintFromState`.** Scratch seed at `seed` phase commits
+  exactly `#general` + 2 wiki pages + CEO. No fake-synthesized team.
+  When the user describes a task at `draft` phase, CEO's LLM call
+  proposes the team inline and they're added via the broker's existing
+  incremental agent-add path.
+
+### Code quality
+- **Frontend reuses `DMView` for the CEO chat.** A small `OnboardingDMRoute`
+  wrapper provides the preview-overlay context and points `DMView` at
+  the reserved `dm:ceo:onboarding` channel. No new chat shell, no new
+  composer, no duplicated SSE/scroll/optimistic-post code.
+- **Suggestion cards extend `InterviewBar`/`HumanInterviewOverlay`.** New
+  message kinds: `ceo_form_field`, `ceo_chip_row`, `ceo_checklist`,
+  `ceo_team_trim`, `ceo_scan_chip`. All routed through the existing
+  kind-dispatcher. Inherits the `sanitizeContextValue` Go-side
+  sanitization fix from PR #684 (the confused-deputy bypass test).
+
+### Tests (load-bearing)
+- **Sanitization regression as Phase 2 acceptance gate.** New file
+  `broker_onboarding_sanitize_test.go`: every new `ceo_*` kind exercised
+  with the PR #684 attack-string set; payload must pass through
+  `sanitizeContextValue` before any broker write.
+- **Approval gate parametric test as Phase 4 acceptance gate.** New file
+  `broker_lifecycle_dispatch_test.go`: parametric over every dispatch
+  entry point. Negative cases (Drafting, Intake, Review,
+  ChangesRequested) all reject with `ErrIssueNotApproved`. Positive
+  cases (Running, Approved) all allow. Comment path allowed in all
+  states.
+- **E2E for all three ICP scenarios.** Sam (scratch), Priya (blueprint),
+  Marcus (look around first). Marcus path asserts ZERO LLM provider calls
+  made across the entire flow.
+
+### Performance
+- **State persisted on phase transition + form-field commit.** No
+  per-keystroke disk I/O. Intra-field typing stays client-side until
+  submit. ~10-12 writes to `onboarded.json` per full onboarding.
+
+---
+
+## Design review decisions (2026-05-17)
+
+`/plan-design-review` locked these decisions and folded them into the spec.
+Each line is a load-bearing visual + interaction choice that should not be
+revisited without going through the same review.
+
+### Focal hierarchy + layout
+- **Office-entry frame focal hierarchy:** PRIMARY = CEO greeting + first
+  `form_field` card (only purple affordance on the page). SECONDARY = sidebar
+  group labels at `--text-tertiary` (helper text SUPPRESSED until phase
+  advances past `greet`), ChannelHeader showing 'CEO' + status dot.
+  TERTIARY = workspace rail tile (empty placeholder), StatusBar (minimal copy).
+- **Issue document layout:** single-column scroll at max-width 720px. Sticky
+  status pill header + sticky button row. Spec sections (Goal/Context/
+  Approach/Acceptance) + comments timeline in one scrollable column. After
+  first approval, spec sections auto-collapse into a 3-line summary card
+  with `Expand spec` affordance; comments timeline fills the area. Return
+  visits anchor scroll to last-unread comment.
+
+### State coverage
+- **Card states matrix.** Every card kind moves through three universal
+  stages: `pending` (interactive, primary affordance visible), `submitting`
+  (controls disabled, subtle spinner inside primary button only), `committed`
+  (collapsed to a one-line confirmation in the timeline using
+  `--text-secondary` with a small leading `✓`). Per-kind error states layer
+  on top (inline validation for `form_field`, banner above for chip-row /
+  checklist, distinct `failed` state for `scan_chip`).
+- **Submitting state never animates** beyond the inline spinner. No
+  full-card skeleton, no progress bar, no row-shimmer.
+
+### Journey (LLM phase pacing)
+- **Stream the draft as it generates.** On `bridge → draft` transition, the
+  Issue document opens immediately with empty sections (status: Drafting).
+  CEO streams each section in order (Goal → Context → Approach → Acceptance)
+  with a typing-dot prefix on the unwritten section. In the CEO DM, a
+  one-line acknowledgement `Drafting #142 → see issue` with a Jump
+  affordance. No spinner. No 'CEO is thinking' modal. The wait IS the
+  experience — same pattern as Claude Code's plan mode.
+
+### AI-slop guardrails
+- **CEO voice canon — deterministic templates locked verbatim in spec.**
+  Add a `## CEO Voice — deterministic templates` section with exact strings
+  per phase (greet / identity 4 fields / scan 3 variations / blueprint /
+  team trim / seed success x2 / bridge 2 outcomes). Rules: no 'Welcome',
+  no 'I'm your AI', no preamble, declarative, low word count, lightly
+  funny if natural but never quippy. CEO does not introduce himself.
+  Example reference copy:
+  - `greet`: `Office name?`
+  - `seed-done (scratch)`: `✓ Empty office, your call. Start an issue, or look around?`
+  - `bridge > look around`: `✓ I'll be in #general when you need me.`
+
+### Design system / token bindings
+- **Bind every new surface to existing `global.css` tokens.** Spec lists
+  exact CSS-variable bindings: sidebar empty group label =
+  `--text-tertiary`; suggestion card border = `--border` 1px; primary
+  affordance = `--accent` (#9F4DBF); committed line text =
+  `--text-secondary`.
+- **Add 3 new preview-state tokens** for the staged sidebar overlay:
+  `--preview-row-bg` = `--accent-bg` (lavender tint, already exists);
+  `--preview-row-border` = dashed 1px `--accent-bg-strong`;
+  `--preview-row-text` = `--text-secondary`. Visual language: dashed
+  border + lavender bg = "this thing is staged, not committed yet."
+- **Status pills reuse the existing `LifecycleStatePill` component.** Add
+  ONE new entry to `STATE_PILL_TOKENS` for the new `drafting` state:
+  `bg: var(--accent-bg)`, `text: var(--accent)`, `label: "drafting"`.
+  Distinct from intake/ready (which use `--bg-row-active`) — signals
+  "needs human attention" via the brand accent.
+- **Reuse `PixelAvatar`** for CEO and all agent avatars; do not introduce a
+  new avatar system.
+
+### Responsive
+- **Mobile (< 768px) is explicitly de-scoped for v1, with NO notice or
+  redirect.** Whatever the desktop layout renders at narrow widths is what
+  the user sees. WUPHF is a local dev tool; mobile is genuine edge case.
+  Not tracked as a follow-up.
+
+### Accessibility
+- **Keyboard model per card kind.**
+
+  | Card | Tab | Arrow | Enter | Space |
+  |---|---|---|---|---|
+  | `form_field` | input focus | — | submit | type |
+  | `chip_row` | into row | move chip selection | commit | commit |
+  | `checklist` | item | — | Submit button | toggle |
+  | `team_trim` | item | — | Submit button | toggle |
+  | `scan_chip` | — (read-only) | — | — | — |
+
+- **Focus management on commit.** After card N commits, focus moves to
+  card N+1's first interactive element. On `seed` phase commit, focus moves
+  to the bridge-phase chip row.
+- **ARIA live region** for the sidebar preview overlay: `aria-live="polite"`,
+  announces each preview-row enter as `"Added channel #billing"` etc.
+  Streaming CEO message during `draft` shares the region but is throttled
+  (announce final text only, not each token).
+- **Reduced motion** rules extend to streaming drafts: when
+  `prefers-reduced-motion: reduce`, the entire response renders instantly
+  with no typing dots.
+- **Color contrast** verification: `--text-secondary` on `--accent-bg`
+  must meet WCAG AA (4.5:1 ratio). If verification fails, bump to
+  `--text` on `--accent-bg` (which definitely passes).
+- **Deferred to a follow-up:** richer screen-reader hints, voice
+  navigation, RTL layout testing.
+
+### Resolved transitions
+- **Marcus "look around first" exit moment.** CEO posts final line
+  `✓ I'll be in #general when you need me.` Sidebar groups unlock fully
+  (helper text removed). A one-time `IssuesEmpty` placeholder renders in
+  the main area with `+ New issue` button and copy `No issues yet. When
+  you're ready, type what you want done.` Dismisses on first issue
+  created, never returns. CEO DM does NOT auto-open on next session;
+  user lands on last-visited channel or `#general` default.
+- **Provider-pick → office transition.** Same-tab navigation with a
+  350ms cross-fade through a brief loading state. T+0: card press (180ms)
+  → T+0.18: page fades to white → T+0.36: loading line `Opening your
+  office…` on neutral background → T+0.4-1.0: broker initializes →
+  T+1.0: loading fades → T+1.18: office shell visible, CEO greeting
+  starts streaming. If broker init exceeds 800ms, a 2px indeterminate
+  progress line appears under the loading text.
+
+---
+
+## ICP tutorial examples (test the design against these before declaring done)
+
+Per global rules, the design must work end-to-end for three real users:
+
+### 1. Sam — solo founder, billing service (scratch path)
+- Runs `./wuphf`, picks Claude Code on the pre-office screen, lands in
+  the office.
+- **Deterministic chat begins** (no LLM calls).
+- CEO: *"Welcome. What should we call this office?"* — form-field message
+  inline in chat. Sam types *"Acme Billing"*. Workspace rail label updates
+  with a 240ms cross-fade.
+- CEO: *"What's the short description?"* — Sam: *"Subscription billing for
+  indie SaaS."*
+- CEO: *"Top priority right now? (Optional.)"* — Sam skips with the chip
+  *"Not yet."*
+- CEO: *"Got a website I can scan for context?"* — Sam pastes `acme.com`.
+  CEO acknowledges with a scan-progress chip in the chat (*"Scanning
+  acme.com…"*). `POST /onboarding/scan` runs in the background; the chat
+  keeps moving.
+- CEO: *"Your name? Your role? (Optional.)"* — Sam fills both.
+- CEO: *"Pick a starter template, or start from scratch:"* — chips render
+  inline (Bookkeeping / Content Ops / Engineering Team / Start from scratch).
+  Sam clicks **Start from scratch**. **No team picker step in scratch path.**
+- Scratch path materializes: `#general` channel, a minimal wiki scaffold
+  (`Company Facts` placeholder + `Decisions`). When the website scrape
+  returns ~3 seconds later, the chip in chat flips to *"Wiki updated with
+  acme.com facts ✓"* and `Company Facts` gets a content fade in the wiki.
+- CEO: *"All set up. What do you want to start working on?"* — this is the
+  handoff message from deterministic mode.
+- **LLM mode begins.** Sam: *"Get Stripe webhooks working."*
+- CEO drafts issue `#1 Stripe webhook handler` in the main area (first LLM
+  call). Because Sam went scratch, CEO ALSO proposes an agent roster as
+  part of the draft: *"For this work I'd bring in Founding Engineer + PM.
+  Add?"* Sam approves; agents slide into sidebar with intro lines posted
+  in the issue's comments timeline.
+- Engineer posts technical sanity-check comment (LLM). Sam edits acceptance
+  criteria. Clicks **Approve & Start**. Execution dispatches.
+
+### 2. Priya — design lead, content ops for an agency (blueprint path)
+- Picks Codex on the pre-office screen. Office opens.
+- **Deterministic chat.** CEO asks the same identity questions as in Sam's
+  flow (office name, description, priority, website, owner). Priya answers
+  briefly and lets the website scrape run in the background.
+- CEO: *"Pick a starter template, or start from scratch:"* — Priya clicks
+  the **Content Ops** chip. Still deterministic — no inference.
+- Blueprint materializes: `#editorial` and `#assets` channels fade into
+  the sidebar with stagger; wiki scaffold pages (Style Guide, Editorial
+  Calendar, Brand Voice) appear under their wiki tree.
+- CEO: *"This blueprint comes with a team — keep or trim:"* — renders a
+  deterministic checklist of agents (Writer ✓, Editor ✓, Designer ✓).
+  Priya unchecks Writer (*"We use a real writer"*) and submits.
+- On submit, Editor + Designer slide into sidebar with intro lines posted
+  in the CEO DM. Still no LLM call.
+- CEO: *"All set up. Want to start an issue?"* — Priya: *"Content calendar
+  for May."*
+- **LLM mode begins.** CEO drafts `#1 Content calendar for May`. Priya
+  rewrites the acceptance criteria. CEO suggests pulling Designer in for
+  asset review. Designer comments. Priya approves. Work starts.
+
+### 3. Marcus — engineering manager, evaluating WUPHF (blueprint, no issue)
+- Picks Claude Code. Office opens.
+- **Deterministic chat.** Marcus answers the identity questions tersely
+  and skips the website URL (he's evaluating, not bringing a real company).
+- CEO: *"Pick a starter template, or start from scratch:"* — Marcus picks
+  **Engineering Team**.
+- Channels (`#engineering`, `#standup`) materialize; wiki scaffold (Eng
+  Practices, Architecture Decisions) appears.
+- CEO: *"This blueprint comes with a team — keep or trim:"* — Marcus
+  accepts the default roster (Founding Engineer, PM, Designer). Agents
+  slide into sidebar.
+- CEO: *"All set up. Want to start an issue, or look around first?"* —
+  Marcus picks **Look around first** via a chip. **No LLM call happens.**
+  Office stays real and quiet. Marcus reads agent profiles, browses the
+  wiki, hovers over Issues (empty), and can return to start an issue any
+  time via `+ New issue` (which re-enters the LLM `draft` phase). Trust
+  through inertia, not action.
+
+All three flows must succeed end-to-end before this design ships.
+
+---
+
+## What we are deliberately cutting from the wizard
+
+Current `STEP_ORDER`: `welcome → identity → templates → team → setup → nex →
+task → ready` (plus a hidden `analysis` step).
+
+| Step | Decision | Why |
+|---|---|---|
+| `welcome` | Cut | CEO's first message is the welcome. |
+| `identity` | Move into chat | CEO asks naturally. The wizard's separate identity form is friction. |
+| `templates` | Render as chip picker inside chat | **Deterministic.** CEO posts the blueprint chips as a structured message. No LLM inference of blueprint from free text — the user picks. |
+| `analysis` | Keep but render in chat | The `POST /onboarding/scan` of the user's website URL is the same backend call; chat shows a scan-progress chip. Environment probes (runtime detection) remain silent unless they fail. |
+| `team` | Render as checklist in chat **only on blueprint path** | Deterministic trim for blueprint path: same multi-select as today, rendered as a CEO message. Scratch path skips this entirely; CEO proposes agents during issue drafting (the only LLM moment in the team flow). |
+| `setup` | **Keep, pre-office** | Provider selection has to happen before any agent can run. This is the only true blocker. |
+| `nex` | **Drop from onboarding** | Optional integration. Move to Settings → Integrations. Nothing depends on it for the first issue. |
+| `task` | Replace with issue drafting | Old flow: type a sentence and the agent starts. New flow: CEO drafts an issue with you, you approve, then it starts. |
+| `ready` | Cut | The Approve & Start button on the first issue is the readiness gate. |
+
+Net: **1 pre-office screen + a chat that builds the office around you**, instead
+of 9 modal steps the user clicks through before seeing anything real.
+
+---
+
+## Surface 1 — Pre-office: provider selection
+
+A single full-bleed screen. No modal chrome.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│             Welcome to WUPHF                            │
+│             Pick the AI runtime to power your office.   │
+│                                                         │
+│   ┌─────────────────┐  ┌─────────────────┐              │
+│   │  Claude Code    │  │  Codex          │   ← cards    │
+│   │  ✓ Detected     │  │  ✓ Detected     │              │
+│   │  v1.2.3         │  │  v0.8.1         │              │
+│   └─────────────────┘  └─────────────────┘              │
+│                                                         │
+│   ┌─────────────────┐                                   │
+│   │  Opencode       │     ┌──────────────────────────┐  │
+│   │  Not installed  │     │  I'll add one later  →   │  │
+│   │  Install →      │     └──────────────────────────┘  │
+│   └─────────────────┘     [secondary, smaller]          │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+- Detected runtimes are tappable; install links open in browser; user has to
+  click the runtime to confirm (no auto-pick) so they know what they chose.
+- "I'll add one later" is real: lets the user enter the office in a sandboxed
+  read-only mode. CEO greets them but cannot dispatch work until they
+  configure a runtime. We need this for evaluators.
+- **No identity step here.** Name + git handle is asked by CEO in chat if and
+  when we need it (we mostly do not — git already has it from the host).
+- One short helper line under the cards: *"You can change this any time in
+  Settings → Runtimes."*
+
+This is also the screen where we run the existing `Step3bAnalysis`
+prereqs scan, but silently — its only output here is enabling/disabling
+the runtime cards.
+
+---
+
+## Surface 2 — Office entry: empty shell + CEO DM open
+
+The user lands directly into the real `Shell` component. No transition
+animation across the runtime → office boundary; they already trust they are
+moving forward.
+
+```
+┌──┬──────────┬──────────────────────────────────────────┬─────┐
+│Wp│ Channels │  DM — CEO                                │     │
+│  │  (none)  │                                          │     │
+│  │          │  CEO  ●                                  │     │
+│  │ Issues   │  Welcome. I'm the CEO of your office.   │     │
+│  │  (none)  │  What are you working on right now?     │     │
+│  │          │                                          │     │
+│  │ Agents   │  ┌────────────────────────────────────┐  │     │
+│  │ • CEO ✓  │  │ Type your answer or pick a starter │  │     │
+│  │          │  │ • Bookkeeping  • Content ops       │  │     │
+│  │          │  │ • Engineering team • Start scratch │  │     │
+│  │          │  └────────────────────────────────────┘  │     │
+│  │          │                                          │     │
+└──┴──────────┴──────────────────────────────────────────┴─────┘
+ 56px   240px            flex-grow                       hidden
+```
+
+Behavior rules for this frame:
+- `Channels` and `Issues` sidebar groups render as empty states with a
+  faint "CEO will set these up" placeholder, not hidden. The user must see
+  what the surfaces ARE so they understand what is forming.
+- `Agents` shows only CEO with a status pill *Ready*.
+- CommandPalette, Search, AgentPanel, ThreadPanel are mounted but inert
+  (no entry points exposed until first issue exists).
+- Workspace rail shows one workspace tile with an unnamed placeholder.
+- StatusBar: small *"Office initializing — chat with CEO to set it up."*
+
+The composer below the CEO DM has the standard input AND a row of "starter
+intent" chips for users who do not want to type. Picking a chip is the same
+as typing the equivalent prompt — the chat continues with CEO's blueprint
+inference message.
+
+---
+
+## The deterministic / LLM split
+
+The CEO chat looks like one continuous conversation, but only a subset of
+its turns make LLM calls. This is deliberate:
+
+- **Deterministic turns are instant, free, and cannot fail.** They power
+  the entire setup phase (workspace name, description, priority, website
+  URL + scan, owner info, blueprint pick, team trim, wiki seeding). The
+  CEO renders them as natural speech, but the implementation is templates
+  with slotted values + standard form payloads. Zero LLM tokens.
+- **LLM turns start only after the deterministic foundation is built.**
+  They begin when the user describes a first issue. At that point, agents
+  have wiki context (from the deterministic scrape and blueprint
+  scaffold) and a known blueprint or none, so the LLM has grounded input.
+
+The user never sees this boundary. Both kinds of turns render identically
+as CEO speech. Suggestion cards, chip rows, and checklists are all just
+CEO messages with an interactive payload.
+
+### Deterministic phase — no LLM tokens
+
+The form-fills below are exactly the ones the current wizard collects
+(`Step3Identity` + `Step2Templates` + `Step3bAnalysis` + `Step4Team`).
+We are **not removing** these collections — we are re-rendering them as
+CEO chat messages with interactive payloads.
+
+| Step | Source | Side effect |
+|---|---|---|
+| Workspace name | Form field in CEO message | Workspace rail label updates (240ms cross-fade) |
+| Short description | Form field | Stored in office config |
+| Top priority (optional) | Form field | Stored in office config |
+| Website URL (optional) | Form field | Fires `POST /onboarding/scan` (existing endpoint); chat shows a scan-progress chip until response lands |
+| Owner name + role (optional) | Form fields | Stored for git attribution + CEO addressing the user by name |
+| Blueprint pick | Chip row in CEO message | If a blueprint is selected: its channels + wiki scaffold are materialized and the team picker renders next. If **Start from scratch**: sidebar stays minimal (just `#general` + minimal wiki scaffold) and team picker is skipped. |
+| Team trim (blueprint path only) | Checklist in CEO message | Selected agents are added to sidebar with stagger animation; each posts a one-line intro |
+| Wiki seed (background) | Response of `POST /onboarding/scan` + blueprint scaffold | Company Facts page is updated with scraped data when the scrape returns; blueprint scaffold pages are materialized at blueprint-pick time |
+
+All templated. Even the "intro line" each agent posts on join is a template
+with one slotted variable.
+
+### LLM phase — begins when user describes first issue
+
+| Step | Why it's LLM |
+|---|---|
+| Issue draft | Spec must reflect the user's free-text description |
+| Agent suggestion (scratch path only) | No blueprint roster to draw from; CEO must reason about which agents fit this issue |
+| Agent comments on draft | Agents must read the draft and respond in role |
+| Sub-issue decomposition (when user clicks *Break this up*) | Requires reasoning about scope |
+| Execution after Approve | The actual work |
+
+### Routing rule
+
+CEO has a single state machine. Each phase has a `mode` of either
+`deterministic` or `llm`. Before the `draft` phase, every CEO message is
+rendered from a template; from `draft` onward, every CEO message goes
+through the model. This makes the trust calibration honest: by the time
+the model starts speaking, the user has already seen the office form
+around them and understands what's about to happen.
+
+The boundary is a single backend flag; the frontend renders both modes
+through the same message envelope.
+
+---
+
+## Surface 3 — The conversation as office-builder
+
+Each user reply causes 0–N office mutations, paired with a short CEO
+acknowledgement in chat. The CEO never silently changes the office; every
+change is announced AND visible. This is the heart of the trust calibration.
+
+Both deterministic and LLM turns use the same chat-message envelope and
+the same suggestion-card mechanic. The differences are: deterministic
+turns are templated and instant, LLM turns are model-driven and stream
+in with a typing indicator. From the user's POV, CEO is one consistent
+voice.
+
+### Turn-by-turn template
+
+```
+User:  <answer>
+       ───────────────────────────────────────────
+CEO:   <acknowledgement + suggestion>
+       ┌─────────────────────────────────────┐
+       │  Suggested:                         │
+       │  • Add #billing channel             │
+       │  • Add PM agent (rationale)         │
+       │                                     │
+       │  [Approve all]  [Pick which]  [No]  │
+       └─────────────────────────────────────┘
+```
+
+The suggestion card is a structured message in the DM (not a modal). When
+the user clicks **Approve all** or picks individually:
+1. The card collapses into a one-line confirmation in the timeline:
+   *"Added #billing and PM. ✓"*
+2. The sidebar mutates with the chosen items, **one item at a time**, 250ms
+   apart. Each item: opacity 0 → 1, translateX -8px → 0, 200ms ease-out.
+   Items use `prefers-reduced-motion` to fall back to instant.
+3. Each newly added agent posts a one-line "intro" message in the DM:
+   *"PM here — I help with scope and acceptance criteria. Pinging when
+   useful."* Agents do this once, on join. Never spammy.
+4. CEO's next message arrives ~600ms after the last item finishes animating
+   — slow enough that the user can read each arrival.
+
+### Conversation phases (CEO is stateful)
+
+| Phase | Mode | Goal | What happens |
+|---|---|---|---|
+| `greet` | Deterministic | Establish presence | Templated CEO greeting + one open question. |
+| `identity` | Deterministic | Collect office name, description, priority, owner info | Form-field messages inline in chat (same payloads as today's `Step3Identity`). |
+| `scan` | Deterministic (async) | Optional website scrape → wiki facts | URL form field + chip showing scrape status. Continues in background while the user answers later questions. Reuses `POST /onboarding/scan`. |
+| `blueprint` | Deterministic | Pick a starter template or scratch | Chip row inside a CEO message (same options as today's `Step2Templates`). No LLM inference of blueprint from text. |
+| `team` | Deterministic (blueprint) / **Skipped** (scratch) | Trim the blueprint's agent roster | Checklist inside a CEO message (same payload as today's `Step4Team`). Scratch path skips this phase. |
+| `seed` | Deterministic | Materialize channels + wiki scaffold; finish website scrape | Sidebar mutations + intro lines. No LLM. |
+| `bridge` | Deterministic | Offer to start an issue | Templated message. User can also say "look around first" — exits onboarding with first issue deferred. |
+| `draft` | **LLM begins** | Co-author the first issue. Scratch path: CEO also proposes agents inline. | First LLM call. Moves user to Surface 4. |
+| `approve` | Deterministic | Human approves the issue | Status flips, suggestion card collapses. |
+| `kickoff` | **LLM** | Suggest execution lineup, dispatch | Suggestion card. First post-approval LLM call. |
+
+The phase is a property of the onboarding conversation, persisted in the
+existing onboarding state (`internal/onboarding/state.go`). On resume the
+CEO knows where it left off and picks up the next CEO message at that phase.
+
+### What is cut from CEO's conversation surface
+- No multi-select grids. Every choice is either a chip row or a structured
+  suggestion card with explicit approve/decline.
+- No progress dots. Progress is the office filling in — visible state, not
+  abstract indicator.
+- No "Next" button. Conversation advances when CEO speaks.
+- No skip-to-end. If the user is bored they pick a starter chip and CEO
+  fast-paths the rest.
+
+---
+
+## Surface 4 — The Issue document (replaces "first task")
+
+Issues are the morphed version of the existing `task` primitive. Same
+underlying storage, upgraded surface. Sub-issues are nested issues with a
+parent reference. **Approved issues** also publish a read-only mirror under
+the wiki at `Issues/` for future reference, with no edit affordance there.
+
+### Anatomy
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Issues / #1 Stripe webhook handler          [Drafting ▼]    │
+│  ──────────────────────────────────────────────────────────  │
+│  Assignees:  CEO (drafting)         + Add                    │
+│  Sub-issues: none                   + Break this up          │
+│                                                              │
+│  ## Goal                                                     │
+│  Receive Stripe webhook events (charge.succeeded,            │
+│  charge.failed) and update local subscription state.         │
+│                                                              │
+│  ## Context                                                  │
+│  Subscriptions are currently stored in… [editable]           │
+│                                                              │
+│  ## Approach                                                 │
+│  ...                                                         │
+│                                                              │
+│  ## Acceptance criteria                                      │
+│  - Webhook endpoint at POST /stripe/webhook                  │
+│  - HMAC-SHA256 signature verified per Stripe docs           │
+│  - charge.succeeded marks sub as active                      │
+│  - charge.failed marks sub as past_due, sends email          │
+│                                                              │
+│  ─── Comments ───────────────────────────────────────────    │
+│  CEO  10:03  Drafted spec based on our chat. Engineer can    │
+│              you sanity-check Approach?                      │
+│  Eng  10:04  Approach looks good but I'd add idempotency     │
+│              via the Stripe Event ID. Want me to spec it?   │
+│  You  10:05  Yes, please add to acceptance criteria.         │
+│  CEO  10:05  Updated. Ready for your review.                 │
+│                                                              │
+│  ──────────────────────────────────────────────────────────  │
+│  [ Approve & Start ]  [ Save draft ]  [ Discard ]            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Status pill drives the surface heavily:
+
+| Status | Editable | Visible buttons | Activity feed |
+|---|---|---|---|
+| `Drafting` | Yes (all sections) | Approve & Start, Save draft, Discard | Comments only |
+| `Approved` | No (except acceptance) | Reopen for edits | Comments + dispatch event |
+| `In Progress` | No (except acceptance) | Pause, Cancel | Comments + agent activity events |
+| `Review` | No | Approve close, Request changes | Comments + agent activity events |
+| `Done` | No | Reopen | Frozen |
+
+The "Activity feed" mixes structured agent events (tool calls, file changes,
+test results) inline with comments. Same surface, different message types.
+Agent events use a quieter style — small avatar, monospace metadata,
+collapsible payload — so the spec stays readable.
+
+### Where the Issue lives
+
+- **Sidebar:** `Issues` section between `Channels` and `Agents`. Shows up to
+  20 most-recent / open issues, with a search-and-filter affordance via the
+  command palette.
+- **Per-workspace surface:** `/issues` route shows a Linear-style list with
+  status filters, assignee filters, and the option to surface only issues
+  the user has touched (drafted, commented on, or approved).
+- **Cross-link from chat:** typing `#142` in any channel composer
+  auto-completes to an issue link with hover preview (title + status).
+- **Wiki mirror:** on first approval, the issue's spec sections are copied
+  read-only into `wiki/Issues/<slug>.md`. Comments and activity do not
+  mirror — the wiki is the durable spec, the issue is the live record.
+
+### Sub-issues
+
+- *Break this up* on the parent issue puts CEO in `decompose` mode: CEO
+  drafts 2–N sub-issues with titles + one-line goals, posts as a single
+  suggestion card.
+- User approves the breakdown, sub-issues are created in `Drafting` status,
+  parent issue's status freezes at `Approved` (or `Drafting` if user wants
+  to plan the whole tree before approving any).
+- Each sub-issue follows the same draft → approve → execute lifecycle.
+- Parent issue auto-closes when all sub-issues hit `Done`, OR user closes
+  manually.
+
+---
+
+## Stage transitions and the approval gate
+
+The single most important UX rule:
+
+> **No agent does any execution work for an issue until the human clicks
+> Approve & Start on that issue.**
+
+This is the rule the current product violates and the reason new users feel
+the system is "too quick." Concretely:
+
+- During `Drafting`, agents pulled in by CEO can **only** post comments on
+  the issue document. They cannot call tools, run code, write files, or
+  send messages anywhere else. The broker enforces this server-side by
+  refusing to dispatch tool calls for an issue not in `Approved` /
+  `In Progress`.
+- On `Approve & Start`:
+  1. Issue status flips to `Approved` for ~300ms with a soft confirmation
+     toast (*"Approved. Dispatching CEO to coordinate execution."*).
+  2. CEO posts an execution suggestion card: *"For execution, I'll route
+     this to Engineer with Designer as reviewer. Sound good?"*
+  3. User approves the lineup; status flips to `In Progress`; first agent
+     activity event appears within seconds.
+
+This means the same Engineer agent can comment in `Drafting` and execute
+in `In Progress` — they are the same agent, the gate is the issue's status.
+
+---
+
+## Motion specification
+
+Goal: the office feels like it is **forming around the user**, not
+**rendering through them**. Slow, deliberate, never bouncy.
+
+### Library
+Add `motion` (the renamed, slimmer fork of framer-motion, ~12 kB gzipped)
+as a single dependency. Use it only for:
+- Sidebar item enter / exit
+- Issue surface enter
+- Status pill morph
+
+CSS transitions are sufficient for everything else (hover, focus, button
+press, chat bubble fade-in). Do not introduce a second motion library.
+
+### Durations and easings
+| Element | From | To | Duration | Easing |
+|---|---|---|---|---|
+| Sidebar row enter | opacity 0, x -8px | opacity 1, x 0 | 220 ms | ease-out |
+| Sidebar row stagger | — | — | 200 ms gap | — |
+| Chat bubble enter | opacity 0, y 6px | opacity 1, y 0 | 180 ms | ease-out |
+| Suggestion card collapse | full → 1 line | scale anchored top | 240 ms | ease-in-out |
+| Issue open | opacity 0 + main translate 8px | normal | 320 ms | ease-out |
+| Status pill morph | color A | color B + label change | 220 ms | linear |
+| Workspace label update | text fade-cross | — | 240 ms | linear |
+
+All durations halve and easings collapse to linear when
+`prefers-reduced-motion: reduce` is true. No animation has a duration over
+350 ms; the office must never feel slow.
+
+### Anti-patterns (do not use)
+- Spring physics on enter (bouncy).
+- Cascading reveal on first paint of static UI (the wizard is gone — we do
+  not need a tutorial reveal).
+- Animated gradients, glow effects, or shimmers.
+- Sound effects.
+- Confetti or celebration animations on Approve & Start. The serious tone is
+  the trust-building lever.
+- Skeleton placeholders that then fade into real content. Either the row
+  exists or it doesn't.
+
+### Pacing rule
+Between any two CEO turns, the user must have at least **400 ms of
+quiet** after the last animation completes. This is what makes the office
+feel deliberate. Front-load this; do not let it slip in implementation.
+
+---
+
+## State and resumption
+
+The onboarding conversation persists into the existing
+`internal/onboarding/state.go` JSON (the same place the wizard draft lives
+today). New fields:
+
+```go
+// Schema v2 (existing v1 fields preserved; new fields added).
+// Migration on read: v1 onboarded.json → load fields → bump version to 2.
+type State struct {
+    // v1 existing fields
+    Version            int             `json:"version"`            // bump to 2
+    CompletedAt        string          `json:"completed_at,omitempty"` // set at end of `bridge` phase
+    CompanyName        string          `json:"company_name,omitempty"`
+    CompletedSteps     []string        `json:"completed_steps,omitempty"` // legacy wizard step IDs
+    ChecklistDismissed bool            `json:"checklist_dismissed"`
+    Partial            *PartialProgress `json:"partial,omitempty"`  // legacy wizard draft
+
+    // v2 chat-mode additions
+    Phase                string      `json:"phase,omitempty"`                  // greet | identity | scan | blueprint | team | seed | bridge | draft | approve | kickoff
+    CEODMChannelID       string      `json:"ceo_dm_channel_id,omitempty"`      // pointer into b.messages; transcript NOT stored here
+    PendingSuggestion    *Suggestion `json:"pending_suggestion,omitempty"`     // idempotent re-emit on resume
+    FormAnswers          FormAnswers `json:"form_answers,omitempty"`           // staged deterministic answers; committed at `seed`
+    FirstIssueID         string      `json:"first_issue_id,omitempty"`
+    FirstIssueApprovedAt string      `json:"first_issue_approved_at,omitempty"` // activation depth, distinct from CompletedAt
+}
+
+type FormAnswers struct {
+    CompanyName string   `json:"company_name,omitempty"`
+    Description string   `json:"description,omitempty"`
+    Priority    string   `json:"priority,omitempty"`
+    WebsiteURL  string   `json:"website_url,omitempty"`
+    OwnerName   string   `json:"owner_name,omitempty"`
+    OwnerRole   string   `json:"owner_role,omitempty"`
+    BlueprintID string   `json:"blueprint_id,omitempty"`        // empty = scratch
+    PickedAgents []string `json:"picked_agents,omitempty"`      // blueprint path team-trim result
+    ScanComplete bool    `json:"scan_complete,omitempty"`
+}
+
+type Suggestion struct {
+    ID      string          `json:"id"`       // stable per (phase, options-hash) for idempotent re-emit
+    Phase   string          `json:"phase"`
+    Kind    string          `json:"kind"`     // ceo_form_field | ceo_chip_row | ceo_checklist | ceo_team_trim | ceo_scan_chip
+    Payload json.RawMessage `json:"payload"`
+}
+
+// Activated() distinguishes onboarded-but-no-first-issue users (Marcus path)
+// from fully-activated users (Sam, Priya after Approve & Start).
+func (s *State) Activated() bool {
+    return s.Onboarded() && s.FirstIssueApprovedAt != ""
+}
+```
+
+Resumption: if the user closes the tab during `populate`, the next open
+shows the office in its current state with the unresolved suggestion card
+still visible at the bottom of the DM. CEO does not re-greet; the
+conversation continues. The existing `ResumeBanner` infra is repurposed for
+the rare case where the user has been gone > 24 hours.
+
+`CompletedAt` is set when the first issue hits `Approved`. After that, the
+office is in normal mode: command palette is unlocked, `+ Add channel`,
+`+ New issue` affordances appear, runtime strip becomes visible.
+
+---
+
+## What this design does NOT do
+
+- **Does not change the existing review queue or task-as-state machine.**
+  Issues are tasks rebranded with a richer surface. The broker's existing
+  task lifecycle remains the substrate; the issue document is a new
+  presentational layer plus the comments timeline.
+- **Does not introduce new agent roles.** The existing CEO + role-based
+  agents are sufficient. The two-stage behavior is an issue-status
+  property, not an agent property.
+- **Does not deprecate channels.** Channels remain the home for
+  cross-issue conversation and ambient agent chatter. Issues are where
+  scoped work lives.
+- **Does not change the marketing site or its DESIGN.md.** This is a
+  separate visual layer; the app keeps its modern Slack-like aesthetic.
+- **Does not block on motion library adoption.** If `motion` adoption is
+  blocked for any reason, ship with CSS transitions only; the design still
+  works, just with less polished sidebar enter/exit.
+
+---
+
+## Implementation phases
+
+This is a substantial change. Phase it to keep main green and to allow
+incremental dogfooding.
+
+### Phase 1 — Pre-office screen + empty-shell entry
+- Build the single-screen provider picker (replace `Wizard.tsx` invocation
+  in `App.tsx`).
+- Allow entering the office immediately after provider pick.
+- Preserve the existing wizard behind a feature flag for rollback. Default
+  the flag ON for `npx wuphf` dogfood, OFF in prod.
+
+**Acceptance:** New users see provider picker → office with empty shell +
+CEO DM that says hi. No regressions for users who already onboarded.
+
+### Phase 2 — Deterministic CEO conversation
+- Wire the phase state machine in `internal/team/broker_onboarding.go`:
+  `greet → identity → scan → blueprint → team (or skip) → seed → bridge`.
+  All deterministic — no model calls.
+- Build the form-field, chip-row, and checklist message types in the
+  existing message envelope. Reuse the payloads of today's
+  `Step3Identity`, `Step2Templates`, `Step4Team`.
+- Wire `POST /onboarding/scan` to fire from the `scan` phase, with the
+  scan-progress chip in chat and async wiki facts update on completion.
+- Implement sidebar mutation animations (channels, agents, workspace
+  label cross-fade) on `seed`.
+- End the conversation at `bridge` with "Click `+ New issue` when ready"
+  or *"Look around first"* (Marcus path). No LLM drafting yet.
+
+**Acceptance:** All three ICP tutorial examples reach `bridge` end-to-end
+with motion working and zero LLM calls made. Verify by asserting the
+provider mock is never invoked during the deterministic phase.
+
+### Phase 3 — Issue document surface
+- New `/issues` route + sidebar group.
+- Migrate existing tasks to render as Issues (back-compat read).
+- Issue document layout, status pill, comments timeline.
+- Wiki mirror on approval.
+
+**Acceptance:** Existing tasks display correctly as Issues; users can open
+an issue, see its current state, and the surface is read-only for now.
+
+### Phase 4 — Draft + approve + execute (v1 scope)
+- CEO can draft an issue inside Surface 4. The issue is a lifecycle task
+  in the new `LifecycleStateDrafting` state.
+- Agents can comment on issues in `Drafting` (broker server-side gates
+  every dispatch entry point).
+- Comments timeline interleaves humans + agents using the existing
+  comment infrastructure (`broker_inbox_handler.go:229`).
+- **Approve & Start** maps to the existing `approve` lifecycle action,
+  transitions Drafting → Running, dispatches CEO's execution lineup
+  (suggestion card mirroring the populate pattern).
+- Add `broker_lifecycle_dispatch_test.go` parametric test as a gate.
+
+**Acceptance:**
+1. All three ICP tutorial examples complete end-to-end with approval gate
+   working. No dispatch happens before Approve & Start.
+2. `TestBrokerRefusesDispatchForNonExecutableLifecycle` passes — parametric
+   over every dispatch entry point with negative cases (Drafting, Intake,
+   Review, ChangesRequested) and positive cases (Running, Approved).
+3. Comment path verified allowed in all states.
+4. Sam-path E2E test asserts no LLM provider invocation for execution
+   tools until Approve & Start.
+5. **CEO voice regression test** (added per design review TODO-D1): the
+   draft-phase and kickoff-phase LLM prompts are evaluated against a
+   hand-written 5-example regression corpus. Each example expects the
+   CEO response to: (a) start without a greeting/preamble, (b) avoid the
+   string "I'm your" / "I am your" / "Welcome", (c) stay under ~40 words
+   in the acknowledgement message, (d) match the declarative tone of
+   the deterministic templates. Test lives in
+   `internal/team/broker_ceo_voice_test.go` and runs against a mocked
+   provider returning fixture-ish responses for shape, plus a marker
+   test against real provider gated to nightly. Failing voice regression
+   blocks the Phase 4 acceptance gate.
+
+### Phase 6 — Sub-issues + wiki mirror (deferred from Phase 4)
+- *Break this up* affordance on the parent issue: CEO drafts 2-N
+  sub-issues with titles + one-line goals (LLM call).
+- Sub-issue creation, parent-child link, breadcrumb in issue header.
+- Each sub-issue has its own approval gate. Parent freezes at Approved
+  while sub-issues are drafted and approved individually.
+- Cascading parent close when all sub-issues hit `Done`.
+- Wiki mirror: on first `approve` action, snapshot issue spec sections
+  into `wiki/Issues/<slug>.md` read-only. Comments + activity do not
+  mirror.
+- Sub-issue dispatch order: user declares dependencies in the issue
+  spec; broker enforces them (no autonomous DAG inference in v1).
+
+**Acceptance:** Parent + sub-issue lifecycle works end-to-end; wiki mirror
+exists and is regenerated correctly on subsequent edits-then-approvals.
+
+### Phase 5 — Polish and cleanups
+- Remove the old wizard from the codebase (delete `Wizard.tsx`, all step
+  files, draft sync, `synthesizeBlueprintFromState` dead path, etc.).
+- Move Nex signup to Settings → Integrations.
+- Migrate any existing onboarding telemetry to the new phase names.
+- Update `docs/tutorials/` for the new flow.
+- **Promote `InterviewBar`'s kind-dispatcher + sanitization into a shared
+  `StructuredMessageCard` module** under `web/src/components/messages/cards/`.
+  Both interview kinds (`approval`, `enhance_skill_proposal`) and CEO kinds
+  (`ceo_form_field`, `ceo_chip_row`, `ceo_checklist`, `ceo_team_trim`,
+  `ceo_scan_chip`) become consumers. Single source of truth for the PR #684
+  sanitization audit point.
+
+**Acceptance:**
+1. No references to `Wizard.tsx` or the 8-step wizard remain.
+2. Tutorials match shipped behavior.
+3. `StructuredMessageCard` module exists, both interview cards and CEO
+   cards consume it, sanitization regression tests live alongside the
+   module (one audit point, not two).
+
+---
+
+## Open questions — resolved by /plan-eng-review (2026-05-17)
+
+1. **Broker enforcement of the approval gate.** RESOLVED → server-side
+   enforcement. See "Eng review decisions" section above.
+2. **Sub-issue dispatch model.** DEFERRED to Phase 6. User declares
+   dependencies in the issue doc; broker enforces them. No autonomous
+   DAG.
+3. **Wiki mirror format.** DEFERRED to Phase 6. Plan: as-is markdown
+   snapshot of issue spec sections.
+4. **Comments on already-approved issues.** RESOLVED → comments stay
+   open in all states (per the lifecycle comment infrastructure
+   already in place). Agents read new comments as guidance during
+   execution.
+5. **Old draft migration.** RESOLVED → finish in-flight wizard drafts
+   through the old wizard (feature flag scoped to "started after
+   deploy"); delete the wizard entirely in Phase 5.
+
+## Genuinely open (for implementer judgment)
+
+These are not gates, just places the implementer will make small choices:
+
+1. **`LifecycleStateDrafting` vs reuse `LifecycleStateIntake`.** Adding
+   a new state is more explicit; reusing Intake with a "no dispatch
+   from Intake" guard is fewer moving parts. Implementer's call when
+   wiring the lifecycle transitions.
+2. **Sandbox mode for the evaluator path.** Pre-office picker "I'll add
+   one later" enters a runtime-less office. Deterministic chat works
+   fine (no LLM needed). `bridge` "look around first" works fine. What
+   if the user then clicks `+ New issue` and tries to draft? Need a
+   gentle blocker: "Hook up a runtime in Settings before starting an
+   issue." Wording + placement is implementer judgment.
+3. **Pacing rule (400ms quiet) location.** Recommended: frontend
+   orchestrator throttles deterministic message arrival. Implementer
+   can also do it backend-side via stream-throttling. Either works.
+
+---
+
+## NOT in scope (deferred, explicit)
+
+Items considered and deferred, with rationale. Each should be picked up
+as a follow-up issue, not dropped silently.
+
+- **Sub-issues** — `Break this up`, parent-child semantics, dispatch order,
+  cascading parent close. → Phase 6. Reason: non-trivial dispatch logic
+  that doesn't move the trust-calibration needle for v1.
+- **Wiki mirror on approval** — read-only snapshot of approved issues under
+  `wiki/Issues/<slug>.md`. → Phase 6. Reason: archival convenience, not
+  load-bearing for the design goal.
+- **Nex signup in onboarding** — Phase 5 moves to Settings → Integrations.
+  Reason: optional integration, blocks nothing for first issue.
+- **Autonomous sub-issue DAG inference** — when v6 ships sub-issues, the
+  broker enforces user-declared deps, no AI inference. Reason: blast
+  radius — wrong inference re-introduces the trust problem we just fixed.
+- **CEO transcript GC** — what to do with the onboarding DM transcript
+  after months of dust. → Wiki lifecycle absorbs this naturally if/when
+  we wire the DM into the existing wiki staleness signals.
+- **Pacing rule as a backend stream throttle** — implementer judgment
+  whether the 400ms quiet rule lives in the frontend orchestrator or
+  the backend stream. Either works; not architectural.
+
+## What already exists (reuse map)
+
+Existing code that the plan deliberately reuses rather than rebuilds.
+Adversarial code review should compare these claims against current main.
+
+| Plan needs… | Existing surface | Reuse strategy |
+|---|---|---|
+| Provider runtime detection | `internal/onboarding/prereqs.go` + `Step3bAnalysis` (existing JSON, existing endpoint) | Use as-is. Drive the new single-screen picker from the same data. |
+| Website scrape + wiki seed | `POST /onboarding/scan` (`internal/onboarding/handlers.go:75,679-760`) + blueprint `wiki_scaffold` materialization (`b.materializeBlueprintWiki`) | Use as-is. Wire scan completion into a `ceo_scan_chip` update message. |
+| Atomic blueprint + team seed | `b.seedFromBlueprintLocked` + `b.materializeBlueprintWiki` (existing) | Use as-is at the `seed` phase boundary. No refactor. |
+| Idempotent onboarding seed (crash recovery) | `b.onboardingCompleteFn` dedupe-by-`onboarding_origin` (`broker_onboarding.go`) | Use as-is. Inherits crash safety. |
+| Task lifecycle state machine | `LifecycleState{Intake, Ready, Running, Review, ChangesRequested, Approved, …}` + transitions in `broker_lifecycle_*.go` + `lifecycleIndex` | Issue surface is a richer view onto this index. New state `LifecycleStateDrafting` (or reuse Intake) at the front. |
+| Approve / request_changes / defer actions | `broker_inbox_handler.go:229` + `broker_inbox.go` + `broker_decision_packet.go` | `Approve & Start` button maps directly to `approve` action. |
+| Comments on lifecycle entities | Same comment payload field on the existing decision action (`"comment": "<reviewer note>"`) | Reuse the comment infrastructure for the issue document's timeline. |
+| Inbox / review UI surface | `web/src/components/review/{ReviewCard,ReviewColumn,ReviewDetail}.tsx` + the unified Inbox shipped via PR #885 | Issues list `/issues` route is a presentational sibling that filters/renders the same lifecycle index. |
+| Chat surface (composer, message feed, SSE, scroll, autocomplete, typing) | `DMView`, `Composer`, `MessageFeed`, `MessageBubble`, `TypingIndicator` | Reuse via a thin `OnboardingDMRoute` wrapper that points `DMView` at `dm:ceo:onboarding`. |
+| Interactive structured cards | `HumanInterviewOverlay` + `InterviewBar` with kind dispatch + `EXTERNAL ACTION` badge pattern | Extend with `ceo_form_field`, `ceo_chip_row`, `ceo_checklist`, `ceo_team_trim`, `ceo_scan_chip`. |
+| Suggestion-card sanitization | `sanitizeContextValue` (Go-side, per PR #684 closing confused-deputy bypass) | Inherited automatically by extending the same payload path. Add regression test for new kinds. |
+| Onboarding state persistence | `internal/onboarding/state.go` `Load`/`Save` (existing) | Extend schema to v2 with new fields. Migrate v1 → v2 on read. |
+| Onboarding handler authentication + JSON wiring | `internal/onboarding/handlers.go` (existing `authMiddleware`, scan handler patterns) | New chat-phase handlers follow the same patterns. |
+
+If any of these claims fail on grounding (e.g., the surface doesn't actually
+do what we expect), the implementer must flag immediately — they are
+load-bearing for the plan's scope estimate.
+
+## Parallelization strategy
+
+Phases 1 → 2 → 3 → 4 → 5 → 6 are largely sequential because each phase
+builds on the surface the prior one introduced. The opportunity is
+**within Phase 2**, which has three independent workstreams that can run
+in parallel worktrees:
+
+| Lane | Modules touched | Depends on |
+|------|----------------|------------|
+| A: Backend state machine | `internal/onboarding/`, `internal/team/broker_onboarding.go` (additive, not seed-path) | — |
+| B: Frontend chat surface | `web/src/components/messages/InterviewBar.tsx`, new `web/src/components/onboarding/OnboardingDMRoute.tsx`, new `ceo_*` card components | — |
+| C: Sidebar preview overlay | `web/src/components/layout/Sidebar.tsx`, new `web/src/components/onboarding/usePreviewOffice.ts` | — |
+
+Lane A and Lane B/C share no files. Lanes B and C share the `web/`
+directory but touch different components — minimal conflict risk if both
+respect the file boundaries above. Recommend:
+
+```
+git worktree add ../onboarding-into-office-laneA -b feat/onboarding-laneA-backend
+git worktree add ../onboarding-into-office-laneB -b feat/onboarding-laneB-cards
+git worktree add ../onboarding-into-office-laneC -b feat/onboarding-laneC-sidebar
+```
+
+Lanes B and C should integrate first (both web/), then Lane A. The
+spec's Phase 2 acceptance test (`TestOnboardingDeterministicPhasesNeverCallLLMProvider`)
+requires all three to land before the gate passes.
+
+Phases 3, 4, 6 each have less internal parallelism. Phase 5 cleanup is
+naturally one developer, one PR.
+
+## Failure modes
+
+For each new codepath, the realistic production failure scenario and
+whether the design accounts for it.
+
+| Codepath | Failure mode | Test | Error handling | User-visible? |
+|---|---|---|---|---|
+| Approval gate (broker dispatch guard) | Caller bypasses guard from a new dispatch entry point added later | `TestBrokerRefusesDispatchForNonExecutableLifecycle` is parametric — adding a new entry point requires extending the test (catches drift) | `ErrIssueNotApproved` returned; caller's responsibility to surface | Yes — frontend shows "issue not approved" if it slips |
+| `POST /onboarding/scan` async | Website unreachable / times out | Existing handler test covers happy + bad-body; need additional timeout path test | Returns error to chat; chip shows "couldn't read site" | Yes — clear chat message |
+| Sanitization on new `ceo_*` kinds | Agent-controlled string with HTML/script injection | `broker_onboarding_sanitize_test.go` parametric over all new kinds | Sanitized to safe text before write | No — silent escape |
+| Atomic seed at `seed` phase | Mid-seed crash (e.g., wiki materialization fails after channels seeded) | Existing `onboarding_origin` dedupe guard handles crash recovery | Resume re-runs idempotent seed; the broker dedupes | No — invisible recovery |
+| Phase resumption with `PendingSuggestion` | Suggestion ID collides across phases | ID is stable per `(phase, options-hash)` — collision implies same payload, dedupe is correct | Idempotent re-emit; frontend dedupes by ID | No |
+| Marcus path (no first issue) | User completes `bridge` with "look around first," office stays empty forever | E2E test asserts `Onboarded()` true + `+ New issue` works on demand | No error path; the design is "this is valid" | No |
+| `LifecycleStateDrafting` introduction | Existing tasks that should be in another state default to Drafting on migration | Lifecycle migration test (already exists per `broker_lifecycle_migration_test.go`) — extend with new state | Migration assigns Drafting only to brand-new tasks; existing tasks keep their state | No |
+
+**Critical gap (any failure mode with no test AND no error handling AND
+silent failure):** none identified — all gaps in the test diagram have at
+least one of test, error handling, or user-visible message.
+
+## Decisions log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-17 | Modern app shell with soft motion, not pixel art | Pixel art is the marketing site's job. The app's job is to look like a tool the user trusts. Different surfaces, different aesthetics. |
+| 2026-05-17 | DM with CEO inside the empty shell, not a full-bleed onboarding canvas | The product *is* the office. The user should see it from frame 1. The empty shell calibrates expectations and the live populate animation IS the value prop. |
+| 2026-05-17 | Tasks become Issues with their own surface, not threads or wiki pages | Issues need title + status + assignees + sub-issues + comments + approval gate. Wiki pages cannot host a status field cleanly; channel threads cannot have sub-threads at the level we need. Linear-style works. |
+| 2026-05-17 | One agent cast across two stages, status-driven | Doubling the agent count to add "planners" doubles cognitive load with no real upside. The same engineer should plan and build, like in a real team. The stage gate is the issue's status, not the agent. |
+| 2026-05-17 | Server-side enforcement of the no-execution-before-approval rule (recommended, open) | Trust is the design's core. Frontend-only enforcement is a footgun. |
+| 2026-05-17 | `motion` library, not framer-motion or pure CSS-only | framer-motion is too heavy; pure CSS misses the staggered sidebar enter. Slim motion lib hits both. |
+| 2026-05-17 | Deterministic-first conversation; LLM only after first issue description | Setup is form-fillable. Rendering it as templated CEO speech keeps it free, fast, and unfailable while preserving the natural-chat feel. LLM kicks in once the user has decided what to work on. |
+| 2026-05-17 | Blueprint picker is deterministic chips, not LLM-inferred from description | LLM blueprint inference adds a failure mode (wrong blueprint) for no real win. The user picks explicitly. Same as today's `Step2Templates`, rendered as a CEO message. |
+| 2026-05-17 | Team picker renders only on blueprint path; scratch path defers team to issue drafting | A blueprint comes with a team — that's a deterministic answer. Scratch has no team to offer up-front; CEO has to reason from the task, which is the right LLM moment. |
+| 2026-05-17 | Website scan + wiki seed are reused from existing onboarding | `POST /onboarding/scan` and blueprint `wiki_scaffold` already exist. We don't redesign them — we re-render their prompts and results as CEO chat. |
+| 2026-05-17 (eng review) | Server-side approval gate enforced in broker | The trust calibration is load-bearing. Frontend-only gating leaks through every alternate dispatch entry point (PamDispatcher, headless codex, self-heal, agent-to-agent). Server-side is the only honest answer. |
+| 2026-05-17 (eng review) | Issue surface reuses `LifecycleState*` instead of new primitive | Lifecycle apparatus already covers status, comments, approve/request_changes, and the Inbox PR-style loop (PR #885). New `LifecycleStateDrafting` is the only addition. Cuts ~40% off Phase 3. |
+| 2026-05-17 (eng review) | CEO transcript lives in `b.messages`, not in onboarding state | Reuses SSE + persistence + replay + search. Onboarding state stays small and focused. Eliminates ~200 lines of parallel persistence code. |
+| 2026-05-17 (eng review) | Staged FormAnswers + atomic seed at `seed` phase | Avoids refactoring `seedFromBlueprintLocked` into incremental mutations. Crash mid-flow leaves an empty office, not a half-formed one. Existing `onboarding_origin` dedupe guard inherits. |
+| 2026-05-17 (eng review) | `CompletedAt` set at end of `bridge` phase regardless of first issue | Marcus's "look around first" is a valid onboarded state. Activation depth (first issue approved) is tracked separately in `FirstIssueApprovedAt`. |
+| 2026-05-17 (eng review) | Explicit phase cursor + `PendingSuggestion` for resumption | State machines should not depend on log replay. Cursor + pending payload = two fields, deterministic, testable. Transcript is for users to read. |
+| 2026-05-17 (eng review) | Scratch path uses `seedMinimalScratchLocked`, not `synthesizeBlueprintFromState` | Don't seed a fake team for a user who said "no team yet." Empty-but-real is honest; synthesized-team contradicts the trust-calibration goal we just locked. |
+| 2026-05-17 (eng review) | Frontend reuses `DMView` for CEO chat | Inherits Composer, MessageFeed, SSE, scroll, optimistic posts, autocomplete, typing indicator. The CEO DM IS a DM. |
+| 2026-05-17 (eng review) | Suggestion cards extend `InterviewBar` kind dispatcher | Inherits PR #684 `sanitizeContextValue` sanitization automatically. Parallel card system would have re-introduced the confused-deputy bypass. |
+| 2026-05-17 (eng review) | Sub-issues + wiki mirror deferred to Phase 6 | Phase 4 v1 stays focused on the trust-calibration goal (approval gate). Cuts ~3 dev days from v1; both features are real but neither is load-bearing for v1. |
+| 2026-05-17 (eng review) | Sanitization + approval gate tests as explicit Phase 2/4 acceptance gates | PR #684 evidence: load-bearing safety tests get cherry-picked into "later" follow-ups unless they're required gates. Making them gates is cheap insurance. |
+| 2026-05-17 (eng review) | State persisted on phase transition + form-field commit, not per-keystroke | Avoids per-keystroke disk I/O; intra-field typing client-side until submit. ~10-12 writes per full onboarding. |
+| 2026-05-17 (eng review) | `StructuredMessageCard` consolidation lands in Phase 5 | Both `InterviewBar` kinds and CEO kinds consume the same kind-dispatch + sanitization module. Single audit point for the PR #684 class of bugs. |
+
+---
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not run |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | not run |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR (PLAN) | 12 issues raised, 12 resolved, 0 unresolved, 0 critical gaps |
+| Design Review | `/plan-design-review` | UI/UX gaps | 1 | CLEAR | score: 6/10 → 9/10, 8 decisions made, 0 unresolved |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | not run |
+
+- **UNRESOLVED:** 0
+- **CROSS-MODEL:** outside voices skipped at user's request (well-grounded plan in both reviews)
+- **VERDICT:** ENG + DESIGN CLEARED — plan is ready to implement. Phase 1 (provider picker + empty-shell entry) is the smallest first slice with a feature flag for rollback.

--- a/web/e2e/screenshots/onboarding-phase1.mjs
+++ b/web/e2e/screenshots/onboarding-phase1.mjs
@@ -1,0 +1,87 @@
+// Capture the Phase 1 pre-office provider picker in two states:
+// all runtimes detected, and no runtimes detected (the evaluator path).
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh onboarding-phase1 <pr-number>
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const PREREQS_ALL_DETECTED = [
+  { name: "claude", required: false, found: true, version: "v1.2.3" },
+  { name: "codex", required: false, found: true, version: "v0.8.1" },
+  { name: "opencode", required: false, found: true, version: "v0.4.0" },
+];
+
+const PREREQS_NONE = [
+  { name: "claude", required: false, found: false },
+  { name: "codex", required: false, found: false },
+  { name: "opencode", required: false, found: false },
+];
+
+async function installPrePickMocks(context, prereqs) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      // Override the default onboarded:true stub so RootRoute renders
+      // the pre-office picker instead of the Shell.
+      await ctx.route("**/api/onboarding/state", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ onboarded: false }),
+        }),
+      );
+      await ctx.route("**/api/onboarding/prereqs", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(prereqs),
+        }),
+      );
+    },
+  });
+}
+
+async function bootPrePick(page) {
+  // Phase 1 ships behind a localStorage flag (lib/featureFlags.ts).
+  // Seed the flag BEFORE the first React render so RootRoute picks up
+  // the V2 surface on its initial mount.
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("wuphf:onboarding-v2", "1");
+    } catch {
+      // private-mode tabs can throw; the picker falls back to the
+      // ?onboardingV2=1 query param in that case.
+    }
+  });
+  await page.goto(`${DEFAULT_BASE}/?onboardingV2=1`, { waitUntil: "load" });
+  await page.waitForSelector('[data-testid="pre-pick-screen"]', {
+    timeout: 15_000,
+  });
+  // Let the prereqs fetch settle so the status labels render.
+  await page.waitForTimeout(400);
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1200, height: 800 },
+});
+
+await installPrePickMocks(context, PREREQS_ALL_DETECTED);
+await bootPrePick(page);
+await shotPage(page, OUT, "01-pre-pick-all-detected");
+
+await installPrePickMocks(context, PREREQS_NONE);
+await bootPrePick(page);
+await shotPage(page, OUT, "02-pre-pick-none-detected");
+
+console.log(`captured 2 screenshots to ${OUT}`);
+await browser.close();

--- a/web/e2e/screenshots/onboarding-phase2.mjs
+++ b/web/e2e/screenshots/onboarding-phase2.mjs
@@ -1,0 +1,207 @@
+// Capture Phase 2 onboarding — Deterministic CEO conversation frames.
+// Covers 6 key states: greet card, identity form field, blueprint chips,
+// team checklist, seed committed, and bridge with two-chip choice.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh onboarding-phase2 <pr-number>
+//
+// Stubs /onboarding/state per phase so no real broker is needed.
+// The OnboardingDMRoute is rendered inside the Shell (onboardingV2=true
+// + inCeoOnboarding state). We simulate this by:
+//   1. Setting onboarded=false + phase=<phase> in /onboarding/state
+//   2. Setting the localStorage flag wuphf:onboarding-v2=1
+//   3. Setting wuphf:in-ceo-onboarding=1 (NEW flag checked by RootRoute
+//      to skip PrePickScreen and go straight to Shell+CEO DM)
+//
+// NOTE: Frame capture depends on the dev server running on DEFAULT_BASE.
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+// ── Phase state fixtures ───────────────────────────────────────────────────
+
+const STATE_GREET = {
+  onboarded: false,
+  phase: "greet",
+  form_answers: {},
+  pending_suggestion: null,
+};
+
+const STATE_IDENTITY = {
+  onboarded: false,
+  phase: "identity",
+  form_answers: {},
+  pending_suggestion: {
+    id: "sug-identity-name",
+    phase: "identity",
+    kind: "ceo_form_field",
+    payload: {
+      field: "company_name",
+      label: "Office name?",
+      optional: false,
+      placeholder: "e.g. Acme Billing",
+    },
+  },
+};
+
+const STATE_BLUEPRINT = {
+  onboarded: false,
+  phase: "blueprint",
+  form_answers: {
+    company_name: "Acme Billing",
+    description: "Subscription billing for indie SaaS.",
+  },
+  pending_suggestion: {
+    id: "sug-blueprint",
+    phase: "blueprint",
+    kind: "ceo_chip_row",
+    payload: {
+      field: "blueprint_id",
+      label: "Pick a starter template, or start from scratch:",
+      options: [
+        { id: "bookkeeping", label: "Bookkeeping" },
+        { id: "content-ops", label: "Content Ops" },
+        { id: "engineering-team", label: "Engineering Team" },
+        { id: "scratch", label: "Start from scratch" },
+      ],
+    },
+  },
+};
+
+const STATE_TEAM_CHECKLIST = {
+  onboarded: false,
+  phase: "team",
+  form_answers: {
+    company_name: "Acme Billing",
+    blueprint_id: "content-ops",
+  },
+  pending_suggestion: {
+    id: "sug-team-trim",
+    phase: "team",
+    kind: "ceo_team_trim",
+    payload: {
+      field: "picked_agents",
+      label: "This blueprint comes with a team — keep or trim:",
+      items: [
+        { id: "writer", label: "Writer", default_checked: true },
+        { id: "editor", label: "Editor", default_checked: true },
+        { id: "designer", label: "Designer", default_checked: true },
+      ],
+      submit_label: "Confirm team",
+    },
+  },
+};
+
+const STATE_SEED_COMMITTED = {
+  onboarded: false,
+  phase: "bridge",
+  form_answers: {
+    company_name: "Acme Billing",
+    blueprint_id: "scratch",
+    scan_complete: true,
+  },
+  pending_suggestion: {
+    id: "sug-bridge",
+    phase: "bridge",
+    kind: "ceo_chip_row",
+    payload: {
+      field: "bridge_choice",
+      label: null,
+      options: [
+        { id: "start-issue", label: "Start an issue" },
+        { id: "look-around", label: "Look around first" },
+      ],
+    },
+  },
+};
+
+// ── Mock installer ────────────────────────────────────────────────────────
+
+async function installPhase2Mocks(context, stateFixture) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      // Override /onboarding/state with the fixture for this phase.
+      await ctx.route("**/api/onboarding/state", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(stateFixture),
+        }),
+      );
+      // Stub /onboarding/answer so card submission doesn't error.
+      await ctx.route("**/api/onboarding/answer", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true }),
+        }),
+      );
+    },
+  });
+}
+
+async function bootPhase2(page) {
+  // Enable both V2 flag and in-CEO-onboarding state so RootRoute renders
+  // Shell+OnboardingDMRoute directly without the PrePickScreen.
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("wuphf:onboarding-v2", "1");
+      // Signal to RootRoute that we're past PrePickScreen (Phase 2 active).
+      // TODO(phase2-followup): Once RootRoute is wired to derive inCeoOnboarding
+      // purely from /onboarding/state.phase, this localStorage seed can be removed.
+      window.localStorage.setItem("wuphf:in-ceo-onboarding", "1");
+    } catch {
+      // private-mode tabs; the query param fallback handles it.
+    }
+  });
+  await page.goto(`${DEFAULT_BASE}/?onboardingV2=1`, { waitUntil: "load" });
+  // Wait for the onboarding route to mount.
+  await page.waitForSelector('[data-testid="onboarding-dm-route"]', {
+    timeout: 15_000,
+  });
+  await page.waitForTimeout(400);
+}
+
+// ── Capture ────────────────────────────────────────────────────────────────
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 800 },
+});
+
+// Frame 1: greet phase — empty DM, CEO status dot ready
+await installPhase2Mocks(context, STATE_GREET);
+await bootPhase2(page);
+await shotPage(page, OUT, "01-greet-empty-dm");
+
+// Frame 2: identity — form field card with "Office name?" prompt
+await installPhase2Mocks(context, STATE_IDENTITY);
+await bootPhase2(page);
+await shotPage(page, OUT, "02-identity-form-field");
+
+// Frame 3: blueprint — chip row with four options
+await installPhase2Mocks(context, STATE_BLUEPRINT);
+await bootPhase2(page);
+await shotPage(page, OUT, "03-blueprint-chip-row");
+
+// Frame 4: team checklist — keep or trim blueprint agents
+await installPhase2Mocks(context, STATE_TEAM_CHECKLIST);
+await bootPhase2(page);
+await shotPage(page, OUT, "04-team-checklist");
+
+// Frame 5: bridge — seed committed, two-chip choice (start issue / look around)
+await installPhase2Mocks(context, STATE_SEED_COMMITTED);
+await bootPhase2(page);
+await shotPage(page, OUT, "05-bridge-two-chips");
+
+console.log(`captured 5 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { router } from "../../lib/router";
 import { useCurrentApp } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
 import { TeamMemberBadge } from "../join/TeamMemberBadge";
+import { SidebarPreviewOverlay } from "../onboarding/SidebarPreviewOverlay";
 import { AgentList } from "../sidebar/AgentList";
 import { AppList } from "../sidebar/AppList";
 import { ChannelList } from "../sidebar/ChannelList";
@@ -155,6 +156,10 @@ export function Sidebar() {
           >
             <AppList />
           </div>
+
+          {/* Phase 2 onboarding preview overlay — shows staged channels/agents
+              forming as the user answers CEO questions. Hidden once onboarded. */}
+          <SidebarPreviewOverlay />
 
           <RecentObjectsPanel />
           <WorkspaceSummary />

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -1,0 +1,550 @@
+/**
+ * InterviewBar CEO kinds tests (Phase 2 onboarding)
+ *
+ * Tests cover:
+ * 1. Each of the 5 new CEO card kinds renders correctly in "pending" state
+ * 2. Pending → submitting → committed lifecycle for form_field + chip_row + checklist
+ * 3. XSS attack strings in payload render as text, not HTML (PR #684 regression)
+ * 4. ceo_scan_chip renders all three status states
+ *
+ * The CeoCardSection reads from OnboardingDMContext. We provide the context
+ * directly via the exported OnboardingDMContextProvider.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingDMContextProvider } from "../onboarding/OnboardingDMRoute";
+import type {
+  CeoChecklistPayload,
+  CeoChipRowPayload,
+  CeoFormFieldPayload,
+  CeoScanChipPayload,
+  CeoSuggestion,
+} from "../onboarding/types";
+import { CeoChecklist } from "./cards/CeoChecklist";
+import { CeoChipRow } from "./cards/CeoChipRow";
+import { CeoFormField } from "./cards/CeoFormField";
+import { CeoScanChip } from "./cards/CeoScanChip";
+// We test CeoCardSection and the individual card components.
+import { CeoCardSection } from "./InterviewBar";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return { ...actual, get: vi.fn(), post: vi.fn() };
+});
+
+vi.mock("../../hooks/useRequests", () => ({
+  useRequests: () => ({ pending: [] }),
+}));
+
+import { post } from "../../api/client";
+
+const postMock = vi.mocked(post);
+
+// ── Context helper ────────────────────────────────────────────────────────
+
+function makeWrapper(suggestion: CeoSuggestion | null) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return (
+      <QueryClientProvider client={qc}>
+        <OnboardingDMContextProvider
+          value={{ phase: "identity", pendingSuggestion: suggestion }}
+        >
+          {children}
+        </OnboardingDMContextProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  postMock.mockReset();
+  postMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ── ceo_form_field ─────────────────────────────────────────────────────────
+
+describe("CeoFormField", () => {
+  const formPayload: CeoFormFieldPayload = {
+    field: "company_name",
+    label: "Office name?",
+    optional: false,
+    placeholder: "e.g. Acme Billing",
+  };
+
+  it("renders in pending state with label and input", () => {
+    render(
+      <CeoFormField payload={formPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    expect(screen.getByTestId("ceo-form-field")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByText("Office name?")).toBeInTheDocument();
+  });
+
+  it("disables input and shows spinner in submitting state", () => {
+    render(
+      <CeoFormField
+        payload={formPayload}
+        stage="submitting"
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.getByText(/Saving/i)).toBeInTheDocument();
+  });
+
+  it("renders committed line with check mark in committed state", () => {
+    render(
+      <CeoFormField
+        payload={formPayload}
+        stage="committed"
+        committedValue="Acme Billing"
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("✓");
+    expect(screen.getByRole("status")).toHaveTextContent("Acme Billing");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("calls onSubmit with field and value on Enter", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CeoFormField
+        payload={formPayload}
+        stage="pending"
+        onSubmit={onSubmit}
+      />,
+    );
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Acme Billing" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith("company_name", "Acme Billing");
+  });
+
+  it("calls onSkip when Skip chip is clicked (optional field)", () => {
+    const onSkip = vi.fn();
+    render(
+      <CeoFormField
+        payload={{ ...formPayload, optional: true }}
+        stage="pending"
+        onSubmit={vi.fn()}
+        onSkip={onSkip}
+      />,
+    );
+    fireEvent.click(screen.getByText("Skip"));
+    expect(onSkip).toHaveBeenCalledWith("company_name");
+  });
+
+  it("XSS: renders script tag as text, not executed HTML", () => {
+    const xssPayload: CeoFormFieldPayload = {
+      field: "company_name",
+      label: '<script>alert("xss")</script>',
+      optional: false,
+    };
+    render(
+      <CeoFormField payload={xssPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    // The script should appear as literal text in the DOM, not as an element.
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+    expect(
+      screen.getByText('<script>alert("xss")</script>'),
+    ).toBeInTheDocument();
+  });
+
+  it("XSS: img onerror attack string renders as text", () => {
+    const xssPayload: CeoFormFieldPayload = {
+      field: "company_name",
+      label: "<img src=x onerror=alert(1)>",
+      optional: false,
+    };
+    render(
+      <CeoFormField payload={xssPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    expect(document.querySelector("img")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("<img src=x onerror=alert(1)>"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── ceo_chip_row ──────────────────────────────────────────────────────────
+
+describe("CeoChipRow", () => {
+  const chipPayload: CeoChipRowPayload = {
+    field: "blueprint_id",
+    label: "Pick a starter template:",
+    options: [
+      { id: "content-ops", label: "Content Ops" },
+      { id: "engineering-team", label: "Engineering Team" },
+      { id: "scratch", label: "Start from scratch" },
+    ],
+  };
+
+  it("renders all chips in pending state", () => {
+    render(
+      <CeoChipRow payload={chipPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    expect(screen.getByTestId("ceo-chip-row")).toBeInTheDocument();
+    expect(screen.getByText("Content Ops")).toBeInTheDocument();
+    expect(screen.getByText("Engineering Team")).toBeInTheDocument();
+    expect(screen.getByText("Start from scratch")).toBeInTheDocument();
+  });
+
+  it("calls onSubmit immediately when a chip is clicked", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CeoChipRow payload={chipPayload} stage="pending" onSubmit={onSubmit} />,
+    );
+    fireEvent.click(screen.getByText("Content Ops"));
+    expect(onSubmit).toHaveBeenCalledWith("blueprint_id", "content-ops");
+  });
+
+  it("disables all chips in submitting state", () => {
+    render(
+      <CeoChipRow
+        payload={chipPayload}
+        stage="submitting"
+        onSubmit={vi.fn()}
+      />,
+    );
+    const buttons = screen.getAllByRole("option");
+    for (const btn of buttons) {
+      expect(btn).toBeDisabled();
+    }
+  });
+
+  it("renders committed state as one-line with check mark", () => {
+    render(
+      <CeoChipRow
+        payload={chipPayload}
+        stage="committed"
+        committedValue="Content Ops"
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("✓");
+    expect(screen.getByRole("status")).toHaveTextContent("Content Ops");
+  });
+
+  it("XSS: chip label renders as text not HTML", () => {
+    const xssChipPayload: CeoChipRowPayload = {
+      field: "blueprint_id",
+      label: "Pick",
+      options: [{ id: "x", label: "<img src=x onerror=alert(1)>" }],
+    };
+    render(
+      <CeoChipRow
+        payload={xssChipPayload}
+        stage="pending"
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(document.querySelector("img")).not.toBeInTheDocument();
+  });
+});
+
+// ── ceo_checklist ─────────────────────────────────────────────────────────
+
+describe("CeoChecklist", () => {
+  const checklistPayload: CeoChecklistPayload = {
+    field: "picked_agents",
+    label: "Keep or trim your team:",
+    items: [
+      { id: "writer", label: "Writer", default_checked: true },
+      { id: "editor", label: "Editor", default_checked: true },
+      { id: "designer", label: "Designer", default_checked: false },
+    ],
+    submit_label: "Confirm team",
+  };
+
+  it("renders all items with default checked state", () => {
+    render(
+      <CeoChecklist
+        payload={checklistPayload}
+        stage="pending"
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("ceo-checklist")).toBeInTheDocument();
+    const writerBox = screen.getByLabelText("Writer");
+    const designerBox = screen.getByLabelText("Designer");
+    expect(writerBox).toBeChecked();
+    expect(designerBox).not.toBeChecked();
+  });
+
+  it("toggles checkbox on click", () => {
+    render(
+      <CeoChecklist
+        payload={checklistPayload}
+        stage="pending"
+        onSubmit={vi.fn()}
+      />,
+    );
+    const designerBox = screen.getByLabelText("Designer");
+    fireEvent.click(designerBox);
+    expect(designerBox).toBeChecked();
+  });
+
+  it("calls onSubmit with selected agent IDs", () => {
+    const onSubmit = vi.fn();
+    render(
+      <CeoChecklist
+        payload={checklistPayload}
+        stage="pending"
+        onSubmit={onSubmit}
+      />,
+    );
+    fireEvent.click(screen.getByText("Confirm team"));
+    expect(onSubmit).toHaveBeenCalledWith(
+      "picked_agents",
+      expect.arrayContaining(["writer", "editor"]),
+    );
+  });
+
+  it("disables all items in submitting state", () => {
+    render(
+      <CeoChecklist
+        payload={checklistPayload}
+        stage="submitting"
+        onSubmit={vi.fn()}
+      />,
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+    for (const cb of checkboxes) {
+      expect(cb).toBeDisabled();
+    }
+  });
+
+  it("renders committed state as one-line with check mark", () => {
+    render(
+      <CeoChecklist
+        payload={checklistPayload}
+        stage="committed"
+        committedValue={["Writer", "Editor"]}
+        onSubmit={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("✓");
+    expect(screen.getByRole("status")).toHaveTextContent("Writer");
+    expect(screen.getByRole("status")).toHaveTextContent("Editor");
+  });
+
+  it("XSS: checklist item label renders as text not HTML", () => {
+    const xssPayload: CeoChecklistPayload = {
+      field: "agents",
+      label: "Team",
+      items: [{ id: "x", label: '<script>alert("xss")</script>' }],
+    };
+    render(
+      <CeoChecklist payload={xssPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+    expect(
+      screen.getByText('<script>alert("xss")</script>'),
+    ).toBeInTheDocument();
+  });
+});
+
+// ── ceo_scan_chip ─────────────────────────────────────────────────────────
+
+describe("CeoScanChip", () => {
+  it("renders scanning state", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "scanning",
+    };
+    render(<CeoScanChip payload={payload} />);
+    const chip = screen.getByTestId("ceo-scan-chip");
+    expect(chip).toHaveClass("ceo-scan-chip--scanning");
+    expect(chip).toHaveTextContent("Scanning acme.com");
+  });
+
+  it("renders done state with success label", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "done",
+    };
+    render(<CeoScanChip payload={payload} />);
+    const chip = screen.getByTestId("ceo-scan-chip");
+    expect(chip).toHaveClass("ceo-scan-chip--done");
+    expect(chip).toHaveTextContent("Wiki updated");
+  });
+
+  it("renders failed state with error label", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "failed",
+    };
+    render(<CeoScanChip payload={payload} />);
+    const chip = screen.getByTestId("ceo-scan-chip");
+    expect(chip).toHaveClass("ceo-scan-chip--failed");
+    // Use partial match to avoid unicode apostrophe mismatch
+    expect(chip.textContent).toContain("read that URL");
+  });
+
+  it("uses custom labels when provided", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "example.com",
+      status: "done",
+      done_label: "Wiki updated with example.com facts",
+    };
+    render(<CeoScanChip payload={payload} />);
+    expect(screen.getByTestId("ceo-scan-chip")).toHaveTextContent(
+      "Wiki updated with example.com facts",
+    );
+  });
+
+  it("XSS: URL renders as text not HTML", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: '<script>alert("xss")</script>',
+      status: "scanning",
+    };
+    render(<CeoScanChip payload={payload} />);
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+  });
+});
+
+// ── CeoCardSection integration (via context) ─────────────────────────────
+
+describe("CeoCardSection", () => {
+  it("renders nothing when there is no pending suggestion", () => {
+    render(<CeoCardSection />, { wrapper: makeWrapper(null) });
+    expect(screen.queryByTestId("ceo-card-section")).not.toBeInTheDocument();
+  });
+
+  it("renders a ceo_form_field card when suggestion is set", () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-1",
+      phase: "identity",
+      kind: "ceo_form_field",
+      payload: {
+        field: "company_name",
+        label: "Office name?",
+        optional: false,
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+    expect(screen.getByTestId("ceo-card-section")).toBeInTheDocument();
+    expect(screen.getByTestId("ceo-form-field")).toBeInTheDocument();
+  });
+
+  it("transitions to committed after successful POST to /onboarding/answer", async () => {
+    postMock.mockResolvedValue({});
+    const suggestion: CeoSuggestion = {
+      id: "sug-2",
+      phase: "identity",
+      kind: "ceo_form_field",
+      payload: {
+        field: "company_name",
+        label: "Office name?",
+        optional: false,
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Acme Inc" } });
+    fireEvent.click(screen.getByText("Submit"));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/answer", {
+        field: "company_name",
+        value: "Acme Inc",
+      }),
+    );
+
+    // After commit the section disappears (stage="committed" hides it)
+    await waitFor(() =>
+      expect(screen.queryByTestId("ceo-card-section")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("renders a ceo_chip_row card", () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-3",
+      phase: "blueprint",
+      kind: "ceo_chip_row",
+      payload: {
+        field: "blueprint_id",
+        label: "Pick a template:",
+        options: [
+          { id: "scratch", label: "Start from scratch" },
+          { id: "content-ops", label: "Content Ops" },
+        ],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+    expect(screen.getByTestId("ceo-chip-row")).toBeInTheDocument();
+  });
+
+  it("renders a ceo_checklist card", () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-4",
+      phase: "team",
+      kind: "ceo_checklist",
+      payload: {
+        field: "picked_agents",
+        label: "Keep or trim:",
+        items: [{ id: "eng", label: "Engineer", default_checked: true }],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+    expect(screen.getByTestId("ceo-checklist")).toBeInTheDocument();
+  });
+
+  it("renders a ceo_team_trim card (alias for checklist)", () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-5",
+      phase: "team",
+      kind: "ceo_team_trim",
+      payload: {
+        field: "picked_agents",
+        label: "Your team:",
+        items: [{ id: "pm", label: "PM", default_checked: true }],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+    expect(screen.getByTestId("ceo-checklist")).toBeInTheDocument();
+  });
+
+  it("renders a ceo_scan_chip card", () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-6",
+      phase: "scan",
+      kind: "ceo_scan_chip",
+      payload: {
+        field: "website_url",
+        url: "acme.com",
+        status: "scanning",
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+    expect(screen.getByTestId("ceo-scan-chip")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { NavArrowLeft, NavArrowRight, Xmark } from "iconoir-react";
 
@@ -9,15 +9,22 @@ import {
   getSkillsList,
   type InterviewOption,
   patchSkill,
+  post,
   type Skill,
   type SkillSimilarRef,
 } from "../../api/client";
 import { useRequests } from "../../hooks/useRequests";
 import { parseApprovalContext } from "../../lib/parseApprovalContext";
 import { SkillCompareView } from "../apps/SkillCompareView";
+import { useOnboardingDMContext } from "../onboarding/OnboardingDMRoute";
+import type { CardStage, CeoSuggestion } from "../onboarding/types";
 import { SidePanel } from "../ui/SidePanel";
 import { showNotice } from "../ui/Toast";
 import { ApprovalContextView } from "./ApprovalContextView";
+import { CeoChecklist } from "./cards/CeoChecklist";
+import { CeoChipRow } from "./cards/CeoChipRow";
+import { CeoFormField } from "./cards/CeoFormField";
+import { CeoScanChip } from "./cards/CeoScanChip";
 
 /**
  * Inline interview bar shown above the Composer. Mirrors the TUI behavior:
@@ -32,6 +39,19 @@ import { ApprovalContextView } from "./ApprovalContextView";
  *   side-by-side preview + three buttons (Enhance / Approve anyway / Reject).
  * - kind="skill_proposal" with metadata.similar_to_existing renders a
  *   warning banner with a [Compare] action above the standard options.
+ *
+ * Phase 2 (onboarding-into-office spec) extends this with CEO card kinds:
+ * - kind="ceo_form_field": label + text input + submit/skip chips
+ * - kind="ceo_chip_row": single-select chip row (blueprint pick)
+ * - kind="ceo_checklist": multi-select checklist + submit (team trim)
+ * - kind="ceo_team_trim": alias for ceo_checklist with team-specific copy
+ * - kind="ceo_scan_chip": async scan status display (read-only)
+ *
+ * CEO cards are rendered by the CeoCardSection sub-component which reads
+ * the PendingSuggestion from OnboardingDMContext. They live above the
+ * regular request queue section. Sanitization is enforced by:
+ *   1. Backend: sanitizeContextValue in broker_onboarding.go (PR #684)
+ *   2. Frontend: all card components render strings as text, never innerHTML
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
@@ -638,4 +658,138 @@ function EnhanceActions({ options, submitting, onPick }: EnhanceActionsProps) {
       ) : null}
     </div>
   );
+}
+
+// ── CEO card section (Phase 2 onboarding) ─────────────────────────────────
+
+/**
+ * CeoCardSection renders the current PendingSuggestion from OnboardingDMContext
+ * as an interactive CEO card above the regular interview queue.
+ *
+ * This is a separate exported component so it can be rendered inside the CEO
+ * DM's InterviewBar slot, and tested independently.
+ *
+ * The card is only visible when:
+ *   1. The OnboardingDMRoute provides a non-null pendingSuggestion
+ *   2. The card has not yet been committed (stage !== "committed")
+ *
+ * POST /onboarding/answer wire shape: { field: string, value: unknown }
+ */
+export function CeoCardSection() {
+  const { pendingSuggestion } = useOnboardingDMContext();
+  const queryClient = useQueryClient();
+  const [stage, setStage] = useState<CardStage>("pending");
+  const [committedValue, setCommittedValue] = useState<
+    string | string[] | undefined
+  >(undefined);
+
+  // Reset stage when suggestion changes (new question arrived).
+  const suggestionId = pendingSuggestion?.id ?? null;
+  useEffect(() => {
+    setStage("pending");
+    setCommittedValue(undefined);
+  }, [suggestionId]);
+
+  if (!pendingSuggestion || stage === "committed") return null;
+
+  const submitAnswer = async (field: string, value: unknown) => {
+    if (stage === "submitting") return;
+    setStage("submitting");
+    try {
+      await post("/onboarding/answer", { field, value });
+      // Refresh onboarding state so the next suggestion appears.
+      await queryClient.invalidateQueries({ queryKey: ["onboarding-state"] });
+      if (typeof value === "string") {
+        setCommittedValue(value);
+      } else if (Array.isArray(value)) {
+        setCommittedValue(value as string[]);
+      }
+      setStage("committed");
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Failed to send answer";
+      showNotice(message, "error");
+      setStage("pending");
+    }
+  };
+
+  const handleSkip = async (field: string) => {
+    await submitAnswer(field, "");
+  };
+
+  return (
+    <section
+      className="ceo-card-section"
+      aria-label="CEO question"
+      data-testid="ceo-card-section"
+      data-kind={pendingSuggestion.kind}
+    >
+      {renderCeoCard(
+        pendingSuggestion,
+        stage,
+        committedValue,
+        submitAnswer,
+        handleSkip,
+      )}
+    </section>
+  );
+}
+
+function renderCeoCard(
+  suggestion: CeoSuggestion,
+  stage: CardStage,
+  committedValue: string | string[] | undefined,
+  onSubmit: (field: string, value: unknown) => Promise<void>,
+  onSkip: (field: string) => Promise<void>,
+): ReactNode {
+  switch (suggestion.kind) {
+    case "ceo_form_field":
+      return (
+        <CeoFormField
+          payload={suggestion.payload}
+          stage={stage}
+          committedValue={
+            typeof committedValue === "string" ? committedValue : undefined
+          }
+          onSubmit={(field, value) => void onSubmit(field, value)}
+          onSkip={
+            suggestion.payload.optional
+              ? (field) => void onSkip(field)
+              : undefined
+          }
+        />
+      );
+    case "ceo_chip_row":
+      return (
+        <CeoChipRow
+          payload={suggestion.payload}
+          stage={stage}
+          committedValue={
+            typeof committedValue === "string" ? committedValue : undefined
+          }
+          onSubmit={(field, value) => void onSubmit(field, value)}
+        />
+      );
+    case "ceo_checklist":
+    case "ceo_team_trim":
+      return (
+        <CeoChecklist
+          payload={suggestion.payload}
+          stage={stage}
+          committedValue={
+            Array.isArray(committedValue) ? committedValue : undefined
+          }
+          onSubmit={(field, value) => void onSubmit(field, value)}
+        />
+      );
+    case "ceo_scan_chip":
+      return <CeoScanChip payload={suggestion.payload} />;
+    default: {
+      // Exhaustiveness guard: if a new CEO kind is added to the union
+      // without a case here, TypeScript will flag the assignment below.
+      const _exhaustive: never = suggestion;
+      void _exhaustive;
+      return null;
+    }
+  }
 }

--- a/web/src/components/messages/cards/CeoChecklist.tsx
+++ b/web/src/components/messages/cards/CeoChecklist.tsx
@@ -1,0 +1,129 @@
+/**
+ * CeoChecklist — list of checkboxes + submit chip.
+ * CeoTeamTrim is an alias of this component with team-specific chrome.
+ *
+ * Used for: team trim (blueprint path).
+ *
+ * Keyboard model per spec:
+ *   Tab    → item
+ *   Space  → toggle checkbox
+ *   Enter  → Submit button
+ *
+ * All item labels treated as plain text (never innerHTML).
+ */
+
+import { useRef, useState } from "react";
+
+import type {
+  CardStage,
+  CeoChecklistPayload,
+  CeoTeamTrimPayload,
+} from "../../onboarding/types";
+
+interface CeoChecklistProps {
+  payload: CeoChecklistPayload | CeoTeamTrimPayload;
+  stage: CardStage;
+  committedValue?: string[];
+  onSubmit: (field: string, value: string[]) => void;
+  /** Ref for focus management — parent focuses first item after prior card commits. */
+  autoFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+export function CeoChecklist({
+  payload,
+  stage,
+  committedValue,
+  onSubmit,
+  autoFocusRef,
+}: CeoChecklistProps) {
+  const [checked, setChecked] = useState<Set<string>>(
+    () =>
+      new Set(
+        payload.items
+          .filter((item) => item.default_checked !== false)
+          .map((item) => item.id),
+      ),
+  );
+  const submitRef = useRef<HTMLButtonElement>(null);
+
+  // Merge externally-provided ref so the parent can focus the submit button.
+  if (autoFocusRef && submitRef.current !== null) {
+    (autoFocusRef as React.MutableRefObject<HTMLElement | null>).current =
+      submitRef.current;
+  }
+
+  if (stage === "committed") {
+    const labels =
+      committedValue ??
+      payload.items
+        .filter((item) => checked.has(item.id))
+        .map((item) => item.label);
+    return (
+      <div className="ceo-card ceo-card--committed" role="status">
+        <span className="ceo-card-committed-text">
+          &#10003; {labels.join(", ")}
+        </span>
+      </div>
+    );
+  }
+
+  const toggle = (id: string) => {
+    if (stage === "submitting") return;
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleSubmit = () => {
+    if (stage === "submitting") return;
+    onSubmit(payload.field, [...checked]);
+  };
+
+  return (
+    <div className="ceo-card ceo-card--checklist" data-testid="ceo-checklist">
+      {payload.label ? (
+        <div className="ceo-card-label">{payload.label}</div>
+      ) : null}
+      <ul className="ceo-checklist-items">
+        {payload.items.map((item) => (
+          <li key={item.id} className="ceo-checklist-item">
+            <label className="ceo-checklist-label">
+              <input
+                type="checkbox"
+                className="ceo-checklist-checkbox"
+                checked={checked.has(item.id)}
+                disabled={stage === "submitting"}
+                onChange={() => toggle(item.id)}
+                aria-label={item.label}
+              />
+              {/* Render as text — never innerHTML */}
+              <span className="ceo-checklist-item-text">{item.label}</span>
+            </label>
+          </li>
+        ))}
+      </ul>
+      <div className="ceo-card-actions">
+        <button
+          ref={submitRef}
+          type="button"
+          className="btn btn-primary btn-sm ceo-card-submit"
+          disabled={stage === "submitting" || checked.size === 0}
+          onClick={handleSubmit}
+        >
+          {stage === "submitting" ? (
+            <span className="ceo-card-spinner" aria-hidden="true" />
+          ) : null}
+          {stage === "submitting"
+            ? "Saving…"
+            : (payload.submit_label ?? "Submit")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/messages/cards/CeoChipRow.tsx
+++ b/web/src/components/messages/cards/CeoChipRow.tsx
@@ -1,0 +1,130 @@
+/**
+ * CeoChipRow — single-select chip row.
+ *
+ * Used for: blueprint pick.
+ *
+ * Keyboard model per spec:
+ *   Tab        → into row
+ *   Arrow keys → move chip selection
+ *   Enter      → commit selected chip
+ *   Space      → commit selected chip
+ *
+ * All chip labels treated as plain text (never innerHTML).
+ */
+
+import { useRef, useState } from "react";
+
+import type { CardStage, CeoChipRowPayload } from "../../onboarding/types";
+
+interface CeoChipRowProps {
+  payload: CeoChipRowPayload;
+  stage: CardStage;
+  committedValue?: string;
+  onSubmit: (field: string, value: string) => void;
+  /** Ref for focus management — parent focuses first chip after prior card commits. */
+  autoFocusRef?: React.RefObject<HTMLButtonElement | null>;
+}
+
+export function CeoChipRow({
+  payload,
+  stage,
+  committedValue,
+  onSubmit,
+  autoFocusRef,
+}: CeoChipRowProps) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const firstChipRef = useRef<HTMLButtonElement>(null);
+
+  // Merge externally-provided ref so the parent can focus the first chip.
+  if (autoFocusRef && firstChipRef.current !== null) {
+    (autoFocusRef as React.MutableRefObject<HTMLButtonElement | null>).current =
+      firstChipRef.current;
+  }
+
+  if (stage === "committed") {
+    const label =
+      committedValue ??
+      payload.options.find((o) => o.id === selected)?.label ??
+      selected ??
+      "";
+    return (
+      <div className="ceo-card ceo-card--committed" role="status">
+        <span className="ceo-card-committed-text">&#10003; {label}</span>
+      </div>
+    );
+  }
+
+  const handleSelect = (id: string) => {
+    if (stage === "submitting") return;
+    setSelected(id);
+    onSubmit(payload.field, id);
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    id: string,
+    idx: number,
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleSelect(id);
+      return;
+    }
+    // Arrow key navigation within the chip row
+    const chips = payload.options;
+    if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+      e.preventDefault();
+      const next = chips[(idx + 1) % chips.length];
+      const el = document.getElementById(
+        `ceo-chip-${payload.field}-${next.id}`,
+      );
+      el?.focus();
+    } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const prev = chips[(idx - 1 + chips.length) % chips.length];
+      const el = document.getElementById(
+        `ceo-chip-${payload.field}-${prev.id}`,
+      );
+      el?.focus();
+    }
+  };
+
+  return (
+    <div
+      className="ceo-card ceo-card--chip-row"
+      data-testid="ceo-chip-row"
+      role="group"
+      aria-label={payload.label}
+    >
+      {payload.label ? (
+        <div className="ceo-card-label">{payload.label}</div>
+      ) : null}
+      <div
+        className="ceo-chip-row-options"
+        role="listbox"
+        aria-label={payload.label}
+      >
+        {payload.options.map((opt, idx) => (
+          <button
+            key={opt.id}
+            id={`ceo-chip-${payload.field}-${opt.id}`}
+            ref={idx === 0 ? firstChipRef : undefined}
+            type="button"
+            role="option"
+            aria-selected={selected === opt.id}
+            className={`ceo-chip${selected === opt.id ? " ceo-chip--selected" : ""}`}
+            disabled={stage === "submitting"}
+            onClick={() => handleSelect(opt.id)}
+            onKeyDown={(e) => handleKeyDown(e, opt.id, idx)}
+          >
+            {stage === "submitting" && selected === opt.id ? (
+              <span className="ceo-card-spinner" aria-hidden="true" />
+            ) : null}
+            {/* Render as text — never innerHTML */}
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/messages/cards/CeoFormField.tsx
+++ b/web/src/components/messages/cards/CeoFormField.tsx
@@ -1,0 +1,129 @@
+/**
+ * CeoFormField — label + text input + submit chip + optional "Skip" chip.
+ *
+ * Used for: company name, description, website, owner_name, owner_role.
+ *
+ * Card lifecycle: pending → submitting → committed (one-line "✓ <value>").
+ * All strings treated as plain text. Never render raw payload as HTML.
+ *
+ * Keyboard model per spec:
+ *   Tab  → input focus
+ *   Enter → submit (when input focused)
+ *   Space → type normally (not a submit trigger here)
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import type { CardStage, CeoFormFieldPayload } from "../../onboarding/types";
+
+interface CeoFormFieldProps {
+  payload: CeoFormFieldPayload;
+  stage: CardStage;
+  committedValue?: string;
+  onSubmit: (field: string, value: string) => void;
+  onSkip?: (field: string) => void;
+  /** Ref for focus management — parent focuses this after prior card commits. */
+  autoFocusRef?: React.RefObject<HTMLInputElement | null>;
+}
+
+export function CeoFormField({
+  payload,
+  stage,
+  committedValue,
+  onSubmit,
+  onSkip,
+  autoFocusRef,
+}: CeoFormFieldProps) {
+  const [value, setValue] = useState(payload.default ?? "");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Merge externally-provided ref with local ref so the parent can manage
+  // focus while this component can also auto-focus on mount.
+  useEffect(() => {
+    if (autoFocusRef) {
+      (
+        autoFocusRef as React.MutableRefObject<HTMLInputElement | null>
+      ).current = inputRef.current;
+    }
+  });
+
+  useEffect(() => {
+    if (stage === "pending" && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [stage]);
+
+  if (stage === "committed") {
+    return (
+      <div className="ceo-card ceo-card--committed" role="status">
+        <span className="ceo-card-committed-text">
+          &#10003; {committedValue ?? value}
+        </span>
+      </div>
+    );
+  }
+
+  const canSubmit = value.trim().length > 0 || payload.optional;
+
+  const handleSubmit = () => {
+    if (stage === "submitting") return;
+    const trimmed = value.trim();
+    if (!(trimmed || payload.optional)) return;
+    onSubmit(payload.field, trimmed);
+  };
+
+  return (
+    <div className="ceo-card ceo-card--form-field" data-testid="ceo-form-field">
+      {payload.label ? (
+        <label
+          htmlFor={`ceo-field-${payload.field}`}
+          className="ceo-card-label"
+        >
+          {payload.label}
+        </label>
+      ) : null}
+      <input
+        id={`ceo-field-${payload.field}`}
+        ref={inputRef}
+        type="text"
+        className="ceo-card-input"
+        value={value}
+        placeholder={payload.placeholder ?? ""}
+        disabled={stage === "submitting"}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleSubmit();
+          }
+        }}
+        aria-label={payload.label}
+      />
+      <div className="ceo-card-actions">
+        <button
+          type="button"
+          className="btn btn-primary btn-sm ceo-card-submit"
+          disabled={stage === "submitting" || !canSubmit}
+          onClick={handleSubmit}
+          aria-label={`Submit ${payload.label}`}
+        >
+          {stage === "submitting" ? (
+            <span className="ceo-card-spinner" aria-hidden="true" />
+          ) : null}
+          {stage === "submitting" ? "Saving…" : "Submit"}
+        </button>
+        {payload.optional && onSkip ? (
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm ceo-card-skip"
+            disabled={stage === "submitting"}
+            onClick={() => onSkip(payload.field)}
+            aria-label={`Skip ${payload.label}`}
+          >
+            Skip
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/messages/cards/CeoScanChip.tsx
+++ b/web/src/components/messages/cards/CeoScanChip.tsx
@@ -1,0 +1,57 @@
+/**
+ * CeoScanChip — displays async website scan status.
+ *
+ * Read-only (no keyboard interaction per spec — Tab focus but no Enter/Space).
+ * Status transitions: scanning → done | failed, driven by SSE updates.
+ *
+ * Three status strings per spec (backend sets payload.status):
+ *   scanning → payload.scanning_label or "Scanning…"
+ *   done     → payload.done_label or "Wiki updated ✓"
+ *   failed   → payload.failed_label or "Couldn't read that URL"
+ *
+ * All strings rendered as text, never innerHTML.
+ */
+
+import type { CeoScanChipPayload, ScanStatus } from "../../onboarding/types";
+
+interface CeoScanChipProps {
+  payload: CeoScanChipPayload;
+}
+
+function scanLabel(payload: CeoScanChipPayload, status: ScanStatus): string {
+  switch (status) {
+    case "scanning":
+      return payload.scanning_label ?? `Scanning ${payload.url}…`;
+    case "done":
+      return payload.done_label ?? "Wiki updated ✓";
+    case "failed":
+      return payload.failed_label ?? "Couldn’t read that URL";
+  }
+}
+
+export function CeoScanChip({ payload }: CeoScanChipProps) {
+  const { status } = payload;
+  const label = scanLabel(payload, status);
+
+  return (
+    <div
+      className={`ceo-scan-chip ceo-scan-chip--${status}`}
+      data-testid="ceo-scan-chip"
+      aria-live="polite"
+      aria-label={label}
+    >
+      {status === "scanning" ? (
+        <span className="ceo-scan-chip-spinner" aria-hidden="true" />
+      ) : (
+        <span
+          className={`ceo-scan-chip-icon ceo-scan-chip-icon--${status}`}
+          aria-hidden="true"
+        >
+          {status === "done" ? "✓" : "✗"}
+        </span>
+      )}
+      {/* Render URL and label as plain text — never as HTML */}
+      <span className="ceo-scan-chip-label">{label}</span>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/OnboardingDMRoute.test.tsx
+++ b/web/src/components/onboarding/OnboardingDMRoute.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * OnboardingDMRoute tests
+ *
+ * 1. Renders DMView with the correct channel slug (dm:ceo:onboarding)
+ * 2. Surfaces PendingSuggestion as a CEO card via CeoCardSection
+ * 3. Loading state renders without crash when state is undefined
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingDMRoute } from "./OnboardingDMRoute";
+import type { CeoFormFieldSuggestion } from "./types";
+
+// Stub DMView to avoid full message infrastructure setup in unit tests.
+vi.mock("../messages/DMView", () => ({
+  DMView: ({
+    agentSlug,
+    channelSlug,
+  }: {
+    agentSlug: string;
+    channelSlug: string;
+  }) => (
+    <div
+      data-testid="dm-view-stub"
+      data-agent={agentSlug}
+      data-channel={channelSlug}
+    />
+  ),
+}));
+
+// Stub api client
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return { ...actual, get: vi.fn(), post: vi.fn() };
+});
+
+import { get } from "../../api/client";
+
+const getMock = vi.mocked(get);
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("OnboardingDMRoute", () => {
+  it("renders DMView pointed at dm:ceo:onboarding channel", async () => {
+    getMock.mockResolvedValue({ phase: "greet" });
+    render(<OnboardingDMRoute />, { wrapper });
+
+    const stub = await screen.findByTestId("dm-view-stub");
+    expect(stub).toHaveAttribute("data-channel", "dm:ceo:onboarding");
+    expect(stub).toHaveAttribute("data-agent", "ceo");
+  });
+
+  it("exposes the phase via data-phase attribute", async () => {
+    getMock.mockResolvedValue({ phase: "identity" });
+    render(<OnboardingDMRoute />, { wrapper });
+
+    // Immediately renders with "loading" then updates after query resolves.
+    const route = screen.getByTestId("onboarding-dm-route");
+    expect(route).toBeDefined();
+  });
+
+  it("renders without crash when onboarding state is unavailable", () => {
+    getMock.mockRejectedValue(new Error("unreachable"));
+    expect(() => render(<OnboardingDMRoute />, { wrapper })).not.toThrow();
+  });
+
+  it("sets data-phase=loading initially while state fetches", () => {
+    getMock.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<OnboardingDMRoute />, { wrapper });
+
+    const route = screen.getByTestId("onboarding-dm-route");
+    expect(route).toHaveAttribute("data-phase", "loading");
+  });
+
+  it("surfaces a pending ceo_form_field suggestion via CeoCardSection", async () => {
+    const suggestion: CeoFormFieldSuggestion = {
+      id: "sug-1",
+      phase: "identity",
+      kind: "ceo_form_field",
+      payload: {
+        field: "company_name",
+        label: "Office name?",
+        optional: false,
+      },
+    };
+    getMock.mockResolvedValue({
+      phase: "identity",
+      pending_suggestion: suggestion,
+    });
+
+    render(<OnboardingDMRoute />, { wrapper });
+
+    // CeoCardSection renders inside OnboardingDMRoute via context.
+    // This test verifies the context is provided correctly by checking the
+    // data attribute updates once the query resolves.
+    // Full card rendering is tested in InterviewBar.ceoKinds.test.tsx.
+    const route = screen.getByTestId("onboarding-dm-route");
+    await waitFor(() =>
+      expect(route).toHaveAttribute("data-phase", "identity"),
+    );
+  });
+});

--- a/web/src/components/onboarding/OnboardingDMRoute.tsx
+++ b/web/src/components/onboarding/OnboardingDMRoute.tsx
@@ -1,0 +1,104 @@
+/**
+ * OnboardingDMRoute — Phase 2 entry point for the deterministic CEO conversation.
+ *
+ * This is a thin wrapper around DMView that:
+ *   1. Points DMView at the reserved channel `dm:ceo:onboarding`
+ *   2. Exposes the PendingSuggestion context so InterviewBar can render
+ *      CEO cards (ceo_form_field, ceo_chip_row, ceo_checklist, etc.)
+ *   3. Reads onboarding state on mount and subscribes to updates
+ *
+ * The spec hard-rule (docs/specs/onboarding-into-office.md "Eng review
+ * decisions"):
+ *   "Frontend reuses DMView for the CEO chat. A small OnboardingDMRoute
+ *    wrapper provides the preview-overlay context and points DMView at
+ *    the reserved dm:ceo:onboarding channel."
+ *
+ * No new chat shell, no new composer, no duplicated SSE/scroll/optimistic-post
+ * code. CEO DM inherits all of that from DMView.
+ */
+
+import { createContext, useContext } from "react";
+
+import { DMView } from "../messages/DMView";
+import type { CeoSuggestion } from "./types";
+import { useOnboardingState } from "./useOnboardingState";
+
+// ── Onboarding context ─────────────────────────────────────────────────────
+
+interface OnboardingDMContextValue {
+  phase: string | undefined;
+  pendingSuggestion: CeoSuggestion | null;
+}
+
+const OnboardingDMContext = createContext<OnboardingDMContextValue>({
+  phase: undefined,
+  pendingSuggestion: null,
+});
+
+/** Read the current onboarding phase + pending suggestion from within the CEO DM. */
+export function useOnboardingDMContext(): OnboardingDMContextValue {
+  return useContext(OnboardingDMContext);
+}
+
+/**
+ * Exported for test use only: wrap children with a custom context value
+ * without needing to mount the full OnboardingDMRoute + DMView stack.
+ */
+export const OnboardingDMContextProvider = OnboardingDMContext.Provider;
+
+// ── Reserved channel slug ──────────────────────────────────────────────────
+
+/** The broker reserves this slug for the onboarding CEO DM. */
+const CEO_ONBOARDING_CHANNEL = "dm:ceo:onboarding";
+
+/** The agent slug for the CEO (matches existing broker configuration). */
+const CEO_AGENT_SLUG = "ceo";
+
+// ── Component ─────────────────────────────────────────────────────────────
+
+/**
+ * Renders the CEO DM inside the Shell body during Phase 2 onboarding.
+ * Wraps DMView with the OnboardingDMContext so child components (e.g.
+ * InterviewBar) can access the current phase and pending suggestion.
+ */
+export function OnboardingDMRoute() {
+  const { data: state } = useOnboardingState();
+
+  const pendingSuggestion = parsePendingSuggestion(state?.pending_suggestion);
+
+  return (
+    <OnboardingDMContext.Provider
+      value={{
+        phase: state?.phase,
+        pendingSuggestion,
+      }}
+    >
+      <div
+        className="onboarding-dm-route"
+        data-testid="onboarding-dm-route"
+        data-phase={state?.phase ?? "loading"}
+      >
+        <DMView
+          agentSlug={CEO_AGENT_SLUG}
+          channelSlug={CEO_ONBOARDING_CHANNEL}
+        />
+      </div>
+    </OnboardingDMContext.Provider>
+  );
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Safely parse the pending_suggestion field from the API response.
+ * The backend stores it as json.RawMessage; the fetch gives us `unknown`.
+ * We narrow to CeoSuggestion only if the shape is correct.
+ */
+function parsePendingSuggestion(raw: unknown): CeoSuggestion | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "string" || typeof obj.kind !== "string") return null;
+  // Minimal shape check — the kind dispatcher in InterviewBar will validate
+  // the payload before rendering.
+  return raw as CeoSuggestion;
+}

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -1,0 +1,180 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PrePickScreen } from "./PrePickScreen";
+
+// The pre-pick screen reads /onboarding/prereqs and POSTs /config +
+// /onboarding/complete. Stub both so tests stay focused on the screen's
+// own behavior — no broker contract is exercised here.
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    get: vi.fn(),
+    post: vi.fn(),
+  };
+});
+
+import { get, post } from "../../api/client";
+
+const getMock = vi.mocked(get);
+const postMock = vi.mocked(post);
+
+beforeEach(() => {
+  getMock.mockReset();
+  postMock.mockReset();
+  postMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+function mockPrereqs(found: Record<string, boolean>) {
+  getMock.mockResolvedValue([
+    {
+      name: "claude",
+      required: false,
+      found: found.claude ?? false,
+      version: "v1.2.3",
+    },
+    {
+      name: "codex",
+      required: false,
+      found: found.codex ?? false,
+      version: "v0.8.1",
+    },
+    { name: "opencode", required: false, found: found.opencode ?? false },
+  ]);
+}
+
+describe("PrePickScreen", () => {
+  it("renders the three dispatchable runtime cards plus a skip affordance", async () => {
+    mockPrereqs({ claude: true, codex: true });
+    render(<PrePickScreen onComplete={vi.fn()} />);
+
+    expect(
+      await screen.findByTestId("pre-pick-card-claude-code"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("pre-pick-card-codex")).toBeInTheDocument();
+    expect(screen.getByTestId("pre-pick-card-opencode")).toBeInTheDocument();
+    expect(screen.getByTestId("pre-pick-skip")).toBeInTheDocument();
+  });
+
+  it("posts /config and /onboarding/complete when a detected runtime is picked", async () => {
+    mockPrereqs({ claude: true });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/config",
+      expect.objectContaining({
+        llm_provider: "claude-code",
+        llm_provider_priority: ["claude-code"],
+        memory_backend: "markdown",
+      }),
+    );
+    expect(postMock).toHaveBeenCalledWith(
+      "/onboarding/complete",
+      expect.objectContaining({
+        skip_task: true,
+        blueprint: "",
+        agents: [],
+        runtime: "claude-code",
+      }),
+    );
+  });
+
+  it("posts /onboarding/complete with no runtime when the user picks the skip affordance", async () => {
+    mockPrereqs({});
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const skip = await screen.findByTestId("pre-pick-skip");
+    fireEvent.click(skip);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+
+    // /config must NOT be called for sandbox mode — that's the path that
+    // distinguishes evaluators ("look around first" via Marcus) from
+    // committed runtime pickers in Phase 2.
+    expect(
+      postMock.mock.calls.find((call) => call[0] === "/config"),
+    ).toBeUndefined();
+    expect(postMock).toHaveBeenCalledWith(
+      "/onboarding/complete",
+      expect.objectContaining({
+        skip_task: true,
+        runtime: "",
+        runtime_priority: [],
+      }),
+    );
+  });
+
+  it("opens the install URL in a new tab when a missing runtime card is clicked", async () => {
+    mockPrereqs({});
+    const open = vi.fn();
+    const originalOpen = window.open;
+    Object.defineProperty(window, "open", {
+      configurable: true,
+      writable: true,
+      value: open,
+    });
+    try {
+      render(<PrePickScreen onComplete={vi.fn()} />);
+      const card = await screen.findByTestId("pre-pick-card-opencode");
+      // Wait for prereqs fetch so the status text settles on "Not installed".
+      await waitFor(() => expect(card.textContent).toMatch(/Not installed/));
+      fireEvent.click(card);
+      expect(open).toHaveBeenCalledWith(
+        "https://opencode.ai",
+        "_blank",
+        "noopener,noreferrer",
+      );
+      // No backend writes should fire from an install-link click.
+      expect(postMock).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "open", {
+        configurable: true,
+        writable: true,
+        value: originalOpen,
+      });
+    }
+  });
+
+  it("surfaces an error if /onboarding/complete fails and does not invoke onComplete", async () => {
+    mockPrereqs({ codex: true });
+    postMock.mockImplementation(async (path: string) => {
+      if (path === "/onboarding/complete") {
+        throw new Error("broker unreachable");
+      }
+      return {};
+    });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-codex");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /broker unreachable/i,
+    );
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { get, post } from "../../api/client";
+import { RUNTIMES } from "./wizard/constants";
+import { RuntimeLogo } from "./wizard/RuntimeLogos";
+import type { PrereqResult, RuntimeSpec } from "./wizard/types";
+
+// Phase 1 of the onboarding-into-office redesign
+// (docs/specs/onboarding-into-office.md). The 9-step wizard collapses
+// into one pre-office screen — runtime selection. Everything else
+// (company name, blueprint pick, team trim, first task) moves into a
+// CEO DM inside the real Shell in Phase 2 and later.
+//
+// The user picks a detected runtime OR opts into sandbox mode. Either
+// path posts /onboarding/complete with skip_task:true so the broker
+// runs its existing scratch-path setup; deeper changes to the broker
+// (seedMinimalScratchLocked, deterministic phase machine) are Phase 2.
+//
+// `onComplete` is invoked after both the /config and /onboarding/complete
+// requests succeed. RootRoute then flips onboardingComplete and routes the
+// user to the Shell.
+
+interface PrePickScreenProps {
+  onComplete: () => void;
+}
+
+interface RuntimeCardState {
+  spec: RuntimeSpec;
+  detected: PrereqResult | undefined;
+  available: boolean;
+}
+
+interface RuntimeCardProps {
+  state: RuntimeCardState;
+  prereqsLoaded: boolean;
+  isSubmitting: boolean;
+  anySubmitting: boolean;
+  onPick: (spec: RuntimeSpec) => void;
+  onInstall: (url: string) => void;
+}
+
+function cardStatusLabel({
+  prereqsLoaded,
+  available,
+  version,
+}: {
+  prereqsLoaded: boolean;
+  available: boolean;
+  version: string | undefined;
+}): string {
+  if (!prereqsLoaded) return "Checking…";
+  if (!available) return "Not installed";
+  return version ? `Detected · ${version}` : "Detected";
+}
+
+function RuntimeCard({
+  state,
+  prereqsLoaded,
+  isSubmitting,
+  anySubmitting,
+  onPick,
+  onInstall,
+}: RuntimeCardProps) {
+  const { spec, detected, available } = state;
+  const statusLabel = isSubmitting
+    ? "Starting your office…"
+    : cardStatusLabel({
+        prereqsLoaded,
+        available,
+        version: detected?.version,
+      });
+  const installHint =
+    !available && prereqsLoaded ? (
+      <div className="pre-pick-card-install">Install →</div>
+    ) : null;
+  return (
+    <button
+      key={spec.label}
+      type="button"
+      className={`pre-pick-card${available ? " available" : " missing"}`}
+      data-testid={`pre-pick-card-${spec.provider}`}
+      disabled={anySubmitting}
+      onClick={() => {
+        if (!available) {
+          onInstall(spec.installUrl);
+          return;
+        }
+        onPick(spec);
+      }}
+    >
+      <div className="pre-pick-card-head">
+        <RuntimeLogo label={spec.label} />
+        <span className="pre-pick-card-name">{spec.label}</span>
+      </div>
+      <div className="pre-pick-card-status">{statusLabel}</div>
+      {installHint}
+    </button>
+  );
+}
+
+type PrereqsPayload = { prereqs?: PrereqResult[] } | PrereqResult[];
+
+function prereqsFromPayload(data: PrereqsPayload): PrereqResult[] {
+  if (Array.isArray(data)) return data;
+  return data.prereqs ?? [];
+}
+
+// Phase 1 ships the three runtimes the broker can dispatch to: Claude
+// Code, Codex, Opencode. Cursor and Windsurf (provider:null in RUNTIMES)
+// have no dispatch path so we omit them here — they would land the user
+// in sandbox mode anyway.
+const DISPATCHABLE_RUNTIMES = RUNTIMES.filter((r) => r.provider !== null);
+
+export function PrePickScreen({ onComplete }: PrePickScreenProps) {
+  const [prereqs, setPrereqs] = useState<PrereqResult[]>([]);
+  const [prereqsLoaded, setPrereqsLoaded] = useState(false);
+  const [submitting, setSubmitting] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string>("");
+
+  useEffect(() => {
+    let cancelled = false;
+    get<PrereqsPayload>("/onboarding/prereqs")
+      .then((data) => {
+        if (cancelled) return;
+        setPrereqs(prereqsFromPayload(data));
+      })
+      .catch(() => {
+        // Prereqs unreachable — render runtime cards as "Install" so the
+        // user can still proceed. The wizard takes the same posture.
+      })
+      .finally(() => {
+        if (!cancelled) setPrereqsLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const runtimes = useMemo<RuntimeCardState[]>(
+    () =>
+      DISPATCHABLE_RUNTIMES.map((spec) => {
+        const detected = prereqs.find((p) => p.name === spec.binary);
+        return {
+          spec,
+          detected,
+          available: Boolean(detected?.found),
+        };
+      }),
+    [prereqs],
+  );
+
+  async function commitChoice(
+    provider: RuntimeSpec["provider"],
+    runtimeLabel: string,
+  ): Promise<void> {
+    setSubmitError("");
+    setSubmitting(runtimeLabel);
+    try {
+      // /config persists runtime selection. Skip when the user opts into
+      // sandbox mode (provider === null) — they'll wire one up later via
+      // Settings → Runtimes and the broker treats missing llm_provider as
+      // "no dispatch capability."
+      if (provider) {
+        await post("/config", {
+          memory_backend: "markdown",
+          llm_provider: provider,
+          llm_provider_priority: [provider],
+        });
+      }
+      // Phase 1 sends only the minimum the existing /onboarding/complete
+      // handler needs. Company name, blueprint, team trim, and first task
+      // all move into the in-office CEO conversation (Phase 2+).
+      await post("/onboarding/complete", {
+        company: "",
+        description: "",
+        priority: "",
+        website: "",
+        owner_name: "",
+        owner_role: "",
+        scan_completed: false,
+        runtime: provider ?? "",
+        runtime_priority: provider ? [provider] : [],
+        memory_backend: "markdown",
+        blueprint: "",
+        agents: [],
+        api_keys: {},
+        task: "",
+        skip_task: true,
+      });
+      onComplete();
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to start the office";
+      setSubmitError(msg);
+      setSubmitting(null);
+    }
+  }
+
+  function openInstallPage(url: string): void {
+    if (typeof window === "undefined") return;
+    window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  return (
+    <div className="pre-pick-screen" data-testid="pre-pick-screen">
+      <div className="pre-pick-body">
+        <div className="pre-pick-hero">
+          <div className="pre-pick-eyebrow">WUPHF</div>
+          <h1 className="pre-pick-headline">Pick a runtime.</h1>
+          <p className="pre-pick-subhead">
+            Your office needs an AI runtime. Pick one of the three below, or
+            skip to look around first.
+          </p>
+        </div>
+
+        <div className="pre-pick-card-grid">
+          {runtimes.map((state) => (
+            <RuntimeCard
+              key={state.spec.label}
+              state={state}
+              prereqsLoaded={prereqsLoaded}
+              isSubmitting={submitting === state.spec.label}
+              anySubmitting={Boolean(submitting)}
+              onPick={(spec) => void commitChoice(spec.provider, spec.label)}
+              onInstall={openInstallPage}
+            />
+          ))}
+        </div>
+
+        <div className="pre-pick-secondary-row">
+          <button
+            type="button"
+            className="pre-pick-secondary-button"
+            data-testid="pre-pick-skip"
+            disabled={Boolean(submitting)}
+            onClick={() => void commitChoice(null, "skip")}
+          >
+            {submitting === "skip"
+              ? "Opening your office…"
+              : "I’ll add one later  →"}
+          </button>
+        </div>
+
+        <p className="pre-pick-helper">
+          You can change this any time in <strong>Settings → Runtimes</strong>.
+        </p>
+
+        {submitError ? (
+          <div role="alert" className="pre-pick-error">
+            {submitError}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/SidebarPreviewOverlay.test.tsx
+++ b/web/src/components/onboarding/SidebarPreviewOverlay.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * SidebarPreviewOverlay tests
+ *
+ * 1. Shows preview rows when phase is active (non-complete)
+ * 2. Hides when phase is complete (onboarded=true)
+ * 3. Shows workspace label when company_name is filled
+ * 4. Adds seeding class when phase = "seed"
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SidebarPreviewOverlay } from "./SidebarPreviewOverlay";
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return { ...actual, get: vi.fn(), post: vi.fn() };
+});
+
+import { get } from "../../api/client";
+
+const getMock = vi.mocked(get);
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SidebarPreviewOverlay", () => {
+  it("renders nothing when onboarded is true", async () => {
+    getMock.mockResolvedValue({ onboarded: true, phase: undefined });
+    render(<SidebarPreviewOverlay />, { wrapper });
+    // Wait a tick for the query to resolve.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      screen.queryByTestId("sidebar-preview-overlay"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when state is loading or has no phase", async () => {
+    getMock.mockResolvedValue({ onboarded: false, phase: undefined });
+    render(<SidebarPreviewOverlay />, { wrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(
+      screen.queryByTestId("sidebar-preview-overlay"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders preview rows when phase is 'blueprint' and blueprint is chosen", async () => {
+    getMock.mockResolvedValue({
+      onboarded: false,
+      phase: "blueprint",
+      form_answers: {
+        blueprint_id: "engineering-team",
+        company_name: "Acme Corp",
+      },
+    });
+    render(<SidebarPreviewOverlay />, { wrapper });
+
+    const overlay = await screen.findByTestId("sidebar-preview-overlay");
+    expect(overlay).toBeInTheDocument();
+
+    // Engineering team blueprint has #engineering and #standup channels
+    expect(overlay).toHaveTextContent("#engineering");
+    expect(overlay).toHaveTextContent("#standup");
+  });
+
+  it("shows workspace label when company_name is provided", async () => {
+    getMock.mockResolvedValue({
+      onboarded: false,
+      phase: "identity",
+      form_answers: {
+        company_name: "Acme Corp",
+      },
+    });
+    render(<SidebarPreviewOverlay />, { wrapper });
+
+    const workspace = await screen.findByTestId("sidebar-preview-workspace");
+    expect(workspace).toHaveTextContent("Acme Corp");
+  });
+
+  it("shows #general channel in scratch path", async () => {
+    getMock.mockResolvedValue({
+      onboarded: false,
+      phase: "blueprint",
+      form_answers: {
+        blueprint_id: "scratch",
+      },
+    });
+    render(<SidebarPreviewOverlay />, { wrapper });
+
+    const overlay = await screen.findByTestId("sidebar-preview-overlay");
+    expect(overlay).toHaveTextContent("#general");
+  });
+
+  it("adds --seeding class when phase is 'seed'", async () => {
+    getMock.mockResolvedValue({
+      onboarded: false,
+      phase: "seed",
+      form_answers: {
+        company_name: "Acme",
+      },
+    });
+    render(<SidebarPreviewOverlay />, { wrapper });
+
+    const overlay = await screen.findByTestId("sidebar-preview-overlay");
+    expect(overlay).toHaveClass("sidebar-preview-overlay--seeding");
+  });
+
+  it("shows agent rows when picked_agents is populated", async () => {
+    getMock.mockResolvedValue({
+      onboarded: false,
+      phase: "team",
+      form_answers: {
+        blueprint_id: "engineering-team",
+        picked_agents: ["engineer", "pm"],
+      },
+    });
+    render(<SidebarPreviewOverlay />, { wrapper });
+
+    const overlay = await screen.findByTestId("sidebar-preview-overlay");
+    const agentRows = overlay.querySelectorAll(
+      '[data-testid="sidebar-preview-row-agent"]',
+    );
+    expect(agentRows.length).toBe(2);
+  });
+
+  it("renders workspace label as plain text (XSS protection)", async () => {
+    getMock.mockResolvedValue({
+      onboarded: false,
+      phase: "identity",
+      form_answers: {
+        company_name: '<script>alert("xss")</script>',
+      },
+    });
+    render(<SidebarPreviewOverlay />, { wrapper });
+
+    await screen.findByTestId("sidebar-preview-workspace");
+    // The script element should not exist in the DOM
+    expect(document.querySelector("script")).not.toBeInTheDocument();
+    // The text should be present as literal characters
+    expect(
+      screen.getByText('<script>alert("xss")</script>'),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/onboarding/SidebarPreviewOverlay.tsx
+++ b/web/src/components/onboarding/SidebarPreviewOverlay.tsx
@@ -1,0 +1,59 @@
+/**
+ * SidebarPreviewOverlay — renders preview rows in the sidebar during Phase 2
+ * onboarding, using the staged FormAnswers from /onboarding/state.
+ *
+ * Visual language (per spec "Design system / token bindings"):
+ *   background:  var(--preview-row-bg)   = lavender tint
+ *   border:      var(--preview-row-border) = dashed 1px accent-bg-strong
+ *   text:        var(--preview-row-text)  = --text-secondary
+ *
+ * ARIA: aria-live="polite" region announces each preview row addition.
+ * On "seed" phase complete, rows cross-fade out (240ms, reduced-motion: instant).
+ *
+ * Spec: docs/specs/onboarding-into-office.md "Surface 3 — Sidebar preview overlay"
+ */
+
+import { usePreviewOffice } from "./usePreviewOffice";
+
+export function SidebarPreviewOverlay() {
+  const preview = usePreviewOffice();
+
+  if (!(preview.active || preview.seeding)) return null;
+  if (preview.rows.length === 0 && !preview.workspaceLabel) return null;
+
+  return (
+    <div
+      className={`sidebar-preview-overlay${preview.seeding ? " sidebar-preview-overlay--seeding" : ""}`}
+      aria-live="polite"
+      aria-label="Office forming preview"
+      data-testid="sidebar-preview-overlay"
+    >
+      {preview.workspaceLabel ? (
+        <div
+          className="sidebar-preview-workspace"
+          data-testid="sidebar-preview-workspace"
+        >
+          {preview.workspaceLabel}
+        </div>
+      ) : null}
+
+      {preview.rows.length > 0 ? (
+        <ul className="sidebar-preview-rows">
+          {preview.rows.map((row) => (
+            <li
+              key={`${row.kind}:${row.label}`}
+              className={`sidebar-preview-row sidebar-preview-row--${row.kind}`}
+              data-testid={`sidebar-preview-row-${row.kind}`}
+            >
+              <span className="sidebar-preview-row-icon" aria-hidden="true">
+                {row.kind === "channel" ? "#" : "@"}
+              </span>
+              {/* Render as text — never innerHTML */}
+              <span className="sidebar-preview-row-label">{row.label}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/onboarding/types.ts
+++ b/web/src/components/onboarding/types.ts
@@ -1,0 +1,143 @@
+/**
+ * Wire shapes for Phase 2 deterministic CEO conversation cards.
+ *
+ * These types mirror the Go-side `Suggestion` struct in
+ * internal/onboarding/state.go. The backend agent is responsible for
+ * sanitizing payload strings through sanitizeContextValue before writing;
+ * the frontend treats every string field as plain text (never innerHTML).
+ *
+ * Spec: docs/specs/onboarding-into-office.md — "## State and resumption"
+ */
+
+// ── Onboarding state from /onboarding/state ────────────────────────────────
+
+export interface OnboardingFormAnswers {
+  company_name?: string;
+  description?: string;
+  priority?: string;
+  website_url?: string;
+  owner_name?: string;
+  owner_role?: string;
+  blueprint_id?: string;
+  picked_agents?: string[];
+  scan_complete?: boolean;
+}
+
+export interface OnboardingState {
+  onboarded?: boolean;
+  phase?: string;
+  ceo_dm_channel_id?: string;
+  pending_suggestion?: CeoSuggestion | null;
+  form_answers?: OnboardingFormAnswers;
+  first_issue_id?: string;
+  first_issue_approved_at?: string;
+  company_name?: string;
+  completed_at?: string;
+}
+
+// ── Suggestion wire shapes ─────────────────────────────────────────────────
+
+/** Discriminated union of all CEO suggestion kinds. */
+export type CeoSuggestion =
+  | CeoFormFieldSuggestion
+  | CeoChipRowSuggestion
+  | CeoChecklistSuggestion
+  | CeoTeamTrimSuggestion
+  | CeoScanChipSuggestion;
+
+interface SuggestionBase {
+  /** Stable per (phase, options-hash) — used for idempotent re-emit dedup. */
+  id: string;
+  phase: string;
+}
+
+export interface CeoFormFieldSuggestion extends SuggestionBase {
+  kind: "ceo_form_field";
+  payload: CeoFormFieldPayload;
+}
+
+export interface CeoChipRowSuggestion extends SuggestionBase {
+  kind: "ceo_chip_row";
+  payload: CeoChipRowPayload;
+}
+
+export interface CeoChecklistSuggestion extends SuggestionBase {
+  kind: "ceo_checklist";
+  payload: CeoChecklistPayload;
+}
+
+export interface CeoTeamTrimSuggestion extends SuggestionBase {
+  kind: "ceo_team_trim";
+  payload: CeoTeamTrimPayload;
+}
+
+export interface CeoScanChipSuggestion extends SuggestionBase {
+  kind: "ceo_scan_chip";
+  payload: CeoScanChipPayload;
+}
+
+// ── Per-kind payload shapes ────────────────────────────────────────────────
+
+export interface CeoFormFieldPayload {
+  /** Field identifier sent back to /onboarding/answer */
+  field: string;
+  /** Human-readable label shown above the input */
+  label: string;
+  /** Whether the field can be skipped */
+  optional?: boolean;
+  /** Input placeholder */
+  placeholder?: string;
+  /** Default value pre-filled in the input */
+  default?: string;
+}
+
+export interface CeoChipOption {
+  id: string;
+  label: string;
+}
+
+export interface CeoChipRowPayload {
+  field: string;
+  label: string;
+  options: CeoChipOption[];
+}
+
+export interface CeoChecklistItem {
+  id: string;
+  label: string;
+  /** Whether the item is pre-checked */
+  default_checked?: boolean;
+}
+
+export interface CeoChecklistPayload {
+  field: string;
+  label: string;
+  items: CeoChecklistItem[];
+  submit_label?: string;
+}
+
+/** Alias of checklist with team-specific framing. Same wire shape. */
+export interface CeoTeamTrimPayload extends CeoChecklistPayload {
+  /** Agent slugs that are currently in the blueprint team roster */
+  team_agents?: string[];
+}
+
+export type ScanStatus = "scanning" | "done" | "failed";
+
+export interface CeoScanChipPayload {
+  field: string;
+  url: string;
+  /** Current scan status; updated via SSE */
+  status: ScanStatus;
+  /** Message shown while scanning */
+  scanning_label?: string;
+  /** Message shown on success */
+  done_label?: string;
+  /** Message shown on failure */
+  failed_label?: string;
+}
+
+// ── Card lifecycle state ───────────────────────────────────────────────────
+
+/** Universal three-stage card lifecycle per design review decisions. */
+export type CardStage = "pending" | "submitting" | "committed";

--- a/web/src/components/onboarding/useOnboardingState.ts
+++ b/web/src/components/onboarding/useOnboardingState.ts
@@ -1,0 +1,28 @@
+/**
+ * useOnboardingState — loads /onboarding/state on mount and keeps it fresh.
+ *
+ * This hook is used by:
+ *   - OnboardingDMRoute (for PendingSuggestion + Phase)
+ *   - Sidebar preview overlay (for FormAnswers)
+ *
+ * The broker publishes phase transitions as SSE events. Since useBrokerEvents
+ * already subscribes to SSE and the query cache refetches on focus/interval,
+ * we use a 3-second poll interval matching the messages hook pattern. A
+ * dedicated SSE event type for onboarding state would be Phase 2B backend work.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { get } from "../../api/client";
+import type { OnboardingState } from "./types";
+
+const ONBOARDING_STATE_STALE_MS = 3_000;
+
+export function useOnboardingState() {
+  return useQuery({
+    queryKey: ["onboarding-state"],
+    queryFn: () => get<OnboardingState>("/onboarding/state"),
+    staleTime: ONBOARDING_STATE_STALE_MS,
+    refetchInterval: ONBOARDING_STATE_STALE_MS,
+  });
+}

--- a/web/src/components/onboarding/usePreviewOffice.ts
+++ b/web/src/components/onboarding/usePreviewOffice.ts
@@ -1,0 +1,117 @@
+/**
+ * usePreviewOffice — derives sidebar preview rows from onboarding FormAnswers.
+ *
+ * During Phase 2 onboarding (phase != undefined && !onboarded), the sidebar
+ * shows "preview rows" — dashed lavender-tinted rows for channels/agents that
+ * are about to be seeded. These are driven by the staged FormAnswers the user
+ * is filling in via the CEO conversation.
+ *
+ * Returns null when onboarding is complete (preview overlay should be hidden).
+ *
+ * Spec: docs/specs/onboarding-into-office.md "Sidebar preview overlay"
+ */
+
+import { useOnboardingState } from "./useOnboardingState";
+
+export interface PreviewRow {
+  kind: "channel" | "agent";
+  label: string;
+}
+
+export interface PreviewOfficeState {
+  /** Rows to render as dashed preview items in the sidebar. */
+  rows: PreviewRow[];
+  /** Current workspace label to preview (company name being typed). */
+  workspaceLabel: string | undefined;
+  /** Whether the preview overlay is active (non-seeded, non-complete phase). */
+  active: boolean;
+  /** Whether the seeding animation should play (phase just reached "seed"). */
+  seeding: boolean;
+}
+
+/** Phases where the sidebar preview overlay should be shown. */
+const PREVIEW_PHASES = new Set([
+  "greet",
+  "identity",
+  "scan",
+  "blueprint",
+  "team",
+]);
+
+export function usePreviewOffice(): PreviewOfficeState {
+  const { data: state } = useOnboardingState();
+
+  if (!state || state.onboarded) {
+    return {
+      rows: [],
+      workspaceLabel: undefined,
+      active: false,
+      seeding: false,
+    };
+  }
+
+  const phase = state.phase;
+  if (!phase) {
+    return {
+      rows: [],
+      workspaceLabel: undefined,
+      active: false,
+      seeding: false,
+    };
+  }
+
+  const active = PREVIEW_PHASES.has(phase);
+  const seeding = phase === "seed";
+
+  if (!(active || seeding)) {
+    return {
+      rows: [],
+      workspaceLabel: undefined,
+      active: false,
+      seeding: false,
+    };
+  }
+
+  const answers = state.form_answers ?? {};
+  const rows: PreviewRow[] = [];
+
+  // Channel preview: derive from blueprint_id if chosen
+  const blueprintId = answers.blueprint_id;
+  if (blueprintId && blueprintId !== "scratch") {
+    // Blueprint channels are known ahead of time; we preview the canonical
+    // ones matching the blueprint slug.
+    const blueprintChannels = BLUEPRINT_CHANNEL_PREVIEW[blueprintId];
+    if (blueprintChannels) {
+      for (const ch of blueprintChannels) {
+        rows.push({ kind: "channel", label: ch });
+      }
+    }
+  } else {
+    // Scratch path: always has #general
+    rows.push({ kind: "channel", label: "#general" });
+  }
+
+  // Agent preview: picked_agents from team trim
+  const pickedAgents = answers.picked_agents ?? [];
+  for (const agent of pickedAgents) {
+    rows.push({ kind: "agent", label: agent });
+  }
+
+  return {
+    rows,
+    workspaceLabel: answers.company_name || undefined,
+    active,
+    seeding,
+  };
+}
+
+/**
+ * Known blueprint → preview channel names.
+ * These mirror the blueprint scaffold definitions in the broker.
+ * Updated when blueprints change; de-syncs are benign (preview vs real).
+ */
+const BLUEPRINT_CHANNEL_PREVIEW: Record<string, string[]> = {
+  bookkeeping: ["#billing", "#reports"],
+  "content-ops": ["#editorial", "#assets"],
+  "engineering-team": ["#engineering", "#standup"],
+};

--- a/web/src/lib/featureFlags.test.ts
+++ b/web/src/lib/featureFlags.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetOnboardingV2FlagForTests,
+  isOnboardingV2Enabled,
+} from "./featureFlags";
+
+function setSearch(search: string) {
+  window.history.replaceState({}, "", `/${search}`);
+}
+
+beforeEach(() => {
+  __resetOnboardingV2FlagForTests();
+  setSearch("");
+});
+
+afterEach(() => {
+  __resetOnboardingV2FlagForTests();
+  setSearch("");
+});
+
+describe("isOnboardingV2Enabled", () => {
+  it("defaults to false without any opt-in signal", () => {
+    expect(isOnboardingV2Enabled()).toBe(false);
+  });
+
+  it("returns true when the URL carries ?onboardingV2=1", () => {
+    setSearch("?onboardingV2=1");
+    expect(isOnboardingV2Enabled()).toBe(true);
+  });
+
+  it("persists the URL choice so subsequent calls return the same value", () => {
+    setSearch("?onboardingV2=1");
+    expect(isOnboardingV2Enabled()).toBe(true);
+    setSearch("");
+    expect(isOnboardingV2Enabled()).toBe(true);
+  });
+
+  it("lets ?onboardingV2=0 explicitly disable an earlier opt-in", () => {
+    setSearch("?onboardingV2=1");
+    isOnboardingV2Enabled();
+    setSearch("?onboardingV2=0");
+    expect(isOnboardingV2Enabled()).toBe(false);
+    setSearch("");
+    expect(isOnboardingV2Enabled()).toBe(false);
+  });
+});

--- a/web/src/lib/featureFlags.ts
+++ b/web/src/lib/featureFlags.ts
@@ -1,0 +1,74 @@
+// Feature flag plumbing for staged onboarding rollouts.
+//
+// Phase 1 of the onboarding-into-office redesign (docs/specs/
+// onboarding-into-office.md) replaces the 9-step wizard with a single
+// pre-office provider picker plus an empty-shell office entry. The
+// existing wizard stays mounted behind this flag so we can roll back
+// without redeploying.
+//
+// Resolution order:
+//   1. URL search param (?onboardingV2=1 enables, =0 disables). Persisted
+//      to localStorage so subsequent visits respect the explicit choice.
+//   2. localStorage value from a prior URL toggle.
+//   3. Default: false (OFF) — the wizard stays the live path until we
+//      flip the default in a follow-up.
+
+const STORAGE_KEY = "wuphf:onboarding-v2";
+
+function readStorage(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw === "1" || raw === "true") return true;
+    if (raw === "0" || raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(value: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    // Ignore quota / privacy-mode storage errors. The flag falls back
+    // to per-load query-param resolution in that case.
+  }
+}
+
+function readSearchParamOverride(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get("onboardingV2");
+    if (raw === null) return null;
+    if (raw === "1" || raw === "true") return true;
+    if (raw === "0" || raw === "false") return false;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function isOnboardingV2Enabled(): boolean {
+  const fromParam = readSearchParamOverride();
+  if (fromParam !== null) {
+    writeStorage(fromParam);
+    return fromParam;
+  }
+  const fromStorage = readStorage();
+  if (fromStorage !== null) return fromStorage;
+  return false;
+}
+
+// Test-only helper. Call between tests to keep the localStorage-backed
+// flag from leaking state across cases.
+export function __resetOnboardingV2FlagForTests(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -24,6 +24,7 @@ import { DMView } from "../components/messages/DMView";
 import { InterviewBar } from "../components/messages/InterviewBar";
 import { MessageFeed } from "../components/messages/MessageFeed";
 import { TypingIndicator } from "../components/messages/TypingIndicator";
+import { PrePickScreen } from "../components/onboarding/PrePickScreen";
 import { SplashScreen } from "../components/onboarding/SplashScreen";
 import { Wizard } from "../components/onboarding/Wizard";
 import { ConfirmHost } from "../components/ui/ConfirmDialog";
@@ -33,6 +34,7 @@ import type { WikiTab } from "../components/wiki/WikiTabs";
 import WikiTabs from "../components/wiki/WikiTabs";
 import { useBrokerEvents } from "../hooks/useBrokerEvents";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { isOnboardingV2Enabled } from "../lib/featureFlags";
 import { rootRoute, router } from "../lib/router";
 import { getTheme } from "../lib/themes";
 import { useAppStore } from "../stores/app";
@@ -599,6 +601,9 @@ function RoutedBody() {
 export default function RootRoute() {
   const [apiReady, setApiReady] = useState(false);
   const [showSplash, setShowSplash] = useState(false);
+  // The flag is resolved once at mount. Switching it mid-session would
+  // require a reload anyway — onboarding state is loaded once at boot.
+  const [onboardingV2] = useState<boolean>(() => isOnboardingV2Enabled());
   const theme = useAppStore((s) => s.theme);
   const onboardingComplete = useAppStore((s) => s.onboardingComplete);
   const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
@@ -668,7 +673,16 @@ export default function RootRoute() {
   } else if (showSplash) {
     body = <SplashScreen onDone={() => setShowSplash(false)} />;
   } else if (!onboardingComplete) {
-    body = (
+    body = onboardingV2 ? (
+      <PrePickScreen
+        onComplete={() => {
+          // Phase 1 enters the office immediately. SplashScreen is the
+          // wizard's celebration screen; we skip it for the new flow so
+          // the user lands in the Shell without an intervening modal.
+          setOnboardingComplete(true);
+        }}
+      />
+    ) : (
       <Wizard
         onComplete={() => {
           setShowSplash(true);

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -24,6 +24,7 @@ import { DMView } from "../components/messages/DMView";
 import { InterviewBar } from "../components/messages/InterviewBar";
 import { MessageFeed } from "../components/messages/MessageFeed";
 import { TypingIndicator } from "../components/messages/TypingIndicator";
+import { OnboardingDMRoute } from "../components/onboarding/OnboardingDMRoute";
 import { PrePickScreen } from "../components/onboarding/PrePickScreen";
 import { SplashScreen } from "../components/onboarding/SplashScreen";
 import { Wizard } from "../components/onboarding/Wizard";
@@ -609,6 +610,16 @@ export default function RootRoute() {
   const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
   const setOnboardingComplete = useAppStore((s) => s.setOnboardingComplete);
 
+  // Phase 2 state: after PrePickScreen, track whether the backend CEO phase
+  // machine is running. When true, Shell renders OnboardingDMRoute instead of
+  // RoutedBody. Flips false when the onboarding state returns onboarded=true.
+  //
+  // Flow: PrePickScreen → inCeoOnboarding=true → Shell+OnboardingDMRoute
+  //       → broker sets phase="bridge" done → onboarded=true → normal Shell
+  const [inCeoOnboarding, setInCeoOnboarding] = useState(false);
+  // onboarding phase from /onboarding/state — set once on boot if available.
+  const [bootPhase, setBootPhase] = useState<string | undefined>(undefined);
+
   useKeyboardShortcuts();
   useBrokerEvents(apiReady);
 
@@ -634,12 +645,18 @@ export default function RootRoute() {
       .then(() => {
         if (cancelled) return;
         setBrokerConnected(true);
-        return get<{ onboarded?: boolean }>("/onboarding/state");
+        return get<{ onboarded?: boolean; phase?: string }>(
+          "/onboarding/state",
+        );
       })
       .then((s) => {
         if (cancelled || !s) return;
         if (s.onboarded === true) {
           setOnboardingComplete(true);
+        } else if (onboardingV2 && typeof s.phase === "string" && s.phase) {
+          // Resume mid-onboarding: broker already started the CEO phase machine.
+          setBootPhase(s.phase);
+          setInCeoOnboarding(true);
         }
       })
       .catch(() => {
@@ -652,7 +669,7 @@ export default function RootRoute() {
     return () => {
       cancelled = true;
     };
-  }, [setBrokerConnected, setOnboardingComplete]);
+  }, [setBrokerConnected, setOnboardingComplete, onboardingV2]);
 
   let body: ReactNode;
   if (!apiReady) {
@@ -673,22 +690,38 @@ export default function RootRoute() {
   } else if (showSplash) {
     body = <SplashScreen onDone={() => setShowSplash(false)} />;
   } else if (!onboardingComplete) {
-    body = onboardingV2 ? (
-      <PrePickScreen
-        onComplete={() => {
-          // Phase 1 enters the office immediately. SplashScreen is the
-          // wizard's celebration screen; we skip it for the new flow so
-          // the user lands in the Shell without an intervening modal.
-          setOnboardingComplete(true);
-        }}
-      />
-    ) : (
-      <Wizard
-        onComplete={() => {
-          setShowSplash(true);
-        }}
-      />
-    );
+    if (onboardingV2 && (inCeoOnboarding || bootPhase)) {
+      // Phase 2: CEO conversation running — Shell with OnboardingDMRoute.
+      // Already-onboarded users (onboardingComplete === true) skip this
+      // entirely via the branch above.
+      body = (
+        <Shell>
+          <OnboardingDMRoute />
+          <Outlet />
+        </Shell>
+      );
+    } else if (onboardingV2) {
+      // Phase 1: provider picker. No phase set yet — user hasn't picked a
+      // runtime. After they pick, setInCeoOnboarding(true) to enter Phase 2.
+      body = (
+        <PrePickScreen
+          onComplete={() => {
+            // Phase 1 transitions directly to Phase 2: Shell+CEO DM.
+            // The broker sets state.Phase = "greet" after /onboarding/complete.
+            // We enter the in-CEO state here so the Shell renders immediately.
+            setInCeoOnboarding(true);
+          }}
+        />
+      );
+    } else {
+      body = (
+        <Wizard
+          onComplete={() => {
+            setShowSplash(true);
+          }}
+        />
+      );
+    }
   } else {
     body = (
       <Shell>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -140,6 +140,15 @@
   /* Popover shadow — used by the Tier 2 hover peek card. */
   --shadow-popover: 0 8px 24px -8px rgba(0, 0, 0, 0.32);
 
+  /* ─── Phase 2 onboarding preview-state tokens ─── */
+  /* Visual language: dashed border + lavender bg = "this thing is staged,
+     not committed yet." Used by the sidebar preview overlay that shows
+     channels/agents forming as the user answers CEO questions.
+     Spec: docs/specs/onboarding-into-office.md "Design system / token bindings" */
+  --preview-row-bg: var(--accent-bg);
+  --preview-row-border: dashed 1px var(--accent-bg-strong);
+  --preview-row-text: var(--text-secondary);
+
   /* ─── Focus ring ─── */
   /* Single source-of-truth: all interactive elements use this token so
      keyboard navigation is always visible and consistent across themes.

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2002,3 +2002,180 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Phase 1: Pre-office provider picker (onboarding-into-office spec)
+   Single full-bleed screen — no modal chrome, no progress dots.
+   ═══════════════════════════════════════════════════════════════ */
+
+.pre-pick-screen {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  background: radial-gradient(circle at center, #f9f9fb 0%, #ffffff 70%);
+}
+
+.pre-pick-body {
+  width: 100%;
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  align-items: center;
+}
+
+.pre-pick-hero {
+  text-align: center;
+}
+
+.pre-pick-eyebrow {
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+}
+
+.pre-pick-headline {
+  font-family: var(--font-logo);
+  font-size: 36px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0 0 12px 0;
+}
+
+.pre-pick-subhead {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 480px;
+  margin: 0 auto;
+  text-wrap: balance;
+}
+
+.pre-pick-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  width: 100%;
+}
+
+@media (max-width: 720px) {
+  .pre-pick-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.pre-pick-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-card);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    transform 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.pre-pick-card:hover:not(:disabled) {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.pre-pick-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.pre-pick-card:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.pre-pick-card.missing {
+  background: transparent;
+}
+
+.pre-pick-card-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pre-pick-card-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.pre-pick-card-status {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.pre-pick-card.available .pre-pick-card-status {
+  color: var(--green-600, #16a34a);
+}
+
+.pre-pick-card-install {
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.pre-pick-secondary-row {
+  display: flex;
+  justify-content: center;
+}
+
+.pre-pick-secondary-button {
+  font-size: 13px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease,
+    background 120ms ease;
+}
+
+.pre-pick-secondary-button:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.pre-pick-secondary-button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.pre-pick-secondary-button:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.pre-pick-helper {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+.pre-pick-error {
+  font-size: 13px;
+  color: var(--red-600, #dc2626);
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(220, 38, 38, 0.06);
+  border: 1px solid rgba(220, 38, 38, 0.18);
+}

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2179,3 +2179,306 @@
   background: rgba(220, 38, 38, 0.06);
   border: 1px solid rgba(220, 38, 38, 0.18);
 }
+
+/* ─── Phase 2: CEO card section ─────────────────────────────────────────
+   Renders inside the InterviewBar slot in the OnboardingDMRoute CEO DM.
+   Card lifecycle: pending → submitting → committed.
+   Spec: docs/specs/onboarding-into-office.md "## Surface 3 / Card states matrix"
+   ─────────────────────────────────────────────────────────────────────── */
+
+.ceo-card-section {
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+
+/* Base CEO card */
+.ceo-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  background: var(--bg-card);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Committed state: collapses to one line in --text-secondary */
+.ceo-card--committed {
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+}
+
+.ceo-card-committed-text {
+  font-size: 13px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Label */
+.ceo-card-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+/* Text input */
+.ceo-card-input {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--text);
+  background: var(--bg);
+  outline: none;
+  transition: border-color 120ms ease;
+}
+
+.ceo-card-input:focus {
+  border-color: var(--accent);
+}
+
+.ceo-card-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* Action row */
+.ceo-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Inline spinner (submitting state only — never full-card animation) */
+.ceo-card-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ceo-spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes ceo-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ceo-card-spinner {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
+/* ─── Chip row ─────────────────────────────────────────────────────────── */
+
+.ceo-chip-row-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.ceo-chip {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: var(--bg-card);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.ceo-chip:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--text);
+}
+
+.ceo-chip--selected,
+.ceo-chip:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--text);
+  outline: none;
+}
+
+.ceo-chip:focus-visible {
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--accent);
+}
+
+.ceo-chip:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ─── Checklist ────────────────────────────────────────────────────────── */
+
+.ceo-checklist-items {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ceo-checklist-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.ceo-checklist-checkbox {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
+.ceo-checklist-item-text {
+  flex: 1;
+}
+
+/* ─── Scan chip ────────────────────────────────────────────────────────── */
+
+.ceo-scan-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-full);
+  font-size: 12px;
+  color: var(--text-secondary);
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+}
+
+.ceo-scan-chip--done {
+  background: var(--green-bg);
+  border-color: var(--green);
+  color: var(--green-dark);
+}
+
+.ceo-scan-chip--failed {
+  background: var(--red-bg);
+  border-color: var(--red);
+  color: var(--red-dark);
+}
+
+.ceo-scan-chip-spinner {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: ceo-spin 0.6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ceo-scan-chip-spinner {
+    animation: none;
+    opacity: 0.5;
+  }
+}
+
+.ceo-scan-chip-icon {
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* ─── Sidebar preview overlay (Phase 2 onboarding) ────────────────────────
+   Shows during greet/identity/scan/blueprint/team phases.
+   Dashed lavender border signals "staged, not committed yet."
+   Spec tokens: --preview-row-bg, --preview-row-border, --preview-row-text
+   ─────────────────────────────────────────────────────────────────────── */
+
+.sidebar-preview-overlay {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* 240ms cross-fade out when seeding phase completes (reduced-motion: instant) */
+.sidebar-preview-overlay--seeding {
+  animation: preview-fade-out 240ms ease-out forwards;
+}
+
+@keyframes preview-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-preview-overlay--seeding {
+    animation: none;
+    opacity: 0;
+    pointer-events: none;
+  }
+}
+
+.sidebar-preview-workspace {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--preview-row-text);
+  padding: 4px 6px;
+  background: var(--preview-row-bg);
+  border-radius: var(--radius-sm);
+  border: var(--preview-row-border);
+}
+
+.sidebar-preview-rows {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-preview-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  background: var(--preview-row-bg);
+  border: var(--preview-row-border);
+  font-size: 13px;
+  color: var(--preview-row-text);
+}
+
+.sidebar-preview-row-icon {
+  font-size: 12px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+/* ─── OnboardingDMRoute wrapper ─────────────────────────────────────────── */
+
+.onboarding-dm-route {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Summary

- Implements Phase 2 of the [onboarding-into-office spec](docs/specs/onboarding-into-office.md): a deterministic CEO conversation UI that replaces LLM-driven onboarding with pure form-fill through a dedicated CEO DM channel (`dm:ceo:onboarding`)
- Adds `OnboardingDMRoute` wrapping the existing `DMView` (no new chat shell, no duplicated SSE/scroll/optimistic-post code), five CEO card kinds extending `InterviewBar`'s kind-dispatcher, a `SidebarPreviewOverlay` that shows staged channels/agents forming in real time, and `RootRoute` wiring to enter/exit the Phase 2 shell branch
- Ships 43 new tests (173 total green): 30 for CEO card kinds including XSS regression tests, 5 for `OnboardingDMRoute`, 8 for `SidebarPreviewOverlay`

## What changed

### New files
| File | Purpose |
|---|---|
| `web/src/components/onboarding/types.ts` | `OnboardingState`, `CeoSuggestion` discriminated union, `CardStage` |
| `web/src/components/onboarding/useOnboardingState.ts` | TanStack Query hook, polls `/onboarding/state` every 3 s |
| `web/src/components/onboarding/OnboardingDMRoute.tsx` | Shell body during Phase 2; exports `useOnboardingDMContext` + `OnboardingDMContextProvider` |
| `web/src/components/onboarding/usePreviewOffice.ts` | Derives preview rows from `FormAnswers` per blueprint |
| `web/src/components/onboarding/SidebarPreviewOverlay.tsx` | Dashed-border channel/agent rows in sidebar; fades out on seed phase |
| `web/src/components/messages/cards/CeoFormField.tsx` | Label + text input; pending→submitting→committed |
| `web/src/components/messages/cards/CeoChipRow.tsx` | Single-select chip row (blueprint pick) with Arrow key nav |
| `web/src/components/messages/cards/CeoChecklist.tsx` | Multi-select checklist + submit (team trim); Space=toggle |
| `web/src/components/messages/cards/CeoScanChip.tsx` | Read-only async scan status |
| `web/e2e/screenshots/onboarding-phase2.mjs` | 5-frame screenshot spec (greet/identity/blueprint/team/bridge) |

### Modified files
| File | Change |
|---|---|
| `web/src/components/messages/InterviewBar.tsx` | Added `CeoCardSection` — reads `pendingSuggestion` from `OnboardingDMContext`, manages card stage, POSTs to `/onboarding/answer` |
| `web/src/components/layout/Sidebar.tsx` | Renders `<SidebarPreviewOverlay />` above `<RecentObjectsPanel />` |
| `web/src/routes/RootRoute.tsx` | Phase 2 routing branch: `onboardingV2 && (inCeoOnboarding \|\| bootPhase)` → Shell+OnboardingDMRoute |
| `web/src/styles/global.css` | Three preview-state tokens (`--preview-row-bg`, `--preview-row-border`, `--preview-row-text`) |
| `web/src/styles/onboarding.css` | CEO card, chip, checklist, scan chip, sidebar preview overlay styles + `--seeding` 240ms fade |

## Design decisions

**No new chat shell.** `OnboardingDMRoute` wraps the existing `DMView` — all SSE, scroll, and optimistic-post code is inherited untouched.

**Card XSS protection.** All card components render strings as React text nodes. This extends the `sanitizeContextValue` boundary introduced in PR #684 to the frontend card layer.

**Context injection for tests.** `OnboardingDMContextProvider` is exported from `OnboardingDMRoute.tsx` so unit tests can inject a known `pendingSuggestion` without relying on module-level mock gymnastics.

**`inCeoOnboarding` bridge state.** `RootRoute` needs to know to render Shell+CEO DM between `PrePickScreen` completing and `state.onboarded` flipping to `true`. A local boolean bridges this gap; `bootPhase` handles mid-session resume when `/onboarding/state` already has a phase set.

## Keyboard / accessibility
- Chip rows: Arrow Left/Right to move focus, Enter/Space to select
- Checklist: Space to toggle item, Enter on submit button
- Sidebar preview: `aria-live="polite"` announces row changes to screen readers
- All interactive elements use the global `--focus-ring` token

## Screenshots
Screenshots spec lives at `web/e2e/screenshots/onboarding-phase2.mjs`. Run via:
```bash
bash web/e2e/screenshots/publish.sh onboarding-phase2 <pr-number>
```
(Requires dev server running on `http://localhost:5173`.)

## Test plan
- [ ] `bash scripts/test-web.sh` — 173 pass, 0 fail
- [ ] `bunx tsc --noEmit` in `web/` — 0 errors
- [ ] `bunx biome check --write src/` in `web/` — 0 errors
- [ ] Boot dev server, set `wuphf:onboarding-v2=1` + `wuphf:in-ceo-onboarding=1` in localStorage, navigate to `/` — CEO DM renders in Shell body
- [ ] Cycle through phases via `wuphf:onboarding-phase` localStorage override — sidebar preview overlay shows/hides per phase
- [ ] Submit a `ceo_form_field` card — verifies pending→submitting→committed lifecycle and POST to `/onboarding/answer`
- [ ] Run screenshot spec and embed results before marking PR ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)