### PR TITLE
feat(onboarding): full-screen CEO chat wizard outside the office Shell

### DIFF
--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -117,6 +117,11 @@ export function InterviewBar() {
     }
   }, [textMode]);
 
+  // When there's no agent interview request, fall back to the CEO card
+  // section so the deterministic onboarding chip / form-field input still
+  // renders during Phase 2. CeoCardSection returns null on its own when
+  // there's no pendingSuggestion either, so this is safe in non-onboarding
+  // surfaces (the context default is `phase: undefined`).
   if (!current) return <CeoCardSection />;
 
   const rawOptions = current.options ?? current.choices ?? [];

--- a/web/src/components/onboarding/OnboardingChat.test.tsx
+++ b/web/src/components/onboarding/OnboardingChat.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * OnboardingChat tests
+ *
+ * The wizard renders outside the office Shell. Pins the structural
+ * contract:
+ *   - data-phase reflects the current onboarding phase
+ *   - phase labels read like a wizard ("Step N of 5 · …") not raw enum
+ *     names
+ *   - InterviewBar mounts inside the footer so chip / form-field cards
+ *     surface as the input zone
+ *   - When there's no pending suggestion, a hint banner appears in place
+ *     of the absent input so users don't think the wizard is stuck.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingChat } from "./OnboardingChat";
+
+vi.mock("../../hooks/useMessages", () => ({
+  useMessages: () => ({ data: [] }),
+}));
+
+vi.mock("../messages/MessageBubble", () => ({
+  MessageBubble: () => <div data-testid="message-bubble" />,
+}));
+
+vi.mock("../messages/TypingIndicator", () => ({
+  TypingIndicator: () => <div data-testid="typing-indicator" />,
+}));
+
+vi.mock("../messages/InterviewBar", () => ({
+  InterviewBar: () => <div data-testid="interview-bar" />,
+}));
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return { ...actual, get: vi.fn(), post: vi.fn() };
+});
+
+import { get } from "../../api/client";
+
+const getMock = vi.mocked(get);
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  getMock.mockReset();
+});
+
+afterEach(() => cleanup());
+
+describe("OnboardingChat", () => {
+  it("renders the wizard chrome and InterviewBar inside its footer", async () => {
+    getMock.mockResolvedValue({ phase: "greet", pending_suggestion: null });
+    render(<OnboardingChat />, { wrapper });
+
+    const root = await screen.findByTestId("onboarding-chat");
+    expect(root).toBeDefined();
+    // The wizard owns its own viewport — it is intentionally NOT inside
+    // .office so it can be styled position:fixed without the Shell layout
+    // boxing it in.
+    expect(root.closest(".office")).toBeNull();
+    expect(screen.getByTestId("interview-bar")).toBeDefined();
+  });
+
+  it("translates phase enum into a wizard-style step label", async () => {
+    getMock.mockResolvedValue({ phase: "blueprint", pending_suggestion: null });
+    render(<OnboardingChat />, { wrapper });
+    await waitFor(() => expect(screen.getByText(/Step 3 of 5/)).toBeDefined());
+  });
+
+  it("shows a hint when no pending suggestion is present", async () => {
+    getMock.mockResolvedValue({ phase: "greet", pending_suggestion: null });
+    render(<OnboardingChat />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText(/CEO is composing/)).toBeDefined();
+    });
+  });
+
+  it("hides the hint when a pending suggestion exists", async () => {
+    getMock.mockResolvedValue({
+      phase: "greet",
+      pending_suggestion: {
+        id: "greet-1",
+        kind: "ceo_form_field",
+        question: "Office name?",
+      },
+    });
+    render(<OnboardingChat />, { wrapper });
+    // Wait for phase to settle, then assert hint is absent.
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("onboarding-chat").getAttribute("data-phase"),
+      ).toBe("greet"),
+    );
+    expect(screen.queryByText(/CEO is composing/)).toBeNull();
+  });
+
+  it("renders without crash when state load is still pending", () => {
+    getMock.mockReturnValue(new Promise(() => {}));
+    render(<OnboardingChat />, { wrapper });
+    expect(screen.getByTestId("onboarding-chat")).toBeDefined();
+  });
+});

