### PR TITLE
fix(nex): degrade gracefully when only the @nex-ai/nex shim is installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -852,6 +852,7 @@ jobs:
             tests/route-matrix.spec.ts \
             tests/route-regressions.spec.ts \
             tests/sidebar-scroll.spec.ts \
+            tests/nex-connect.spec.ts \
             tests/chat.spec.ts \
             tests/slash-commands.spec.ts \
             tests/dm.spec.ts \

--- a/internal/nex/cli.go
+++ b/internal/nex/cli.go
@@ -89,12 +89,24 @@ func quoteArg(s string) string {
 	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
 }
 
+// shimNotInstalledMarker is the phrase the @nex-ai/nex npm shim prints to
+// stderr when it runs but cannot locate the real nex-cli binary. BinaryPath()
+// accepts the `nex` alias, which may resolve to that shim; a shim with no
+// binary behind it is functionally "not installed", so Run() translates this
+// signature back to ErrNotInstalled instead of surfacing the shim's raw
+// install blurb to callers (and, ultimately, to the onboarding UI).
+const shimNotInstalledMarker = "nex-cli binary not found"
+
 // Run executes `nex-cli --cmd "<args...>"` with the given context/timeout and
 // returns stdout (trimmed) on success. nex-cli refuses to start without a TTY
 // unless --cmd/--script is used, so every shell-out goes through --cmd with
 // the args joined (and quoted where necessary) into a single command string.
 // A non-zero exit code, missing binary, or context timeout are all returned
 // as errors. The caller is responsible for logging and falling back.
+//
+// A shell-out that fails because the resolved binary is really the npm shim
+// without its backing binary is reported as ErrNotInstalled, so callers can
+// errors.Is-check a single "not installed" condition.
 func Run(ctx context.Context, args ...string) (string, error) {
 	if Disabled() {
 		return "", ErrDisabled
@@ -126,6 +138,12 @@ func Run(ctx context.Context, args ...string) (string, error) {
 			return "", fmt.Errorf("nex-cli %s: timeout after %s", cmdStr, DefaultTimeout)
 		}
 		trimmed := strings.TrimSpace(stderr.String())
+		// The npm shim ran but found no real binary behind it — treat as
+		// not-installed so callers hit the same fallback path as a bare
+		// missing binary, not a hard error with a raw install blurb.
+		if strings.Contains(trimmed, shimNotInstalledMarker) {
+			return "", ErrNotInstalled
+		}
 		if trimmed != "" {
 			return "", fmt.Errorf("nex-cli %s: %s", cmdStr, trimmed)
 		}

--- a/internal/nex/cli_test.go
+++ b/internal/nex/cli_test.go
@@ -105,6 +105,21 @@ func TestRun_MissingBinary(t *testing.T) {
 	}
 }
 
+// TestRun_ShimWithoutBinary covers the case the WUPHF onboarding flow hit in
+// the wild: the `nex` alias on PATH is the @nex-ai/nex npm shim, which runs
+// but can't find the real binary, prints "nex-cli binary not found", and
+// exits non-zero. Run() must report that as ErrNotInstalled, not a raw error.
+func TestRun_ShimWithoutBinary(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex",
+		"echo 'nex-cli binary not found. Install it with: curl ...' >&2; exit 1")
+	t.Setenv("WUPHF_NO_NEX", "")
+	_, err := Run(context.Background(), "setup", "user@example.com")
+	if !errors.Is(err, ErrNotInstalled) {
+		t.Fatalf("Run: expected ErrNotInstalled for a shim without its binary, got %v", err)
+	}
+}
+
 func TestRun_Disabled(t *testing.T) {
 	dir := withIsolatedPATH(t)
 	writeFakeNexCLI(t, dir, "nex-cli", "echo ok")

--- a/internal/team/broker_nex_register_test.go
+++ b/internal/team/broker_nex_register_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -160,6 +161,65 @@ func TestNexRegisterEndpoint_CLIMissing(t *testing.T) {
 	}
 	if got, _ := out["error"].(string); got == "" {
 		t.Fatalf("expected non-empty error message when nex-cli missing")
+	}
+}
+
+// TestNexRegisterEndpoint_ShimWithoutBinary covers the reported bug: the
+// @nex-ai/nex npm shim is on PATH as `nex`, but the real nex-cli binary is
+// not — so the shim runs, prints "nex-cli binary not found", and exits 1.
+// The handler must surface this as the SAME 502 "not installed" response as
+// a bare missing binary, so the web panel flips to the external-link
+// fallback instead of rendering the shim's raw install blurb.
+func TestNexRegisterEndpoint_ShimWithoutBinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script requires a POSIX shell")
+	}
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	t.Setenv("WUPHF_NO_NEX", "")
+	// Mimic the npm shim's behaviour when its backing binary is absent.
+	writeFakeNexCLIForBroker(t, dir, "nex",
+		`echo 'nex-cli binary not found. Install it with: curl ...' >&2; exit 1`)
+
+	b := newTestBroker(t)
+	b.token = "test-token"
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer func() {
+		if b.server != nil {
+			_ = b.server.Shutdown(context.Background())
+		}
+	}()
+
+	body := bytes.NewBufferString(`{"email":"hi@mustafa.li"}`)
+	req, _ := http.NewRequest(http.MethodPost, "http://"+b.addr+"/nex/register", body)
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /nex/register: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502 for a shim without its binary, got %d body=%s", resp.StatusCode, string(raw))
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, string(raw))
+	}
+	if got, _ := out["status"].(string); got != "error" {
+		t.Fatalf("expected status=error, got %q", got)
+	}
+	// The body must carry the not-installed signal the web panel matches on
+	// — and must NOT leak the shim's raw "binary not found" install blurb.
+	errMsg, _ := out["error"].(string)
+	if !strings.Contains(errMsg, "not installed") {
+		t.Fatalf("expected error to read as not-installed, got %q", errMsg)
+	}
+	if strings.Contains(errMsg, "binary not found") || strings.Contains(errMsg, "curl") {
+		t.Fatalf("shim install blurb leaked into the response: %q", errMsg)
 	}
 }
 

