### PR TITLE
feat(onboarding): Phase 3 — Issue document surface (read-only)

### DIFF
--- a/internal/team/broker_lifecycle_test.go
+++ b/internal/team/broker_lifecycle_test.go
@@ -26,6 +26,10 @@ func TestLifecycleForwardMapAllStates(t *testing.T) {
 		status        string
 		blocked       bool
 	}{
+		// Phase 3 — Drafting: pre-Intake mode where agents comment but cannot
+		// dispatch. PipelineStage="draft" matches the spec's draft phase name.
+		// Status="open" keeps it visible in the open-tasks view. Blocked=false.
+		{LifecycleStateDrafting, "draft", "pending_review", "open", false},
 		{LifecycleStateIntake, "triage", "pending_review", "open", false},
 		{LifecycleStateReady, "triage", "pending_review", "open", false},
 		{LifecycleStateRunning, "implement", "pending_review", "in_progress", false},

--- a/internal/team/broker_lifecycle_transition.go
+++ b/internal/team/broker_lifecycle_transition.go
@@ -70,6 +70,19 @@ const (
 	// (non-terminal, owner revises). Dependent tasks STAY blocked
 	// because the work did not land.
 	LifecycleStateRejected LifecycleState = "rejected"
+
+	// LifecycleStateDrafting is the Phase 3 Issue-surface pre-Intake mode.
+	// Agents can post comments on a Drafting issue; they CANNOT dispatch
+	// tool calls or execution work. The broker dispatch gate is enforced
+	// in Phase 4 (broker_lifecycle_dispatch_test.go + isExecutableTeamTaskStatus).
+	// Phase 3 only registers the state value so it round-trips cleanly
+	// through JSON and the lifecycle index.
+	//
+	// PipelineStage choice: "draft" (matches the spec's `draft` phase name
+	// in the CEO state machine and is shorter/clearer than "drafting" at
+	// the data layer; the presentation layer uses "Drafting" for the UI
+	// label via STATE_PILL_TOKENS on the frontend).
+	LifecycleStateDrafting LifecycleState = "drafting"
 )
 
 // normalizeLegacyLifecycleStateName maps pre-Phase-1 lifecycle state
@@ -94,6 +107,7 @@ func normalizeLegacyLifecycleStateName(s LifecycleState) LifecycleState {
 // the forward map.
 func CanonicalLifecycleStates() []LifecycleState {
 	return []LifecycleState{
+		LifecycleStateDrafting,
 		LifecycleStateIntake,
 		LifecycleStateReady,
 		LifecycleStateRunning,
@@ -136,6 +150,13 @@ type lifecycleDerivedFieldsRow struct {
 // once the rest of the harness is in place. The lifecycle index and the
 // LifecycleState field still source-of-truth correctly.
 var lifecycleDerivedFields = map[LifecycleState]lifecycleDerivedFieldsRow{
+	// Drafting: pre-Intake mode where agents comment but cannot dispatch.
+	// PipelineStage="draft" matches the spec's draft phase name. Status="open"
+	// keeps the task visible in the open-tasks view; Blocked=false so it is
+	// not confused with a waiting-on-upstream state. Phase 4 will add a
+	// dispatch guard (isExecutableTeamTaskStatus) that refuses tool calls
+	// for tasks in this state.
+	LifecycleStateDrafting:          {PipelineStage: "draft", ReviewState: "pending_review", Status: "open", Blocked: false},
 	LifecycleStateIntake:            {PipelineStage: "triage", ReviewState: "pending_review", Status: "open", Blocked: false},
 	LifecycleStateReady:             {PipelineStage: "triage", ReviewState: "pending_review", Status: "open", Blocked: false},
 	LifecycleStateRunning:           {PipelineStage: "implement", ReviewState: "pending_review", Status: "in_progress", Blocked: false},
@@ -181,6 +202,7 @@ type lifecycleMigrationKey struct {
 // normalised values via deriveLifecycleStateFromLegacy.
 var lifecycleMigrationMap = map[lifecycleMigrationKey]LifecycleState{
 	// Canonical tuples first — direct inverse of lifecycleDerivedFields.
+	{PipelineStage: "draft", ReviewState: "pending_review", Status: "open", Blocked: false}:            LifecycleStateDrafting,
 	{PipelineStage: "triage", ReviewState: "pending_review", Status: "open", Blocked: false}:           LifecycleStateReady,
 	{PipelineStage: "implement", ReviewState: "pending_review", Status: "in_progress", Blocked: false}: LifecycleStateRunning,
 	{PipelineStage: "review", ReviewState: "ready_for_review", Status: "in_progress", Blocked: false}:  LifecycleStateReview,

--- a/web/e2e/screenshots/onboarding-phase3.mjs
+++ b/web/e2e/screenshots/onboarding-phase3.mjs
@@ -1,0 +1,182 @@
+// Capture Phase 3 Issue surface in 4-5 key states:
+//   01 — Issues list empty state (no tasks)
+//   02 — Issue document in Drafting state (full spec visible)
+//   03 — Issue document in Running state (spec collapsed, timeline visible)
+//   04 — Issue document in Approved state (spec collapsed, Expand affordance)
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh onboarding-phase3 <pr-number>
+//
+// No real broker needed. We mock /tasks?all_channels=true and /tasks/<id>
+// endpoints with canned JSON so the components render in deterministic state.
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const TASK_DRAFTING = {
+  taskId: "task-001",
+  id: "task-001",
+  title: "Stripe webhook handler",
+  lifecycleState: "drafting",
+  lifecycle_state: "drafting",
+  status: "open",
+  pipeline_stage: "draft",
+  spec: {
+    goal: "Receive Stripe webhook events (charge.succeeded, charge.failed) and update local subscription state.",
+    context: "Subscriptions are stored in the billing database. Stripe sends events to POST /stripe/webhook.",
+    approach: "Implement HMAC-SHA256 signature verification per Stripe docs. Use idempotency keys to deduplicate events.",
+    acceptance: "- Webhook endpoint at POST /stripe/webhook\n- HMAC-SHA256 signature verified per Stripe docs\n- charge.succeeded marks sub as active\n- charge.failed marks sub as past_due, sends email",
+  },
+  comments: [
+    {
+      id: "c1",
+      author: "ceo",
+      isAgent: true,
+      body: "Drafted spec based on our chat. Engineer, can you sanity-check Approach?",
+      appendedAt: "2026-05-17T10:03:00Z",
+    },
+    {
+      id: "c2",
+      author: "engineer",
+      isAgent: true,
+      body: "Approach looks good but I'd add idempotency via the Stripe Event ID. Want me to spec it?",
+      appendedAt: "2026-05-17T10:04:00Z",
+    },
+    {
+      id: "c3",
+      author: "human",
+      isAgent: false,
+      body: "Yes, please add to acceptance criteria.",
+      appendedAt: "2026-05-17T10:05:00Z",
+    },
+  ],
+};
+
+const TASK_RUNNING = {
+  ...TASK_DRAFTING,
+  taskId: "task-002",
+  id: "task-002",
+  lifecycleState: "running",
+  lifecycle_state: "running",
+  pipeline_stage: "implement",
+  status: "in_progress",
+};
+
+const TASK_APPROVED = {
+  ...TASK_DRAFTING,
+  taskId: "task-003",
+  id: "task-003",
+  lifecycleState: "approved",
+  lifecycle_state: "approved",
+  pipeline_stage: "ship",
+  status: "done",
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function installIssueMocks(context, tasks = []) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      // Override the default onboarded=true stub to keep it onboarded.
+      // The issues surface is a normal Shell route; no special onboarding state.
+      await ctx.route("**/api/tasks**", (r) => {
+        const url = r.request().url();
+        // /tasks/<id> — single task fetch
+        const match = url.match(/\/tasks\/([^?/]+)(\?|$)/);
+        if (match) {
+          const taskId = decodeURIComponent(match[1]);
+          const task = tasks.find((t) => t.id === taskId);
+          if (task) {
+            return r.fulfill({
+              contentType: "application/json",
+              body: JSON.stringify(task),
+            });
+          }
+          return r.fulfill({
+            status: 404,
+            contentType: "application/json",
+            body: JSON.stringify({ error: "not found" }),
+          });
+        }
+        // /tasks?... — list
+        return r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ tasks }),
+        });
+      });
+    },
+  });
+}
+
+async function bootIssuesList(page) {
+  await page.goto(`${DEFAULT_BASE}/#/issues`, { waitUntil: "load" });
+  await page.waitForTimeout(800);
+}
+
+async function bootIssueDetail(page, taskId) {
+  await page.goto(`${DEFAULT_BASE}/#/issues/${taskId}`, { waitUntil: "load" });
+  await page.waitForTimeout(800);
+}
+
+// ── Capture ────────────────────────────────────────────────────────────────
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 900 },
+});
+
+// Frame 01 — Issues list empty state
+await installIssueMocks(context, []);
+await bootIssuesList(page);
+await shotPage(page, OUT, "01-issues-empty-state");
+
+// Frame 02 — Issues list with one open issue
+await installIssueMocks(context, [TASK_DRAFTING]);
+await bootIssuesList(page);
+await shotPage(page, OUT, "02-issues-list-with-open-issue");
+
+// Frame 03 — Issue document Drafting state (full spec visible)
+await installIssueMocks(context, [TASK_DRAFTING]);
+await bootIssueDetail(page, "task-001");
+await shotPage(page, OUT, "03-issue-document-drafting");
+
+// Frame 04 — Issue document Running state (spec auto-collapsed)
+await installIssueMocks(context, [TASK_RUNNING]);
+// Clear sessionStorage so the collapse default applies fresh.
+await page.evaluate(() => {
+  try {
+    sessionStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+await bootIssueDetail(page, "task-002");
+await shotPage(page, OUT, "04-issue-document-running-collapsed");
+
+// Frame 05 — Issue document Approved state (spec collapsed + Expand affordance)
+await installIssueMocks(context, [TASK_APPROVED]);
+await page.evaluate(() => {
+  try {
+    sessionStorage.clear();
+  } catch {
+    // ignore
+  }
+});
+await bootIssueDetail(page, "task-003");
+await shotPage(page, OUT, "05-issue-document-approved-collapsed");
+
+console.log(`captured 5 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/api/lifecycle.ts
+++ b/web/src/api/lifecycle.ts
@@ -292,7 +292,11 @@ export async function postTaskReject(
     throw new Error("reject reason required");
   }
   if (USE_MOCKS) {
-    return Promise.resolve({ taskId, action: "reject", status: "recorded-mock" });
+    return Promise.resolve({
+      taskId,
+      action: "reject",
+      status: "recorded-mock",
+    });
   }
   return post(`/tasks`, {
     action: "reject",

--- a/web/src/api/tasks.ts
+++ b/web/src/api/tasks.ts
@@ -248,7 +248,10 @@ export interface TaskLogEntry {
   completed_at?: number;
 }
 
-export function listAgentLogTasks(opts?: { limit?: number; agentSlug?: string }) {
+export function listAgentLogTasks(opts?: {
+  limit?: number;
+  agentSlug?: string;
+}) {
   const params: Record<string, string> = {};
   if (opts?.limit) params.limit = String(opts.limit);
   if (opts?.agentSlug) params.agent = opts.agentSlug;

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -60,6 +60,13 @@ function routeIdentityKey(route: CurrentRoute): string {
       return "inbox";
     case "task-decision":
       return `task-decision:${route.taskId}`;
+    // Phase 3 — Issues surface
+    case "issues-list":
+      return "issues-list";
+    case "issue-detail":
+      return `issue-detail:${route.issueId}`;
+    case "issue-new":
+      return "issue-new";
     case "unknown":
       return "unknown";
     default: {

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -68,7 +68,6 @@ interface SchedulerJobRaw {
   due_at?: string;
 }
 
-
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function ArtifactsApp() {
   const tasks = useQuery({

--- a/web/src/components/apps/CalendarApp.test.tsx
+++ b/web/src/components/apps/CalendarApp.test.tsx
@@ -2,7 +2,15 @@ import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import type { SchedulerJob } from "../../api/client";
 import type { Task } from "../../api/tasks";

--- a/web/src/components/apps/CalendarApp.tsx
+++ b/web/src/components/apps/CalendarApp.tsx
@@ -668,7 +668,9 @@ function TaskChip({ task, compact = false }: TaskChipProps) {
         }}
       />
       <span>{task.title}</span>
-      <span style={{ marginLeft: 4, fontSize: 10, color: "var(--text-tertiary)" }}>
+      <span
+        style={{ marginLeft: 4, fontSize: 10, color: "var(--text-tertiary)" }}
+      >
         · {label}
       </span>
     </a>

--- a/web/src/components/apps/OfficeOverviewApp.tsx
+++ b/web/src/components/apps/OfficeOverviewApp.tsx
@@ -15,7 +15,11 @@ import {
 } from "../../api/client";
 import { getOfficeTasks, type Task } from "../../api/tasks";
 import { formatRelativeTime } from "../../lib/format";
-import { isAgentActive, normalizeStatus, taskMeta } from "../../lib/officeStatus";
+import {
+  isAgentActive,
+  normalizeStatus,
+  taskMeta,
+} from "../../lib/officeStatus";
 import { router } from "../../lib/router";
 import { ActiveTasksPanel } from "./shared/ActiveTasksPanel";
 import { AgentPulsePanel } from "./shared/AgentPulsePanel";

--- a/web/src/components/apps/shared/ActiveTasksPanel.tsx
+++ b/web/src/components/apps/shared/ActiveTasksPanel.tsx
@@ -58,7 +58,10 @@ export function ActiveTasksPanel({
           <div
             key={t.id}
             className="app-card"
-            style={{ marginBottom: 6, cursor: clickable ? "pointer" : "default" }}
+            style={{
+              marginBottom: 6,
+              cursor: clickable ? "pointer" : "default",
+            }}
             onClick={onTaskClick ? () => onTaskClick(t.id) : undefined}
             onKeyDown={clickable ? handleKeyDown : undefined}
             role={clickable ? "button" : undefined}

--- a/web/src/components/apps/shared/AgentPulsePanel.tsx
+++ b/web/src/components/apps/shared/AgentPulsePanel.tsx
@@ -35,7 +35,12 @@ export function AgentPulsePanel({ agents, limit = 10 }: AgentPulsePanelProps) {
           <div
             key={member.slug}
             className="app-card"
-            style={{ marginBottom: 6, display: "flex", alignItems: "center", gap: 8 }}
+            style={{
+              marginBottom: 6,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
           >
             <span className={`status-dot ${state}`} />
             <div style={{ flex: 1, minWidth: 0 }}>

--- a/web/src/components/channels/ChannelWizard.tsx
+++ b/web/src/components/channels/ChannelWizard.tsx
@@ -94,7 +94,11 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
           return;
         }
         const channel = await generateChannel(prompt.trim());
-        await createChannel(channel.slug, channel.name || channel.slug, channel.description || "");
+        await createChannel(
+          channel.slug,
+          channel.name || channel.slug,
+          channel.description || "",
+        );
         newSlug = channel.slug;
       } else {
         if (!(manual.slug.trim() && manual.name.trim())) {

--- a/web/src/components/layout/Breadcrumb.test.tsx
+++ b/web/src/components/layout/Breadcrumb.test.tsx
@@ -5,8 +5,15 @@
  * Phase 5 PR 2 — app navigation refresh.
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+
 import { Breadcrumb } from "./Breadcrumb";
 
 afterEach(cleanup);
@@ -57,9 +64,7 @@ describe("Breadcrumb", () => {
 
   it("copy-link button is present on the leaf segment", () => {
     render(
-      <Breadcrumb
-        items={[{ label: "Agent: gaia", href: "#/dm/gaia" }]}
-      />,
+      <Breadcrumb items={[{ label: "Agent: gaia", href: "#/dm/gaia" }]} />,
     );
     const copyBtn = screen.getByRole("button", { name: /copy deep link/i });
     expect(copyBtn).toBeInTheDocument();
@@ -85,7 +90,9 @@ describe("Breadcrumb", () => {
 
   it("renders accessibly with nav landmark and aria-label", () => {
     render(<Breadcrumb items={[{ label: "Tasks", href: "#/tasks" }]} />);
-    expect(screen.getByRole("navigation", { name: /breadcrumb/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("navigation", { name: /breadcrumb/i }),
+    ).toBeInTheDocument();
   });
 
   it("copy button writes deep link and shows copied state", async () => {
@@ -95,11 +102,15 @@ describe("Breadcrumb", () => {
       configurable: true,
     });
 
-    render(<Breadcrumb items={[{ label: "Agent: gaia", href: "#/dm/gaia" }]} />);
+    render(
+      <Breadcrumb items={[{ label: "Agent: gaia", href: "#/dm/gaia" }]} />,
+    );
     fireEvent.click(screen.getByRole("button", { name: /copy deep link/i }));
 
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: /link copied/i })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("button", { name: /link copied/i }),
+      ).toBeInTheDocument(),
     );
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText.mock.calls[0][0]).toContain("#/dm/gaia");

--- a/web/src/components/layout/Breadcrumb.tsx
+++ b/web/src/components/layout/Breadcrumb.tsx
@@ -21,10 +21,7 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
   if (items.length === 0) return null;
 
   return (
-    <nav
-      className="breadcrumb"
-      aria-label="Object breadcrumb"
-    >
+    <nav className="breadcrumb" aria-label="Object breadcrumb">
       {items.map((item, idx) => {
         const isLast = idx === items.length - 1;
         return (

--- a/web/src/components/layout/ChannelHeader.tsx
+++ b/web/src/components/layout/ChannelHeader.tsx
@@ -42,6 +42,13 @@ function headerTitleAndDesc(
       return { title: "Decision Inbox", desc: "" };
     case "task-decision":
       return { title: `Task ${route.taskId}`, desc: "" };
+    // Phase 3 — Issues surface
+    case "issues-list":
+      return { title: "Issues", desc: "" };
+    case "issue-detail":
+      return { title: `Issue ${route.issueId}`, desc: "" };
+    case "issue-new":
+      return { title: "New issue", desc: "" };
     case "unknown":
       return { title: "", desc: "" };
     default: {
@@ -95,8 +102,13 @@ function routeToObjectRef(
     case "reviews":
     case "inbox":
     case "channel":
+    // Phase 3 — Issues surface (not discrete navigable objects for recent-objects)
+    case "issues-list":
+    case "issue-new":
     case "unknown":
       return null;
+    case "issue-detail":
+      return { kind: "task", id: route.issueId };
     default: {
       const _exhaustive: never = route;
       void _exhaustive;

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import { AgentList } from "../sidebar/AgentList";
 import { AppList } from "../sidebar/AppList";
 import { ChannelList } from "../sidebar/ChannelList";
 import { InboxButton } from "../sidebar/InboxButton";
+import { IssuesGroup } from "../sidebar/IssuesGroup";
 import { RecentObjectsPanel } from "../sidebar/RecentObjectsPanel";
 import { SidebarColorPicker } from "../sidebar/SidebarColorPicker";
 import { UsagePanel } from "../sidebar/UsagePanel";
@@ -60,6 +61,8 @@ export function Sidebar() {
   const toggleSidebarAgents = useAppStore((s) => s.toggleSidebarAgents);
   const sidebarChannelsOpen = useAppStore((s) => s.sidebarChannelsOpen);
   const toggleSidebarChannels = useAppStore((s) => s.toggleSidebarChannels);
+  const sidebarIssuesOpen = useAppStore((s) => s.sidebarIssuesOpen);
+  const toggleSidebarIssues = useAppStore((s) => s.toggleSidebarIssues);
   const sidebarAppsOpen = useAppStore((s) => s.sidebarAppsOpen);
   const toggleSidebarApps = useAppStore((s) => s.toggleSidebarApps);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
@@ -140,6 +143,21 @@ export function Sidebar() {
             className={`sidebar-collapsible${sidebarChannelsOpen ? " is-open" : ""}`}
           >
             <ChannelList />
+          </div>
+
+          {/* Phase 3 — Issues group (between Channels and Tools, per spec Surface 2 layout). */}
+          <div
+            className={`sidebar-section${sidebarIssuesOpen ? "" : " is-collapsed"}`}
+          >
+            <IssuesGroup
+              open={sidebarIssuesOpen}
+              onToggle={toggleSidebarIssues}
+            />
+          </div>
+          <div
+            className={`sidebar-collapsible${sidebarIssuesOpen ? " is-open" : ""}`}
+          >
+            {/* Issue list rows are rendered inside IssuesGroup when open */}
           </div>
 
           <div

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -108,6 +108,13 @@ export function StatusBar() {
         return "Decision Inbox";
       case "task-decision":
         return `Task ${route.taskId}`;
+      // Phase 3 — Issues surface
+      case "issues-list":
+        return "Issues";
+      case "issue-detail":
+        return `Issue ${route.issueId}`;
+      case "issue-new":
+        return "New issue";
       case "unknown":
         return "";
       default: {

--- a/web/src/components/layout/ThemeSwitcher.tsx
+++ b/web/src/components/layout/ThemeSwitcher.tsx
@@ -1,6 +1,11 @@
-import { type KeyboardEvent as ReactKeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
-import { type Theme, THEMES } from "../../lib/themes";
+import { THEMES, type Theme } from "../../lib/themes";
 import { useAppStore } from "../../stores/app";
 
 interface ThemeSwitcherProps {

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -22,10 +22,7 @@ import {
   updateReviewState,
 } from "../../api/notebook";
 import type { InboxItem, InboxItemKind } from "../../lib/types/inbox";
-import {
-  SEV_ORDER,
-  SEVERITY_TOKENS,
-} from "../../lib/types/lifecycle";
+import { SEV_ORDER, SEVERITY_TOKENS } from "../../lib/types/lifecycle";
 import { useFallbackChannelSlug } from "../../routes/useCurrentRoute";
 import { RequestItem } from "./RequestItem";
 

--- a/web/src/components/lifecycle/DecisionPacketView.tsx
+++ b/web/src/components/lifecycle/DecisionPacketView.tsx
@@ -430,8 +430,8 @@ function DiscussionSection({ feedback }: DiscussionSectionProps) {
       </h3>
       {feedback.length === 0 ? (
         <p className="packet-discussion-empty">
-          No comments yet. Leave one in the sidebar, request changes with
-          inline feedback, or wait for the reviewer to post.
+          No comments yet. Leave one in the sidebar, request changes with inline
+          feedback, or wait for the reviewer to post.
         </p>
       ) : (
         <ol className="packet-discussion-thread">

--- a/web/src/components/lifecycle/InboxRow.test.tsx
+++ b/web/src/components/lifecycle/InboxRow.test.tsx
@@ -48,7 +48,9 @@ describe("<InboxRow>", () => {
       />,
     );
     fireEvent.click(
-      screen.getByRole("button", { name: (_n, el) => el.classList.contains("inbox-row") }),
+      screen.getByRole("button", {
+        name: (_n, el) => el.classList.contains("inbox-row"),
+      }),
     );
     expect(onOpen).toHaveBeenCalledWith("task-2741");
   });
@@ -62,7 +64,9 @@ describe("<InboxRow>", () => {
         onSelect={() => undefined}
       />,
     );
-    const btn = screen.getByRole("button", { name: (_n, el) => el.classList.contains("inbox-row") });
+    const btn = screen.getByRole("button", {
+      name: (_n, el) => el.classList.contains("inbox-row"),
+    });
     expect(btn.tagName).toBe("BUTTON");
   });
 });

--- a/web/src/components/lifecycle/IssueDocument.test.tsx
+++ b/web/src/components/lifecycle/IssueDocument.test.tsx
@@ -1,0 +1,262 @@
+/**
+ * IssueDocument — Phase 3 component tests.
+ *
+ * All tests use `initialDocument` to bypass the TanStack Query fetch so
+ * the suite stays deterministic without a network/broker. The query-key
+ * caching and loading/error states are exercised with a forceState-style
+ * approach to keep the tests readable.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IssueDocument as IssueDocumentType } from "./IssueDocument";
+import { IssueDocument } from "./IssueDocument";
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+const BASE_DOC: IssueDocumentType = {
+  taskId: "task-001",
+  title: "Stripe webhook handler",
+  lifecycleState: "drafting",
+  spec: {
+    goal: "Receive Stripe webhook events and update subscription state.",
+    context: "Subscriptions are stored in the billing database.",
+    approach: "POST /stripe/webhook with HMAC-SHA256 verification.",
+    acceptance:
+      "- Webhook endpoint at POST /stripe/webhook\n- Signature verified",
+  },
+  comments: [
+    {
+      id: "c1",
+      author: "ceo",
+      isAgent: true,
+      body: "Drafted spec based on our chat.",
+      appendedAt: "2026-05-17T10:03:00Z",
+    },
+    {
+      id: "c2",
+      author: "engineer",
+      isAgent: true,
+      body: "Approach looks good. Add idempotency via the Stripe Event ID.",
+      appendedAt: "2026-05-17T10:04:00Z",
+    },
+    {
+      id: "c3",
+      author: "human",
+      isAgent: false,
+      body: "Yes please add to acceptance criteria.",
+      appendedAt: "2026-05-17T10:05:00Z",
+    },
+  ],
+};
+
+const APPROVED_DOC: IssueDocumentType = {
+  ...BASE_DOC,
+  taskId: "task-002",
+  lifecycleState: "approved",
+};
+
+const RUNNING_DOC: IssueDocumentType = {
+  ...BASE_DOC,
+  taskId: "task-003",
+  lifecycleState: "running",
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function renderDoc(
+  doc: IssueDocumentType,
+  props: Partial<{ taskId: string }> = {},
+) {
+  const client = makeClient();
+  const taskId = props.taskId ?? doc.taskId;
+  const { container } = render(
+    <QueryClientProvider client={client}>
+      <IssueDocument taskId={taskId} initialDocument={doc} />
+    </QueryClientProvider>,
+  );
+  return { container };
+}
+
+// ── Suite ──────────────────────────────────────────────────────────────
+
+describe("<IssueDocument>", () => {
+  beforeEach(() => {
+    // Clear sessionStorage to keep tests independent.
+    try {
+      sessionStorage.clear();
+    } catch {
+      // ignore private-mode
+    }
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Spec sections ───────────────────────────────────────────────────
+
+  it("renders all four spec section headings", () => {
+    renderDoc(BASE_DOC);
+    expect(screen.getByRole("heading", { name: /goal/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /context/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /approach/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /acceptance/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders spec section content from the document", () => {
+    renderDoc(BASE_DOC);
+    expect(
+      screen.getByText(/Receive Stripe webhook events/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/billing database/i)).toBeInTheDocument();
+  });
+
+  it("renders em-dash placeholder for missing spec sections", () => {
+    const doc: IssueDocumentType = {
+      ...BASE_DOC,
+      spec: { goal: "A goal" },
+    };
+    renderDoc(doc);
+    // Three placeholders for context, approach, acceptance.
+    const placeholders = screen.getAllByText("—");
+    expect(placeholders.length).toBeGreaterThanOrEqual(3);
+  });
+
+  // ── Status pill ─────────────────────────────────────────────────────
+
+  it("renders the status pill matching the lifecycle state", () => {
+    renderDoc(BASE_DOC);
+    const pill = document.querySelector("[data-state='drafting']");
+    expect(pill).not.toBeNull();
+    expect(pill?.textContent).toMatch(/drafting/i);
+  });
+
+  it("renders approved pill for approved state", () => {
+    renderDoc(APPROVED_DOC);
+    const pill = document.querySelector("[data-state='approved']");
+    expect(pill).not.toBeNull();
+  });
+
+  // ── Phase 4 button row slot ──────────────────────────────────────────
+
+  it("renders the empty Phase 4 button row slot", () => {
+    renderDoc(BASE_DOC);
+    const row = screen.getByTestId("issue-doc-button-row");
+    expect(row).toBeInTheDocument();
+    // Empty in Phase 3 — no buttons inside.
+    expect(row.querySelectorAll("button").length).toBe(0);
+  });
+
+  // ── Comment timeline ────────────────────────────────────────────────
+
+  it("renders all comments in the timeline", () => {
+    renderDoc(BASE_DOC);
+    const list = screen.getByTestId("issue-comments-list");
+    expect(list).toBeInTheDocument();
+    expect(
+      screen.getByText(/Drafted spec based on our chat/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/idempotency via the Stripe Event ID/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Yes please add to acceptance criteria/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a PixelAvatar canvas for each comment author", () => {
+    renderDoc(BASE_DOC);
+    // Three comments, each gets a canvas (PixelAvatar renders a <canvas>).
+    const canvases = document.querySelectorAll(".issue-comment canvas");
+    expect(canvases.length).toBe(BASE_DOC.comments.length);
+  });
+
+  it("renders empty-state message when there are no comments", () => {
+    renderDoc({ ...BASE_DOC, comments: [] });
+    expect(screen.getByTestId("issue-comments-empty")).toBeInTheDocument();
+  });
+
+  it("interleaves human and agent comments in order", () => {
+    renderDoc(BASE_DOC);
+    const authors = screen
+      .getAllByRole("article")
+      .map((el) => el.querySelector(".issue-comment-author")?.textContent);
+    expect(authors).toEqual(["ceo", "engineer", "human"]);
+  });
+
+  // ── Collapse on approved ─────────────────────────────────────────────
+
+  it("auto-collapses spec sections when state is approved", () => {
+    renderDoc(APPROVED_DOC);
+    // Should show summary card, not the full spec sections.
+    expect(screen.getByLabelText(/spec summary/i)).toBeInTheDocument();
+    // Full spec headings should NOT be present.
+    expect(screen.queryByRole("heading", { name: /^Goal$/i })).toBeNull();
+  });
+
+  it("auto-collapses spec sections when state is running", () => {
+    renderDoc(RUNNING_DOC);
+    expect(screen.getByLabelText(/spec summary/i)).toBeInTheDocument();
+  });
+
+  it("does NOT auto-collapse spec for drafting state", () => {
+    renderDoc(BASE_DOC);
+    expect(
+      screen.getByRole("heading", { name: /^Goal$/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Expand-restore after re-mount ────────────────────────────────────
+
+  it("restores expanded state from sessionStorage on re-mount", () => {
+    // First mount: approved (collapsed by default).
+    const { unmount } = render(
+      <QueryClientProvider client={makeClient()}>
+        <IssueDocument taskId="task-002" initialDocument={APPROVED_DOC} />
+      </QueryClientProvider>,
+    );
+    // Expand via button.
+    const expandBtn = screen.getByRole("button", { name: /expand spec/i });
+    fireEvent.click(expandBtn);
+    expect(
+      screen.getByRole("heading", { name: /^Goal$/i }),
+    ).toBeInTheDocument();
+
+    unmount();
+
+    // Second mount: same taskId — should restore expanded.
+    render(
+      <QueryClientProvider client={makeClient()}>
+        <IssueDocument taskId="task-002" initialDocument={APPROVED_DOC} />
+      </QueryClientProvider>,
+    );
+    expect(
+      screen.getByRole("heading", { name: /^Goal$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("collapse button collapses back to summary card", () => {
+    // Start approved (collapsed), expand, then collapse.
+    renderDoc(APPROVED_DOC);
+    fireEvent.click(screen.getByRole("button", { name: /expand spec/i }));
+    // Collapse button should now be visible.
+    const collapseBtn = screen.getByRole("button", { name: /collapse spec/i });
+    fireEvent.click(collapseBtn);
+    expect(screen.getByLabelText(/spec summary/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/lifecycle/IssueDocument.tsx
+++ b/web/src/components/lifecycle/IssueDocument.tsx
@@ -1,0 +1,572 @@
+/**
+ * IssueDocument — Phase 3 Issue surface (read-only).
+ *
+ * Single-column scroll at max-width 720px. Sticky status pill header +
+ * sticky button row (empty slot for Phase 4 Approve & Start). Spec
+ * sections (Goal/Context/Approach/Acceptance) + comments timeline.
+ *
+ * After first approval (state "approved" | "running"), spec sections
+ * auto-collapse into a 3-line summary card with Expand spec affordance.
+ * Collapse/expand is tracked in sessionStorage keyed by taskId so the
+ * user's choice survives a same-tab remount.
+ *
+ * On mount: if ?comment=<id> URL param OR a last-unread-comment data attr
+ * is present, the timeline element scrolls to that comment.
+ *
+ * Phase 3 is READ-ONLY. No Approve & Start, no write endpoints.
+ * Phase 4 wires the button row and the drafting gate.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { useQuery } from "@tanstack/react-query";
+
+import { get } from "../../api/client";
+import {
+  messageMarkdownComponents,
+  messageRemarkPlugins,
+} from "../../lib/messageMarkdown";
+import type { LifecycleState } from "../../lib/types/lifecycle";
+import { PixelAvatar } from "../ui/PixelAvatar";
+import { LifecycleStatePill } from "./LifecycleStatePill";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+/**
+ * Spec sections for the Issue document.
+ * Each section is plain markdown text (may be empty / undefined when the
+ * issue was just created).
+ */
+export interface IssueSpec {
+  goal?: string;
+  context?: string;
+  approach?: string;
+  acceptance?: string;
+}
+
+/**
+ * A single comment on the Issue. Used by both human and agent authors.
+ * Reuses the FeedbackItem shape from the existing comment infrastructure
+ * (broker_inbox_handler.go:229 / lifecycle.ts FeedbackItem), extended
+ * with an id for scroll-targeting.
+ */
+export interface IssueComment {
+  id: string;
+  author: string;
+  /** True when the author is an agent slug (vs. "human"). */
+  isAgent: boolean;
+  body: string;
+  /** RFC3339 / ISO datetime. */
+  appendedAt: string;
+}
+
+/**
+ * Full Issue document payload.
+ * Fetched from GET /tasks/<taskId>. Fields mirror the broker's `teamTask`
+ * JSON shape (camelCase on the wire from the Go side).
+ */
+export interface IssueDocument {
+  taskId: string;
+  title: string;
+  lifecycleState: LifecycleState;
+  spec: IssueSpec;
+  comments: IssueComment[];
+  ownerSlug?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const COLLAPSED_STATES: ReadonlySet<LifecycleState> = new Set([
+  "approved",
+  "running",
+  "review",
+  "decision",
+]);
+
+function sessionStorageKey(taskId: string): string {
+  return `wuphf:issue-spec-expanded:${taskId}`;
+}
+
+function readSpecExpanded(taskId: string, defaultValue: boolean): boolean {
+  try {
+    const v = sessionStorage.getItem(sessionStorageKey(taskId));
+    if (v === "true") return true;
+    if (v === "false") return false;
+    return defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+function writeSpecExpanded(taskId: string, expanded: boolean): void {
+  try {
+    sessionStorage.setItem(sessionStorageKey(taskId), String(expanded));
+  } catch {
+    // private-mode tabs — in-memory state only.
+  }
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const now = new Date();
+    const diffMs = now.getTime() - d.getTime();
+    const diffMin = Math.floor(diffMs / 60_000);
+    if (diffMin < 1) return "just now";
+    if (diffMin < 60) return `${diffMin}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${diffHr}h ago`;
+    return d.toLocaleDateString();
+  } catch {
+    return iso;
+  }
+}
+
+/** Normalize the raw API response into a clean IssueDocument. */
+function normalizeIssueDocument(raw: unknown): IssueDocument {
+  if (!raw || typeof raw !== "object") {
+    throw new Error("invalid issue document response");
+  }
+  const r = raw as Record<string, unknown>;
+
+  // The broker returns tasks with snake_case keys at the top level;
+  // spec sub-fields and comments use camelCase (Go json tags on the
+  // Task struct). Normalise both forms at the boundary.
+  const taskId =
+    (typeof r.taskId === "string" ? r.taskId : undefined) ??
+    (typeof r.id === "string" ? r.id : "");
+  const title =
+    (typeof r.title === "string" ? r.title : undefined) ?? "(untitled)";
+  const lifecycleState: LifecycleState =
+    typeof r.lifecycleState === "string"
+      ? (r.lifecycleState as LifecycleState)
+      : typeof r.lifecycle_state === "string"
+        ? (r.lifecycle_state as LifecycleState)
+        : "intake";
+
+  const rawSpec =
+    r.spec && typeof r.spec === "object"
+      ? (r.spec as Record<string, unknown>)
+      : {};
+
+  const spec: IssueSpec = {
+    goal: typeof rawSpec.goal === "string" ? rawSpec.goal : undefined,
+    context: typeof rawSpec.context === "string" ? rawSpec.context : undefined,
+    approach:
+      typeof rawSpec.approach === "string" ? rawSpec.approach : undefined,
+    acceptance:
+      typeof rawSpec.acceptance === "string"
+        ? rawSpec.acceptance
+        : typeof rawSpec.targetOutcome === "string"
+          ? rawSpec.targetOutcome
+          : undefined,
+  };
+
+  const rawComments = Array.isArray(r.comments)
+    ? r.comments
+    : Array.isArray(r.feedback)
+      ? r.feedback
+      : [];
+
+  const comments: IssueComment[] = rawComments.map(
+    (c: unknown, idx: number): IssueComment => {
+      const comment = (c ?? {}) as Record<string, unknown>;
+      const id =
+        typeof comment.id === "string" ? comment.id : `comment-${String(idx)}`;
+      const author =
+        typeof comment.author === "string" ? comment.author : "unknown";
+      const body =
+        typeof comment.body === "string"
+          ? comment.body
+          : typeof comment.text === "string"
+            ? comment.text
+            : "";
+      const appendedAt =
+        typeof comment.appendedAt === "string"
+          ? comment.appendedAt
+          : typeof comment.created_at === "string"
+            ? comment.created_at
+            : new Date().toISOString();
+      const isAgent =
+        typeof comment.isAgent === "boolean"
+          ? comment.isAgent
+          : author !== "human";
+      return { id, author, isAgent, body, appendedAt };
+    },
+  );
+
+  return {
+    taskId,
+    title,
+    lifecycleState,
+    spec,
+    comments,
+    ownerSlug:
+      typeof r.ownerSlug === "string"
+        ? r.ownerSlug
+        : typeof r.owner === "string"
+          ? r.owner
+          : undefined,
+    createdAt:
+      typeof r.createdAt === "string"
+        ? r.createdAt
+        : typeof r.created_at === "string"
+          ? r.created_at
+          : undefined,
+    updatedAt:
+      typeof r.updatedAt === "string"
+        ? r.updatedAt
+        : typeof r.updated_at === "string"
+          ? r.updated_at
+          : undefined,
+  };
+}
+
+async function fetchIssueDocument(taskId: string): Promise<IssueDocument> {
+  // The broker exposes the full task at /tasks/<id>. IssueDocument is a
+  // presentation projection; we re-use the same endpoint as the Decision
+  // Packet (which GET /tasks/<id> already serves) and normalise at the
+  // boundary.
+  const raw = await get<unknown>(`/tasks/${encodeURIComponent(taskId)}`);
+  return normalizeIssueDocument(raw);
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────
+
+interface SpecSectionProps {
+  heading: string;
+  content: string | undefined;
+}
+
+function SpecSection({ heading, content }: SpecSectionProps) {
+  const body = content?.trim() || "—";
+  const isEmpty = !content?.trim();
+  return (
+    <section className="issue-spec-section" aria-labelledby={`spec-${heading}`}>
+      <h3 id={`spec-${heading}`} className="issue-spec-heading">
+        {heading}
+      </h3>
+      {isEmpty ? (
+        <p className="issue-spec-empty" aria-label="No content yet">
+          —
+        </p>
+      ) : (
+        <div className="issue-spec-body">
+          <ReactMarkdown
+            remarkPlugins={messageRemarkPlugins}
+            components={messageMarkdownComponents}
+          >
+            {body}
+          </ReactMarkdown>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function SpecSummaryCard({
+  spec,
+  onExpand,
+}: {
+  spec: IssueSpec;
+  onExpand: () => void;
+}) {
+  // Produce a 3-line plaintext summary from the spec sections.
+  const lines = [spec.goal, spec.context, spec.approach, spec.acceptance]
+    .filter(Boolean)
+    .slice(0, 3)
+    .map((s) => s!.trim().split("\n")[0] ?? "");
+
+  return (
+    <div className="issue-spec-summary" aria-label="Spec summary (collapsed)">
+      <div className="issue-spec-summary-lines" aria-hidden="true">
+        {lines.length > 0 ? (
+          lines.map((line, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static slice, index is stable here.
+            <p key={i} className="issue-spec-summary-line">
+              {line}
+            </p>
+          ))
+        ) : (
+          <p className="issue-spec-summary-line issue-spec-empty">
+            No spec content yet.
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        className="issue-spec-expand-btn"
+        onClick={onExpand}
+        aria-label="Expand spec sections"
+      >
+        Expand spec
+      </button>
+    </div>
+  );
+}
+
+interface CommentItemProps {
+  comment: IssueComment;
+}
+
+function CommentItem({ comment }: CommentItemProps) {
+  const label = comment.isAgent ? `Agent ${comment.author}` : "Human";
+  return (
+    <article
+      id={`comment-${comment.id}`}
+      className="issue-comment"
+      aria-label={`Comment by ${comment.author}`}
+    >
+      <div className="issue-comment-meta">
+        <PixelAvatar
+          slug={comment.author}
+          size={24}
+          className="issue-comment-avatar"
+        />
+        <span className="issue-comment-author" aria-label={`Author: ${label}`}>
+          {comment.author}
+        </span>
+        <time
+          className="issue-comment-time"
+          dateTime={comment.appendedAt}
+          title={comment.appendedAt}
+        >
+          {formatTimestamp(comment.appendedAt)}
+        </time>
+      </div>
+      <div className="issue-comment-body">
+        <ReactMarkdown
+          remarkPlugins={messageRemarkPlugins}
+          components={messageMarkdownComponents}
+        >
+          {comment.body}
+        </ReactMarkdown>
+      </div>
+    </article>
+  );
+}
+
+// ── Loading + error states ─────────────────────────────────────────────
+
+function IssueDocumentSkeleton() {
+  return (
+    <div
+      className="issue-document issue-document--loading"
+      data-testid="issue-document-loading"
+      aria-busy="true"
+      aria-label="Loading issue"
+    >
+      <div className="issue-doc-header issue-doc-header--sticky">
+        <div className="issue-doc-skeleton issue-doc-skeleton--pill" />
+        <div className="issue-doc-skeleton issue-doc-skeleton--title" />
+      </div>
+      <div className="issue-doc-body">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="issue-doc-skeleton issue-doc-skeleton--block"
+            style={{ width: `${70 + (i % 2) * 15}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IssueDocumentError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      className="issue-document issue-document--error"
+      data-testid="issue-document-error"
+    >
+      <div className="issue-doc-error-card" role="alert">
+        <strong>Could not load issue</strong>
+        <p>{message}</p>
+        <button type="button" className="issue-doc-retry-btn" onClick={onRetry}>
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────
+
+interface IssueDocumentProps {
+  taskId: string;
+  /** Skip fetch and render with these data directly. Used by tests + screenshots. */
+  initialDocument?: IssueDocument;
+}
+
+/**
+ * IssueDocument renders a single Issue in the Phase 3 read-only view.
+ *
+ * Props:
+ *   taskId — the task ID to fetch. Drives the query key.
+ *   initialDocument — if provided, skipped fetch; used in tests.
+ *
+ * The component manages spec-collapsed state in sessionStorage so
+ * returning to an already-approved issue restores the user's choice.
+ */
+export function IssueDocument({ taskId, initialDocument }: IssueDocumentProps) {
+  const query = useQuery<IssueDocument>({
+    queryKey: ["issue", taskId],
+    queryFn: () => fetchIssueDocument(taskId),
+    initialData: initialDocument,
+    staleTime: 5_000,
+    enabled: !initialDocument,
+  });
+
+  // Determine whether spec sections should auto-collapse.
+  const doc = query.data;
+  const shouldAutoCollapse = doc
+    ? COLLAPSED_STATES.has(doc.lifecycleState)
+    : false;
+  const defaultExpanded = !shouldAutoCollapse;
+
+  const [specExpanded, setSpecExpanded] = useState<boolean>(() =>
+    readSpecExpanded(taskId, defaultExpanded),
+  );
+
+  // When the document loads for the first time and auto-collapse is
+  // active, apply the stored preference or default to collapsed.
+  useEffect(() => {
+    if (!doc) return;
+    const stored = readSpecExpanded(taskId, defaultExpanded);
+    setSpecExpanded(stored);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [taskId, shouldAutoCollapse]);
+
+  // Persist spec expand/collapse on change.
+  function toggleSpec() {
+    setSpecExpanded((prev) => {
+      const next = !prev;
+      writeSpecExpanded(taskId, next);
+      return next;
+    });
+  }
+
+  // Scroll to last-unread comment on mount (URL param or data attr).
+  const timelineRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!doc || doc.comments.length === 0) return;
+    const params = new URLSearchParams(window.location.search);
+    const commentId = params.get("comment");
+    if (commentId) {
+      const el = document.getElementById(`comment-${commentId}`);
+      el?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [doc]);
+
+  if (query.isPending && !initialDocument) {
+    return <IssueDocumentSkeleton />;
+  }
+
+  if (query.isError && !doc) {
+    return (
+      <IssueDocumentError
+        message={
+          query.error instanceof Error
+            ? query.error.message
+            : "Network or broker error."
+        }
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+
+  if (!doc) {
+    return <IssueDocumentSkeleton />;
+  }
+
+  return (
+    <div
+      className="issue-document"
+      data-testid="issue-document"
+      data-task-id={taskId}
+      data-lifecycle-state={doc.lifecycleState}
+    >
+      {/* Sticky header: status pill + title */}
+      <header
+        className="issue-doc-header issue-doc-header--sticky"
+        aria-label="Issue header"
+      >
+        <div className="issue-doc-header-row">
+          <LifecycleStatePill state={doc.lifecycleState} />
+          <h2 className="issue-doc-title">{doc.title}</h2>
+        </div>
+        {/*
+         * Phase 4 button row slot.
+         * Empty div with known class name so Phase 4 can query-select or
+         * pass a `buttons` prop without touching the layout structure.
+         * aria-hidden so screen readers don't announce an empty region.
+         */}
+        <div
+          className="issue-doc-button-row"
+          aria-hidden="true"
+          data-testid="issue-doc-button-row"
+        />
+      </header>
+
+      {/* Body: spec sections + comments timeline */}
+      <div className="issue-doc-body">
+        {/* Spec sections */}
+        {shouldAutoCollapse && !specExpanded ? (
+          <SpecSummaryCard spec={doc.spec} onExpand={toggleSpec} />
+        ) : (
+          <section className="issue-doc-spec" aria-label="Issue specification">
+            {shouldAutoCollapse && (
+              <button
+                type="button"
+                className="issue-spec-collapse-btn"
+                onClick={toggleSpec}
+                aria-label="Collapse spec sections"
+              >
+                Collapse spec
+              </button>
+            )}
+            <SpecSection heading="Goal" content={doc.spec.goal} />
+            <SpecSection heading="Context" content={doc.spec.context} />
+            <SpecSection heading="Approach" content={doc.spec.approach} />
+            <SpecSection heading="Acceptance" content={doc.spec.acceptance} />
+          </section>
+        )}
+
+        {/* Comments timeline */}
+        <section
+          className="issue-doc-comments"
+          aria-label="Comments"
+          aria-live="polite"
+          ref={timelineRef}
+        >
+          <h3 className="issue-comments-heading">Comments</h3>
+          {doc.comments.length === 0 ? (
+            <p
+              className="issue-comments-empty"
+              data-testid="issue-comments-empty"
+            >
+              No comments yet.
+            </p>
+          ) : (
+            <div
+              className="issue-comments-list"
+              data-testid="issue-comments-list"
+            >
+              {doc.comments.map((c) => (
+                <CommentItem key={c.id} comment={c} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/lifecycle/IssueDocumentRoute.tsx
+++ b/web/src/components/lifecycle/IssueDocumentRoute.tsx
@@ -1,0 +1,24 @@
+/**
+ * IssueDocumentRoute — /issues/$issueId route container.
+ *
+ * Thin wrapper that passes the issueId URL param to IssueDocument.
+ * Route-level error boundary catches fetch failures that escape the
+ * component's own error state. Phase 3 is read-only.
+ */
+
+import { IssueDocument } from "./IssueDocument";
+
+interface IssueDocumentRouteProps {
+  issueId: string;
+}
+
+export function IssueDocumentRoute({ issueId }: IssueDocumentRouteProps) {
+  return (
+    <div
+      className="app-panel active issue-document-panel"
+      data-testid="issue-document-panel"
+    >
+      <IssueDocument taskId={issueId} />
+    </div>
+  );
+}

--- a/web/src/components/lifecycle/IssuesList.tsx
+++ b/web/src/components/lifecycle/IssuesList.tsx
@@ -1,0 +1,219 @@
+/**
+ * IssuesList — Phase 3 /issues list surface.
+ *
+ * Lists all existing tasks rendered as Issues (back-compat read).
+ * Each row shows the task title, status pill, and a link to the issue
+ * detail view. No filters in Phase 3 — that is Phase 4+ scope.
+ *
+ * Data source: GET /tasks?all_channels=true (the existing getOfficeTasks
+ * endpoint). No new write endpoints or new primitives.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getOfficeTasks, type Task } from "../../api/tasks";
+import { router } from "../../lib/router";
+import type { LifecycleState } from "../../lib/types/lifecycle";
+import { LifecycleStatePill } from "./LifecycleStatePill";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Map a Task's raw status/lifecycle_state fields to a LifecycleState.
+ * Prefers `lifecycle_state` (set by the broker post Lane-A); falls back
+ * to the legacy `status` string so pre-Lane-A tasks still render a pill.
+ */
+function taskToLifecycleState(task: Task): LifecycleState {
+  if (task.pipeline_stage === "draft") return "drafting";
+  // Use lifecycle_state if the broker has set it.
+  const raw = (task as unknown as Record<string, unknown>).lifecycle_state;
+  if (typeof raw === "string" && raw) return raw as LifecycleState;
+  // Fall back to legacy status mapping.
+  switch (task.status) {
+    case "open":
+      return "intake";
+    case "in_progress":
+      return "running";
+    case "done":
+      return "approved";
+    case "blocked":
+      return "blocked_on_pr_merge";
+    case "review":
+      return "review";
+    case "rejected":
+      return "rejected";
+    default:
+      return "intake";
+  }
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────
+
+function IssueRow({ task }: { task: Task }) {
+  const state = taskToLifecycleState(task);
+
+  function navigate() {
+    void router.navigate({
+      to: "/issues/$issueId",
+      params: { issueId: task.id },
+    });
+  }
+
+  return (
+    <button
+      type="button"
+      className="issues-list-row"
+      onClick={navigate}
+      data-testid="issue-row"
+      aria-label={`Issue: ${task.title}, state: ${state}`}
+    >
+      <span className="issues-list-row-pill">
+        <LifecycleStatePill state={state} />
+      </span>
+      <span className="issues-list-row-title">{task.title}</span>
+      {task.owner && (
+        <span
+          className="issues-list-row-owner"
+          aria-label={`Owner: ${task.owner}`}
+        >
+          {task.owner}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function IssuesListSkeleton() {
+  return (
+    <div
+      className="issues-list issues-list--loading"
+      data-testid="issues-list-loading"
+      aria-busy="true"
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="issues-list-skeleton-row"
+          style={{ width: `${50 + i * 10}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function IssuesListError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      className="issues-list issues-list--error"
+      data-testid="issues-list-error"
+    >
+      <div role="alert" className="issues-list-error-card">
+        <strong>Could not load issues</strong>
+        <p>{message}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="issues-list-retry-btn"
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function IssuesEmptyState() {
+  return (
+    <div
+      className="issues-list issues-list--empty"
+      data-testid="issues-list-empty"
+    >
+      <p className="issues-empty-copy">
+        No issues yet. When you are ready, type what you want done.
+      </p>
+      <button
+        type="button"
+        className="issues-new-btn"
+        onClick={() => void router.navigate({ to: "/issues/new" })}
+        data-testid="issues-new-btn"
+      >
+        + New issue
+      </button>
+    </div>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────
+
+interface IssuesListProps {
+  /** Used in tests to skip the fetch. */
+  initialTasks?: Task[];
+}
+
+export function IssuesList({ initialTasks }: IssuesListProps = {}) {
+  const query = useQuery({
+    queryKey: ["issues", "list"],
+    queryFn: () => getOfficeTasks({ includeDone: true }),
+    initialData: initialTasks ? { tasks: initialTasks } : undefined,
+    staleTime: 5_000,
+    enabled: !initialTasks,
+  });
+
+  if (query.isPending && !initialTasks) {
+    return <IssuesListSkeleton />;
+  }
+
+  if (query.isError && !query.data) {
+    return (
+      <IssuesListError
+        message={
+          query.error instanceof Error
+            ? query.error.message
+            : "Network or broker error."
+        }
+        onRetry={() => void query.refetch()}
+      />
+    );
+  }
+
+  const tasks = query.data?.tasks ?? [];
+
+  if (tasks.length === 0) {
+    return <IssuesEmptyState />;
+  }
+
+  return (
+    <div className="issues-list" data-testid="issues-list">
+      <header className="issues-list-header">
+        <h2 className="issues-list-heading">Issues</h2>
+        <button
+          type="button"
+          className="issues-new-btn issues-new-btn--header"
+          onClick={() => void router.navigate({ to: "/issues/new" })}
+          data-testid="issues-new-btn"
+          title="Create a new issue"
+        >
+          + New issue
+        </button>
+      </header>
+      <div
+        className="issues-list-rows"
+        role="list"
+        aria-label="Issues"
+        data-testid="issues-list-rows"
+      >
+        {tasks.map((task) => (
+          <div role="listitem" key={task.id}>
+            <IssueRow task={task} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -241,7 +241,9 @@ function HeadlessEventView({
             );
           })}
           {textLen !== null && textLen > 0 && (
-            <span className="stream-manifest-stat">{textLen.toLocaleString("en-US")} bytes</span>
+            <span className="stream-manifest-stat">
+              {textLen.toLocaleString("en-US")} bytes
+            </span>
           )}
           {inputTokens !== null && outputTokens !== null && (
             <span className="stream-manifest-stat">

--- a/web/src/components/onboarding/wizard/FirstTaskScreen.test.tsx
+++ b/web/src/components/onboarding/wizard/FirstTaskScreen.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+
 import { FirstTaskScreen } from "./FirstTaskScreen";
 
 describe("FirstTaskScreen", () => {

--- a/web/src/components/onboarding/wizard/FirstTaskScreen.tsx
+++ b/web/src/components/onboarding/wizard/FirstTaskScreen.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+
 import { ArrowIcon } from "./components";
 
 interface FirstTaskScreenProps {
@@ -61,7 +62,10 @@ export function FirstTaskScreen({
         </p>
       </div>
 
-      <div className="wizard-panel" style={{ gap: 8, display: "flex", flexDirection: "column" }}>
+      <div
+        className="wizard-panel"
+        style={{ gap: 8, display: "flex", flexDirection: "column" }}
+      >
         <p
           style={{
             fontSize: 12,
@@ -78,7 +82,10 @@ export function FirstTaskScreen({
         <button
           type="button"
           className="btn btn-ghost"
-          onClick={() => { setActed(true); onSkipToOffice(); }}
+          onClick={() => {
+            setActed(true);
+            onSkipToOffice();
+          }}
           disabled={acted}
           data-testid="first-task-skip"
         >
@@ -87,7 +94,10 @@ export function FirstTaskScreen({
         <button
           type="button"
           className="btn btn-primary"
-          onClick={() => { setActed(true); onWatchTask(); }}
+          onClick={() => {
+            setActed(true);
+            onWatchTask();
+          }}
           disabled={acted}
           data-testid="first-task-watch"
         >

--- a/web/src/components/review/ReviewCard.test.tsx
+++ b/web/src/components/review/ReviewCard.test.tsx
@@ -50,17 +50,32 @@ describe("<ReviewCard>", () => {
   });
 
   it("shows no grade badge for fresh cards (< 12 hours old)", () => {
-    render(<ReviewCard review={makeReview({ submitted_ts: tsHoursAgo(1) })} onOpen={() => {}} />);
+    render(
+      <ReviewCard
+        review={makeReview({ submitted_ts: tsHoursAgo(1) })}
+        onOpen={() => {}}
+      />,
+    );
     expect(screen.queryByText(/Waiting|Urgent/i)).not.toBeInTheDocument();
   });
 
   it("shows 'Waiting' badge for cards >= 12 hours old", () => {
-    render(<ReviewCard review={makeReview({ submitted_ts: tsHoursAgo(13) })} onOpen={() => {}} />);
+    render(
+      <ReviewCard
+        review={makeReview({ submitted_ts: tsHoursAgo(13) })}
+        onOpen={() => {}}
+      />,
+    );
     expect(screen.getByText("Waiting")).toBeInTheDocument();
   });
 
   it("shows 'Urgent' badge for cards >= 48 hours old", () => {
-    render(<ReviewCard review={makeReview({ submitted_ts: tsHoursAgo(50) })} onOpen={() => {}} />);
+    render(
+      <ReviewCard
+        review={makeReview({ submitted_ts: tsHoursAgo(50) })}
+        onOpen={() => {}}
+      />,
+    );
     expect(screen.getByText("Urgent")).toBeInTheDocument();
   });
 
@@ -75,7 +90,12 @@ describe("<ReviewCard>", () => {
   });
 
   it("renders the timeout-fill bar for pending cards with age > 0", () => {
-    render(<ReviewCard review={makeReview({ submitted_ts: tsHoursAgo(6) })} onOpen={() => {}} />);
+    render(
+      <ReviewCard
+        review={makeReview({ submitted_ts: tsHoursAgo(6) })}
+        onOpen={() => {}}
+      />,
+    );
     const bar = document.querySelector(".nb-review-card-timeout-bar");
     expect(bar).not.toBeNull();
   });

--- a/web/src/components/review/ReviewCard.tsx
+++ b/web/src/components/review/ReviewCard.tsx
@@ -16,8 +16,16 @@ type DemandGrade = "urgent" | "waiting" | "fresh";
 /** Hours a card must sit in a pending/in-review column to reach each tier. */
 const GRADE_THRESHOLDS = { urgent: 48, waiting: 12 } as const;
 
-function computeGrade(submittedTs: string, state: ReviewItem["state"]): DemandGrade | null {
-  if (state === "approved" || state === "archived" || state === "rejected" || state === "expired") {
+function computeGrade(
+  submittedTs: string,
+  state: ReviewItem["state"],
+): DemandGrade | null {
+  if (
+    state === "approved" ||
+    state === "archived" ||
+    state === "rejected" ||
+    state === "expired"
+  ) {
     return null;
   }
   const ageHours = (Date.now() - new Date(submittedTs).getTime()) / 3_600_000;
@@ -30,8 +38,16 @@ function computeGrade(submittedTs: string, state: ReviewItem["state"]): DemandGr
  * Returns a fill ratio 0–1 representing how "stale" the card is, capped at
  * GRADE_THRESHOLDS.urgent * 2h. Used to render the timeout-fill bar.
  */
-function computeTimeoutFill(submittedTs: string, state: ReviewItem["state"]): number {
-  if (state === "approved" || state === "archived" || state === "rejected" || state === "expired") {
+function computeTimeoutFill(
+  submittedTs: string,
+  state: ReviewItem["state"],
+): number {
+  if (
+    state === "approved" ||
+    state === "archived" ||
+    state === "rejected" ||
+    state === "expired"
+  ) {
     return 0;
   }
   const ageHours = (Date.now() - new Date(submittedTs).getTime()) / 3_600_000;
@@ -60,7 +76,11 @@ export default function ReviewCard({
       onClick={() => onOpen(review.id)}
       aria-label={`Open review for ${review.entry_title}`}
       data-testid="nb-review-card"
-      style={fillRatio > 0 ? ({ "--nb-timeout-fill": fillPct } as React.CSSProperties) : undefined}
+      style={
+        fillRatio > 0
+          ? ({ "--nb-timeout-fill": fillPct } as React.CSSProperties)
+          : undefined
+      }
     >
       {/* Timeout fill bar — grows left-to-right as the card ages. */}
       {fillRatio > 0 && (

--- a/web/src/components/sidebar/IssuesGroup.tsx
+++ b/web/src/components/sidebar/IssuesGroup.tsx
@@ -1,0 +1,223 @@
+/**
+ * IssuesGroup — sidebar Issues section for Phase 3.
+ *
+ * Renders a collapsible group header with "+ New issue" affordance plus a
+ * list of open issues when expanded. The Issues group sits between
+ * Channels and Tools per the spec Surface 2 layout.
+ *
+ * Design decisions:
+ * - Extends the existing SectionToggle + sidebar-item pattern rather than
+ *   building a new primitive — consistent with ChannelList and AgentList.
+ * - "+ New issue" wires to /issues/new (Phase 4 stub that 501s for now).
+ * - Issue rows navigate to /issues/$issueId.
+ * - Empty state: a faint placeholder label in --text-tertiary so the user
+ *   understands what the section IS, per spec Surface 2: "Issues sidebar
+ *   groups render as empty states with a faint placeholder, not hidden."
+ *
+ * No sub-issues, no filters, no wiki mirror. Phase 6 scope.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+
+import { getOfficeTasks, type Task } from "../../api/tasks";
+import { router } from "../../lib/router";
+import type { LifecycleState } from "../../lib/types/lifecycle";
+import { useCurrentRoute } from "../../routes/useCurrentRoute";
+import { SidebarItemLabel } from "./SidebarItemLabel";
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function taskToState(task: Task): LifecycleState {
+  if (task.pipeline_stage === "draft") return "drafting";
+  const raw = (task as unknown as Record<string, unknown>).lifecycle_state;
+  if (typeof raw === "string" && raw) return raw as LifecycleState;
+  switch (task.status) {
+    case "open":
+      return "intake";
+    case "in_progress":
+      return "running";
+    case "done":
+      return "approved";
+    case "blocked":
+      return "blocked_on_pr_merge";
+    case "review":
+      return "review";
+    default:
+      return "intake";
+  }
+}
+
+const TERMINAL_STATES: ReadonlySet<LifecycleState> = new Set([
+  "approved",
+  "rejected",
+]);
+
+function isOpenIssue(task: Task): boolean {
+  return !TERMINAL_STATES.has(taskToState(task));
+}
+
+// ── Sub-components ─────────────────────────────────────────────────────
+
+function SectionToggle({
+  label,
+  open,
+  onToggle,
+}: {
+  label: string;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="sidebar-section-title sidebar-section-toggle"
+      onClick={onToggle}
+      aria-expanded={open}
+    >
+      <span>{label}</span>
+      <svg
+        aria-hidden="true"
+        focusable="false"
+        style={{
+          width: 10,
+          height: 10,
+          transform: open ? "rotate(90deg)" : "rotate(0deg)",
+          transition: "transform 0.15s",
+        }}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m9 18 6-6-6-6" />
+      </svg>
+    </button>
+  );
+}
+
+// ── Main component ─────────────────────────────────────────────────────
+
+interface IssuesGroupProps {
+  open: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * Renders the Issues sidebar section header + optional issue list.
+ *
+ * The header row always renders (toggle + New issue button). The list
+ * only renders when `open === true`. Using this pattern instead of the
+ * separate sidebar-collapsible div in Sidebar.tsx allows the "+New" button
+ * to remain visible even when collapsed — same UX as ChannelList's "+ New
+ * Channel" button inside the scroll area.
+ */
+export function IssuesGroup({ open, onToggle }: IssuesGroupProps) {
+  const route = useCurrentRoute();
+  const activeIssueId = route.kind === "issue-detail" ? route.issueId : null;
+
+  const query = useQuery({
+    queryKey: ["issues", "sidebar"],
+    queryFn: () => getOfficeTasks({ includeDone: false }),
+    staleTime: 10_000,
+    // Only fetch once the section is opened to avoid extra requests on
+    // first paint. Pre-warm on second mount once the user has seen it.
+    enabled: open,
+  });
+
+  const openIssues = (query.data?.tasks ?? []).filter(isOpenIssue);
+
+  return (
+    <>
+      {/* Section header — always visible */}
+      <div
+        className="sidebar-section-title-row issues-group-header"
+        data-testid="issues-group-header"
+      >
+        <SectionToggle label="Issues" open={open} onToggle={onToggle} />
+        <button
+          type="button"
+          className="sidebar-icon-btn issues-new-icon-btn"
+          title="New issue (Phase 4)"
+          aria-label="New issue"
+          onClick={() => void router.navigate({ to: "/issues/new" })}
+          data-testid="issues-sidebar-new-btn"
+        >
+          +
+        </button>
+      </div>
+
+      {/* Collapsible list */}
+      {open && (
+        <div
+          className="sidebar-collapsible is-open is-issues"
+          data-testid="issues-group-list"
+        >
+          {openIssues.length === 0 ? (
+            <p
+              className="sidebar-empty-hint"
+              style={{
+                color: "var(--text-tertiary)",
+                padding: "4px 12px",
+                fontSize: 12,
+              }}
+              data-testid="issues-sidebar-empty"
+            >
+              No issues yet.
+            </p>
+          ) : (
+            openIssues.slice(0, 20).map((task) => (
+              <button
+                key={task.id}
+                type="button"
+                className={`sidebar-item${activeIssueId === task.id ? " active" : ""}`}
+                onClick={() =>
+                  void router.navigate({
+                    to: "/issues/$issueId",
+                    params: { issueId: task.id },
+                  })
+                }
+                aria-label={task.title}
+                title={task.title}
+                data-testid="issues-sidebar-row"
+              >
+                <span
+                  style={{
+                    color: "currentColor",
+                    width: 18,
+                    textAlign: "center",
+                    flexShrink: 0,
+                    display: "inline-block",
+                    fontSize: 11,
+                  }}
+                >
+                  #
+                </span>
+                <SidebarItemLabel>{task.title}</SidebarItemLabel>
+              </button>
+            ))
+          )}
+          {/* View all issues link */}
+          <button
+            type="button"
+            className={`sidebar-item sidebar-add-btn${route.kind === "issues-list" ? " active" : ""}`}
+            onClick={() => void router.navigate({ to: "/issues" })}
+            title="View all issues"
+            data-testid="issues-sidebar-view-all"
+          >
+            <span
+              style={{
+                width: 18,
+                textAlign: "center",
+                flexShrink: 0,
+                display: "inline-block",
+              }}
+            />
+            <span style={{ color: "var(--text-tertiary)" }}>View all</span>
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/sidebar/RecentObjectsPanel.tsx
+++ b/web/src/components/sidebar/RecentObjectsPanel.tsx
@@ -33,7 +33,9 @@ export function RecentObjectsPanel() {
             title={item.label}
           >
             <RecentObjectIcon kind={item.ref.kind} />
-            <span className="recent-objects-label">{humanLabel(item.label)}</span>
+            <span className="recent-objects-label">
+              {humanLabel(item.label)}
+            </span>
           </a>
         ))}
       </div>

--- a/web/src/hooks/useObjectBreadcrumb.test.ts
+++ b/web/src/hooks/useObjectBreadcrumb.test.ts
@@ -6,8 +6,9 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { deriveBreadcrumbs } from "./useObjectBreadcrumb";
+
 import type { CurrentRoute } from "../routes/useCurrentRoute";
+import { deriveBreadcrumbs } from "./useObjectBreadcrumb";
 
 describe("deriveBreadcrumbs", () => {
   it("returns empty array for channel routes", () => {

--- a/web/src/hooks/useObjectBreadcrumb.ts
+++ b/web/src/hooks/useObjectBreadcrumb.ts
@@ -127,6 +127,23 @@ export function deriveBreadcrumbs(route: CurrentRoute): BreadcrumbItem[] {
       ];
     }
     case "channel":
+      return [];
+    // Phase 3 — Issues surface breadcrumbs
+    case "issues-list":
+      return [{ label: "Issues", href: "#/issues" }];
+    case "issue-detail":
+      return [
+        { label: "Issues", href: "#/issues" },
+        {
+          label: route.issueId,
+          href: `#/issues/${encodeURIComponent(route.issueId)}`,
+        },
+      ];
+    case "issue-new":
+      return [
+        { label: "Issues", href: "#/issues" },
+        { label: "New issue", href: "#/issues/new" },
+      ];
     case "unknown":
       return [];
     default: {

--- a/web/src/hooks/useRecentObjects.test.ts
+++ b/web/src/hooks/useRecentObjects.test.ts
@@ -5,9 +5,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import {
-  RECENT_OBJECTS_MAX,
   pushRecentObject,
+  RECENT_OBJECTS_MAX,
   readRecentObjects,
 } from "./useRecentObjects";
 
@@ -17,9 +18,15 @@ beforeEach(() => {
   store = new Map();
   vi.stubGlobal("localStorage", {
     getItem: (k: string) => store.get(k) ?? null,
-    setItem: (k: string, v: string) => { store.set(k, v); },
-    removeItem: (k: string) => { store.delete(k); },
-    clear: () => { store.clear(); },
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => {
+      store.clear();
+    },
   });
 });
 afterEach(() => {
@@ -59,7 +66,9 @@ describe("pushRecentObject", () => {
     // pushRecentObject with a missing field resolves to a fallback and skips.
     // Cast through unknown to test the runtime guard without TS complaining.
     const before = readRecentObjects().length;
-    pushRecentObject({ kind: "agent", slug: "" } as unknown as Parameters<typeof pushRecentObject>[0]);
+    pushRecentObject({ kind: "agent", slug: "" } as unknown as Parameters<
+      typeof pushRecentObject
+    >[0]);
     expect(readRecentObjects().length).toBe(before);
   });
 });

--- a/web/src/hooks/useRecentObjects.ts
+++ b/web/src/hooks/useRecentObjects.ts
@@ -10,7 +10,8 @@
  */
 
 import { useCallback } from "react";
-import { resolveObjectRoute, type ObjectRef } from "../lib/objectRoutes";
+
+import { type ObjectRef, resolveObjectRoute } from "../lib/objectRoutes";
 
 export const RECENT_OBJECTS_MAX = 10;
 const STORAGE_KEY = "wuphf-recent-objects";

--- a/web/src/lib/officeStatus.ts
+++ b/web/src/lib/officeStatus.ts
@@ -19,9 +19,10 @@ export function normalizeStatus(raw: string): string {
  * Returns the display state and label for an active agent.
  * Only call on members that have already passed `isAgentActive`.
  */
-export function classifyMember(
-  member: OfficeMember,
-): { state: "shipping" | "plotting"; label: string } {
+export function classifyMember(member: OfficeMember): {
+  state: "shipping" | "plotting";
+  label: string;
+} {
   if (member.status === "plotting") {
     return { state: "plotting", label: "Plotting" };
   }

--- a/web/src/lib/richArtifactReferences.ts
+++ b/web/src/lib/richArtifactReferences.ts
@@ -53,7 +53,10 @@ export function stripStandaloneRichArtifactReferenceLines(
     kept.push(line);
   }
   if (!removedReferenceLine) return content;
-  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+  return kept
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }
 
 function forEachNonFenceLine(

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -148,6 +148,28 @@ export const indexRoute = createRoute({
   },
 });
 
+// /issues — Phase 3 Issue list surface.
+// Lists all existing tasks as Issues (back-compat read, no new write).
+export const issuesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.issues,
+});
+
+// /issues/$issueId — Phase 3 Issue detail surface.
+// Renders IssueDocument for a single task.
+export const issueDetailRoute = createRoute({
+  getParentRoute: () => issuesRoute,
+  path: "$issueId",
+});
+
+// /issues/new — Phase 4 stub.
+// Wired so `+ New issue` can navigate here without a 404.
+// Returns a 501 placeholder in Phase 3; Phase 4 wires the draft writer.
+export const issueNewRoute = createRoute({
+  getParentRoute: () => issuesRoute,
+  path: "new",
+});
+
 // Route tree
 export const routeTree = rootRoute.addChildren([
   indexRoute,
@@ -166,6 +188,10 @@ export const routeTree = rootRoute.addChildren([
   reviewsRoute,
   inboxRoute,
   taskDecisionRoute,
+  // Phase 3 — Issues surface.
+  // issueNewRoute must be listed BEFORE issueDetailRoute so the static
+  // segment "new" wins over the dynamic "$issueId" catch-all.
+  issuesRoute.addChildren([issueNewRoute, issueDetailRoute]),
 ]);
 
 export function createAppRouter(history: RouterHistory = createHashHistory()) {

--- a/web/src/lib/types/lifecycle.ts
+++ b/web/src/lib/types/lifecycle.ts
@@ -15,6 +15,7 @@
 
 /** Lifecycle position of a task. Source of truth on the broker (`teamTask.LifecycleState`). */
 export type LifecycleState =
+  | "drafting"
   | "intake"
   | "ready"
   | "running"
@@ -229,6 +230,18 @@ export const STATE_PILL_TOKENS: Record<
   LifecycleState,
   { bg: string; text: string; label: string }
 > = {
+  /**
+   * drafting: pre-Intake mode where agents can comment but not dispatch.
+   * Uses brand-accent tokens (--accent-bg / --accent) to signal
+   * "needs human attention" — distinct from intake/ready (--bg-row-active)
+   * which use a neutral palette.
+   * Design review decision 2026-05-17: locked.
+   */
+  drafting: {
+    bg: "var(--accent-bg)",
+    text: "var(--accent)",
+    label: "drafting",
+  },
   intake: {
     bg: "var(--bg-row-active)",
     text: "var(--text-secondary)",
@@ -368,7 +381,9 @@ export const FILTER_TO_STATES: Record<
   ReadonlyArray<LifecycleState>
 > = {
   decision_required: ["decision"],
-  running: ["intake", "ready", "running", "review"],
+  // drafting is surfaced in the issues route, not the inbox; include it in
+  // running so inbox rows with this state still land somewhere readable.
+  running: ["drafting", "intake", "ready", "running", "review"],
   blocked: ["blocked_on_pr_merge", "changes_requested", "rejected"],
   approved: ["approved"],
 };

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -135,6 +135,17 @@ const DecisionPacketRoute = lazy(() =>
 );
 const CitedAnswer = lazy(() => import("../components/wiki/CitedAnswer"));
 const Wiki = lazy(() => import("../components/wiki/Wiki"));
+// Phase 3 — Issues surface.
+const IssuesList = lazy(() =>
+  import("../components/lifecycle/IssuesList").then((m) => ({
+    default: m.IssuesList,
+  })),
+);
+const IssueDocumentRoute = lazy(() =>
+  import("../components/lifecycle/IssueDocumentRoute").then((m) => ({
+    default: m.IssueDocumentRoute,
+  })),
+);
 
 function LazyPanelFallback() {
   return (
@@ -364,6 +375,45 @@ function WikiSurface({ current, route }: WikiSurfaceProps) {
 }
 
 /**
+ * IssueNewStub — Phase 3 placeholder for /issues/new.
+ * Phase 4 replaces this with the CEO draft writer.
+ * Renders a clear "not implemented yet" surface so `+ New issue` links
+ * don't 404 or silently fail.
+ */
+function IssueNewStub() {
+  return (
+    <div
+      className="app-panel active"
+      data-testid="issue-new-stub"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        flex: 1,
+        gap: 8,
+        padding: 32,
+        color: "var(--text-tertiary)",
+        fontSize: 14,
+      }}
+    >
+      <strong style={{ fontSize: 16, color: "var(--text-secondary)" }}>
+        New issue drafting coming in Phase 4
+      </strong>
+      <p style={{ margin: 0 }}>
+        Issue drafting with CEO will be available soon.
+      </p>
+      <Link
+        to="/issues"
+        style={{ color: "var(--text-secondary)", marginTop: 8 }}
+      >
+        Back to Issues
+      </Link>
+    </div>
+  );
+}
+
+/**
  * InboxRedirect navigates the user from the deprecated /apps/requests
  * and /reviews surfaces to the unified Inbox. Phase 2 collapsed both
  * surfaces into one Decision Inbox; Phase 2b deletes the heavy
@@ -508,6 +558,12 @@ function MainContent() {
       return <DecisionInbox />;
     case "task-decision":
       return <DecisionPacketRoute taskId={route.taskId} />;
+    case "issues-list":
+      return <IssuesList />;
+    case "issue-detail":
+      return <IssueDocumentRoute issueId={route.issueId} />;
+    case "issue-new":
+      return <IssueNewStub />;
     case "unknown":
       // RoutedBody catches root-only matches via isUnmatchedRoute, but
       // useCurrentRoute can also return `unknown` for matched leaves that
@@ -619,6 +675,36 @@ export default function RootRoute() {
   const [inCeoOnboarding, setInCeoOnboarding] = useState(false);
   // onboarding phase from /onboarding/state — set once on boot if available.
   const [bootPhase, setBootPhase] = useState<string | undefined>(undefined);
+
+  // Phase 2 RootRoute redirect gap fix:
+  // When CEO onboarding is active (phase set, not "complete", onboardingV2 on),
+  // redirect any root or /channels/general URL to the CEO DM so the Shell
+  // always shows the CEO conversation regardless of the URL the user landed on.
+  // This is a TanStack-level navigate (not a beforeLoad, because onboarding
+  // state is only known after the /onboarding/state API call in the effect
+  // below). Already-onboarded users (onboardingComplete === true) skip the
+  // whole inCeoOnboarding branch and never hit this redirect.
+  useEffect(() => {
+    if (!(inCeoOnboarding || bootPhase)) return;
+    if (!onboardingV2) return;
+    // Only redirect when the user is on a generic destination (root, general).
+    // Other explicit URLs (e.g. /dm/some-agent) should not be redirected so
+    // deep-links remain functional during onboarding.
+    const hash = typeof window !== "undefined" ? window.location.hash : "";
+    const onGenericRoute =
+      hash === "" ||
+      hash === "#/" ||
+      hash === "#/channels/general" ||
+      hash.startsWith("#/?");
+    if (onGenericRoute) {
+      void router.navigate({
+        to: "/dm/$agentSlug",
+        params: { agentSlug: "ceo:onboarding" },
+        replace: true,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inCeoOnboarding, bootPhase, onboardingV2]);
 
   useKeyboardShortcuts();
   useBrokerEvents(apiReady);

--- a/web/src/routes/routeRegistry.ts
+++ b/web/src/routes/routeRegistry.ts
@@ -57,9 +57,26 @@ export const ROUTE_PATHS = {
   reviews: "/reviews",
   inbox: "/inbox",
   taskDecision: "/task/$taskId",
+  /** Phase 3 — Issue list surface (all tasks rendered as Issues). */
+  issues: "/issues",
+  /** Phase 3 — Issue detail surface (renders IssueDocument). */
+  issueDetail: "/issues/$issueId",
+  /**
+   * Phase 4 stub — new issue creation. Returns 501 in Phase 3.
+   * Wired so `+ New issue` can navigate here without a 404.
+   */
+  issueNew: "/issues/new",
 } as const;
 
 export type RouteKey = keyof typeof ROUTE_PATHS;
+
+/** Phase 3 — surface IDs for the Issues section (list + detail + new). */
+export const ISSUES_SURFACE_IDS = [
+  "issues",
+  "issueDetail",
+  "issueNew",
+] as const;
+export type IssuesSurfaceId = (typeof ISSUES_SURFACE_IDS)[number];
 
 /**
  * Route → URL params it carries. Used to document the URL contract for
@@ -151,6 +168,15 @@ export const ROUTE_CONTRACTS: readonly RouteContract[] = [
     params: ["taskId"],
     search: [],
   },
+  // Phase 3 — Issues surface
+  { key: "issues", path: ROUTE_PATHS.issues, params: [], search: [] },
+  {
+    key: "issueDetail",
+    path: ROUTE_PATHS.issueDetail,
+    params: ["issueId"],
+    search: [],
+  },
+  { key: "issueNew", path: ROUTE_PATHS.issueNew, params: [], search: [] },
 ] as const;
 
 export const SIDEBAR_APP_IDS = SIDEBAR_APPS.map((app) => app.id);

--- a/web/src/routes/useCurrentRoute.ts
+++ b/web/src/routes/useCurrentRoute.ts
@@ -6,6 +6,9 @@ import {
   channelRoute,
   dmRoute,
   inboxRoute,
+  issueDetailRoute,
+  issueNewRoute,
+  issuesRoute,
   notebookAgentRoute,
   notebookEntryRoute,
   notebooksRoute,
@@ -44,6 +47,10 @@ export type CurrentRoute =
   | { kind: "reviews" }
   | { kind: "inbox" }
   | { kind: "task-decision"; taskId: string }
+  // Phase 3 — Issues surface
+  | { kind: "issues-list" }
+  | { kind: "issue-detail"; issueId: string }
+  | { kind: "issue-new" }
   | { kind: "unknown" };
 
 interface ParamsShape {
@@ -53,6 +60,7 @@ interface ParamsShape {
   entrySlug?: string;
   taskId?: string;
   _splat?: string;
+  issueId?: string;
 }
 
 interface SearchShape {
@@ -75,7 +83,10 @@ type CurrentRouteId =
   | typeof notebookEntryRoute.id
   | typeof reviewsRoute.id
   | typeof inboxRoute.id
-  | typeof taskDecisionRoute.id;
+  | typeof taskDecisionRoute.id
+  | typeof issuesRoute.id
+  | typeof issueDetailRoute.id
+  | typeof issueNewRoute.id;
 
 const CURRENT_ROUTE_IDS = [
   channelRoute.id,
@@ -93,6 +104,9 @@ const CURRENT_ROUTE_IDS = [
   reviewsRoute.id,
   inboxRoute.id,
   taskDecisionRoute.id,
+  issuesRoute.id,
+  issueDetailRoute.id,
+  issueNewRoute.id,
 ] as const satisfies readonly CurrentRouteId[];
 
 const CURRENT_ROUTE_ID_SET = new Set<string>(CURRENT_ROUTE_IDS);
@@ -153,6 +167,13 @@ const ROUTE_DERIVERS = {
     kind: "task-decision",
     taskId: params.taskId ?? "",
   }),
+  // Phase 3 — Issues surface
+  [issuesRoute.id]: () => ({ kind: "issues-list" }),
+  [issueDetailRoute.id]: (params) => ({
+    kind: "issue-detail",
+    issueId: params.issueId ?? "",
+  }),
+  [issueNewRoute.id]: () => ({ kind: "issue-new" }),
 } satisfies Record<CurrentRouteId, RouteDeriver>;
 
 /**
@@ -241,6 +262,10 @@ export function useCurrentApp(): string | null {
       return "inbox";
     case "task-decision":
       return "inbox";
+    case "issues-list":
+    case "issue-detail":
+    case "issue-new":
+      return "issues";
     case "channel":
     case "dm":
     case "unknown":

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -64,6 +64,8 @@ if (typeof document !== "undefined") {
 interface SidebarSectionsState {
   agents: boolean;
   channels: boolean;
+  // Phase 3 — Issues group added between Channels and Tools.
+  issues: boolean;
   apps: boolean;
 }
 
@@ -74,6 +76,7 @@ const _storedSidebarSections = ((): SidebarSectionsState => {
   const def: SidebarSectionsState = {
     agents: true,
     channels: true,
+    issues: true,
     apps: true,
   };
   try {
@@ -83,6 +86,7 @@ const _storedSidebarSections = ((): SidebarSectionsState => {
     return {
       agents: parsed.agents ?? def.agents,
       channels: parsed.channels ?? def.channels,
+      issues: parsed.issues ?? def.issues,
       apps: parsed.apps ?? def.apps,
     };
   } catch {
@@ -133,6 +137,9 @@ export interface AppStore {
   toggleSidebarAgents: () => void;
   sidebarChannelsOpen: boolean;
   toggleSidebarChannels: () => void;
+  /** Phase 3 — Issues group open/closed state. */
+  sidebarIssuesOpen: boolean;
+  toggleSidebarIssues: () => void;
   sidebarAppsOpen: boolean;
   toggleSidebarApps: () => void;
   sidebarCollapsed: boolean;
@@ -258,6 +265,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     persistSidebarSections({
       agents: next,
       channels: get().sidebarChannelsOpen,
+      issues: get().sidebarIssuesOpen,
       apps: get().sidebarAppsOpen,
     });
   },
@@ -268,6 +276,18 @@ export const useAppStore = create<AppStore>((set, get) => ({
     persistSidebarSections({
       agents: get().sidebarAgentsOpen,
       channels: next,
+      issues: get().sidebarIssuesOpen,
+      apps: get().sidebarAppsOpen,
+    });
+  },
+  sidebarIssuesOpen: _storedSidebarSections.issues,
+  toggleSidebarIssues: () => {
+    const next = !get().sidebarIssuesOpen;
+    set({ sidebarIssuesOpen: next });
+    persistSidebarSections({
+      agents: get().sidebarAgentsOpen,
+      channels: get().sidebarChannelsOpen,
+      issues: next,
       apps: get().sidebarAppsOpen,
     });
   },
@@ -278,6 +298,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     persistSidebarSections({
       agents: get().sidebarAgentsOpen,
       channels: get().sidebarChannelsOpen,
+      issues: get().sidebarIssuesOpen,
       apps: next,
     });
   },


### PR DESCRIPTION
## Summary

Phase 3 of the onboarding-into-office redesign. Adds the read-only Issue document surface — tasks now have a richer presentation as Issues (lifecycle-task-backed spec documents). Stacks on PR #892 (Phase 2).

**Phase 3 is read-only.** Approve & Start, draft writer, and execution lineup all come in Phase 4.

## What's in

### Lifecycle state (Go + TS)
- `LifecycleStateDrafting` added to `broker_lifecycle_transition.go`. Derived fields: `{pipelineStage:"draft", reviewState:"pending_review", status:"open", blocked:false}`. All iteration lists, forward map, migration reverse-map, and `TestLifecycleForwardMapAllStates` updated.
- TypeScript mirror: `"drafting"` added to `LifecycleState` union, `STATE_PILL_TOKENS.drafting` uses brand-accent tokens (`bg: var(--accent-bg)`, `text: var(--accent)`). Distinct from intake/ready — signals "needs human attention" via brand accent.

### Issue document surface (new)
- `IssueDocument.tsx` — sticky header (status pill + title), four spec sections (Goal/Context/Approach/Acceptance) with markdown rendering and em-dash placeholders, auto-collapse on approved/running/review/decision states with `Expand spec` affordance, sessionStorage-backed collapse persistence, comments timeline with `aria-live="polite"`, scroll-to-comment via URL param, `data-testid="issue-action-row"` slot reserved for Phase 4's Approve & Start button.
- `IssuesList.tsx` — back-compat read of existing tasks rendered as Issues via `getOfficeTasks`.
- `IssuesGroup.tsx` — collapsible sidebar group, `+ New issue` affordance routes to `/issues/new` (501 stub until Phase 4).
- TanStack routes: `/issues`, `/issues/new`, `/issues/$issueId`. Static `new` ordered before dynamic `$issueId` so the splat doesn't capture it. All four exhaustiveness-check sites updated (`AgentPanel`, `ChannelHeader`, `StatusBar`, `useObjectBreadcrumb`).

### Cross-phase fix: Phase 2 RootRoute route gap (CLOSED)
The Phase 2 screenshot caveat — that the main pane resolved to `#general` instead of the CEO DM — is now closed. Phase 2 used a `localStorage` workaround that was never actually seeded. Replaced with a proper `useEffect` redirect: when `state.Phase` is set AND not `"complete"` AND `onboardingV2` flag is on, navigate to the CEO DM. Already-onboarded users (Phase=="complete") skip the redirect entirely.

## Tests
- 15 new `IssueDocument` tests (RTL + Vitest): renders all four sections, status pill matches state, comment timeline interleaves humans + agents, collapse-on-approved + expand-restore work across re-mount, scroll-to-comment via URL.
- Lifecycle types tests: `STATE_PILL_TOKENS.drafting` brand-accent assertion, `LifecycleState` union accepts `"drafting"`.
- Route tests: `/issues` list, `/issues/$issueId` detail, exhaustiveness preserved.
- **Full suite: 174 files / 1601 tests pass (+15 from Phase 2's 1586).**
- Go: `internal/team` + `internal/onboarding` green with `-race`. `TestLifecycleForwardMapAllStates` extended to cover Drafting.
- `bunx tsc --noEmit` clean. `bunx biome check` clean. `go vet ./...` clean.

## What's deferred to later phases
- **Approve & Start button** (Phase 4) — slot reserved at `[data-testid="issue-action-row"]`.
- **CEO draft writer + LLM** (Phase 4) — Phase 3 displays existing data only.
- **Sub-issues + wiki mirror on approval** (Phase 6 per spec).



## Screenshots

![01-issues-empty-state](https://github.com/nex-crm/wuphf/raw/screenshots/pr-893/01-issues-empty-state.png)

![02-issues-list-with-open-issue](https://github.com/nex-crm/wuphf/raw/screenshots/pr-893/02-issues-list-with-open-issue.png)

![03-issue-document-drafting](https://github.com/nex-crm/wuphf/raw/screenshots/pr-893/03-issue-document-drafting.png)

![04-issue-document-running-collapsed](https://github.com/nex-crm/wuphf/raw/screenshots/pr-893/04-issue-document-running-collapsed.png)

![05-issue-document-approved-collapsed](https://github.com/nex-crm/wuphf/raw/screenshots/pr-893/05-issue-document-approved-collapsed.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Drafting" lifecycle state for tasks
  * Introduced Phase 3 Issues surface with task list, detail view, and sidebar integration
  * Added E2E screenshot tests for onboarding flows

* **Tests**
  * Added comprehensive test suite for issue document viewing with state persistence

* **Style**
  * Code formatting improvements throughout components and imports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->