--- a/web/src/components/onboarding/OnboardingChat.tsx
+++ b/web/src/components/onboarding/OnboardingChat.tsx
@@ -1,0 +1,131 @@
+/**
+ * OnboardingChat — full-screen CEO wizard.
+ *
+ * The user is NOT yet "in the office": until the broker flips
+ * `onboarded=true`, RootRoute mounts this component instead of the office
+ * Shell. It masquerades as a chat with the CEO, but the only valid input
+ * zone is the chip / form-field card surfaced by InterviewBar (which falls
+ * back to CeoCardSection when no agent interview request is pending). No
+ * sidebar, no workspace rail, no workbench panes — those are the
+ * destination, not the wizard.
+ *
+ * Lifts from the onboarding spec (docs/specs/onboarding-into-office.md):
+ *   "Onboarding is a wizard mocked as a CEO chat. The user is not really in
+ *    the office yet until onboarding finishes."
+ *
+ * Component shape mirrors DMView's chat region but drops the workbench
+ * (`AgentWorkbenchPane`) and the free-form `Composer`. We keep the same
+ * `useMessages` / `MessageBubble` / `InterviewBar` plumbing so streaming
+ * updates and pending-suggestion cards behave identically.
+ */
+
+import { useEffect, useRef } from "react";
+
+import { useMessages } from "../../hooks/useMessages";
+import { directChannelSlug } from "../../stores/app";
+import { InterviewBar } from "../messages/InterviewBar";
+import { MessageBubble } from "../messages/MessageBubble";
+import { TypingIndicator } from "../messages/TypingIndicator";
+import { OnboardingDMContextProvider } from "./OnboardingDMRoute";
+import type { CeoSuggestion } from "./types";
+import { useOnboardingState } from "./useOnboardingState";
+
+/** Agent slug used in the broker for the onboarding CEO. */
+const CEO_AGENT_SLUG = "ceo";
+
+/** The broker canonicalises DM channels as pair-sorted slugs. */
+const CEO_ONBOARDING_CHANNEL = directChannelSlug(CEO_AGENT_SLUG);
+
+/**
+ * Phase → human-readable label for the wizard header. Order matches the
+ * deterministic state machine in broker_onboarding_phase2.go. The labels
+ * are intentionally short — they replace the dot-progress indicator the
+ * old wizard used so the user can see where they are without leaving the
+ * conversation.
+ */
+const PHASE_LABELS: Record<string, string> = {
+  greet: "Step 1 of 5 · Office name",
+  identity: "Step 2 of 5 · Who you are",
+  blueprint: "Step 3 of 5 · Pick a starting blueprint",
+  team: "Step 4 of 5 · Confirm the team",
+  bridge: "Step 5 of 5 · First task",
+  draft: "Drafting your first issue",
+  approve: "Review and approve",
+  kickoff: "Starting your office",
+  complete: "Done",
+};
+
+function phaseLabel(phase: string | undefined): string {
+  if (!phase) return "Loading…";
+  return PHASE_LABELS[phase] ?? `Phase: ${phase}`;
+}
+
+function parsePendingSuggestion(raw: unknown): CeoSuggestion | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.id !== "string" || typeof obj.kind !== "string") return null;
+  return raw as CeoSuggestion;
+}
+
+export function OnboardingChat() {
+  const { data: state } = useOnboardingState();
+  const { data: messages = [] } = useMessages(CEO_ONBOARDING_CHANNEL);
+  const streamRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll the message feed when new CEO messages arrive. We pin to the
+  // bottom because the wizard is strictly forward — old messages stay visible
+  // above as a transcript, but the action is always at the bottom.
+  const messagesLength = messages.length;
+  useEffect(() => {
+    if (streamRef.current) {
+      streamRef.current.scrollTop = streamRef.current.scrollHeight;
+    }
+  }, [messagesLength]);
+
+  const phase = state?.phase;
+  const pendingSuggestion = parsePendingSuggestion(state?.pending_suggestion);
+
+  return (
+    <OnboardingDMContextProvider value={{ phase, pendingSuggestion }}>
+      <div
+        className="onboarding-chat"
+        data-testid="onboarding-chat"
+        data-phase={phase ?? "loading"}
+      >
+        <header className="onboarding-chat-header">
+          <span className="onboarding-chat-brand">WUPHF</span>
+          <span className="onboarding-chat-phase">{phaseLabel(phase)}</span>
+        </header>
+
+        <main className="onboarding-chat-body" ref={streamRef}>
+          <div className="onboarding-chat-stream">
+            {messages.length === 0 ? (
+              <p className="onboarding-chat-stream-empty">
+                CEO is opening the office…
+              </p>
+            ) : (
+              messages.map((msg) => (
+                <MessageBubble key={msg.id} message={msg} />
+              ))
+            )}
+            <TypingIndicator />
+          </div>
+        </main>
+
+        <footer className="onboarding-chat-footer">
+          <div className="onboarding-chat-footer-inner">
+            <InterviewBar />
+            {/* When there's no pending suggestion AND no agent interview
+                request, InterviewBar renders nothing. Surface a hint so the
+                user knows the wizard is mid-transition rather than stuck. */}
+            {!pendingSuggestion && (
+              <p className="onboarding-chat-hint">
+                Hang tight — the CEO is composing the next step.
+              </p>
+            )}
+          </div>
+        </footer>
+      </div>
+    </OnboardingDMContextProvider>
+  );
+}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -24,7 +24,7 @@ import { DMView } from "../components/messages/DMView";
 import { InterviewBar } from "../components/messages/InterviewBar";
 import { MessageFeed } from "../components/messages/MessageFeed";
 import { TypingIndicator } from "../components/messages/TypingIndicator";