--- a/web/e2e/run-local.sh
+++ b/web/e2e/run-local.sh
@@ -161,7 +161,7 @@ EOF
   # Shell-phase specs: post-onboarding UI surfaces (smoke, settings,
   # /connect telegram wizard).
   echo "[run-local] running shell-phase specs"
-  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/smoke.spec.ts tests/app-routes.spec.ts tests/route-matrix.spec.ts tests/route-regressions.spec.ts tests/sidebar-scroll.spec.ts tests/local-llm-settings.spec.ts tests/telegram-connect.spec.ts)
+  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/smoke.spec.ts tests/app-routes.spec.ts tests/route-matrix.spec.ts tests/route-regressions.spec.ts tests/sidebar-scroll.spec.ts tests/local-llm-settings.spec.ts tests/nex-connect.spec.ts tests/telegram-connect.spec.ts)
   stop_wuphf
 }
 

--- a/web/e2e/tests/nex-connect.spec.ts
+++ b/web/e2e/tests/nex-connect.spec.ts
@@ -1,0 +1,99 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  waitForReactMount,
+} from "./_helpers";
+
+// Settings → Integrations → "Connect Nex" e2e (shell phase). Stubs
+// POST /nex/register with route.fulfill so the panel's behaviour is
+// asserted without a live nex-cli — the real CLI shell-out is covered
+// by internal/nex/cli_test.go and internal/team/broker_nex_register_test.go.
+//
+// Regression guard: a user with only the @nex-ai/nex npm shim on PATH
+// (no backing binary) used to see the broker's raw JSON error blob in
+// this panel. It must now degrade to the register-externally fallback.
+
+// stubNexRegister intercepts POST /nex/register and replies with `body`
+// at `status`, mimicking the broker's handleNexRegister response.
+function stubNexRegister(page: Page, status: number, body: unknown) {
+  return page.route("**/nex/register", (route: Route) =>
+    route.fulfill({
+      status,
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+// goToIntegrations lands on the shell and opens Settings → Integrations,
+// where NexConnectPanel renders.
+async function goToIntegrations(page: Page) {
+  await page.goto("/");
+  await waitForReactMount(page);
+  await page.getByLabel("Open settings").click();
+  await page.getByRole("button", { name: "Integrations" }).click();
+  await expect(page.getByTestId("nex-connect-panel")).toBeVisible();
+}
+
+async function submitEmail(page: Page, email: string) {
+  await page.getByLabel("Email address for Nex registration").fill(email);
+  await page.getByRole("button", { name: "Connect Nex" }).click();
+}
+
+test.describe("Settings → Integrations → Connect Nex", () => {
+  test("flips to the external-link fallback when nex-cli is not installed", async ({
+    page,
+  }) => {
+    const getErrors = collectReactErrors(page);
+    // What the broker returns once a shim-without-binary is mapped to
+    // ErrNotInstalled (see broker_nex_register_test.go).
+    await stubNexRegister(page, 502, {
+      status: "error",
+      error: "nex-cli not installed",
+    });
+    await goToIntegrations(page);
+    await submitEmail(page, "founder@example.com");
+
+    const fallback = page.getByRole("link", { name: /nex\.ai\/register/i });
+    await expect(fallback).toBeVisible();
+    await expect(fallback).toHaveAttribute("href", "https://nex.ai/register");
+    await expectNoReactErrors(page, getErrors, "after not-installed fallback");
+  });
+
+  test("does not leak the npm shim's raw error blob into the panel", async ({
+    page,
+  }) => {
+    // The exact failure shape from the field report: the @nex-ai/nex shim
+    // ran, found no binary, and the broker forwarded its stderr verbatim.
+    await stubNexRegister(page, 502, {
+      status: "error",
+      error:
+        "nex-cli setup hi@mustafa.li: nex-cli binary not found. Install it with: curl -fsSL https://...install.sh | sh",
+    });
+    await goToIntegrations(page);
+    await submitEmail(page, "hi@mustafa.li");
+
+    // Fallback shown; none of the raw blob / JSON leaks to the user.
+    await expect(
+      page.getByRole("link", { name: /nex\.ai\/register/i }),
+    ).toBeVisible();
+    const panel = page.getByTestId("nex-connect-panel");
+    await expect(panel).not.toContainText('"status":"error"');
+    await expect(panel).not.toContainText("curl -fsSL");
+  });
+
+  test("confirms success when registration succeeds", async ({ page }) => {
+    await stubNexRegister(page, 200, {
+      status: "ok",
+      email: "founder@example.com",
+    });
+    await goToIntegrations(page);
+    await submitEmail(page, "founder@example.com");
+
+    await expect(page.getByTestId("nex-connect-panel")).toContainText(
+      /check your inbox at founder@example.com/i,
+    );
+  });
+});

--- a/web/e2e/tests/nex-connect.spec.ts
+++ b/web/e2e/tests/nex-connect.spec.ts
@@ -13,7 +13,8 @@ import {
 //
 // Regression guard: a user with only the @nex-ai/nex npm shim on PATH
 // (no backing binary) used to see the broker's raw JSON error blob in
-// this panel. It must now degrade to the register-externally fallback.
+// this panel. It must now degrade to the install-instructions fallback —
+// a copy-paste install command plus a register-at-nex.ai escape hatch.
 
 // stubNexRegister intercepts POST /nex/register and replies with `body`
 // at `status`, mimicking the broker's handleNexRegister response.
@@ -43,7 +44,7 @@ async function submitEmail(page: Page, email: string) {
 }
 
 test.describe("Settings → Integrations → Connect Nex", () => {
-  test("flips to the external-link fallback when nex-cli is not installed", async ({
+  test("offers the install command and retry when nex-cli is not installed", async ({
     page,
   }) => {
     const getErrors = collectReactErrors(page);
@@ -56,9 +57,17 @@ test.describe("Settings → Integrations → Connect Nex", () => {
     await goToIntegrations(page);
     await submitEmail(page, "founder@example.com");
 
+    const panel = page.getByTestId("nex-connect-panel");
+    // Copy-paste install command surfaced (wuphf never runs it for you).
+    await expect(panel).toContainText("install.sh | sh");
+    // No-terminal escape hatch still offered.
     const fallback = page.getByRole("link", { name: /nex\.ai\/register/i });
-    await expect(fallback).toBeVisible();
     await expect(fallback).toHaveAttribute("href", "https://nex.ai/register");
+    // Retry path returns to the email form without a reload.
+    await page.getByRole("button", { name: /try again/i }).click();
+    await expect(
+      page.getByLabel("Email address for Nex registration"),
+    ).toBeVisible();
     await expectNoReactErrors(page, getErrors, "after not-installed fallback");
   });
 
@@ -75,13 +84,12 @@ test.describe("Settings → Integrations → Connect Nex", () => {
     await goToIntegrations(page);
     await submitEmail(page, "hi@mustafa.li");
 
-    // Fallback shown; none of the raw blob / JSON leaks to the user.
-    await expect(
-      page.getByRole("link", { name: /nex\.ai\/register/i }),
-    ).toBeVisible();
+    // Install instructions shown; the raw JSON / stderr blob does not leak.
     const panel = page.getByTestId("nex-connect-panel");
+    await expect(panel).toContainText("install.sh | sh");
     await expect(panel).not.toContainText('"status":"error"');
-    await expect(panel).not.toContainText("curl -fsSL");
+    await expect(panel).not.toContainText("hi@mustafa.li");
+    await expect(panel).not.toContainText("binary not found");
   });
 
   test("confirms success when registration succeeds", async ({ page }) => {

--- a/web/src/components/apps/NexConnectPanel.test.tsx
+++ b/web/src/components/apps/NexConnectPanel.test.tsx
@@ -49,8 +49,8 @@ describe("<NexConnectPanel>", () => {
   // The reported bug: the @nex-ai/nex npm shim is on PATH but the real
   // binary is not, so `nex-cli setup` exits with "nex-cli binary not found".
   // The broker forwards that as a 502 JSON body. The panel must degrade to
-  // the register-externally fallback — never render the raw JSON.
-  it("flips to the fallback when only the npm shim is installed", async () => {
+  // the install-instructions fallback — never render the raw JSON.
+  it("offers the install command when only the npm shim is installed", async () => {
     postMock.mockRejectedValue(
       new Error(
         JSON.stringify({
@@ -62,15 +62,19 @@ describe("<NexConnectPanel>", () => {
     );
     await submitEmail("hi@mustafa.li");
 
+    // The copy-paste install command is surfaced...
+    expect(await screen.findByText(/install\.sh \| sh$/)).toBeInTheDocument();
+    // ...alongside the no-terminal escape hatch.
     expect(
-      await screen.findByRole("link", { name: /nex\.ai\/register/i }),
+      screen.getByRole("link", { name: /nex\.ai\/register/i }),
     ).toBeInTheDocument();
     // The raw JSON / stderr blob must not leak into the UI.
     expect(screen.queryByText(/"status":"error"/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/hi@mustafa\.li/)).not.toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("flips to the fallback when nex-cli is not installed at all", async () => {
+  it("offers the install command when nex-cli is not installed at all", async () => {
     postMock.mockRejectedValue(
       new Error(
         JSON.stringify({ status: "error", error: "nex-cli not installed" }),
@@ -78,9 +82,25 @@ describe("<NexConnectPanel>", () => {
     );
     await submitEmail("founder@example.com");
 
+    expect(await screen.findByText(/install\.sh \| sh$/)).toBeInTheDocument();
+  });
+
+  it("returns to the email form when the user retries after installing", async () => {
+    postMock.mockRejectedValue(
+      new Error(
+        JSON.stringify({ status: "error", error: "nex-cli not installed" }),
+      ),
+    );
+    await submitEmail("founder@example.com");
+    await screen.findByText(/install\.sh \| sh$/);
+
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+
+    // Back to the email input — the user can re-attempt without a reload.
     expect(
-      await screen.findByRole("link", { name: /nex\.ai\/register/i }),
+      screen.getByLabelText("Email address for Nex registration"),
     ).toBeInTheDocument();
+    expect(screen.queryByText(/install\.sh \| sh$/)).not.toBeInTheDocument();
   });
 
   it("shows the parsed message (not raw JSON) for a genuine failure", async () => {

--- a/web/src/components/apps/NexConnectPanel.test.tsx
+++ b/web/src/components/apps/NexConnectPanel.test.tsx
@@ -1,0 +1,101 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const postMock = vi.fn();
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return { ...actual, post: (...args: unknown[]) => postMock(...args) };
+});
+
+const showNoticeMock = vi.fn();
+vi.mock("../ui/Toast", () => ({
+  showNotice: (...args: unknown[]) => showNoticeMock(...args),
+}));
+
+import { NexConnectPanel } from "./NexConnectPanel";
+
+// Drives the panel through one registration attempt with the given email.
+async function submitEmail(email: string) {
+  render(<NexConnectPanel />);
+  fireEvent.change(
+    screen.getByLabelText("Email address for Nex registration"),
+    { target: { value: email } },
+  );
+  fireEvent.click(screen.getByRole("button", { name: "Connect Nex" }));
+}
+
+describe("<NexConnectPanel>", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    showNoticeMock.mockReset();
+  });
+
+  it("confirms success and tells the user to check their inbox", async () => {
+    postMock.mockResolvedValue({ status: "ok" });
+    await submitEmail("founder@example.com");
+
+    expect(
+      await screen.findByText(/check your inbox at founder@example.com/i),
+    ).toBeInTheDocument();
+    expect(showNoticeMock).toHaveBeenCalledWith(
+      expect.stringContaining("Nex API key"),
+      "success",
+    );
+  });
+
+  // The reported bug: the @nex-ai/nex npm shim is on PATH but the real
+  // binary is not, so `nex-cli setup` exits with "nex-cli binary not found".
+  // The broker forwards that as a 502 JSON body. The panel must degrade to
+  // the register-externally fallback — never render the raw JSON.
+  it("flips to the fallback when only the npm shim is installed", async () => {
+    postMock.mockRejectedValue(
+      new Error(
+        JSON.stringify({
+          status: "error",
+          error:
+            "nex-cli setup hi@mustafa.li: nex-cli binary not found. Install it with: curl ...",
+        }),
+      ),
+    );
+    await submitEmail("hi@mustafa.li");
+
+    expect(
+      await screen.findByRole("link", { name: /nex\.ai\/register/i }),
+    ).toBeInTheDocument();
+    // The raw JSON / stderr blob must not leak into the UI.
+    expect(screen.queryByText(/"status":"error"/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("flips to the fallback when nex-cli is not installed at all", async () => {
+    postMock.mockRejectedValue(
+      new Error(
+        JSON.stringify({ status: "error", error: "nex-cli not installed" }),
+      ),
+    );
+    await submitEmail("founder@example.com");
+
+    expect(
+      await screen.findByRole("link", { name: /nex\.ai\/register/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the parsed message (not raw JSON) for a genuine failure", async () => {
+    postMock.mockRejectedValue(
+      new Error(
+        JSON.stringify({
+          status: "error",
+          error: "setup failed: rate limited",
+        }),
+      ),
+    );
+    await submitEmail("founder@example.com");
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("setup failed: rate limited");
+    expect(alert).not.toHaveTextContent("{");
+  });
+});

--- a/web/src/components/apps/NexConnectPanel.tsx
+++ b/web/src/components/apps/NexConnectPanel.tsx
@@ -4,20 +4,29 @@
  * Moved here from the legacy onboarding wizard as part of Phase 5 cleanup.
  *
  * Wire endpoint: POST /nex/register { email } → { status, output? }
- * On 502 the broker returns the nex-cli failure; when that failure means
- * nex-cli isn't usable here (missing binary, or only the @nex-ai/nex npm
- * shim without its backing binary) we flip to the external-link fallback
- * (open nex.ai/register, paste key in API Keys section).
+ * When the broker reports nex-cli is unusable here (missing binary, or only
+ * the @nex-ai/nex npm shim without its backing binary), the panel flips to a
+ * fallback that surfaces the copy-paste install command — wuphf never runs
+ * the install for the user (same policy as the Local LLMs panel) — plus a
+ * register-at-nex.ai escape hatch for machines without terminal access.
  *
  * Nex is a context graph platform for AI agents, not a CRM.
  */
 
+import type { CSSProperties } from "react";
 import { useState } from "react";
 
 import { post } from "../../api/client";
+import { CommandRow } from "../ui/CommandRow";
 import { showNotice } from "../ui/Toast";
 
 type NexConnectStatus = "open" | "submitting" | "ok" | "fallback";
+
+// One-line installer for the nex-cli binary. Matches install.sh and the
+// nex-as-a-skill README; needs no Node and writes the binary directly, so
+// it works regardless of how the user got wuphf.
+const NEX_INSTALL_COMMAND =
+  "curl -fsSL https://raw.githubusercontent.com/nex-crm/nex-as-a-skill/main/install.sh | sh";
 
 /**
  * The broker reports /nex/register failures as a JSON body
@@ -41,7 +50,7 @@ function readNexError(raw: string): string {
  * True when the failure means nex-cli can't run on this machine: the binary
  * is missing, or only the @nex-ai/nex npm shim is present without the real
  * binary behind it (the shim prints "nex-cli binary not found"). Both should
- * flip the panel to the register-externally fallback rather than show an
+ * flip the panel to the install-instructions fallback rather than show an
  * error the user can't act on.
  */
 function isNexUnavailable(detail: string): boolean {
@@ -52,6 +61,13 @@ function isNexUnavailable(detail: string): boolean {
     m.includes("502")
   );
 }
+
+const descStyle: CSSProperties = {
+  fontSize: 12,
+  color: "var(--text-secondary)",
+  margin: "0 0 12px",
+  lineHeight: 1.5,
+};
 
 export function NexConnectPanel() {
   const [email, setEmail] = useState("");
@@ -71,8 +87,8 @@ export function NexConnectPanel() {
     } catch (err: unknown) {
       const raw = err instanceof Error ? err.message : "Registration failed";
       const detail = readNexError(raw);
-      // nex-cli unusable here → external-link fallback. Anything else is a
-      // real, actionable error: show the parsed message, not a JSON blob.
+      // nex-cli unusable here → install-instructions fallback. Anything else
+      // is a real, actionable error: show the parsed message, not a blob.
       if (isNexUnavailable(detail)) {
         setStatus("fallback");
       } else {
@@ -103,87 +119,104 @@ export function NexConnectPanel() {
       >
         Nex
       </div>
-      <p
-        style={{
-          fontSize: 12,
-          color: "var(--text-secondary)",
-          margin: "0 0 12px",
-          lineHeight: 1.5,
-        }}
-      >
-        {status === "fallback"
-          ? "nex-cli is not installed on this machine. Register at nex.ai/register, then paste your API key in the API Keys section above."
-          : status === "ok"
-            ? `Check your inbox at ${email} for the Nex API key. Paste it in the API Keys section above once it arrives.`
-            : "Register an email to get a free Nex API key. Powers shared memory, entity briefs, and integrations."}
-      </p>
 
       {status === "fallback" ? (
-        <a
-          className="btn btn-secondary btn-sm"
-          href="https://nex.ai/register"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Open nex.ai/register
-        </a>
-      ) : status === "ok" ? null : (
-        <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
-          <div style={{ flex: 1 }}>
-            <input
-              style={{
-                width: "100%",
-                padding: "6px 10px",
-                fontSize: 13,
-                border: "1px solid var(--border-light)",
-                borderRadius: 4,
-                background: "var(--bg)",
-                color: "var(--text)",
-                fontFamily: "inherit",
-                boxSizing: "border-box",
+        <>
+          <p style={descStyle}>
+            nex-cli isn't installed on this machine. Install it from a terminal,
+            then come back and connect:
+          </p>
+          <CommandRow command={NEX_INSTALL_COMMAND} />
+          <div style={{ marginTop: 10 }}>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => {
+                setError("");
+                setStatus("open");
               }}
-              id="nex-connect-email"
-              type="email"
-              placeholder="you@example.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              onKeyDown={(e) => {
-                if (
-                  e.key === "Enter" &&
-                  status !== "submitting" &&
-                  email.trim().length > 0
-                ) {
-                  e.preventDefault();
-                  void handleSubmit();
-                }
-              }}
-              disabled={status === "submitting"}
-              aria-label="Email address for Nex registration"
-            />
-            {error ? (
-              <p
-                style={{
-                  color: "var(--red)",
-                  fontSize: 12,
-                  marginTop: 4,
-                  marginBottom: 0,
-                }}
-                role="alert"
-              >
-                {error}
-              </p>
-            ) : null}
+            >
+              I've installed it — try again
+            </button>
           </div>
-          <button
-            type="button"
-            className="btn btn-primary btn-sm"
-            onClick={() => void handleSubmit()}
-            disabled={status === "submitting" || !email.trim()}
-            style={{ flexShrink: 0 }}
-          >
-            {status === "submitting" ? "Sending…" : "Connect Nex"}
-          </button>
-        </div>
+          <p style={{ ...descStyle, margin: "10px 0 0" }}>
+            No terminal access? You can also{" "}
+            <a
+              href="https://nex.ai/register"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              register at nex.ai/register
+            </a>{" "}
+            and paste your API key in the API Keys section above.
+          </p>
+        </>
+      ) : (
+        <>
+          <p style={descStyle}>
+            {status === "ok"
+              ? `Check your inbox at ${email} for the Nex API key. Paste it in the API Keys section above once it arrives.`
+              : "Register an email to get a free Nex API key. Powers shared memory, entity briefs, and integrations."}
+          </p>
+          {status === "ok" ? null : (
+            <div style={{ display: "flex", gap: 8, alignItems: "flex-start" }}>
+              <div style={{ flex: 1 }}>
+                <input
+                  style={{
+                    width: "100%",
+                    padding: "6px 10px",
+                    fontSize: 13,
+                    border: "1px solid var(--border-light)",
+                    borderRadius: 4,
+                    background: "var(--bg)",
+                    color: "var(--text)",
+                    fontFamily: "inherit",
+                    boxSizing: "border-box",
+                  }}
+                  id="nex-connect-email"
+                  type="email"
+                  placeholder="you@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (
+                      e.key === "Enter" &&
+                      status !== "submitting" &&
+                      email.trim().length > 0
+                    ) {
+                      e.preventDefault();
+                      void handleSubmit();
+                    }
+                  }}
+                  disabled={status === "submitting"}
+                  aria-label="Email address for Nex registration"
+                />
+                {error ? (
+                  <p
+                    style={{
+                      color: "var(--red)",
+                      fontSize: 12,
+                      marginTop: 4,
+                      marginBottom: 0,
+                    }}
+                    role="alert"
+                  >
+                    {error}
+                  </p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={() => void handleSubmit()}
+                disabled={status === "submitting" || !email.trim()}
+                style={{ flexShrink: 0 }}
+              >
+                {status === "submitting" ? "Sending…" : "Connect Nex"}
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/web/src/components/apps/NexConnectPanel.tsx
+++ b/web/src/components/apps/NexConnectPanel.tsx
@@ -4,8 +4,10 @@
  * Moved here from the legacy onboarding wizard as part of Phase 5 cleanup.
  *
  * Wire endpoint: POST /nex/register { email } → { status, output? }
- * On 502 the broker returns ErrNotInstalled; we flip to the external-link
- * fallback (open nex.ai/register, paste key in API Keys section).
+ * On 502 the broker returns the nex-cli failure; when that failure means
+ * nex-cli isn't usable here (missing binary, or only the @nex-ai/nex npm
+ * shim without its backing binary) we flip to the external-link fallback
+ * (open nex.ai/register, paste key in API Keys section).
  *
  * Nex is a context graph platform for AI agents, not a CRM.
  */
@@ -16,6 +18,40 @@ import { post } from "../../api/client";
 import { showNotice } from "../ui/Toast";
 
 type NexConnectStatus = "open" | "submitting" | "ok" | "fallback";
+
+/**
+ * The broker reports /nex/register failures as a JSON body
+ * {"status":"error","error":"..."}, which api/client throws verbatim as the
+ * Error message. Pull out the human-readable `error` field so the panel
+ * never renders a raw JSON blob at the user.
+ */
+function readNexError(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { error?: unknown };
+    if (typeof parsed.error === "string" && parsed.error.trim()) {
+      return parsed.error.trim();
+    }
+  } catch {
+    // Not JSON (e.g. a bare "502 Bad Gateway") — fall through to raw text.
+  }
+  return raw;
+}
+
+/**
+ * True when the failure means nex-cli can't run on this machine: the binary
+ * is missing, or only the @nex-ai/nex npm shim is present without the real
+ * binary behind it (the shim prints "nex-cli binary not found"). Both should
+ * flip the panel to the register-externally fallback rather than show an
+ * error the user can't act on.
+ */
+function isNexUnavailable(detail: string): boolean {
+  const m = detail.toLowerCase();
+  return (
+    m.includes("not installed") ||
+    m.includes("binary not found") ||
+    m.includes("502")
+  );
+}
 
 export function NexConnectPanel() {
   const [email, setEmail] = useState("");
@@ -33,12 +69,14 @@ export function NexConnectPanel() {
       setStatus("ok");
       showNotice("Check your inbox for the Nex API key.", "success");
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : "Registration failed";
-      // 502 means nex-cli not installed — flip to external link fallback.
-      if (msg.includes("502") || msg.toLowerCase().includes("not installed")) {
+      const raw = err instanceof Error ? err.message : "Registration failed";
+      const detail = readNexError(raw);
+      // nex-cli unusable here → external-link fallback. Anything else is a
+      // real, actionable error: show the parsed message, not a JSON blob.
+      if (isNexUnavailable(detail)) {
         setStatus("fallback");
       } else {
-        setError(msg);
+        setError(detail);
         setStatus("open");
       }
     }

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../api/client";
 import { router } from "../../lib/router";
 import { useAppStore } from "../../stores/app";
+import { CommandRow } from "../ui/CommandRow";
 import {
   ShredCardSubtitle,
   ShredDeletionsList,
@@ -284,53 +285,6 @@ function StatusDot({ status }: { status: LocalProviderStatus | undefined }) {
         flexShrink: 0,
       }}
     />
-  );
-}
-
-function CommandRow({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false);
-  const onCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    } catch {
-      showNotice("Copy failed — select the text and copy manually.", "error");
-    }
-  };
-  return (
-    <div
-      style={{
-        display: "flex",
-        gap: 8,
-        alignItems: "center",
-        padding: "6px 8px",
-        background: "var(--bg-card-soft, var(--bg-card))",
-        border: "1px solid var(--border-light)",
-        borderRadius: 4,
-        marginTop: 6,
-      }}
-    >
-      <code
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: 12,
-          flex: 1,
-          overflowX: "auto",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {command}
-      </code>
-      <button
-        type="button"
-        className="btn btn-secondary btn-sm"
-        onClick={onCopy}
-        style={{ flexShrink: 0 }}
-      >
-        {copied ? "Copied" : "Copy"}
-      </button>
-    </div>
   );
 }
 

--- a/web/src/components/ui/CommandRow.tsx
+++ b/web/src/components/ui/CommandRow.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+
+import { showNotice } from "./Toast";
+
+/**
+ * CommandRow renders a shell command in a monospace box with a Copy button.
+ *
+ * It is copy-paste ONLY — wuphf deliberately never runs install/shell
+ * commands on the user's behalf from Settings panels (see the Local LLMs
+ * section copy: "install commands are copy-paste only"). Shared by the
+ * Local LLMs panel and the Nex integration panel so that contract — and
+ * the styling — stays in one place.
+ */
+export function CommandRow({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      showNotice("Copy failed — select the text and copy manually.", "error");
+    }
+  };
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        padding: "6px 8px",
+        background: "var(--bg-card-soft, var(--bg-card))",
+        border: "1px solid var(--border-light)",
+        borderRadius: 4,
+        marginTop: 6,
+      }}
+    >
+      <code
+        style={{
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          flex: 1,
+          overflowX: "auto",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {command}
+      </code>
+      <button
+        type="button"
+        className="btn btn-secondary btn-sm"
+        onClick={onCopy}
+        style={{ flexShrink: 0 }}
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

A user running `npx wuphf` hit this in the onboarding **"Power up with Nex"** step — a raw JSON error blob rendered straight at them:

```
{"error":"nex-cli setup hi@mustafa.li: nex-cli binary not found.\n\n Install it with:\n curl -fsSL https://...install.sh | sh\n\n Then run your command again.","status":"error"}
```

### Root cause chain

```mermaid
flowchart TD
  A["Onboarding → POST /nex/register {email}"] --> B["nex.Register → nex.Run(setup, email)"]
  B --> C["BinaryPath() accepts 'nex-cli' OR 'nex'"]
  C --> D["Finds 'nex' — the @nex-ai/nex npm SHIM, not the real binary"]
  D --> E["Runs 'nex --cmd setup ...'"]
  E --> F["Shim can't find real nex-cli → prints install blurb to stderr, exits 1"]
  F --> G["Run() wraps stderr → broker 502 {status:error, error:...}"]
  G --> H["UI fallback never triggers → raw JSON shown"]
```

The shim (`@nex-ai/nex`) ships only a delegator that needs a separately-installed binary. When a user has the shim but not the binary, WUPHF's `BinaryPath()` accepts the `nex` alias, considers Nex installed, runs `setup`, and the shim exits non-zero. The UI's fallback check only matched `"502"` / `"not installed"` — but the error message is the JSON body (no `"502"`) saying `"binary not found"` — so it fell through to the raw-error display.

> The packaging root cause is fixed separately in nex-crm/nex-as-a-skill#161 (npm postinstall now downloads the real binary). This PR makes WUPHF degrade gracefully regardless.

## Fix

**`internal/nex/cli.go`** — `Run()` detects the shim's `nex-cli binary not found` stderr signature on a failed shell-out and returns `ErrNotInstalled`. A shim-without-binary now takes the same path as a bare missing binary, instead of surfacing the shim's raw install blurb.

**`web/.../NexConnectPanel.tsx`** — parses the broker's JSON error body so the panel shows the human-readable message (never a raw blob), and broadens the fallback trigger (`not installed` / `binary not found` / `502`) so an unusable nex-cli reliably flips the card to the register-externally affordance.

## Verification

- `internal/nex` — new `TestRun_ShimWithoutBinary`; full package green. `go build ./...`, `go vet`, `golangci-lint` clean.
- `internal/team` — existing `broker_nex_register` tests still green (502 contract unchanged).
- `web` — new `NexConnectPanel.test.tsx` covers success, shim-only, not-installed, and genuine-error paths (4 pass). `tsc --noEmit` + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Nex integration setup with fallback UI displaying installation instructions when nex-cli is unavailable.

* **Bug Fixes**
  * Improved error handling for missing nex-cli binary, detecting npm shim-only cases and showing clear, user-friendly messages instead of technical errors.

* **Refactor**
  * Extracted reusable command display component with clipboard copy functionality.

* **Tests**
  * Added E2E and unit test coverage for Nex Connect scenarios and missing binary detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->