### PR TITLE
fix(launcher): restore headless Claude default

### DIFF
--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -134,25 +134,15 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)
 	}
 
-	// Default for claude-code: spawn an interactive tmux pane per agent so
-	// the user can attach and watch the real Claude TUI (tools, thinking,
-	// confirmations) for any agent at any time. TrySpawnWebAgentPanes
-	// self-guards on UsesPaneRuntime() (Codex/OpenCode/MLX runtimes skip
-	// this entirely), on visible-member count (blank-slate launches skip
-	// until onboarding adds members), and on tmux availability. Any failure
-	// (tmux missing, terminal too small, dead pane on spawn) flips the agent
-	// back to headless `claude --print` dispatch via the failedPaneSlugs /
-	// paneBackedAgents=false fallback paths already wired into the targeter.
+	// Default path: headless `claude --print` per turn. Anthropic re-sanctioned
+	// this invocation (OpenClaw policy note, 2026-04), so it runs on the user's
+	// normal subscription quota — no separate extra-usage quota is charged on
+	// top. The interactive pane-per-agent mode remains reachable via
+	// TrySpawnWebAgentPanes as an internal fallback primitive, but is not
+	// invoked at startup.
 	//
-	// Anthropic re-sanctioned the `claude --print` invocation (OpenClaw
-	// policy note, 2026-04), so the headless fallback still runs on the
-	// user's normal subscription quota with no extra-usage charge.
-	l.panes().TrySpawnWebAgentPanes()
-
 	// Headless context is used for codex runtime, default dispatch, and
-	// per-turn operations that don't fit a long-lived pane session — and
-	// for every claude-code agent when the pane spawn above failed or
-	// declined.
+	// per-turn operations that don't fit a long-lived pane session.
 	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
 	l.resumeInFlightWork()
 

--- a/internal/team/pane_lifecycle_orchestration_test.go
+++ b/internal/team/pane_lifecycle_orchestration_test.go
@@ -240,10 +240,10 @@ func TestTrySpawnWebAgentPanes_HeadlessRuntimeNoOp(t *testing.T) {
 
 // TestTrySpawnWebAgentPanes_BlankSlateNoOp guards the early-return that
 // prevents an empty tmux session (only the placeholder pane, no agent
-// panes) on blank-slate web launches where the broker has zero members
-// yet. Before this guard, LaunchWeb's pane-default call would create a
-// half-built session and flip paneBackedFlag=true, breaking subsequent
-// reconfigure paths and the capture loops.
+// panes) when this fallback primitive is explicitly invoked while the
+// broker has zero members yet. Without this guard, the fallback path
+// would create a half-built session and flip paneBackedFlag=true,
+// breaking subsequent reconfigure paths and the capture loops.
 func TestTrySpawnWebAgentPanes_BlankSlateNoOp(t *testing.T) {
 	fake := newFakeTmuxRunner()
 	setTmuxRunnerForTest(t, fake)
@@ -269,13 +269,11 @@ func TestTrySpawnWebAgentPanes_BlankSlateNoOp(t *testing.T) {
 	}
 }
 
-// TestTrySpawnWebAgentPanes_HappyPathFlipsFlag is the new default's
-// load-bearing contract: with claude-code + at least one visible
-// member + a working tmux runner, TrySpawnWebAgentPanes flips
-// paneBackedFlag=true so subsequent dispatch routes through the live
-// panes instead of falling through to headless `claude --print`. Before
-// the LaunchWeb wiring change this code path was reachable only via the
-// reconfigure flow.
+// TestTrySpawnWebAgentPanes_HappyPathFlipsFlag is the fallback path's
+// load-bearing contract: with claude-code + at least one visible member
+// + a working tmux runner, TrySpawnWebAgentPanes flips paneBackedFlag=true
+// so subsequent dispatch routes through the live panes instead of falling
+// through to headless `claude --print`.
 func TestTrySpawnWebAgentPanes_HappyPathFlipsFlag(t *testing.T) {
 	fake := newFakeTmuxRunner()
 	fake.outputs["split-window"] = []byte("ok")


### PR DESCRIPTION
## Summary
- Reverts the startup behavior introduced in PR #887 that made Claude Code web launches try tmux panes by default.
- Restores headless `claude --print` as the default LaunchWeb dispatch path.
- Keeps TrySpawnWebAgentPanes available as an explicit fallback primitive and updates test comments accordingly.

## Verification
- bash scripts/test-go.sh ./internal/team

## Context
Regression source: https://github.com/nex-crm/wuphf/pull/887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Default startup now runs agents in headless per-turn execution rather than automatically creating interactive agent panels; interactive panels remain available as an internal fallback.
* **Tests / Documentation**
  * Internal test comments clarified to better describe expected pane-creation guards and happy-path behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->