-import { OnboardingDMRoute } from "../components/onboarding/OnboardingDMRoute";
+import { OnboardingChat } from "../components/onboarding/OnboardingChat";
 import { PrePickScreen } from "../components/onboarding/PrePickScreen";
 import { ConfirmHost } from "../components/ui/ConfirmDialog";
 import { ProviderSwitcherHost } from "../components/ui/ProviderSwitcher";
@@ -766,15 +766,13 @@ export default function RootRoute() {
     );
   } else if (!onboardingComplete) {
     if (inCeoOnboarding || bootPhase) {
-      // CEO conversation running — Shell with OnboardingDMRoute.
-      // Already-onboarded users (onboardingComplete === true) skip this
-      // entirely via the branch above.
-      body = (
-        <Shell>
-          <OnboardingDMRoute />
-          <Outlet />
-        </Shell>
-      );
+      // CEO wizard running — render OnboardingChat full-screen, NOT inside
+      // the office Shell. The user is not "in the office" yet; the wizard
+      // is mocked as a CEO chat so the experience reads as a conversation
+      // while still gating progress through deterministic chip / form
+      // cards. Once the broker flips onboarded=true the user falls through
+      // to the post-onboarding Shell branch below and lands in the office.
+      body = <OnboardingChat />;
     } else {
       // Provider picker. No phase set yet — user hasn't picked a runtime.
       // After they pick, setInCeoOnboarding(true) to enter the CEO DM.

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2572,3 +2572,99 @@
   flex-direction: column;
   overflow: hidden;
 }
+
+/* ─── OnboardingChat — full-screen CEO wizard ───────────────────────────────
+   Phase 2 deterministic CEO conversation is rendered OUTSIDE the office
+   Shell: the user is not "in the office" yet. The wizard masquerades as a
+   chat with the CEO — header + scrolling message feed + chip / form-field
+   card as the only input. No sidebar, no workspace rail, no workbench
+   panes; those appear only once `onboarded=true` flips and RootRoute
+   falls through to the office Shell branch.
+   ────────────────────────────────────────────────────────────────────── */
+
+.onboarding-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: radial-gradient(
+    circle at top,
+    var(--bg-base, #fffefb) 0%,
+    var(--bg-card, #ffffff) 70%
+  );
+  /* Block the whole viewport so deep links to /dm/* etc. land here too. */
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  overflow: hidden;
+}
+
+.onboarding-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 28px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-card);
+}
+
+.onboarding-chat-brand {
+  font-family: var(--font-display, inherit);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.onboarding-chat-phase {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.onboarding-chat-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: auto;
+  padding: 32px 16px 16px;
+}
+
+.onboarding-chat-stream {
+  width: 100%;
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.onboarding-chat-stream-empty {
+  color: var(--text-tertiary);
+  font-size: 13px;
+  text-align: center;
+  padding: 40px 0;
+}
+
+.onboarding-chat-footer {
+  display: flex;
+  justify-content: center;
+  border-top: 1px solid var(--border);
+  background: var(--bg-card);
+  padding: 16px 24px;
+}
+
+.onboarding-chat-footer-inner {
+  width: 100%;
+  max-width: 720px;
+}
+
+.onboarding-chat-hint {
+  margin: 0;
+  padding: 12px 14px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  text-align: center;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
Stacked on #902. After #902 wires the deterministic phase-2 CEO state machine, the wizard still rendered **inside the office Shell** — the user saw the full sidebar, channels, agent list, workbench panes, and a free-form Composer alongside the chip / form-field card. That made the deterministic wizard feel like an optional aside, not the only path forward.

This PR makes onboarding render **outside** the Shell entirely. The user is not "in the office" yet until the broker flips `onboarded=true`; instead they see a single-purpose wizard masquerading as a chat with the CEO.

## What changed
| Before | After |
|---|---|
| `Shell + OnboardingDMRoute + DMView` | `<OnboardingChat />` as the entire body |
| Sidebar + WorkspaceRail visible | Hidden (component lives at `position: fixed; inset: 0; z-index: 50`) |
| Workbench panes (Active Tasks, Live Stream, Recent Activity) visible | Hidden |
| Free-form `Composer` rendered alongside chip card | Chip / form-field card from `CeoCardSection` is the **only** input |
| No progress signal | Header: `WUPHF · Step N of 5 · <phase label>` |

`InterviewBar` falls back to `<CeoCardSection />` when there's no agent interview request, so the broker's `pendingSuggestion` always renders as the input zone during onboarding. One-line change there.

## Files
- `web/src/components/onboarding/OnboardingChat.tsx` — new full-screen wizard component
- `web/src/components/onboarding/OnboardingChat.test.tsx` — 5 tests covering chrome, phase label translation, hint visibility, loading
- `web/src/routes/RootRoute.tsx` — swap `<Shell><OnboardingDMRoute /></Shell>` for `<OnboardingChat />` in the `inCeoOnboarding || bootPhase` branch
- `web/src/components/messages/InterviewBar.tsx` — `if (!current) return null;` → `return <CeoCardSection />;` so the chip card surfaces when there's no agent request
- `web/src/styles/onboarding.css` — `.onboarding-chat*` rules

## Known gaps (NOT in this PR's scope)
These belong to the broker-side wiring sitting in the uncommitted worktree for #902 (`.worktrees/fix-onboarding-fresh-main`):

1. **POST `/onboarding/answer` does not auto-advance the phase** server-side. Submitting "Office name" persists the answer but the next pending-suggestion never arrives — user gets stuck. The bigger refactor wires the state machine to advance on `/onboarding/answer`.
2. **`ceo_form_field` with multi-field payloads** (identity phase asks for owner name + role at once) renders only a single input. `CeoCardSection`'s `renderCeoCard` needs the multi-field branch.

Both are tracked there; this PR is intentionally narrow to ship the visible UX immediately.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` on touched files — clean
- [x] `bash scripts/test-web.sh web/src/components/onboarding/` — 40/40 green
- [x] `bash scripts/test-web.sh web/src/components/messages/InterviewBar` — green
- [x] Manual: fresh `WUPHF_RUNTIME_HOME=/tmp/wuphf-lockdown-home` → click Claude Code on PrePickScreen → lands directly in `OnboardingChat` showing "STEP 1 OF 5 · OFFICE NAME" with Office name input + Submit. No `.office` in DOM, no sidebar, no workspace rail (verified via `document.querySelector('.office')` → null).
- [ ] Screenshots — captured locally; will publish via `web/e2e/screenshots/publish.sh` once a phase-advance fix lands (otherwise screenshots only cover greet+identity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a full-screen chat interface with message streaming, phase-based header labeling, and auto-scrolling transcripts.

* **Tests**
  * Added test coverage for the new chat component.

* **Style**
  * Added comprehensive styling for the new chat interface layout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->