### PR TITLE
docs: Obsidian vault compatibility spec and baseline tests

### DIFF
--- a/docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md
+++ b/docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md
@@ -56,7 +56,7 @@ Everything Obsidian needs to render lives under `team/` and matches the brief la
 | `playbooks/.compiled/**` | derived | archivist | hidden |
 | `entities/.graph.jsonl` | adjacency log | archivist | hidden |
 
-**Lazy directory creation.** `customers/` is not created by `Repo.ensureLayoutLocked` (`internal/team/wiki_git.go:209`); it is created on demand when the first customer brief is filed. Obsidian handles a missing directory gracefully — wikilinks to it surface as broken until the first file lands. This is the documented pattern; do not pre-seed `customers/` just to satisfy Obsidian.
+**Lazy directory creation.** `customers/` is not created by `Repo.ensureLayoutLocked` (see `internal/team/wiki_git.go`); it is created on demand when the first customer brief is filed. Obsidian handles a missing directory gracefully — wikilinks to it surface as broken until the first file lands. This is the documented pattern; do not pre-seed `customers/` just to satisfy Obsidian.
 
 ---
 
@@ -88,7 +88,7 @@ Not bootstrapped (user-specific, gitignored):
 
 ## 5. Wikilink contract — kinded form is canonical
 
-WUPHF emits and stores wikilinks in their **kinded form**: `[[kind/slug]]` or `[[kind/slug|Display]]`. The parser at `internal/team/entity_graph.go:87` accepts `people|companies|customers` as kinds. This form is canonical because:
+WUPHF emits and stores wikilinks in their **kinded form**: `[[kind/slug]]` or `[[kind/slug|Display]]`. The `ExtractRefs` parser (`kindedWikilinkPattern` in `internal/team/entity_graph.go`) accepts `people|companies|customers` as kinds. This form is canonical because:
 
 1. It is unambiguous — `[[people/acme]]` and `[[companies/acme]]` are distinct entities even when slugs collide.
 2. It resolves natively in Obsidian when the vault root is `team/` — `[[people/nazz]]` → `<vault>/people/nazz.md`.
@@ -101,7 +101,7 @@ WUPHF emits and stores wikilinks in their **kinded form**: `[[kind/slug]]` or `[
 - Commits the normalization under the `archivist` identity with message `wiki: normalize wikilinks in {slug}`.
 - Runs only on brief bodies under `team/**/*.md`. Artifacts under `inbox/raw/` are immutable and preserve verbatim text.
 
-**Bare slug ambiguity.** A bare `[[acme]]` whose slug collides across kinds is left unresolved. The `ExtractRefs` parser receives a `known(slug)` callback that returns `("", false)` for ambiguous slugs (`internal/team/entity_graph.go:125-146`), and no edge is created. This is the basename-collision guard required for Obsidian compatibility — see the regression test in `entity_graph_test.go`.
+**Bare slug ambiguity.** A bare `[[acme]]` whose slug collides across kinds is left unresolved. The `ExtractRefs` parser receives a `known(slug)` callback that returns `("", false)` for ambiguous slugs (the bare-slug second pass in `internal/team/entity_graph.go`), and no edge is created. This is the basename-collision guard required for Obsidian compatibility — see `TestExtractRefs_BasenameCollisionAcrossKinds` in `entity_graph_test.go`.
 
 ---
 
@@ -112,7 +112,7 @@ WUPHF emits and stores wikilinks in their **kinded form**: `[[kind/slug]]` or `[
 The Phase 3 reconciliation:
 
 1. **fsnotify watcher on the vault root.** Debounce 1.5s. Commit batches under the user's configured per-human git identity (same resolution used by WikiWorker; falls back to a "needs-attribution" queue if unresolved — never commits as `archivist` for human writes).
-2. **Advisory `flock` in `Repo.Commit`.** WikiWorker takes an OS-level advisory lock on the target file for the duration of write + commit. Obsidian's editor respects advisory locks on most platforms; on platforms where it does not, the watcher's debounce window absorbs interleaved writes.
+2. **Advisory `flock` in `Repo.Commit` — for WUPHF processes only.** `Repo.Commit` takes an OS-level POSIX advisory lock on the target file for the duration of write + commit. This serializes WUPHF's own writers against each other: the in-process `WikiWorker`, the `ObsidianWatcher`, and any sibling `wuphf` CLI process (e.g. `wuphf memory migrate`) hitting the same wiki cannot interleave their commits. **The flock does not coordinate with Obsidian's editor** — Obsidian writes vault files as plain disk I/O without acquiring POSIX advisory locks, by design (it must coexist with Dropbox, Syncthing, git, and a long tail of external tools). Coordination with Obsidian's writes relies on the other three items in this list: the debounce window in (1) absorbs Obsidian's typical write rhythm, Obsidian's atomic temp-file + rename pattern keeps disk reads from ever observing a partial write, and the sentinel in (3) prevents synthesis from stomping a concurrent human edit.
 3. **`last_human_edit_ts` frontmatter sentinel.** The synthesizer checks `last_human_edit_ts > last_synthesized_ts` and switches from rewrite mode to append-section mode. User edits to the brief body are never stomped; synthesis-derived content lands in `## What we've learned` instead.
 4. **Worker-originated write filter in the watcher.** The watcher tracks paths the worker has written within the last 5 seconds and ignores fsnotify events on them. Without this, every worker commit would trigger a watcher commit and the system would loop.
 

--- a/docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md
+++ b/docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md
@@ -1,0 +1,178 @@
+# WIKI-OBSIDIAN-COMPATIBILITY.md — Contract for opening WUPHF's wiki as an Obsidian vault
+
+This document is the source of truth for **how WUPHF's wiki interoperates with Obsidian**. It is a companion to `WIKI-SCHEMA.md`: that document defines the wiki contract; this one defines the additional invariants required to make the on-disk layout work as an Obsidian vault (read and write).
+
+If a decision below conflicts with code, the contract wins. Fix the code.
+
+This is the Obsidian-side counterpart to the substrate guarantee in `WIKI-SCHEMA.md` §1: "`rm -rf .wuphf/index/` → restart broker → the wiki still works." The Obsidian extension is: open the wiki in Obsidian → the vault loads cleanly. Edit a brief in Obsidian → the next reconcile picks it up. Click a wikilink → it resolves to the right brief.
+
+---
+
+## 1. Goal
+
+A user can:
+
+1. Point Obsidian at `~/.wuphf/wiki/team/` and the vault loads cleanly. No `.jsonl` files in the file tree, no broken-link spam, link graph reflects the entity graph.
+2. Edit a brief in Obsidian; the next WikiWorker reconcile picks it up, attributes the commit, and graph/index stay consistent.
+3. Use Obsidian-native primitives that have semantic meaning for WUPHF — `[[wikilinks]]`, `![[image]]` embeds, callouts — and have them survive round-trips through synthesis without stomping user edits.
+4. Open Obsidian's Graph view and see a structure that matches the typed adjacency log at `team/entities/.graph.jsonl`.
+
+---
+
+## 2. Vault root — `team/`
+
+The Obsidian vault root is `<wiki-root>/team/`, not the wiki root itself. The wiki root is the git repository; the vault is a subdirectory of it.
+
+This choice is load-bearing for compatibility:
+
+- **Wikilink resolution.** WUPHF emits `[[people/nazz]]`. Obsidian's resolver looks for `<vault>/people/nazz.md`. With vault root at `team/`, that path matches `team/people/nazz.md` directly. With vault root at the wiki root, Obsidian would fall back to basename matching and silently mis-resolve collisions.
+- **Noise suppression.** Sibling directories `wiki/` (facts, artifacts, lint reports, DLQ), `.reads/`, `.reviews/`, `index/`, and `.git/` all live outside the vault and never appear in Obsidian's file tree.
+- **Single bootstrap point.** `.obsidian/` lives at the vault root, so it lives inside `team/`. It is committed to the wiki git repo so a fresh clone of the wiki gives the user a working Obsidian configuration.
+
+Hidden directories that remain inside `team/` (and must be explicitly excluded by the bootstrap — see §4):
+
+- `team/playbooks/.compiled/` — derived skill files
+- `team/entities/.graph.jsonl` — adjacency log
+- `team/inbox/raw/` — immutable artifacts (visible but read-only by convention)
+- `team/agents/` — runtime skill manifests (visible)
+
+---
+
+## 3. Layout invariants
+
+Everything Obsidian needs to render lives under `team/` and matches the brief layout in `WIKI-SCHEMA.md` §3. The full set, with vault-root-relative paths:
+
+| Path (vault-relative) | Kind | Author | Obsidian-visible |
+|---|---|---|---|
+| `people/{slug}.md` | brief, md+YAML | archivist or human | ✅ |
+| `companies/{slug}.md` | brief, md+YAML | archivist or human | ✅ |
+| `customers/{slug}.md` | brief, md+YAML | archivist or human | ✅ (lazy-created) |
+| `projects/{slug}.md` | brief, md+YAML | archivist or human | ✅ |
+| `playbooks/{slug}.md` | playbook, md+YAML | human | ✅ |
+| `learnings/{slug}.md` | learning, md+YAML | archivist or human | ✅ |
+| `decisions/{slug}.md` | decision, md+YAML | human | ✅ |
+| `inbox/raw/**.md` | artifact, immutable | extractor | ✅ (read-only) |
+| `agents/**` | skill manifest | broker | ✅ |
+| `playbooks/.compiled/**` | derived | archivist | hidden |
+| `entities/.graph.jsonl` | adjacency log | archivist | hidden |
+
+**Lazy directory creation.** `customers/` is not created by `Repo.ensureLayoutLocked` (`internal/team/wiki_git.go:209`); it is created on demand when the first customer brief is filed. Obsidian handles a missing directory gracefully — wikilinks to it surface as broken until the first file lands. This is the documented pattern; do not pre-seed `customers/` just to satisfy Obsidian.
+
+---
+
+## 4. `.obsidian/` bootstrap (Phase 2)
+
+On `Repo.Init` and on every `ensureLayoutLocked`, WUPHF idempotently writes a minimal `.obsidian/app.json` at the vault root. It is **committed** to the wiki git repo — a fresh clone gives the user a working configuration without further setup.
+
+Bootstrapped settings:
+
+| Setting | Value | Reason |
+|---|---|---|
+| `useMarkdownLinks` | `false` | Force `[[wikilink]]` form, not `[label](url)` |
+| `newLinkFormat` | `"absolute"` | New links typed in Obsidian use vault-absolute paths (`people/nazz`), matching our convention |
+| `alwaysUpdateLinks` | `false` | Obsidian does not silently rewrite links when files are renamed (the watcher pipeline owns rename + redirect) |
+| `attachmentFolderPath` | `"inbox/raw"` | Pasted images flow into the artifact directory the extractor already watches |
+| `userIgnoreFilters` | `["playbooks/.compiled/", "entities/.graph.jsonl"]` | Hide derived/internal files from the file tree |
+
+Not bootstrapped (user-specific, gitignored):
+
+- `.obsidian/workspace.json` (pane layout)
+- `.obsidian/workspace-mobile.json`
+- `.obsidian/graph.json` (graph view tuning)
+
+`.obsidian/.gitignore` entries for those files are written on first bootstrap and never overwritten.
+
+**Idempotency.** If `.obsidian/app.json` already exists, the bootstrap reads it, merges WUPHF's required keys with any user customizations (user values win on conflict for non-required keys; WUPHF values win for `useMarkdownLinks`, `newLinkFormat`, `userIgnoreFilters`), and rewrites the file. User customization of other keys (theme, hotkeys, plugins) is preserved.
+
+---
+
+## 5. Wikilink contract — kinded form is canonical
+
+WUPHF emits and stores wikilinks in their **kinded form**: `[[kind/slug]]` or `[[kind/slug|Display]]`. The parser at `internal/team/entity_graph.go:87` accepts `people|companies|customers` as kinds. This form is canonical because:
+
+1. It is unambiguous — `[[people/acme]]` and `[[companies/acme]]` are distinct entities even when slugs collide.
+2. It resolves natively in Obsidian when the vault root is `team/` — `[[people/nazz]]` → `<vault>/people/nazz.md`.
+3. It survives round-trips through synthesis without loss.
+
+**Loose forms** users type in Obsidian (`[[Acme Corp]]`, `[[acme]]`) are accepted but normalized to the kinded form by the watcher commit pipeline (Phase 4). The normalizer:
+
+- Resolves the display text against the SQLite signal index (exact email, normalized name, fuzzy ≥ 0.9).
+- Rewrites `[[Acme Corp]]` to `[[companies/acme-corp|Acme Corp]]`, preserving the display string.
+- Commits the normalization under the `archivist` identity with message `wiki: normalize wikilinks in {slug}`.
+- Runs only on brief bodies under `team/**/*.md`. Artifacts under `inbox/raw/` are immutable and preserve verbatim text.
+
+**Bare slug ambiguity.** A bare `[[acme]]` whose slug collides across kinds is left unresolved. The `ExtractRefs` parser receives a `known(slug)` callback that returns `("", false)` for ambiguous slugs (`internal/team/entity_graph.go:125-146`), and no edge is created. This is the basename-collision guard required for Obsidian compatibility — see the regression test in `entity_graph_test.go`.
+
+---
+
+## 6. Round-trip writes — coexistence with the single-writer invariant
+
+`WIKI-SCHEMA.md` §1.3 establishes the single-writer invariant: all writes go through the WikiWorker queue. Obsidian writes directly to disk and breaks this invariant by construction.
+
+The Phase 3 reconciliation:
+
+1. **fsnotify watcher on the vault root.** Debounce 1.5s. Commit batches under the user's configured per-human git identity (same resolution used by WikiWorker; falls back to a "needs-attribution" queue if unresolved — never commits as `archivist` for human writes).
+2. **Advisory `flock` in `Repo.Commit`.** WikiWorker takes an OS-level advisory lock on the target file for the duration of write + commit. Obsidian's editor respects advisory locks on most platforms; on platforms where it does not, the watcher's debounce window absorbs interleaved writes.
+3. **`last_human_edit_ts` frontmatter sentinel.** The synthesizer checks `last_human_edit_ts > last_synthesized_ts` and switches from rewrite mode to append-section mode. User edits to the brief body are never stomped; synthesis-derived content lands in `## What we've learned` instead.
+4. **Worker-originated write filter in the watcher.** The watcher tracks paths the worker has written within the last 5 seconds and ignores fsnotify events on them. Without this, every worker commit would trigger a watcher commit and the system would loop.
+
+---
+
+## 7. Obsidian-native primitives
+
+The following primitives are supported (Phase 4):
+
+### 7.1 Callouts
+
+Obsidian-flavored callouts (`> [!note]`, `> [!info]`, `> [!warning]`, etc.) render in WUPHF's web wiki surface. The renderer in `web/src/components/wiki/WikiArticle.tsx` recognizes the blockquote-with-bang-tag prefix and emits a styled box matching the design system in `DESIGN-WIKI.md`.
+
+Callouts have no structured-extractor semantics in v1 — they render but do not feed the fact log. See §10 open items.
+
+### 7.2 Image embeds (`![[image.png]]`)
+
+`![[image.png]]` references in brief bodies resolve against the vault attachment folder (`inbox/raw/`). The watcher pipeline:
+
+- Detects new `![[...]]` references on commit.
+- Copies the referenced media into `inbox/raw/` if not already there (Obsidian sometimes paste-saves into the brief's directory; we normalize).
+- Rewrites the reference to use the canonical path.
+
+Embeds of `.md` files (transclusion) are out of scope for v1.
+
+### 7.3 Frontmatter tags
+
+Obsidian uses `tags` and `aliases` as special frontmatter fields. WUPHF already uses `aliases` with matching semantics. `tags` is added as a derived projection at synthesis time: `kind`, key signals (`job_title`, `domain`), and playbook author land in `tags` so Obsidian's tag panel works. The projection is additive — readers that do not know about `tags` ignore it.
+
+---
+
+## 8. Non-goals
+
+The following are explicitly out of scope for the foreseeable future:
+
+- **Obsidian Canvas** (`.canvas` JSON files).
+- **Dataview** queries — WUPHF has its own query layer.
+- **Templater** — Obsidian's template plugin is a local-only convenience.
+- **Excalidraw** and other drawing plugins.
+- **Obsidian Sync** as a replacement for the wiki git transport.
+- **Bidirectional sync of arbitrary external Obsidian vaults** into WUPHF. Importing an external vault is a separate spec.
+- **Dark-mode parity** between Obsidian and WUPHF's web wiki surface (`DESIGN-WIKI.md` §1.7 — light-only in v1).
+- **Mobile Obsidian.** Desktop only.
+
+---
+
+## 9. Phased plan
+
+- **Phase 1 (this commit).** This document. Schema-doc drift fix for playbook paths. Regression test naming the basename-collision guard.
+- **Phase 2.** `.obsidian/` bootstrap in `Repo.ensureLayoutLocked`. Vault-root migration note for existing users.
+- **Phase 3.** fsnotify watcher, advisory `flock` in `Repo.Commit`, `last_human_edit_ts` sentinel, synthesizer guard.
+- **Phase 4.** Loose-link normalizer, Obsidian callout rendering, image embed ingestion, `tags` projection.
+
+Each phase ships behind a single reviewable PR. Phase 2 depends on Phase 1's vault-root decision being public; Phase 3 depends on Phase 2's bootstrap; Phase 4 depends on Phase 3's watcher.
+
+---
+
+## 10. Open items (flagged, not resolved in Phase 1)
+
+1. **Insights drift.** `WIKI-SCHEMA.md` §3 documents `wiki/insights/entity/{slug}.jsonl` and `wiki/insights/knowledge/{slug}.md`. Neither path is referenced in code. Either the insights layer is aspirational (and should be marked as such in `WIKI-SCHEMA.md`) or it has been superseded by something else (e.g. promoted facts). Out of scope for Phase 1 of this work, but tracked here so it does not get forgotten when Phase 4 ships `tags`.
+2. **Two graph files.** `graph.log` (wiki root, typed predicates per `WIKI-SCHEMA.md` §6.2, referenced by `wiki_index.go`) and `team/entities/.graph.jsonl` (auto-generated adjacency log per `entity_graph.go`). Both exist; their relationship is not documented in either file. If they are intentional duplicates (one human-editable, one derived), say so. If one is dead code, remove it. Tracked for a future round.
+3. **Structured callouts.** Whether `> [!fact]`, `> [!decision]`, `> [!question]` should feed the extractor as deliberate filings is deferred to v2. Need usage data on Obsidian-side callout use before defining the predicate vocabulary.
+4. **Per-vault git identity sniffing.** Current plan is to reuse WikiWorker's resolved per-human identity. If multi-tenant runtimes need a different identity per vault (e.g. one machine, two users sharing a wiki), this needs an explicit answer.

--- a/docs/specs/WIKI-SCHEMA.md
+++ b/docs/specs/WIKI-SCHEMA.md
@@ -54,9 +54,9 @@ Layer 2 — The wiki (LLM-owned markdown)
   wiki/facts/{kind}/{slug}.jsonl         # append-only fact log per entity
   wiki/insights/entity/{slug}.jsonl      # append-only typed insight log per entity
   wiki/insights/knowledge/{slug}.md      # workspace-wide facts/decisions/preferences
-  wiki/playbooks/{slug}.md               # compiled playbooks (from executions
+  team/playbooks/{slug}.md               # compiled playbooks (from executions
                                          # and/or insight clusters)
-  wiki/playbooks/{slug}.executions.jsonl # per-playbook execution log
+  team/playbooks/{slug}.executions.jsonl # per-playbook execution log
   wiki/.lint/report-YYYY-MM-DD.md        # daily lint report
   wiki/.dlq/extractions.jsonl            # extraction failures awaiting replay
   wiki/.dlq/permanent-failures.jsonl     # artifacts that exceeded max_retries
@@ -177,7 +177,7 @@ Insights are facts that rise above the noise: status changes, decisions, pattern
 
 `source` = `"synthesis"` | `"save_as_insight"` | `"lint"` | `"human"`.
 
-### 4.5 Playbook — `wiki/playbooks/{slug}.md`
+### 4.5 Playbook — `team/playbooks/{slug}.md`
 
 ```yaml
 ---

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.9.2

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=

--- a/internal/team/entity_graph_test.go
+++ b/internal/team/entity_graph_test.go
@@ -96,6 +96,47 @@ func TestExtractRefs_KindedAndBareNoDoubleCount(t *testing.T) {
 	}
 }
 
+// TestExtractRefs_BasenameCollisionAcrossKinds pins the Obsidian
+// basename-collision guard documented in WIKI-OBSIDIAN-COMPATIBILITY.md §5.
+//
+// When the same slug exists under two kinds (e.g. team/people/acme.md and
+// team/companies/acme.md), a bare `[[acme]]` written by a user in Obsidian
+// is ambiguous. The known() resolver must return ("", false) on ambiguity,
+// and ExtractRefs must produce no edge — silently picking a kind would
+// poison the graph. Kinded forms remain unambiguous and resolve.
+//
+// If this test fails, do not relax the known() contract — the bare-slug
+// path is the Obsidian-compatibility seam and must stay strict.
+func TestExtractRefs_BasenameCollisionAcrossKinds(t *testing.T) {
+	// Two entities share a basename across kinds — the collision case.
+	known := func(slug string) (EntityKind, bool) {
+		if slug == "acme" {
+			return "", false // ambiguous: exists as both person and company
+		}
+		return "", false
+	}
+
+	bare := ExtractRefs(EntityKindPeople, "sarah", "See [[acme]].", known)
+	if len(bare) != 0 {
+		t.Fatalf("bare [[acme]] must not resolve when ambiguous across kinds; got %#v", bare)
+	}
+
+	kinded := ExtractRefs(EntityKindPeople, "sarah", "Person [[people/acme]] vs company [[companies/acme]].", known)
+	if len(kinded) != 2 {
+		t.Fatalf("kinded forms must resolve to distinct entities; got %d refs: %#v", len(kinded), kinded)
+	}
+	seen := map[EntityKind]bool{}
+	for _, ref := range kinded {
+		if ref.Slug != "acme" {
+			t.Errorf("unexpected slug: %#v", ref)
+		}
+		seen[ref.Kind] = true
+	}
+	if !seen[EntityKindPeople] || !seen[EntityKindCompanies] {
+		t.Fatalf("expected both people and companies kinds; got %v", seen)
+	}
+}
+
 func TestRecordFactRefs_WritesEdges(t *testing.T) {
 	factLog, graph, worker, teardown := newGraphFixture(t)
 	defer teardown()

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -369,7 +369,7 @@ func (s *EntitySynthesizer) runJob(ctx context.Context, job SynthesisJob) {
 func (s *EntitySynthesizer) synthesize(ctx context.Context, job SynthesisJob) error {
 	relBrief := briefPath(job.Kind, job.Slug)
 	existingBrief, hadBrief := s.readBrief(relBrief)
-	_, _, lastFactCount := parseSynthesisFrontmatter(existingBrief)
+	_, lastSynthTS, lastFactCount := parseSynthesisFrontmatter(existingBrief)
 
 	facts, err := s.factLog.List(job.Kind, job.Slug)
 	if err != nil {
@@ -452,7 +452,20 @@ func (s *EntitySynthesizer) synthesize(ctx context.Context, job SynthesisJob) er
 
 	now := time.Now().UTC()
 	factCount := len(facts)
-	newBody := applySynthesisFrontmatter(output, headSHA, now, factCount, existingBrief)
+
+	// Sentinel guard: when the brief has been edited from Obsidian since the
+	// last synthesis, preserve the user's body and land new synthesis content
+	// in a sentinel-wrapped "What we've learned" section instead of replacing
+	// the whole body. See WIKI-OBSIDIAN-COMPATIBILITY §6.3.
+	var rewritten string
+	if hadBrief && humanEditedSince(existingBrief, lastSynthTS) {
+		rewritten = applyLearnedSection(stripFrontmatter(existingBrief), output)
+	} else {
+		rewritten = output
+	}
+
+	newBody := applySynthesisFrontmatter(rewritten, headSHA, now, factCount, existingBrief)
+	newBody = applyTagsFrontmatter(newBody, deriveTagsFromBrief(existingBrief))
 
 	// Commit via the wiki queue under the archivist identity. We can't
 	// call CommitBootstrap because that's tree-wide + picks its own slug;

--- a/internal/team/entity_synthesizer_sentinel.go
+++ b/internal/team/entity_synthesizer_sentinel.go
@@ -1,0 +1,373 @@
+package team
+
+// entity_synthesizer_sentinel.go owns the Obsidian-roundtrip helpers the
+// synthesizer uses to avoid stomping user edits. The Obsidian watcher stamps
+// `last_human_edit_ts` on every external edit; this file reads that key,
+// projects derived tags into frontmatter, and renders the append-mode
+// "What we've learned" section that lands new synthesis content without
+// overwriting a user-edited body.
+//
+// See WIKI-OBSIDIAN-COMPATIBILITY.md §6.3 (sentinel) and §7.3 (tags).
+
+import (
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// whatWeLearnedHeading is the canonical heading the synthesizer uses to
+// append synthesis content when the user has edited the body. The block is
+// wrapped in sentinels so successive synthesis runs replace the same block
+// without accumulating duplicates.
+const whatWeLearnedHeading = "## What we've learned"
+
+const (
+	learnedSentinelStart = "<!-- wuphf:learned:start -->"
+	learnedSentinelEnd   = "<!-- wuphf:learned:end -->"
+)
+
+// maxDerivedTags caps the number of WUPHF-derived tags appended to the
+// frontmatter `tags` field, per WIKI-OBSIDIAN-COMPATIBILITY §7.3.
+const maxDerivedTags = 8
+
+// parseLastHumanEditTS extracts `last_human_edit_ts` from the brief's
+// frontmatter. Missing key or missing frontmatter yields the zero time.
+func parseLastHumanEditTS(brief string) time.Time {
+	if !strings.HasPrefix(brief, "---\n") {
+		return time.Time{}
+	}
+	rest := brief[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return time.Time{}
+	}
+	block := rest[:end]
+	for _, line := range strings.Split(block, "\n") {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if m[1] != lastHumanEditKey {
+			continue
+		}
+		if parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(m[2])); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+// humanEditedSince reports whether the brief has a `last_human_edit_ts`
+// strictly greater than `lastSynthesizedTS`. Used to switch from rewrite
+// mode to append-section mode without stomping user edits.
+func humanEditedSince(brief string, lastSynthesizedTS time.Time) bool {
+	hts := parseLastHumanEditTS(brief)
+	if hts.IsZero() {
+		return false
+	}
+	return hts.After(lastSynthesizedTS)
+}
+
+// applyLearnedSection writes (or rewrites) a sentinel-wrapped
+// `## What we've learned` block at the end of body. The block contains the
+// trimmed synthesis content. Existing user-authored body is preserved
+// verbatim.
+func applyLearnedSection(body, content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return body
+	}
+
+	stripped := stripLearnedSection(body)
+	stripped = strings.TrimRight(stripped, "\n")
+
+	var b strings.Builder
+	b.WriteString(stripped)
+	if stripped != "" {
+		b.WriteString("\n\n")
+	}
+	b.WriteString(learnedSentinelStart)
+	b.WriteString("\n")
+	b.WriteString(whatWeLearnedHeading)
+	b.WriteString("\n\n")
+	b.WriteString(content)
+	b.WriteString("\n")
+	b.WriteString(learnedSentinelEnd)
+	b.WriteString("\n")
+	return b.String()
+}
+
+// stripLearnedSection removes a previously-written sentinel-wrapped learned
+// block. Returns body unchanged when no sentinels are present.
+func stripLearnedSection(body string) string {
+	start := strings.Index(body, learnedSentinelStart)
+	if start < 0 {
+		return body
+	}
+	after := body[start+len(learnedSentinelStart):]
+	end := strings.Index(after, learnedSentinelEnd)
+	if end < 0 {
+		return body
+	}
+	tail := after[end+len(learnedSentinelEnd):]
+	return strings.TrimRight(body[:start], "\n") + tail
+}
+
+// deriveTagsFromBrief reads `kind`, the indented `signals` map, and (for
+// playbooks) `author` from the brief's frontmatter and returns a normalised,
+// deduplicated, capped tag set. The order is deterministic: kind first,
+// then signals in fixed order, then author. Empty values are skipped.
+func deriveTagsFromBrief(brief string) []string {
+	if !strings.HasPrefix(brief, "---\n") {
+		return nil
+	}
+	rest := brief[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil
+	}
+	block := rest[:end]
+
+	var (
+		kind, jobTitle, domain, author string
+	)
+	inSignals := false
+	for _, line := range strings.Split(block, "\n") {
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			if !inSignals {
+				continue
+			}
+			trimmed := strings.TrimSpace(line)
+			m := frontmatterKeyLine.FindStringSubmatch(trimmed)
+			if m == nil {
+				continue
+			}
+			switch m[1] {
+			case "job_title":
+				jobTitle = strings.TrimSpace(m[2])
+			case "domain":
+				domain = strings.TrimSpace(m[2])
+			}
+			continue
+		}
+		inSignals = false
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		val := strings.TrimSpace(m[2])
+		switch key {
+		case "kind":
+			kind = val
+		case "author":
+			author = val
+		case "signals":
+			if val == "" {
+				inSignals = true
+			}
+		}
+	}
+
+	out := make([]string, 0, 4)
+	if t := normalizeTag(kind); t != "" {
+		out = append(out, t)
+	}
+	if t := normalizeTag(jobTitle); t != "" {
+		out = append(out, t)
+	}
+	if t := normalizeTag(domainHost(domain)); t != "" {
+		out = append(out, t)
+	}
+	if t := normalizeTag(author); t != "" {
+		out = append(out, t)
+	}
+	out = dedupePreserveOrder(out)
+	if len(out) > maxDerivedTags {
+		out = out[:maxDerivedTags]
+	}
+	return out
+}
+
+// domainHost reduces a domain or URL string to its bare host. Returns "" for
+// inputs that don't have a recoverable host. Strips `www.` for tidiness.
+func domainHost(in string) string {
+	in = strings.TrimSpace(in)
+	if in == "" {
+		return ""
+	}
+	if strings.Contains(in, "://") {
+		if u, err := url.Parse(in); err == nil && u.Host != "" {
+			return strings.TrimPrefix(u.Host, "www.")
+		}
+		return ""
+	}
+	// Bare host or host/path. Take the first path segment off.
+	if i := strings.IndexAny(in, "/?#"); i >= 0 {
+		in = in[:i]
+	}
+	return strings.TrimPrefix(in, "www.")
+}
+
+var tagAllowedRune = regexp.MustCompile(`[^a-z0-9._/-]+`)
+
+// normalizeTag lowercases, replaces whitespace with hyphens, drops
+// disallowed characters (keeping `.`, `_`, `/`, `-` — Obsidian-compatible
+// tag punctuation), and trims leading/trailing punctuation.
+func normalizeTag(s string) string {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return ""
+	}
+	s = strings.Join(strings.Fields(s), "-")
+	s = tagAllowedRune.ReplaceAllString(s, "")
+	s = strings.Trim(s, "-_./")
+	return s
+}
+
+// dedupePreserveOrder drops duplicates while keeping first-seen order.
+func dedupePreserveOrder(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := in[:0]
+	for _, v := range in {
+		if v == "" {
+			continue
+		}
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
+// parseTagsFromFrontmatter reads any existing `tags` entries (flow `[a, b]`
+// or block sequence form) and returns the normalized list. Returns nil when
+// the field is absent.
+func parseTagsFromFrontmatter(brief string) []string {
+	if !strings.HasPrefix(brief, "---\n") {
+		return nil
+	}
+	rest := brief[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil
+	}
+	block := rest[:end]
+	lines := strings.Split(block, "\n")
+	var out []string
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil || m[1] != "tags" {
+			continue
+		}
+		val := strings.TrimSpace(m[2])
+		if strings.HasPrefix(val, "[") && strings.HasSuffix(val, "]") {
+			inner := strings.TrimSuffix(strings.TrimPrefix(val, "["), "]")
+			for _, p := range strings.Split(inner, ",") {
+				if t := strings.Trim(strings.TrimSpace(p), `"'`); t != "" {
+					out = append(out, t)
+				}
+			}
+			break
+		}
+		if val == "" {
+			for j := i + 1; j < len(lines); j++ {
+				next := lines[j]
+				trimmed := strings.TrimLeft(next, " \t")
+				if !strings.HasPrefix(trimmed, "- ") {
+					break
+				}
+				if t := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "- ")), `"'`); t != "" {
+					out = append(out, t)
+				}
+			}
+		}
+		break
+	}
+	return out
+}
+
+// applyTagsFrontmatter writes a `tags` block into body's frontmatter,
+// merging derived tags with any pre-existing user tags. User tags are
+// preserved verbatim; derived tags are normalized and capped before merge.
+// Output uses YAML flow sequence form for compact, diff-friendly rendering.
+//
+// body MUST already have a frontmatter block (the synthesizer pipeline
+// guarantees this — applySynthesisFrontmatter always emits one).
+func applyTagsFrontmatter(body string, derived []string) string {
+	existing := parseTagsFromFrontmatter(body)
+	derivedNorm := make([]string, 0, len(derived))
+	for _, t := range derived {
+		if n := normalizeTag(t); n != "" {
+			derivedNorm = append(derivedNorm, n)
+		}
+	}
+	if len(derivedNorm) > maxDerivedTags {
+		derivedNorm = derivedNorm[:maxDerivedTags]
+	}
+
+	merged := dedupePreserveOrder(append(append([]string{}, existing...), derivedNorm...))
+	if len(merged) == 0 {
+		return body
+	}
+
+	if !strings.HasPrefix(body, "---\n") {
+		return body
+	}
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return body
+	}
+	block := rest[:end]
+	tail := rest[end+len("\n---"):]
+
+	lines := strings.Split(block, "\n")
+	rendered := renderTagsLine(merged)
+
+	rewrote := false
+	out := make([]string, 0, len(lines)+1)
+	skipBlockSeq := false
+	for _, line := range lines {
+		if skipBlockSeq {
+			trimmed := strings.TrimLeft(line, " \t")
+			if strings.HasPrefix(trimmed, "- ") {
+				continue
+			}
+			skipBlockSeq = false
+		}
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m != nil && m[1] == "tags" {
+			out = append(out, rendered)
+			rewrote = true
+			if strings.TrimSpace(m[2]) == "" {
+				skipBlockSeq = true
+			}
+			continue
+		}
+		out = append(out, line)
+	}
+	if !rewrote {
+		out = append(out, rendered)
+	}
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(strings.Join(out, "\n"))
+	b.WriteString("\n---")
+	b.WriteString(tail)
+	return b.String()
+}
+
+// renderTagsLine returns a flow-sequence YAML line for the tag set, with a
+// stable sort so re-running synthesis with the same inputs is byte-stable.
+func renderTagsLine(tags []string) string {
+	sorted := append([]string{}, tags...)
+	sort.Strings(sorted)
+	return "tags: [" + strings.Join(sorted, ", ") + "]"
+}

--- a/internal/team/entity_synthesizer_test.go
+++ b/internal/team/entity_synthesizer_test.go
@@ -315,3 +315,248 @@ func waitForBriefCount(t *testing.T, pub *entityPublisherStub, n int, timeout ti
 	}
 	t.Fatalf("timed out waiting for %d brief events; got %d", n, pub.briefCount())
 }
+
+// seedBrief writes content at the brief's canonical path under the
+// archivist identity. Used by sentinel/tags tests to set up a pre-existing
+// frontmatter shape before invoking synthesis.
+func seedBrief(t *testing.T, worker *WikiWorker, kind EntityKind, slug, body, msg string) {
+	t.Helper()
+	if _, _, err := worker.Enqueue(context.Background(), ArchivistAuthor, briefPath(kind, slug), body, "replace", msg); err != nil {
+		t.Fatalf("seed brief: %v", err)
+	}
+}
+
+func TestSentinel_NoHumanEditFullRewrite(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Acme\n\nFresh body from LLM.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	seedBrief(t, worker, EntityKindCompanies, "acme",
+		"---\nkind: company\nlast_synthesized_ts: 2024-01-01T00:00:00Z\n---\n\n# Acme\n\nOld body.\n",
+		"seed acme brief")
+
+	_, _ = factLog.Append(ctx, EntityKindCompanies, "acme", "Founded 1999.", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindCompanies, "acme", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	got, err := readArticle(worker.Repo(), "team/companies/acme.md")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "Fresh body from LLM") {
+		t.Errorf("expected full rewrite with LLM body; got: %s", body)
+	}
+	if strings.Contains(body, "Old body") {
+		t.Errorf("old body should be gone in full rewrite; got: %s", body)
+	}
+	if strings.Contains(body, whatWeLearnedHeading) {
+		t.Errorf("rewrite mode must not emit learned section; got: %s", body)
+	}
+}
+
+func TestSentinel_HumanEditedSwitchesToAppendMode(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "Synth-derived insight body.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	seedBrief(t, worker, EntityKindCompanies, "acme",
+		"---\nkind: company\nlast_synthesized_ts: 2024-01-01T00:00:00Z\nlast_human_edit_ts: 2025-06-01T12:00:00Z\n---\n\n# Acme\n\nHuman-authored prose that must survive.\n",
+		"seed acme brief")
+
+	_, _ = factLog.Append(ctx, EntityKindCompanies, "acme", "Acme raised Series C.", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindCompanies, "acme", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	got, err := readArticle(worker.Repo(), "team/companies/acme.md")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "Human-authored prose that must survive") {
+		t.Errorf("user body was stomped; got: %s", body)
+	}
+	if !strings.Contains(body, whatWeLearnedHeading) {
+		t.Errorf("expected %q section; got: %s", whatWeLearnedHeading, body)
+	}
+	if !strings.Contains(body, "Synth-derived insight body") {
+		t.Errorf("expected LLM content under learned section; got: %s", body)
+	}
+	// last_synthesized_ts must advance away from the seeded value.
+	if strings.Contains(body, "last_synthesized_ts: 2024-01-01T00:00:00Z") {
+		t.Errorf("last_synthesized_ts must be updated post-synthesis; got: %s", body)
+	}
+}
+
+func TestSentinel_StaleHumanEditTriggersFullRewrite(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Acme\n\nReplacement body.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	// Human edit predates the last synthesis — sentinel is stale, full rewrite is safe.
+	seedBrief(t, worker, EntityKindCompanies, "acme",
+		"---\nkind: company\nlast_synthesized_ts: 2025-06-01T12:00:00Z\nlast_human_edit_ts: 2024-01-01T00:00:00Z\n---\n\n# Acme\n\nStale user body.\n",
+		"seed acme brief")
+
+	_, _ = factLog.Append(ctx, EntityKindCompanies, "acme", "f1", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindCompanies, "acme", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	got, _ := readArticle(worker.Repo(), "team/companies/acme.md")
+	body := string(got)
+	if !strings.Contains(body, "Replacement body") {
+		t.Errorf("expected full rewrite when sentinel is stale; got: %s", body)
+	}
+	if strings.Contains(body, "Stale user body") {
+		t.Errorf("stale body should be gone; got: %s", body)
+	}
+	if strings.Contains(body, whatWeLearnedHeading) {
+		t.Errorf("stale sentinel must not trigger learned section; got: %s", body)
+	}
+}
+
+func TestSentinel_EmptyBriefFullCreation(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Acme\n\nFresh creation.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindCompanies, "acme", "Founded 1999.", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindCompanies, "acme", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	got, _ := readArticle(worker.Repo(), "team/companies/acme.md")
+	body := string(got)
+	if !strings.Contains(body, "Fresh creation") {
+		t.Errorf("expected fresh body on first synthesis; got: %s", body)
+	}
+	if strings.Contains(body, whatWeLearnedHeading) {
+		t.Errorf("first synthesis must not produce learned section; got: %s", body)
+	}
+}
+
+func TestTags_DerivedFromKindAndSignals(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Sarah\n\nbody\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	seedBrief(t, worker, EntityKindPeople, "sarah",
+		"---\nkind: person\nsignals:\n  job_title: VP Sales\n  domain: https://acme.com/x\n---\n\n# Sarah\n\nseeded body\n",
+		"seed sarah brief")
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "sarah", "She closed an $80k deal.", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "sarah", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	got, _ := readArticle(worker.Repo(), "team/people/sarah.md")
+	body := string(got)
+	for _, want := range []string{"person", "vp-sales", "acme.com"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected derived tag %q in tags line; body: %s", want, body)
+		}
+	}
+	// Sanity: should be a `tags:` line.
+	if !strings.Contains(body, "tags:") {
+		t.Errorf("expected tags frontmatter; got: %s", body)
+	}
+}
+
+func TestTags_PreservesUserAddedTags(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Sarah\n\nbody\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	seedBrief(t, worker, EntityKindPeople, "sarah",
+		"---\nkind: person\ntags: [confidential, hot-lead]\nsignals:\n  job_title: VP Sales\n  domain: acme.com\n---\n\n# Sarah\n\nbody\n",
+		"seed sarah brief")
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "sarah", "f1", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "sarah", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	got, _ := readArticle(worker.Repo(), "team/people/sarah.md")
+	body := string(got)
+	for _, want := range []string{"confidential", "hot-lead", "person", "vp-sales", "acme.com"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected tag %q to survive merge; body: %s", want, body)
+		}
+	}
+}
+
+func TestTags_CapAtEightDerived(t *testing.T) {
+	derived := []string{"d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9", "d10"}
+	body := "---\nkind: person\n---\n\n# X\n"
+	out := applyTagsFrontmatter(body, derived)
+
+	// All 10 derived would exceed the cap; only 8 must be present.
+	for i := 1; i <= 8; i++ {
+		want := "d" + itoaTag(i)
+		if !strings.Contains(out, want) {
+			t.Errorf("expected derived tag %q within cap; got: %s", want, out)
+		}
+	}
+	for _, dropped := range []string{"d9", "d10"} {
+		if strings.Contains(out, dropped) {
+			t.Errorf("derived tag %q must have been capped; got: %s", dropped, out)
+		}
+	}
+}
+
+func TestTags_IdempotentNormalization(t *testing.T) {
+	body := "---\nkind: person\nsignals:\n  job_title: VP Sales\n  domain: acme.com\n---\n\n# X\n"
+	derived := deriveTagsFromBrief(body)
+
+	once := applyTagsFrontmatter(body, derived)
+	twice := applyTagsFrontmatter(once, deriveTagsFromBrief(once))
+
+	if once != twice {
+		t.Errorf("non-idempotent: \nonce:  %s\ntwice: %s", once, twice)
+	}
+	// No duplicate occurrences inside the tags line.
+	for _, line := range strings.Split(twice, "\n") {
+		if !strings.HasPrefix(line, "tags:") {
+			continue
+		}
+		seen := map[string]int{}
+		inner := strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(strings.TrimPrefix(line, "tags:")), "["), "]")
+		for _, p := range strings.Split(inner, ",") {
+			seen[strings.TrimSpace(p)]++
+		}
+		for tag, n := range seen {
+			if n > 1 {
+				t.Errorf("duplicate tag %q (count=%d) in: %s", tag, n, line)
+			}
+		}
+	}
+}
+
+// itoaTag — tiny local int-to-string to avoid pulling strconv into test
+// imports just for the cap test.
+func itoaTag(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -228,7 +228,7 @@ func (r *Repo) ensureLayoutLocked() error {
 			}
 		}
 	}
-	return nil
+	return r.ensureObsidianVaultLocked()
 }
 
 // Commit writes content for slug @ path, stages, and commits with a per-commit

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -271,6 +271,15 @@ func (r *Repo) Commit(ctx context.Context, slug, relPath, content, mode, message
 		return "", 0, fmt.Errorf("wiki: mkdir %s: %w", filepath.Dir(fullPath), err)
 	}
 
+	// OS-level advisory lock spans write + git commit so an Obsidian editor
+	// cannot interleave its own write between our os.WriteFile and the staged
+	// commit (WIKI-OBSIDIAN-COMPATIBILITY §6.2).
+	lockFile, err := acquireArticleLock(fullPath)
+	if err != nil {
+		return "", 0, fmt.Errorf("wiki: acquire article lock: %w", err)
+	}
+	defer releaseArticleLock(lockFile)
+
 	var bytesWritten int
 	switch mode {
 	case "create", "replace":

--- a/internal/team/wiki_git_flock_unix.go
+++ b/internal/team/wiki_git_flock_unix.go
@@ -1,0 +1,33 @@
+//go:build darwin || linux
+
+package team
+
+import (
+	"os"
+	"syscall"
+)
+
+// acquireArticleLock takes an exclusive POSIX advisory lock on the article
+// file so an Obsidian editor (which respects flock on macOS / Linux) cannot
+// interleave writes with the worker's atomic commit. The file is opened with
+// the same permissions as the existing write path (0o600) and returned to the
+// caller so releaseArticleLock can both Flock(LOCK_UN) and Close in defer.
+func acquireArticleLock(fullPath string) (*os.File, error) {
+	f, err := os.OpenFile(fullPath, os.O_RDWR|os.O_CREATE, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+func releaseArticleLock(f *os.File) {
+	if f == nil {
+		return
+	}
+	_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	_ = f.Close()
+}

--- a/internal/team/wiki_git_flock_unix.go
+++ b/internal/team/wiki_git_flock_unix.go
@@ -8,9 +8,14 @@ import (
 )
 
 // acquireArticleLock takes an exclusive POSIX advisory lock on the article
-// file so an Obsidian editor (which respects flock on macOS / Linux) cannot
-// interleave writes with the worker's atomic commit. The file is opened with
-// the same permissions as the existing write path (0o600) and returned to the
+// file so concurrent WUPHF writers (WikiWorker, ObsidianWatcher, a sibling
+// `wuphf` CLI process) cannot interleave writes with this commit. It does
+// NOT coordinate with Obsidian's editor — Obsidian writes vault files as
+// plain disk I/O without acquiring POSIX advisory locks (by design, to
+// coexist with Dropbox / Syncthing / git / external scripts). See
+// WIKI-OBSIDIAN-COMPATIBILITY.md §6 for the watcher / debounce / sentinel
+// layers that handle Obsidian-side concurrency. The file is opened with the
+// same permissions as the existing write path (0o600) and returned to the
 // caller so releaseArticleLock can both Flock(LOCK_UN) and Close in defer.
 func acquireArticleLock(fullPath string) (*os.File, error) {
 	f, err := os.OpenFile(fullPath, os.O_RDWR|os.O_CREATE, 0o600)

--- a/internal/team/wiki_git_flock_windows.go
+++ b/internal/team/wiki_git_flock_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package team
+
+import "os"
+
+// TODO(wiki): Windows port should implement LockFileEx via golang.org/x/sys/windows
+// when Obsidian-on-Windows compatibility is in scope.
+func acquireArticleLock(fullPath string) (*os.File, error) { return nil, nil }
+
+func releaseArticleLock(f *os.File) {
+	if f != nil {
+		_ = f.Close()
+	}
+}

--- a/internal/team/wiki_obsidian_bootstrap.go
+++ b/internal/team/wiki_obsidian_bootstrap.go
@@ -149,9 +149,6 @@ func writeObsidianGitignore(path string) error {
 		buf.WriteString(line)
 		buf.WriteByte('\n')
 	}
-	if len(lines) > 0 && lines[len(lines)-1] != "" {
-		// Trailing newline already covered by the loop above; nothing extra.
-	}
 	for _, entry := range missing {
 		buf.WriteString(entry)
 		buf.WriteByte('\n')

--- a/internal/team/wiki_obsidian_bootstrap.go
+++ b/internal/team/wiki_obsidian_bootstrap.go
@@ -1,0 +1,195 @@
+package team
+
+// wiki_obsidian_bootstrap.go writes a minimal .obsidian/ config inside the
+// vault root so the wiki opens cleanly when pointed at by Obsidian. See
+// docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md §4 for the contract.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// obsidianRequiredAppKeys are the keys WUPHF owns inside .obsidian/app.json.
+// On every bootstrap these values are written verbatim; user customisation of
+// these keys is intentionally overridden so the vault keeps matching the
+// wikilink contract in WIKI-OBSIDIAN-COMPATIBILITY.md §5.
+var obsidianRequiredAppKeys = map[string]any{
+	"useMarkdownLinks":     false,
+	"newLinkFormat":        "absolute",
+	"alwaysUpdateLinks":    false,
+	"attachmentFolderPath": "inbox/raw",
+	"userIgnoreFilters":    []any{"playbooks/.compiled/", "entities/.graph.jsonl"},
+}
+
+// obsidianGitignoreEntries are the user-specific files that must never be
+// committed to the wiki repo. Listed in .obsidian/.gitignore.
+var obsidianGitignoreEntries = []string{
+	"workspace.json",
+	"workspace-mobile.json",
+	"graph.json",
+}
+
+// ensureObsidianVaultLocked writes .obsidian/app.json and .obsidian/.gitignore
+// at the vault root (<wiki-root>/team/). Idempotent: existing app.json is
+// merged so WUPHF-owned keys cannot drift while user customisations (theme,
+// hotkeys, plugins, etc.) survive.
+//
+// Caller must hold r.mu.
+func (r *Repo) ensureObsidianVaultLocked() error {
+	dir := filepath.Join(r.root, "team", ".obsidian")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("wiki: mkdir %s: %w", dir, err)
+	}
+	if err := writeObsidianAppJSON(filepath.Join(dir, "app.json")); err != nil {
+		return err
+	}
+	if err := writeObsidianGitignore(filepath.Join(dir, ".gitignore")); err != nil {
+		return err
+	}
+	return nil
+}
+
+// writeObsidianAppJSON reads any existing app.json, merges WUPHF's required
+// keys over the top (WUPHF wins on required keys, user wins on everything
+// else), and rewrites the file. A missing file is bootstrapped with just the
+// required keys. A corrupted file surfaces as an error rather than being
+// silently overwritten — see the failure-mode note in the spec.
+func writeObsidianAppJSON(path string) error {
+	merged := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if len(bytes.TrimSpace(data)) > 0 {
+			if err := json.Unmarshal(data, &merged); err != nil {
+				return fmt.Errorf("wiki: parse existing %s: %w", path, err)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("wiki: read %s: %w", path, err)
+	}
+
+	for k, v := range obsidianRequiredAppKeys {
+		merged[k] = v
+	}
+
+	out, err := marshalStableJSON(merged)
+	if err != nil {
+		return fmt.Errorf("wiki: marshal app.json: %w", err)
+	}
+
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, out) {
+		return nil
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("wiki: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// writeObsidianGitignore writes the user-specific exclusion list. If the file
+// already exists and contains all required entries, it is left byte-for-byte
+// alone. If it exists but is missing entries, the missing entries are
+// appended — set semantics, never duplicating.
+func writeObsidianGitignore(path string) error {
+	existing, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		// Continue to merge below.
+	case os.IsNotExist(err):
+		existing = nil
+	default:
+		return fmt.Errorf("wiki: read %s: %w", path, err)
+	}
+
+	present := map[string]bool{}
+	var lines []string
+	if len(existing) > 0 {
+		scanner := bufio.NewScanner(bytes.NewReader(existing))
+		for scanner.Scan() {
+			line := scanner.Text()
+			lines = append(lines, line)
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				present[trimmed] = true
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("wiki: scan %s: %w", path, err)
+		}
+	}
+
+	var missing []string
+	for _, entry := range obsidianGitignoreEntries {
+		if !present[entry] {
+			missing = append(missing, entry)
+		}
+	}
+	if len(missing) == 0 && existing != nil {
+		return nil
+	}
+
+	if existing == nil {
+		var buf bytes.Buffer
+		for _, entry := range obsidianGitignoreEntries {
+			buf.WriteString(entry)
+			buf.WriteByte('\n')
+		}
+		if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+			return fmt.Errorf("wiki: write %s: %w", path, err)
+		}
+		return nil
+	}
+
+	var buf bytes.Buffer
+	for _, line := range lines {
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	if len(lines) > 0 && lines[len(lines)-1] != "" {
+		// Trailing newline already covered by the loop above; nothing extra.
+	}
+	for _, entry := range missing {
+		buf.WriteString(entry)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		return fmt.Errorf("wiki: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// marshalStableJSON renders m with sorted keys and indentation so re-runs
+// produce byte-identical output when the logical content is unchanged.
+func marshalStableJSON(m map[string]any) ([]byte, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	for i, k := range keys {
+		keyJSON, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		valJSON, err := json.MarshalIndent(m[k], "  ", "  ")
+		if err != nil {
+			return nil, err
+		}
+		buf.WriteString("  ")
+		buf.Write(keyJSON)
+		buf.WriteString(": ")
+		buf.Write(valJSON)
+		if i < len(keys)-1 {
+			buf.WriteByte(',')
+		}
+		buf.WriteByte('\n')
+	}
+	buf.WriteString("}\n")
+	return buf.Bytes(), nil
+}

--- a/internal/team/wiki_obsidian_bootstrap_test.go
+++ b/internal/team/wiki_obsidian_bootstrap_test.go
@@ -1,0 +1,269 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func obsidianPaths(repo *Repo) (appJSON, gitignore string) {
+	dir := filepath.Join(repo.Root(), "team", ".obsidian")
+	return filepath.Join(dir, "app.json"), filepath.Join(dir, ".gitignore")
+}
+
+func readAppJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read app.json: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse app.json: %v\n%s", err, data)
+	}
+	return m
+}
+
+func TestObsidianBootstrap_EmptyTeam(t *testing.T) {
+	repo := newTestRepo(t)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	appPath, ignorePath := obsidianPaths(repo)
+	app := readAppJSON(t, appPath)
+
+	if got, want := app["useMarkdownLinks"], false; got != want {
+		t.Errorf("useMarkdownLinks = %v, want %v", got, want)
+	}
+	if got, want := app["newLinkFormat"], "absolute"; got != want {
+		t.Errorf("newLinkFormat = %v, want %v", got, want)
+	}
+	if got, want := app["alwaysUpdateLinks"], false; got != want {
+		t.Errorf("alwaysUpdateLinks = %v, want %v", got, want)
+	}
+	if got, want := app["attachmentFolderPath"], "inbox/raw"; got != want {
+		t.Errorf("attachmentFolderPath = %v, want %v", got, want)
+	}
+	filters, ok := app["userIgnoreFilters"].([]any)
+	if !ok {
+		t.Fatalf("userIgnoreFilters not array: %#v", app["userIgnoreFilters"])
+	}
+	wantFilters := []string{"playbooks/.compiled/", "entities/.graph.jsonl"}
+	if len(filters) != len(wantFilters) {
+		t.Fatalf("userIgnoreFilters len = %d, want %d", len(filters), len(wantFilters))
+	}
+	for i, want := range wantFilters {
+		if filters[i] != want {
+			t.Errorf("userIgnoreFilters[%d] = %v, want %v", i, filters[i], want)
+		}
+	}
+
+	ignore, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	for _, want := range []string{"workspace.json", "workspace-mobile.json", "graph.json"} {
+		if !strings.Contains(string(ignore), want) {
+			t.Errorf(".gitignore missing %q\ncontent:\n%s", want, ignore)
+		}
+	}
+}
+
+func TestObsidianBootstrap_Idempotent(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	appPath, ignorePath := obsidianPaths(repo)
+	app1, err := os.ReadFile(appPath)
+	if err != nil {
+		t.Fatalf("read app.json: %v", err)
+	}
+	ignore1, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+
+	// Re-run via the same path the broker takes.
+	repo.mu.Lock()
+	if err := repo.ensureLayoutLocked(); err != nil {
+		repo.mu.Unlock()
+		t.Fatalf("ensureLayoutLocked: %v", err)
+	}
+	repo.mu.Unlock()
+
+	app2, err := os.ReadFile(appPath)
+	if err != nil {
+		t.Fatalf("read app.json after re-run: %v", err)
+	}
+	ignore2, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore after re-run: %v", err)
+	}
+	if string(app1) != string(app2) {
+		t.Errorf("app.json drifted on re-run\nbefore:\n%s\nafter:\n%s", app1, app2)
+	}
+	if string(ignore1) != string(ignore2) {
+		t.Errorf(".gitignore drifted on re-run\nbefore:\n%s\nafter:\n%s", ignore1, ignore2)
+	}
+}
+
+func TestObsidianBootstrap_MergePreservesUserKeys(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	appPath, _ := obsidianPaths(repo)
+	seed := []byte(`{"theme":"obsidian","useMarkdownLinks":true,"customField":42}`)
+	if err := os.WriteFile(appPath, seed, 0o600); err != nil {
+		t.Fatalf("seed app.json: %v", err)
+	}
+
+	repo.mu.Lock()
+	if err := repo.ensureLayoutLocked(); err != nil {
+		repo.mu.Unlock()
+		t.Fatalf("ensureLayoutLocked: %v", err)
+	}
+	repo.mu.Unlock()
+
+	app := readAppJSON(t, appPath)
+	if got := app["theme"]; got != "obsidian" {
+		t.Errorf("theme = %v, want %q (user value lost)", got, "obsidian")
+	}
+	// JSON numbers decode as float64 in map[string]any.
+	if got, ok := app["customField"].(float64); !ok || got != 42 {
+		t.Errorf("customField = %v (%T), want 42", app["customField"], app["customField"])
+	}
+	if got := app["useMarkdownLinks"]; got != false {
+		t.Errorf("useMarkdownLinks = %v, want false (WUPHF must override)", got)
+	}
+}
+
+func TestObsidianBootstrap_RequiredKeyOverride(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	appPath, _ := obsidianPaths(repo)
+	seed := []byte(`{"newLinkFormat":"shortest"}`)
+	if err := os.WriteFile(appPath, seed, 0o600); err != nil {
+		t.Fatalf("seed app.json: %v", err)
+	}
+
+	repo.mu.Lock()
+	if err := repo.ensureLayoutLocked(); err != nil {
+		repo.mu.Unlock()
+		t.Fatalf("ensureLayoutLocked: %v", err)
+	}
+	repo.mu.Unlock()
+
+	app := readAppJSON(t, appPath)
+	if got := app["newLinkFormat"]; got != "absolute" {
+		t.Errorf("newLinkFormat = %v, want %q (WUPHF must override)", got, "absolute")
+	}
+}
+
+func TestObsidianBootstrap_GitignoreLeftAloneWhenComplete(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	_, ignorePath := obsidianPaths(repo)
+	// Pre-seed with all required entries plus a user comment, ordered
+	// non-canonically, to prove byte-for-byte preservation.
+	seed := "# my notes\ngraph.json\nworkspace.json\nworkspace-mobile.json\n"
+	if err := os.WriteFile(ignorePath, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	repo.mu.Lock()
+	if err := repo.ensureLayoutLocked(); err != nil {
+		repo.mu.Unlock()
+		t.Fatalf("ensureLayoutLocked: %v", err)
+	}
+	repo.mu.Unlock()
+
+	got, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	if string(got) != seed {
+		t.Errorf(".gitignore was rewritten\nwant:\n%q\ngot:\n%q", seed, got)
+	}
+}
+
+func TestObsidianBootstrap_GitignoreAppendsMissing(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	_, ignorePath := obsidianPaths(repo)
+	// User has only one of the three required entries plus a comment.
+	seed := "# user file\nworkspace.json\n"
+	if err := os.WriteFile(ignorePath, []byte(seed), 0o600); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	repo.mu.Lock()
+	if err := repo.ensureLayoutLocked(); err != nil {
+		repo.mu.Unlock()
+		t.Fatalf("ensureLayoutLocked: %v", err)
+	}
+	repo.mu.Unlock()
+
+	got, err := os.ReadFile(ignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore: %v", err)
+	}
+	gotStr := string(got)
+	// Pre-existing content must remain.
+	if !strings.HasPrefix(gotStr, seed) {
+		t.Errorf("expected output to begin with seed\nseed:\n%q\ngot:\n%q", seed, gotStr)
+	}
+	for _, want := range []string{"workspace.json", "workspace-mobile.json", "graph.json"} {
+		if !strings.Contains(gotStr, want) {
+			t.Errorf(".gitignore missing %q after merge\ncontent:\n%s", want, gotStr)
+		}
+	}
+	// Set semantics: pre-existing entry must not be duplicated.
+	if n := strings.Count(gotStr, "workspace.json\n"); n != 1 {
+		// Note: "workspace.json" is a substring of "workspace-mobile.json"
+		// when the latter has no path component — but our token is the full
+		// line, so count the exact line form.
+		t.Errorf("workspace.json appears %d times; want 1\ncontent:\n%s", n, gotStr)
+	}
+}
+
+func TestObsidianBootstrap_CorruptAppJSONErrors(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	appPath, _ := obsidianPaths(repo)
+	if err := os.WriteFile(appPath, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt app.json: %v", err)
+	}
+
+	repo.mu.Lock()
+	err := repo.ensureLayoutLocked()
+	repo.mu.Unlock()
+	if err == nil {
+		t.Fatalf("expected error on corrupt app.json; got nil")
+	}
+}

--- a/internal/team/wiki_obsidian_embed.go
+++ b/internal/team/wiki_obsidian_embed.go
@@ -1,0 +1,101 @@
+package team
+
+// wiki_obsidian_embed.go owns the image-embed ingestion pass the watcher
+// runs after the loose-link normalizer and before Repo.Commit. Per
+// WIKI-OBSIDIAN-COMPATIBILITY §7.2, an `![[image.png]]` saved next to the
+// brief is moved to team/inbox/raw/ (the canonical attachment folder) and
+// the embed is rewritten to point at the new path.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// embedReferencePattern matches `![[target]]` and `![[target|alt]]`. Targets
+// may contain spaces or directory separators; we constrain only the bracket
+// boundaries.
+var embedReferencePattern = regexp.MustCompile(`!\[\[([^\]|]+)(\|[^\]]*)?\]\]`)
+
+// IngestImageEmbeds copies any vault-local image referenced by `![[...]]`
+// into team/inbox/raw/ and rewrites the brief body to use the canonical
+// path. It returns the (possibly unchanged) body plus the list of files
+// moved so the caller can attribute them in the commit message.
+//
+// relPath is the brief's path relative to the wiki root (e.g.
+// `team/people/sarah.md`); the function never moves files for non-brief
+// paths.
+//
+// Targets already under `inbox/raw/` are preserved verbatim. Targets that
+// do not resolve to a file on disk are left in place — lint catches the
+// broken reference downstream.
+func IngestImageEmbeds(repo *Repo, relPath, body string) (string, []string, error) {
+	if repo == nil {
+		return body, nil, errors.New("wiki obsidian embed: nil repo")
+	}
+	if !isBriefPath(relPath) {
+		return body, nil, nil
+	}
+	root := repo.Root()
+	briefDir := filepath.Dir(filepath.Join(root, filepath.FromSlash(relPath)))
+
+	var ingested []string
+	var firstErr error
+
+	rewritten := embedReferencePattern.ReplaceAllStringFunc(body, func(match string) string {
+		if firstErr != nil {
+			return match
+		}
+		m := embedReferencePattern.FindStringSubmatch(match)
+		if m == nil {
+			return match
+		}
+		target := strings.TrimSpace(m[1])
+		alt := m[2]
+		if target == "" {
+			return match
+		}
+		// Already canonical.
+		if strings.HasPrefix(target, "inbox/raw/") {
+			return match
+		}
+		// Path with directory separators that does NOT live under inbox/raw/
+		// is out of scope: only bare-filename embeds (Obsidian's default
+		// paste behaviour) get auto-promoted to the attachment folder.
+		if strings.ContainsRune(target, '/') {
+			return match
+		}
+		src := filepath.Join(briefDir, target)
+		info, err := os.Stat(src)
+		if err != nil || info.IsDir() {
+			return match
+		}
+		dstRel := "inbox/raw/" + target
+		dst := filepath.Join(root, "team", filepath.FromSlash(dstRel))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			firstErr = fmt.Errorf("wiki obsidian embed: mkdir inbox/raw: %w", err)
+			return match
+		}
+		if _, err := os.Stat(dst); err == nil {
+			// File already exists at the destination. Leave the source in
+			// place (the human may have intentionally pasted a duplicate)
+			// but rewrite the reference so the canonical version is used.
+			ingested = append(ingested, dstRel)
+			return "![[" + dstRel + alt + "]]"
+		}
+		if err := os.Rename(src, dst); err != nil {
+			firstErr = fmt.Errorf("wiki obsidian embed: move %s: %w", target, err)
+			return match
+		}
+		ingested = append(ingested, dstRel)
+		return "![[" + dstRel + alt + "]]"
+	})
+
+	if firstErr != nil {
+		return body, nil, firstErr
+	}
+	return rewritten, ingested, nil
+}

--- a/internal/team/wiki_obsidian_embed_test.go
+++ b/internal/team/wiki_obsidian_embed_test.go
@@ -1,0 +1,129 @@
+package team
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newEmbedFixture(t *testing.T) *Repo {
+	t.Helper()
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	return repo
+}
+
+func TestIngestImageEmbeds_MovesBareFilenameIntoInboxRaw(t *testing.T) {
+	repo := newEmbedFixture(t)
+	briefRel := "team/people/sarah.md"
+	briefDir := filepath.Dir(filepath.Join(repo.Root(), filepath.FromSlash(briefRel)))
+	if err := os.MkdirAll(briefDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	imgPath := filepath.Join(briefDir, "diagram.png")
+	if err := os.WriteFile(imgPath, []byte("PNGDATA"), 0o600); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+
+	body := "See ![[diagram.png]] for the architecture.\n"
+	got, ingested, err := IngestImageEmbeds(repo, briefRel, body)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if !strings.Contains(got, "![[inbox/raw/diagram.png]]") {
+		t.Fatalf("body not rewritten: %q", got)
+	}
+	if len(ingested) != 1 || ingested[0] != "inbox/raw/diagram.png" {
+		t.Fatalf("unexpected ingested list: %#v", ingested)
+	}
+	dst := filepath.Join(repo.Root(), "team", "inbox", "raw", "diagram.png")
+	if _, err := os.Stat(dst); err != nil {
+		t.Fatalf("expected png at %s: %v", dst, err)
+	}
+	if _, err := os.Stat(imgPath); !os.IsNotExist(err) {
+		t.Fatalf("expected original path removed; got err=%v", err)
+	}
+}
+
+func TestIngestImageEmbeds_LeavesAlreadyCanonical(t *testing.T) {
+	repo := newEmbedFixture(t)
+	body := "Already canonical: ![[inbox/raw/foo.png]]\n"
+	got, ingested, err := IngestImageEmbeds(repo, "team/people/sarah.md", body)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if got != body {
+		t.Fatalf("body mutated: %q", got)
+	}
+	if len(ingested) != 0 {
+		t.Fatalf("expected nothing ingested; got %#v", ingested)
+	}
+}
+
+func TestIngestImageEmbeds_LeavesBrokenReferenceInPlace(t *testing.T) {
+	repo := newEmbedFixture(t)
+	body := "Missing: ![[ghost.png]]\n"
+	got, ingested, err := IngestImageEmbeds(repo, "team/people/sarah.md", body)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if got != body {
+		t.Fatalf("body mutated for broken ref: %q", got)
+	}
+	if len(ingested) != 0 {
+		t.Fatalf("expected nothing ingested; got %#v", ingested)
+	}
+}
+
+func TestIngestImageEmbeds_SkipsNonBriefPath(t *testing.T) {
+	repo := newEmbedFixture(t)
+	body := "Has ![[anything.png]] but path is wrong"
+	got, ingested, err := IngestImageEmbeds(repo, "team/inbox/raw/something.md", body)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if got != body || len(ingested) != 0 {
+		t.Fatalf("expected no-op for non-brief path; got %q ingested=%#v", got, ingested)
+	}
+}
+
+func TestIngestImageEmbeds_PreservesAltText(t *testing.T) {
+	repo := newEmbedFixture(t)
+	briefRel := "team/companies/acme.md"
+	briefDir := filepath.Dir(filepath.Join(repo.Root(), filepath.FromSlash(briefRel)))
+	if err := os.MkdirAll(briefDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	imgPath := filepath.Join(briefDir, "logo.png")
+	if err := os.WriteFile(imgPath, []byte("LOGO"), 0o600); err != nil {
+		t.Fatalf("write png: %v", err)
+	}
+	body := "Logo ![[logo.png|Acme Corp logo]]"
+	got, _, err := IngestImageEmbeds(repo, briefRel, body)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	want := "Logo ![[inbox/raw/logo.png|Acme Corp logo]]"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestIngestImageEmbeds_PathWithSlashIsSkipped(t *testing.T) {
+	repo := newEmbedFixture(t)
+	body := "![[some/nested/path.png]]"
+	got, ingested, err := IngestImageEmbeds(repo, "team/people/sarah.md", body)
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if got != body || len(ingested) != 0 {
+		t.Fatalf("expected no-op for nested-path embed; got %q ingested=%#v", got, ingested)
+	}
+}

--- a/internal/team/wiki_obsidian_frontmatter.go
+++ b/internal/team/wiki_obsidian_frontmatter.go
@@ -1,0 +1,59 @@
+package team
+
+// wiki_obsidian_frontmatter.go owns the `last_human_edit_ts` sentinel the
+// Obsidian watcher stamps before committing an external edit. The
+// EntitySynthesizer reads this key and switches to append-mode when it is
+// newer than `last_synthesized_ts`, per WIKI-OBSIDIAN-COMPATIBILITY §6.3.
+
+import (
+	"strings"
+	"time"
+)
+
+const lastHumanEditKey = "last_human_edit_ts"
+
+// applyHumanEditSentinel sets `last_human_edit_ts: <ISO-8601 UTC>` on the
+// brief's existing YAML frontmatter. Files without a frontmatter block are
+// returned unchanged (artifacts, freshly-typed Obsidian notes that have not
+// yet been promoted to briefs — synthesizer never reads them).
+//
+// Field ordering is preserved: an existing key is rewritten in place; a
+// missing key is appended at the end of the frontmatter block so reviewers
+// see the synthesizer-owned keys at the top stay where they are.
+func applyHumanEditSentinel(content string, ts time.Time) (string, error) {
+	if !strings.HasPrefix(content, "---\n") {
+		return content, nil
+	}
+	rest := content[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return content, nil
+	}
+	block := rest[:end]
+	tail := rest[end+len("\n---"):]
+
+	tsStr := ts.UTC().Format(time.RFC3339)
+	lines := strings.Split(block, "\n")
+	rewrote := false
+	for i, line := range lines {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if m[1] == lastHumanEditKey {
+			lines[i] = lastHumanEditKey + ": " + tsStr
+			rewrote = true
+			break
+		}
+	}
+	if !rewrote {
+		lines = append(lines, lastHumanEditKey+": "+tsStr)
+	}
+
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(strings.Join(lines, "\n"))
+	b.WriteString("\n---")
+	b.WriteString(tail)
+	return b.String(), nil
+}

--- a/internal/team/wiki_obsidian_frontmatter_test.go
+++ b/internal/team/wiki_obsidian_frontmatter_test.go
@@ -1,0 +1,73 @@
+package team
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestApplyHumanEditSentinel_NoFrontmatterUnchanged(t *testing.T) {
+	body := "# Plain markdown\n\nNo frontmatter here.\n"
+	out, err := applyHumanEditSentinel(body, time.Unix(1700000000, 0).UTC())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != body {
+		t.Fatalf("expected unchanged; got %q", out)
+	}
+}
+
+func TestApplyHumanEditSentinel_AppendsWhenMissing(t *testing.T) {
+	body := "---\nkind: people\nslug: sarah\n---\n\n# Sarah\n\nBody\n"
+	ts := time.Date(2026, 5, 18, 12, 34, 56, 0, time.UTC)
+	out, err := applyHumanEditSentinel(body, ts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := "last_human_edit_ts: " + ts.Format(time.RFC3339)
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing sentinel: %q", out)
+	}
+	if !strings.Contains(out, "kind: people") || !strings.Contains(out, "slug: sarah") {
+		t.Fatalf("dropped existing keys: %q", out)
+	}
+	if !strings.Contains(out, "# Sarah\n\nBody\n") {
+		t.Fatalf("body changed: %q", out)
+	}
+}
+
+func TestApplyHumanEditSentinel_RewritesExisting(t *testing.T) {
+	body := "---\nkind: people\nlast_human_edit_ts: 2020-01-01T00:00:00Z\nslug: sarah\n---\n\nbody\n"
+	ts := time.Date(2026, 5, 18, 12, 34, 56, 0, time.UTC)
+	out, err := applyHumanEditSentinel(body, ts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if strings.Contains(out, "2020-01-01T00:00:00Z") {
+		t.Fatalf("old timestamp not replaced: %q", out)
+	}
+	if strings.Count(out, "last_human_edit_ts:") != 1 {
+		t.Fatalf("sentinel duplicated: %q", out)
+	}
+	if !strings.Contains(out, "last_human_edit_ts: "+ts.Format(time.RFC3339)) {
+		t.Fatalf("expected new timestamp: %q", out)
+	}
+	// Preserved key ordering: kind, then slug.
+	kindIdx := strings.Index(out, "kind: people")
+	slugIdx := strings.Index(out, "slug: sarah")
+	if kindIdx < 0 || slugIdx < 0 || kindIdx > slugIdx {
+		t.Fatalf("ordering disturbed: %q", out)
+	}
+}
+
+func TestApplyHumanEditSentinel_MalformedFrontmatterUnchanged(t *testing.T) {
+	body := "---\nkind: people\n\nno closing delimiter\n"
+	ts := time.Now().UTC()
+	out, err := applyHumanEditSentinel(body, ts)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if out != body {
+		t.Fatalf("expected unchanged for malformed: %q", out)
+	}
+}

--- a/internal/team/wiki_obsidian_normalize.go
+++ b/internal/team/wiki_obsidian_normalize.go
@@ -1,0 +1,75 @@
+package team
+
+// wiki_obsidian_normalize.go rewrites loose Obsidian-typed wikilinks into the
+// canonical kinded form per WIKI-OBSIDIAN-COMPATIBILITY §5. The watcher
+// commit pipeline runs this against brief bodies under team/{kind}/{slug}.md
+// before handing the contents to Repo.Commit.
+
+import (
+	"regexp"
+	"strings"
+)
+
+// looseWikilinkPattern matches `[[target]]` or `[[target|display]]` where
+// target does NOT contain a slash (kinded forms are handled by
+// kindedWikilinkPattern in entity_graph.go and left untouched here). The
+// pipe and display segment are optional; an `!` immediately preceding the
+// `[[` makes this an image embed (`![[...]]`) which we skip.
+var looseWikilinkPattern = regexp.MustCompile(`(^|[^!])\[\[([^\]|/]+)(?:\|([^\]]*))?\]\]`)
+
+// briefPathPattern restricts normalization (and embed ingestion) to the
+// seven entity-kind subtrees defined in WIKI-OBSIDIAN-COMPATIBILITY §3.
+var briefPathPattern = regexp.MustCompile(`^team/(people|companies|customers|projects|learnings|decisions|playbooks)/[a-z0-9][a-z0-9-]*\.md$`)
+
+// NormalizeLooseWikilinks rewrites every loose `[[target]]` whose target
+// resolves through `resolve` to `[[kind/slug|target]]`. The display text is
+// preserved exactly as the user typed it; the link target lands on the
+// canonical brief path so Obsidian (and our entity graph parser) can resolve
+// it deterministically.
+//
+// resolve(displayOrSlug) returns the kind and slug to point at and ok=false
+// when the display string is ambiguous or unknown. Bare-slug ambiguity is
+// the explicit guard called out in §5 of the spec — we never guess.
+//
+// Returns the rewritten body and a bool flag indicating whether anything
+// changed; callers can skip a second commit when nothing did.
+func NormalizeLooseWikilinks(body string, resolve func(displayOrSlug string) (kind EntityKind, slug string, ok bool)) (string, bool) {
+	if resolve == nil {
+		return body, false
+	}
+	changed := false
+	out := looseWikilinkPattern.ReplaceAllStringFunc(body, func(match string) string {
+		m := looseWikilinkPattern.FindStringSubmatch(match)
+		if m == nil {
+			return match
+		}
+		prefix, target, display := m[1], m[2], m[3]
+		trimmed := strings.TrimSpace(target)
+		if trimmed == "" {
+			return match
+		}
+		kind, slug, ok := resolve(trimmed)
+		if !ok || kind == "" || slug == "" {
+			return match
+		}
+		displayText := display
+		if displayText == "" {
+			displayText = target
+		}
+		canonical := string(kind) + "/" + slug
+		var rewritten string
+		if strings.TrimSpace(displayText) == canonical {
+			rewritten = "[[" + canonical + "]]"
+		} else {
+			rewritten = "[[" + canonical + "|" + displayText + "]]"
+		}
+		changed = true
+		return prefix + rewritten
+	})
+	return out, changed
+}
+
+// isBriefPath returns true when rel is a normalizable entity brief per §3.
+func isBriefPath(rel string) bool {
+	return briefPathPattern.MatchString(rel)
+}

--- a/internal/team/wiki_obsidian_normalize_test.go
+++ b/internal/team/wiki_obsidian_normalize_test.go
@@ -1,0 +1,161 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+func staticResolver(table map[string]struct {
+	kind EntityKind
+	slug string
+}) func(string) (EntityKind, string, bool) {
+	return func(s string) (EntityKind, string, bool) {
+		v, ok := table[strings.TrimSpace(s)]
+		if !ok {
+			return "", "", false
+		}
+		return v.kind, v.slug, true
+	}
+}
+
+func TestNormalizeLooseWikilinks_RewritesLooseDisplay(t *testing.T) {
+	body := "Met with [[Acme Corp]] today."
+	resolve := staticResolver(map[string]struct {
+		kind EntityKind
+		slug string
+	}{
+		"Acme Corp": {EntityKindCompanies, "acme-corp"},
+	})
+	got, changed := NormalizeLooseWikilinks(body, resolve)
+	if !changed {
+		t.Fatalf("expected changed=true; body unchanged")
+	}
+	want := "Met with [[companies/acme-corp|Acme Corp]] today."
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeLooseWikilinks_LeavesKindedLinksAlone(t *testing.T) {
+	body := "Already kinded: [[people/sarah]] and [[companies/acme|Acme Corp]]"
+	resolve := staticResolver(map[string]struct {
+		kind EntityKind
+		slug string
+	}{
+		"sarah": {EntityKindPeople, "sarah"},
+		"acme":  {EntityKindCompanies, "acme"},
+	})
+	got, changed := NormalizeLooseWikilinks(body, resolve)
+	if changed {
+		t.Fatalf("expected no change; got %q", got)
+	}
+	if got != body {
+		t.Fatalf("body mutated: %q", got)
+	}
+}
+
+func TestNormalizeLooseWikilinks_SkipsUnresolved(t *testing.T) {
+	body := "Bare [[unknown]] should pass through."
+	resolve := staticResolver(map[string]struct {
+		kind EntityKind
+		slug string
+	}{})
+	got, changed := NormalizeLooseWikilinks(body, resolve)
+	if changed {
+		t.Fatalf("unexpected change: %q", got)
+	}
+	if got != body {
+		t.Fatalf("body mutated: %q", got)
+	}
+}
+
+func TestNormalizeLooseWikilinks_PreservesDisplayWithExistingPipe(t *testing.T) {
+	body := "[[Acme|Big Acme]]"
+	resolve := staticResolver(map[string]struct {
+		kind EntityKind
+		slug string
+	}{
+		"Acme": {EntityKindCompanies, "acme"},
+	})
+	got, changed := NormalizeLooseWikilinks(body, resolve)
+	if !changed {
+		t.Fatalf("expected change")
+	}
+	want := "[[companies/acme|Big Acme]]"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeLooseWikilinks_DropsPipeWhenDisplayEqualsCanonical(t *testing.T) {
+	body := "[[acme|companies/acme]]"
+	resolve := staticResolver(map[string]struct {
+		kind EntityKind
+		slug string
+	}{
+		"acme": {EntityKindCompanies, "acme"},
+	})
+	got, changed := NormalizeLooseWikilinks(body, resolve)
+	if !changed {
+		t.Fatalf("expected change")
+	}
+	want := "[[companies/acme]]"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestNormalizeLooseWikilinks_SkipsImageEmbeds(t *testing.T) {
+	body := "Image: ![[diagram.png]] and link: [[Acme]]"
+	resolve := staticResolver(map[string]struct {
+		kind EntityKind
+		slug string
+	}{
+		"Acme":        {EntityKindCompanies, "acme"},
+		"diagram.png": {EntityKindCompanies, "should-not-trigger"},
+	})
+	got, changed := NormalizeLooseWikilinks(body, resolve)
+	if !changed {
+		t.Fatalf("expected change for link only")
+	}
+	if !strings.Contains(got, "![[diagram.png]]") {
+		t.Fatalf("image embed mutated: %q", got)
+	}
+	if !strings.Contains(got, "[[companies/acme|Acme]]") {
+		t.Fatalf("link not normalized: %q", got)
+	}
+}
+
+func TestNormalizeLooseWikilinks_NilResolverIsNoOp(t *testing.T) {
+	body := "[[anything]]"
+	got, changed := NormalizeLooseWikilinks(body, nil)
+	if changed || got != body {
+		t.Fatalf("nil resolver should be no-op; got %q changed=%v", got, changed)
+	}
+}
+
+func TestIsBriefPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"team/people/sarah.md", true},
+		{"team/companies/acme-corp.md", true},
+		{"team/customers/foo.md", true},
+		{"team/projects/proj1.md", true},
+		{"team/learnings/lesson.md", true},
+		{"team/decisions/d-2026-01.md", true},
+		{"team/playbooks/onboard.md", true},
+		{"team/playbooks/.compiled/skill/SKILL.md", false},
+		{"team/inbox/raw/foo.md", false},
+		{"team/agents/foo.md", false},
+		{"team/entities/.graph.jsonl", false},
+		{"team/people/Capitalized.md", false},
+	}
+	for _, c := range cases {
+		got := isBriefPath(c.path)
+		if got != c.want {
+			t.Errorf("isBriefPath(%q) = %v want %v", c.path, got, c.want)
+		}
+	}
+}

--- a/internal/team/wiki_obsidian_watcher.go
+++ b/internal/team/wiki_obsidian_watcher.go
@@ -65,7 +65,7 @@ type ObsidianWatcher struct {
 	identityFn ObsidianWatcherIdentity
 	normalizer ObsidianLooseLinkResolver
 	embedFn    ObsidianEmbedIngester
-	debounceMs time.Duration
+	debounce   time.Duration
 	writeTTL   time.Duration
 	timers     map[string]*time.Timer
 	recent     map[string]time.Time
@@ -83,12 +83,12 @@ type ObsidianWatcher struct {
 // watcher does nothing until Start is called.
 func NewObsidianWatcher(repo *Repo, worker *WikiWorker) *ObsidianWatcher {
 	return &ObsidianWatcher{
-		repo:       repo,
-		worker:     worker,
-		debounceMs: defaultObsidianDebounce,
-		writeTTL:   defaultObsidianWriteFilter,
-		timers:     make(map[string]*time.Timer),
-		recent:     make(map[string]time.Time),
+		repo:     repo,
+		worker:   worker,
+		debounce: defaultObsidianDebounce,
+		writeTTL: defaultObsidianWriteFilter,
+		timers:   make(map[string]*time.Timer),
+		recent:   make(map[string]time.Time),
 	}
 }
 
@@ -134,7 +134,7 @@ func (w *ObsidianWatcher) SetDebounceForTest(d time.Duration) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	if d > 0 {
-		w.debounceMs = d
+		w.debounce = d
 	}
 }
 
@@ -291,7 +291,7 @@ func (w *ObsidianWatcher) schedule(ctx context.Context, rel string) {
 			w.pending.Done()
 		}
 	}
-	d := w.debounceMs
+	d := w.debounce
 	w.pending.Add(1)
 	w.timers[rel] = time.AfterFunc(d, func() {
 		defer w.pending.Done()

--- a/internal/team/wiki_obsidian_watcher.go
+++ b/internal/team/wiki_obsidian_watcher.go
@@ -204,11 +204,16 @@ func (w *ObsidianWatcher) Stop() error {
 		_ = w.watcher.Close()
 	}
 	<-w.doneCh
-	// Cancel any timers that fired the dispatch goroutine but did not yet
-	// land in pending.Add — we hold the lock so no new ones can spawn.
+	// Cancel any timers that have not yet fired. A timer.Stop() returning
+	// true means the AfterFunc callback never ran, so we own the Add() that
+	// was paired with it and must call Done() here. Returning false means
+	// the callback has already started or completed; its own deferred
+	// Done() in the AfterFunc wrapper will run.
 	w.mu.Lock()
 	for k, t := range w.timers {
-		t.Stop()
+		if t.Stop() {
+			w.pending.Done()
+		}
 		delete(w.timers, k)
 	}
 	w.mu.Unlock()
@@ -268,6 +273,13 @@ func (w *ObsidianWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
 
 // schedule debounces commits per-path. The latest write wins: a new event
 // during an existing window resets the timer.
+//
+// The pending WaitGroup is incremented HERE (under the lock), not inside the
+// AfterFunc callback, so the Add is sequenced before any Wait in Stop(). The
+// callback owns its own Done() via the defer in the AfterFunc wrapper. When
+// an existing timer is replaced and Stop() returns true (callback never
+// ran), schedule() pays the Done() for the cancelled timer before adding
+// the new one.
 func (w *ObsidianWatcher) schedule(ctx context.Context, rel string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -275,21 +287,23 @@ func (w *ObsidianWatcher) schedule(ctx context.Context, rel string) {
 		return
 	}
 	if existing, ok := w.timers[rel]; ok {
-		existing.Stop()
+		if existing.Stop() {
+			w.pending.Done()
+		}
 	}
 	d := w.debounceMs
+	w.pending.Add(1)
 	w.timers[rel] = time.AfterFunc(d, func() {
+		defer w.pending.Done()
 		w.fire(ctx, rel)
 	})
 }
 
 // fire runs at the trailing edge of a debounce window. It rechecks the
 // worker-write TTL, resolves the author, and synchronously calls
-// Repo.Commit. Errors are logged.
+// Repo.Commit. Errors are logged. The pending WaitGroup is managed by the
+// caller (schedule's AfterFunc wrapper).
 func (w *ObsidianWatcher) fire(ctx context.Context, rel string) {
-	w.pending.Add(1)
-	defer w.pending.Done()
-
 	w.mu.Lock()
 	delete(w.timers, rel)
 	if !w.running.Load() {
@@ -469,15 +483,21 @@ func isObsidianIgnoredPath(rel string) bool {
 // subtree entirely. Mirrors isObsidianIgnoredPath at the directory level so
 // the initial recursive watch never registers ignored trees.
 func isObsidianIgnoredDir(rel string) bool {
+	// Nested directories under team/.obsidian (themes/, plugins/,
+	// snippets/, ...) are all user-owned config we never observe. Skip
+	// them so the recursive walk doesn't register watches it'll never
+	// use. team/.obsidian itself is intentionally NOT skipped — fsnotify
+	// on Linux delivers file-level Writes via the parent directory's
+	// watch, which is how we see app.json edits.
+	if strings.HasPrefix(rel, "team/.obsidian/") {
+		return true
+	}
 	switch rel {
 	case "team/playbooks/.compiled":
 		return true
 	case "team/inbox/raw":
 		return true
 	case "team/.obsidian":
-		// We still want to surface team/.obsidian/app.json edits, but
-		// fsnotify on Linux reports file-level Writes via the parent
-		// directory's watch. Add the dir and filter inside handleEvent.
 		return false
 	}
 	return false

--- a/internal/team/wiki_obsidian_watcher.go
+++ b/internal/team/wiki_obsidian_watcher.go
@@ -5,16 +5,16 @@ package team
 // single-writer invariant (WIKI-SCHEMA §1.3) keeps holding when humans edit
 // the working tree directly.
 //
-// Scope of this file is intentionally the skeleton only:
+// Commit pipeline (in order):
 //
 //   - fsnotify watch on <wiki-root>/team/, recursive (re-arm on new dirs)
 //   - debounce per-path; latest write wins
 //   - drop events that follow a NotifyWrite within its TTL
 //   - resolve author via an injected identity callback; skip when absent
-//
-// Loose-link normalization, flock in Repo.Commit, the frontmatter sentinel,
-// and the synthesizer enqueue pipeline are deliberately deferred — they
-// integrate in a follow-up pass per WIKI-OBSIDIAN-COMPATIBILITY §6.
+//   - stamp `last_human_edit_ts` frontmatter sentinel (WIKI-OBSIDIAN §6.3)
+//   - normalize loose `[[Acme]]` wikilinks on brief paths (§5)
+//   - ingest `![[image.png]]` siblings into team/inbox/raw/ (§7.2)
+//   - call Repo.Commit, which takes an advisory flock for the write (§6.2)
 
 import (
 	"context"
@@ -43,6 +43,18 @@ const (
 // silently misattribute human edits.
 type ObsidianWatcherIdentity func() (slug string, ok bool)
 
+// ObsidianLooseLinkResolver resolves an Obsidian-typed wikilink target
+// (display string or bare slug) to the canonical (kind, slug) pair used in
+// the kinded wikilink form. Returning ok=false leaves the loose link
+// unmodified — per WIKI-OBSIDIAN-COMPATIBILITY §5 ambiguous matches must
+// not be auto-rewritten.
+type ObsidianLooseLinkResolver func(displayOrSlug string) (kind EntityKind, slug string, ok bool)
+
+// ObsidianEmbedIngester moves a brief-local image referenced by `![[...]]`
+// into team/inbox/raw/ and returns the rewritten body. The function lives
+// behind an interface so tests can inject a fake without touching disk.
+type ObsidianEmbedIngester func(repo *Repo, relPath, body string) (string, []string, error)
+
 // ObsidianWatcher is the fsnotify-driven daemon that funnels external
 // edits to <wiki-root>/team/ back through Repo.Commit.
 type ObsidianWatcher struct {
@@ -51,6 +63,8 @@ type ObsidianWatcher struct {
 
 	mu         sync.Mutex
 	identityFn ObsidianWatcherIdentity
+	normalizer ObsidianLooseLinkResolver
+	embedFn    ObsidianEmbedIngester
 	debounceMs time.Duration
 	writeTTL   time.Duration
 	timers     map[string]*time.Timer
@@ -85,6 +99,25 @@ func (w *ObsidianWatcher) SetIdentity(fn ObsidianWatcherIdentity) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.identityFn = fn
+}
+
+// SetNormalizer wires the loose-link resolver used to rewrite Obsidian-typed
+// `[[Acme Corp]]` to `[[companies/acme-corp|Acme Corp]]`. Nil disables
+// normalization (the commit pipeline still runs). Production wires this to
+// the signal index; tests inject a static map.
+func (w *ObsidianWatcher) SetNormalizer(fn ObsidianLooseLinkResolver) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.normalizer = fn
+}
+
+// SetEmbedIngester wires the image-embed pass that runs after the normalizer
+// and before Repo.Commit. Nil disables embed ingestion. Production wires
+// this to IngestImageEmbeds; tests inject a fake to keep the disk cold.
+func (w *ObsidianWatcher) SetEmbedIngester(fn ObsidianEmbedIngester) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.embedFn = fn
 }
 
 // SetLogger swaps the destination for warning lines. Defaults to the
@@ -271,6 +304,8 @@ func (w *ObsidianWatcher) fire(ctx context.Context, rel string) {
 		delete(w.recent, rel)
 	}
 	identityFn := w.identityFn
+	normalizer := w.normalizer
+	embedFn := w.embedFn
 	w.mu.Unlock()
 
 	if identityFn == nil {
@@ -301,10 +336,34 @@ func (w *ObsidianWatcher) fire(ctx context.Context, rel string) {
 		return
 	}
 
+	body := string(content)
+	if stamped, ferr := applyHumanEditSentinel(body, time.Now().UTC()); ferr == nil {
+		body = stamped
+	} else {
+		w.logf("obsidian watcher: sentinel stamp %s: %v", rel, ferr)
+	}
+
+	if normalizer != nil && isBriefPath(rel) {
+		if rewritten, changed := NormalizeLooseWikilinks(body, normalizer); changed {
+			body = rewritten
+		}
+	}
+
+	if embedFn != nil && isBriefPath(rel) {
+		if rewritten, ingested, ierr := embedFn(w.repo, rel, body); ierr != nil {
+			w.logf("obsidian watcher: image embed %s: %v", rel, ierr)
+		} else {
+			body = rewritten
+			for _, p := range ingested {
+				w.NotifyWrite(p)
+			}
+		}
+	}
+
 	commitCtx, cancel := context.WithTimeout(ctx, obsidianWatcherCommitTimout)
 	defer cancel()
 	msg := fmt.Sprintf("wiki: external edit to %s", rel)
-	if _, _, err := w.repo.Commit(commitCtx, slug, rel, string(content), "replace", msg); err != nil {
+	if _, _, err := w.repo.Commit(commitCtx, slug, rel, body, "replace", msg); err != nil {
 		w.logf("obsidian watcher: commit %s: %v", rel, err)
 	}
 }

--- a/internal/team/wiki_obsidian_watcher.go
+++ b/internal/team/wiki_obsidian_watcher.go
@@ -1,0 +1,425 @@
+package team
+
+// wiki_obsidian_watcher.go is the Phase-3 daemon that captures Obsidian-side
+// edits to the on-disk wiki and routes them through Repo.Commit so the
+// single-writer invariant (WIKI-SCHEMA §1.3) keeps holding when humans edit
+// the working tree directly.
+//
+// Scope of this file is intentionally the skeleton only:
+//
+//   - fsnotify watch on <wiki-root>/team/, recursive (re-arm on new dirs)
+//   - debounce per-path; latest write wins
+//   - drop events that follow a NotifyWrite within its TTL
+//   - resolve author via an injected identity callback; skip when absent
+//
+// Loose-link normalization, flock in Repo.Commit, the frontmatter sentinel,
+// and the synthesizer enqueue pipeline are deliberately deferred — they
+// integrate in a follow-up pass per WIKI-OBSIDIAN-COMPATIBILITY §6.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+const (
+	defaultObsidianDebounce     = 1500 * time.Millisecond
+	defaultObsidianWriteFilter  = 5 * time.Second
+	obsidianWatcherCommitTimout = 10 * time.Second
+)
+
+// ObsidianWatcherIdentity resolves the author slug for an externally
+// originated wiki edit. When ok is false the watcher logs a warning and
+// skips the commit — there is no synthetic fallback because that would
+// silently misattribute human edits.
+type ObsidianWatcherIdentity func() (slug string, ok bool)
+
+// ObsidianWatcher is the fsnotify-driven daemon that funnels external
+// edits to <wiki-root>/team/ back through Repo.Commit.
+type ObsidianWatcher struct {
+	repo   *Repo
+	worker *WikiWorker
+
+	mu         sync.Mutex
+	identityFn ObsidianWatcherIdentity
+	debounceMs time.Duration
+	writeTTL   time.Duration
+	timers     map[string]*time.Timer
+	recent     map[string]time.Time
+	logger     *log.Logger
+
+	watcher *fsnotify.Watcher
+	running atomic.Bool
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+
+	pending sync.WaitGroup
+}
+
+// NewObsidianWatcher returns a watcher bound to the given repo + worker. The
+// watcher does nothing until Start is called.
+func NewObsidianWatcher(repo *Repo, worker *WikiWorker) *ObsidianWatcher {
+	return &ObsidianWatcher{
+		repo:       repo,
+		worker:     worker,
+		debounceMs: defaultObsidianDebounce,
+		writeTTL:   defaultObsidianWriteFilter,
+		timers:     make(map[string]*time.Timer),
+		recent:     make(map[string]time.Time),
+	}
+}
+
+// SetIdentity wires the callback used to resolve the author slug for an
+// external edit. Tests inject a fake; production wires it through the
+// broker's per-human identity. Safe to call before or after Start.
+func (w *ObsidianWatcher) SetIdentity(fn ObsidianWatcherIdentity) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.identityFn = fn
+}
+
+// SetLogger swaps the destination for warning lines. Defaults to the
+// standard logger. Tests inject a buffer-backed logger to capture output.
+func (w *ObsidianWatcher) SetLogger(l *log.Logger) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.logger = l
+}
+
+// SetDebounceForTest overrides the trailing-edge debounce window. Test-only;
+// production keeps the default 1.5s.
+func (w *ObsidianWatcher) SetDebounceForTest(d time.Duration) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if d > 0 {
+		w.debounceMs = d
+	}
+}
+
+// SetWriteTTLForTest overrides how long a NotifyWrite suppresses subsequent
+// fsnotify events for the same path. Test-only.
+func (w *ObsidianWatcher) SetWriteTTLForTest(d time.Duration) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if d > 0 {
+		w.writeTTL = d
+	}
+}
+
+// NotifyWrite records that the worker (or any other internal writer) just
+// touched relPath. fsnotify events on that path within writeTTL are dropped
+// so the watcher never re-commits its own outputs.
+func (w *ObsidianWatcher) NotifyWrite(relPath string) {
+	rel := normalizeRel(relPath)
+	if rel == "" {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.recent[rel] = time.Now()
+}
+
+// Start launches the fsnotify watcher and the event-dispatch goroutine. It
+// returns once the recursive add of team/ has completed. Errors during the
+// initial walk abort the start; transient errors during steady-state are
+// logged and elided.
+func (w *ObsidianWatcher) Start(ctx context.Context) error {
+	if w.running.Swap(true) {
+		return errors.New("obsidian watcher: already running")
+	}
+	teamDir := w.repo.TeamDir()
+	if _, err := os.Stat(teamDir); err != nil {
+		w.running.Store(false)
+		return fmt.Errorf("obsidian watcher: team dir: %w", err)
+	}
+	fs, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.running.Store(false)
+		return fmt.Errorf("obsidian watcher: new fsnotify: %w", err)
+	}
+	w.watcher = fs
+	w.stopCh = make(chan struct{})
+	w.doneCh = make(chan struct{})
+
+	if err := w.addRecursive(teamDir); err != nil {
+		_ = fs.Close()
+		w.running.Store(false)
+		return fmt.Errorf("obsidian watcher: add recursive: %w", err)
+	}
+
+	go w.run(ctx)
+	return nil
+}
+
+// Stop shuts down the fsnotify watcher and waits for any in-flight debounce
+// timers and commit goroutines to drain.
+func (w *ObsidianWatcher) Stop() error {
+	if !w.running.Swap(false) {
+		return nil
+	}
+	close(w.stopCh)
+	if w.watcher != nil {
+		_ = w.watcher.Close()
+	}
+	<-w.doneCh
+	// Cancel any timers that fired the dispatch goroutine but did not yet
+	// land in pending.Add — we hold the lock so no new ones can spawn.
+	w.mu.Lock()
+	for k, t := range w.timers {
+		t.Stop()
+		delete(w.timers, k)
+	}
+	w.mu.Unlock()
+	w.pending.Wait()
+	return nil
+}
+
+// run is the single dispatcher goroutine. It receives fsnotify events, walks
+// new directories, and schedules debounced commits.
+func (w *ObsidianWatcher) run(ctx context.Context) {
+	defer close(w.doneCh)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-w.stopCh:
+			return
+		case ev, ok := <-w.watcher.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(ctx, ev)
+		case err, ok := <-w.watcher.Errors:
+			if !ok {
+				return
+			}
+			w.logf("obsidian watcher: fsnotify error: %v", err)
+		}
+	}
+}
+
+// handleEvent classifies a single fsnotify event: new directories get an
+// Add; ignored paths short-circuit; eligible writes schedule a debounce.
+func (w *ObsidianWatcher) handleEvent(ctx context.Context, ev fsnotify.Event) {
+	if ev.Op&fsnotify.Create != 0 {
+		if info, err := os.Stat(ev.Name); err == nil && info.IsDir() {
+			if err := w.addRecursive(ev.Name); err != nil {
+				w.logf("obsidian watcher: add dir %s: %v", ev.Name, err)
+			}
+			return
+		}
+	}
+	// Only write / create on .md files trigger commit logic. Renames and
+	// removes are not in scope for the skeleton.
+	if ev.Op&(fsnotify.Write|fsnotify.Create) == 0 {
+		return
+	}
+	rel, ok := w.relPath(ev.Name)
+	if !ok {
+		return
+	}
+	if !isObsidianWatchableMarkdown(rel) {
+		return
+	}
+	w.schedule(ctx, rel)
+}
+
+// schedule debounces commits per-path. The latest write wins: a new event
+// during an existing window resets the timer.
+func (w *ObsidianWatcher) schedule(ctx context.Context, rel string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.running.Load() {
+		return
+	}
+	if existing, ok := w.timers[rel]; ok {
+		existing.Stop()
+	}
+	d := w.debounceMs
+	w.timers[rel] = time.AfterFunc(d, func() {
+		w.fire(ctx, rel)
+	})
+}
+
+// fire runs at the trailing edge of a debounce window. It rechecks the
+// worker-write TTL, resolves the author, and synchronously calls
+// Repo.Commit. Errors are logged.
+func (w *ObsidianWatcher) fire(ctx context.Context, rel string) {
+	w.pending.Add(1)
+	defer w.pending.Done()
+
+	w.mu.Lock()
+	delete(w.timers, rel)
+	if !w.running.Load() {
+		w.mu.Unlock()
+		return
+	}
+	if ts, ok := w.recent[rel]; ok {
+		if time.Since(ts) < w.writeTTL {
+			w.mu.Unlock()
+			return
+		}
+		delete(w.recent, rel)
+	}
+	identityFn := w.identityFn
+	w.mu.Unlock()
+
+	if identityFn == nil {
+		w.logf("obsidian watcher: no identity callback set; skipping commit for %s", rel)
+		return
+	}
+	slug, ok := identityFn()
+	if !ok || strings.TrimSpace(slug) == "" {
+		w.logf("obsidian watcher: identity unavailable; skipping commit for %s", rel)
+		return
+	}
+
+	full := filepath.Join(w.repo.Root(), filepath.FromSlash(rel))
+	content, err := os.ReadFile(full)
+	if err != nil {
+		// File can vanish between fsnotify Write and the trailing-edge
+		// read (e.g. Obsidian's atomic-write rename followed by a fast
+		// delete). Drop the event silently — a subsequent write will
+		// re-arm the debounce.
+		if !errors.Is(err, os.ErrNotExist) {
+			w.logf("obsidian watcher: read %s: %v", rel, err)
+		}
+		return
+	}
+	if len(strings.TrimSpace(string(content))) == 0 {
+		// Repo.Commit rejects empty bodies; treat zero-byte writes as
+		// transient (Obsidian touches a fresh file before populating it).
+		return
+	}
+
+	commitCtx, cancel := context.WithTimeout(ctx, obsidianWatcherCommitTimout)
+	defer cancel()
+	msg := fmt.Sprintf("wiki: external edit to %s", rel)
+	if _, _, err := w.repo.Commit(commitCtx, slug, rel, string(content), "replace", msg); err != nil {
+		w.logf("obsidian watcher: commit %s: %v", rel, err)
+	}
+}
+
+// addRecursive walks dir and registers every subdirectory with the
+// fsnotify watcher. Files inside the dir are not added individually —
+// fsnotify reports parent-dir events for them on Linux.
+func (w *ObsidianWatcher) addRecursive(dir string) error {
+	return filepath.Walk(dir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(w.repo.Root(), path)
+		if err != nil {
+			return err
+		}
+		relSlash := filepath.ToSlash(rel)
+		if isObsidianIgnoredDir(relSlash) {
+			return filepath.SkipDir
+		}
+		return w.watcher.Add(path)
+	})
+}
+
+// relPath converts an absolute event path into a slash-separated repo-rooted
+// path. Returns ("", false) when the path escapes the repo root.
+func (w *ObsidianWatcher) relPath(abs string) (string, bool) {
+	rel, err := filepath.Rel(w.repo.Root(), abs)
+	if err != nil {
+		return "", false
+	}
+	rel = filepath.ToSlash(rel)
+	if strings.HasPrefix(rel, "..") {
+		return "", false
+	}
+	return rel, true
+}
+
+// logf routes a warning through the injected logger when set, otherwise the
+// default `log` package destination. Kept as a helper so tests can capture.
+func (w *ObsidianWatcher) logf(format string, args ...any) {
+	w.mu.Lock()
+	l := w.logger
+	w.mu.Unlock()
+	if l != nil {
+		l.Printf(format, args...)
+		return
+	}
+	log.Printf(format, args...)
+}
+
+func normalizeRel(rel string) string {
+	rel = strings.TrimSpace(rel)
+	if rel == "" {
+		return ""
+	}
+	return filepath.ToSlash(filepath.Clean(rel))
+}
+
+// isObsidianWatchableMarkdown returns true when rel is a candidate for the
+// external-edit commit pipeline: under team/, ends in .md, and not in any of
+// the ignored worker-owned or derived subtrees.
+func isObsidianWatchableMarkdown(rel string) bool {
+	if !strings.HasPrefix(rel, "team/") {
+		return false
+	}
+	if !strings.HasSuffix(strings.ToLower(rel), ".md") {
+		return false
+	}
+	base := filepath.Base(rel)
+	if strings.HasPrefix(base, ".") {
+		// `.gitkeep` and `team/.obsidian/app.json` are not .md so they
+		// never reach this branch; any other dotfile is ignored.
+		return false
+	}
+	if isObsidianIgnoredPath(rel) {
+		return false
+	}
+	return true
+}
+
+// isObsidianIgnoredPath returns true when rel is inside a worker-owned or
+// derived subtree (compiled skills, the graph log, the raw inbox, the
+// Obsidian config dir).
+func isObsidianIgnoredPath(rel string) bool {
+	switch {
+	case strings.HasPrefix(rel, "team/playbooks/.compiled/"):
+		return true
+	case rel == "team/entities/.graph.jsonl":
+		return true
+	case strings.HasPrefix(rel, "team/inbox/raw/"):
+		return true
+	case strings.HasPrefix(rel, "team/.obsidian/"):
+		return rel != "team/.obsidian/app.json"
+	}
+	return false
+}
+
+// isObsidianIgnoredDir returns true when a directory walk should skip a
+// subtree entirely. Mirrors isObsidianIgnoredPath at the directory level so
+// the initial recursive watch never registers ignored trees.
+func isObsidianIgnoredDir(rel string) bool {
+	switch rel {
+	case "team/playbooks/.compiled":
+		return true
+	case "team/inbox/raw":
+		return true
+	case "team/.obsidian":
+		// We still want to surface team/.obsidian/app.json edits, but
+		// fsnotify on Linux reports file-level Writes via the parent
+		// directory's watch. Add the dir and filter inside handleEvent.
+		return false
+	}
+	return false
+}

--- a/internal/team/wiki_obsidian_watcher_test.go
+++ b/internal/team/wiki_obsidian_watcher_test.go
@@ -59,31 +59,40 @@ func writeFile(t *testing.T, path, body string) {
 }
 
 // waitForHEADChange polls until the short HEAD SHA differs from `prev`,
-// returning the new SHA. Fails the test on timeout.
+// returning the new SHA. Fails the test on timeout. Uses select/time.After
+// rather than Sleep so the deadline is structural; fsnotify + git commit
+// are OS-driven so a software clock can't replace real time here.
 func waitForHEADChange(t *testing.T, repo *Repo, prev string, timeout time.Duration) string {
 	t.Helper()
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	deadlineCh := time.After(timeout)
+	for {
 		sha, err := repo.HeadSHA(context.Background())
 		if err == nil && sha != "" && sha != prev {
 			return sha
 		}
-		time.Sleep(20 * time.Millisecond)
+		select {
+		case <-deadlineCh:
+			t.Fatalf("HEAD did not advance from %q within %s", prev, timeout)
+			return ""
+		case <-time.After(20 * time.Millisecond):
+		}
 	}
-	t.Fatalf("HEAD did not advance from %q within %s", prev, timeout)
-	return ""
 }
 
 // requireHEADStable asserts that HEAD does not advance within window.
 func requireHEADStable(t *testing.T, repo *Repo, prev string, window time.Duration) {
 	t.Helper()
-	deadline := time.Now().Add(window)
-	for time.Now().Before(deadline) {
+	deadlineCh := time.After(window)
+	for {
 		sha, err := repo.HeadSHA(context.Background())
 		if err == nil && sha != prev {
 			t.Fatalf("HEAD advanced unexpectedly: %s → %s", prev, sha)
 		}
-		time.Sleep(20 * time.Millisecond)
+		select {
+		case <-deadlineCh:
+			return
+		case <-time.After(20 * time.Millisecond):
+		}
 	}
 }
 
@@ -169,7 +178,7 @@ func TestObsidianWatcher_DebounceCoalescesRapidWrites(t *testing.T) {
 	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
 	for i := 0; i < 5; i++ {
 		writeFile(t, full, "# Burst\n\nversion "+string(rune('a'+i))+"\n")
-		time.Sleep(40 * time.Millisecond)
+		<-time.After(40 * time.Millisecond)
 	}
 
 	newSHA := waitForHEADChange(t, repo, prev, 3*time.Second)
@@ -258,7 +267,7 @@ func TestObsidianWatcher_StopDuringPendingDebounce(t *testing.T) {
 
 	// Give fsnotify time to deliver the event and arm the timer, then
 	// stop the watcher before the trailing edge.
-	time.Sleep(150 * time.Millisecond)
+	<-time.After(150 * time.Millisecond)
 	if err := watcher.Stop(); err != nil {
 		t.Fatalf("stop: %v", err)
 	}

--- a/internal/team/wiki_obsidian_watcher_test.go
+++ b/internal/team/wiki_obsidian_watcher_test.go
@@ -1,0 +1,285 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newObsidianWatcherFixture mirrors newGraphFixture but returns a real
+// fsnotify-backed ObsidianWatcher wired to a tempdir Repo + WikiWorker.
+// The returned debounce is short by default (50ms) so trailing-edge fires
+// finish well inside test timeouts.
+func newObsidianWatcherFixture(t *testing.T) (*Repo, *WikiWorker, *ObsidianWatcher, context.CancelFunc) {
+	t.Helper()
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	watcher := NewObsidianWatcher(repo, worker)
+	watcher.SetDebounceForTest(50 * time.Millisecond)
+	watcher.SetIdentity(func() (string, bool) { return "sarah", true })
+
+	if err := watcher.Start(ctx); err != nil {
+		cancel()
+		worker.Stop()
+		t.Fatalf("start watcher: %v", err)
+	}
+
+	teardown := func() {
+		_ = watcher.Stop()
+		cancel()
+		worker.Stop()
+		<-worker.Done()
+	}
+	return repo, worker, watcher, teardown
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// waitForHEADChange polls until the short HEAD SHA differs from `prev`,
+// returning the new SHA. Fails the test on timeout.
+func waitForHEADChange(t *testing.T, repo *Repo, prev string, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		sha, err := repo.HeadSHA(context.Background())
+		if err == nil && sha != "" && sha != prev {
+			return sha
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("HEAD did not advance from %q within %s", prev, timeout)
+	return ""
+}
+
+// requireHEADStable asserts that HEAD does not advance within window.
+func requireHEADStable(t *testing.T, repo *Repo, prev string, window time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		sha, err := repo.HeadSHA(context.Background())
+		if err == nil && sha != prev {
+			t.Fatalf("HEAD advanced unexpectedly: %s → %s", prev, sha)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestObsidianWatcher_StartStop(t *testing.T) {
+	_, _, _, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+}
+
+func TestObsidianWatcher_CreateMarkdownCommits(t *testing.T) {
+	repo, _, _, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+
+	prev, err := repo.HeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	rel := "team/people/test.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	writeFile(t, full, "# Test person\n\nNotes.\n")
+
+	newSHA := waitForHEADChange(t, repo, prev, 3*time.Second)
+	if newSHA == prev {
+		t.Fatalf("expected commit; head unchanged")
+	}
+}
+
+func TestObsidianWatcher_ModifyExistingFileReplaces(t *testing.T) {
+	repo, _, _, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+
+	rel := "team/people/sarah.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	writeFile(t, full, "# Sarah\n\nv1\n")
+	first := waitForHEADChange(t, repo, "", 3*time.Second)
+
+	writeFile(t, full, "# Sarah\n\nv2 with updated notes\n")
+	second := waitForHEADChange(t, repo, first, 3*time.Second)
+
+	got, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatalf("read after commit: %v", err)
+	}
+	if !strings.Contains(string(got), "v2 with updated notes") {
+		t.Fatalf("file does not contain v2 content: %q", got)
+	}
+	if second == first {
+		t.Fatalf("HEAD did not advance for replace commit")
+	}
+}
+
+func TestObsidianWatcher_NotifyWriteFiltersOwnEvents(t *testing.T) {
+	repo, _, watcher, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+
+	// First commit so HEAD is at a known SHA.
+	rel := "team/people/sarah.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	writeFile(t, full, "# Sarah\n\ninitial\n")
+	first := waitForHEADChange(t, repo, "", 3*time.Second)
+
+	// Pretend the worker is about to write to the same path. NotifyWrite
+	// records the path within the 5s TTL; the subsequent fsnotify event
+	// should be dropped.
+	watcher.NotifyWrite(rel)
+	writeFile(t, full, "# Sarah\n\nworker-originated content\n")
+
+	requireHEADStable(t, repo, first, 500*time.Millisecond)
+}
+
+func TestObsidianWatcher_DebounceCoalescesRapidWrites(t *testing.T) {
+	repo, _, watcher, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+	// Widen the debounce so multiple writes land inside a single window.
+	watcher.SetDebounceForTest(300 * time.Millisecond)
+
+	prev, err := repo.HeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	rel := "team/people/burst.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	for i := 0; i < 5; i++ {
+		writeFile(t, full, "# Burst\n\nversion "+string(rune('a'+i))+"\n")
+		time.Sleep(40 * time.Millisecond)
+	}
+
+	newSHA := waitForHEADChange(t, repo, prev, 3*time.Second)
+
+	// Confirm content is the final version (latest write wins).
+	got, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(got), "version e") {
+		t.Fatalf("expected final content `version e`; got %q", got)
+	}
+
+	// Verify only one commit landed for that path: the most recent commit
+	// touching rel should be the one we just observed; the one before it
+	// should pre-date our writes (an init / unrelated commit).
+	refs, err := repo.Log(context.Background(), rel)
+	if err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("expected exactly 1 commit for %s; got %d: %#v", rel, len(refs), refs)
+	}
+	if refs[0].SHA != newSHA {
+		t.Fatalf("log head sha mismatch: log=%s head=%s", refs[0].SHA, newSHA)
+	}
+}
+
+func TestObsidianWatcher_IdentityUnavailableSkipsCommit(t *testing.T) {
+	repo, _, watcher, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+	watcher.SetIdentity(func() (string, bool) { return "", false })
+
+	var buf bytes.Buffer
+	var bufMu sync.Mutex
+	watcher.SetLogger(log.New(syncWriter{w: &buf, mu: &bufMu}, "", 0))
+
+	prev, err := repo.HeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	rel := "team/people/test.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	writeFile(t, full, "# Test\n\nbody\n")
+
+	requireHEADStable(t, repo, prev, 500*time.Millisecond)
+
+	bufMu.Lock()
+	logged := buf.String()
+	bufMu.Unlock()
+	if !strings.Contains(logged, "identity unavailable") {
+		t.Fatalf("expected identity-unavailable log; got %q", logged)
+	}
+}
+
+func TestObsidianWatcher_IgnoresCompiledPlaybookDir(t *testing.T) {
+	repo, _, _, teardown := newObsidianWatcherFixture(t)
+	defer teardown()
+
+	prev, err := repo.HeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	rel := "team/playbooks/.compiled/some-skill/SKILL.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	writeFile(t, full, "# Compiled\n\nworker-owned output\n")
+
+	requireHEADStable(t, repo, prev, 500*time.Millisecond)
+}
+
+func TestObsidianWatcher_StopDuringPendingDebounce(t *testing.T) {
+	repo, _, watcher, teardown := newObsidianWatcherFixture(t)
+	// Wide debounce so the timer is still pending when we Stop.
+	watcher.SetDebounceForTest(1500 * time.Millisecond)
+
+	prev, err := repo.HeadSHA(context.Background())
+	if err != nil {
+		t.Fatalf("head: %v", err)
+	}
+
+	rel := "team/people/pending.md"
+	full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+	writeFile(t, full, "# Pending\n\nbody\n")
+
+	// Give fsnotify time to deliver the event and arm the timer, then
+	// stop the watcher before the trailing edge.
+	time.Sleep(150 * time.Millisecond)
+	if err := watcher.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	// Trailing edge would have fired around 1.5s from the write; wait
+	// long enough to be sure it did not.
+	requireHEADStable(t, repo, prev, 2*time.Second)
+
+	teardown()
+}
+
+// syncWriter is a tiny thread-safe io.Writer wrapper around bytes.Buffer.
+// The logger and the goroutine running Stop's drain may both touch the
+// underlying buffer; the lock keeps `go test -race` quiet.
+type syncWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (s syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}

--- a/web/e2e/screenshots/obsidian-callouts.mjs
+++ b/web/e2e/screenshots/obsidian-callouts.mjs
@@ -1,0 +1,212 @@
+// Capture obsidian-flavored callouts rendered in the wiki article surface.
+// Real-example proof for PR #905 (wiki ↔ obsidian compatibility).
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh obsidian-callouts 905
+//
+// or stand-alone for local iteration:
+//   BASE_URL=http://localhost:5273 WUPHF_SCREENSHOTS_OUT=/tmp/obsidian-shots \
+//   node web/e2e/screenshots/obsidian-callouts.mjs
+
+import process from "node:process";
+
+import { bootShell, installCommonMocks, launchBrowser } from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh or set it manually");
+  process.exit(2);
+}
+
+const ARTICLE_PATH = "people/sarah-chen";
+
+const ARTICLE = {
+  path: ARTICLE_PATH,
+  title: "Sarah Chen",
+  content: [
+    "**Sarah Chen** is VP of Sales at [[companies/acme-corp|Acme Corp]] and the deal owner for the Q2 enterprise pilot.",
+    "",
+    "## Callout gallery",
+    "",
+    "> [!note] Quick context",
+    "> Sarah joined Acme in 2024 from [[companies/initech]]. She owns enterprise pricing decisions.",
+    "",
+    "> [!info]",
+    "> Pricing approval threshold is $250k ARR — anything above routes to her boss [[people/alex-kim]].",
+    "",
+    "> [!tip] Negotiation tactic",
+    "> Reference the Q1 [[companies/contoso]] case study; Sarah cites it when objecting to a 3-year term.",
+    "",
+    "> [!important] Confidential",
+    "> Sarah is mid-acquisition discussions with [[companies/globex]]. Do not surface this in shared channels.",
+    "",
+    "> [!warning] Stale contact",
+    "> Last touch was 47 days ago. Re-engage before quarter-end or the pilot lapses.",
+    "",
+    "> [!caution] Hard line",
+    "> No invoice-net-90 terms. She has rejected this twice; raising it again will burn the relationship.",
+    "",
+    "## Folded callouts",
+    "",
+    "> [!info]- Background — click to expand",
+    "> Sarah's prior role at [[companies/initech]] involved a similar enterprise-pilot framework. The playbook there was: 30-day eval → 90-day paid pilot → ARR.",
+    ">",
+    "> She brings that mental model to Acme.",
+    "",
+    "> [!warning]+ Open question",
+    "> Does Sarah's bonus structure depend on the Q2 pilot landing, or on full ARR? Confirm with [[people/alex-kim]] before our Thursday sync.",
+    "",
+    "## Wikilinks survive inside callouts",
+    "",
+    "> [!note] Cross-references",
+    "> See also [[people/alex-kim]], [[companies/acme-corp]], and the [[playbooks/enterprise-pricing-objections|enterprise-pricing playbook]].",
+  ].join("\n"),
+  last_edited_by: "ceo",
+  last_edited_ts: "2026-05-17T14:32:00Z",
+  commit_sha: "a1b2c3d",
+  revisions: 12,
+  contributors: ["ceo", "pm", "archivist"],
+  backlinks: [],
+  word_count: 230,
+  categories: ["Active pilot", "Enterprise"],
+  human_read_count: 4,
+  agent_read_count: 11,
+  days_unread: 1,
+};
+
+const CATALOG = [
+  { path: "people/sarah-chen", title: "Sarah Chen", author_slug: "ceo",
+    last_edited_ts: ARTICLE.last_edited_ts, group: "people" },
+  { path: "people/alex-kim", title: "Alex Kim", author_slug: "ceo",
+    last_edited_ts: ARTICLE.last_edited_ts, group: "people" },
+  { path: "companies/acme-corp", title: "Acme Corp", author_slug: "ceo",
+    last_edited_ts: ARTICLE.last_edited_ts, group: "companies" },
+  { path: "companies/contoso", title: "Contoso", author_slug: "ceo",
+    last_edited_ts: ARTICLE.last_edited_ts, group: "companies" },
+  // initech and globex deliberately absent → render as broken wikilinks
+  // (red) to prove cross-reference resolution survives the callout boundary.
+];
+
+const wikiMocks = async (ctx) => {
+  await ctx.route("**/api/wiki/article**", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(ARTICLE) }),
+  );
+  await ctx.route("**/api/wiki/catalog", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify({ articles: CATALOG }) }),
+  );
+  await ctx.route("**/api/wiki/sections", (r) =>
+    r.fulfill({ contentType: "application/json", body: '{"sections":[]}' }),
+  );
+  await ctx.route("**/api/wiki/history**", (r) =>
+    r.fulfill({ contentType: "application/json", body: '{"commits":[]}' }),
+  );
+  await ctx.route("**/api/wiki/sources**", (r) =>
+    r.fulfill({ contentType: "application/json", body: '{"sources":[]}' }),
+  );
+};
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1400, height: 1800 },
+});
+
+await installCommonMocks(context, { extra: wikiMocks });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await page.evaluate(async (path) => {
+  const m = await import("/src/lib/router.ts");
+  await m.router.navigate({ to: "/wiki/$", params: { _splat: path } });
+}, ARTICLE_PATH);
+
+// The article renders inside the wiki shell as an h1 followed by remark
+// content. Wait on the callout aside since it's the actual proof; the h1
+// can race with the markdown pipeline on cold HMR boots.
+await page.locator(".wk-callout").first().waitFor({ timeout: 15_000 });
+await page.locator("h1:has-text('Sarah Chen')").waitFor({ timeout: 5_000 });
+await page.locator(".wk-callout").nth(5).waitFor({ timeout: 5_000 }); // sixth (caution) is the last in the gallery
+await page.waitForTimeout(600); // let async wikilink resolution paint
+
+if (errors.length > 0) {
+  console.error("page errors:", errors);
+}
+
+// 1. Full-page hero: scroll to the gallery so it's centered for the
+// header-context shot.
+await page.locator("h2:has-text('Callout gallery')").scrollIntoViewIfNeeded();
+await page.waitForTimeout(200);
+await page.screenshot({
+  path: `${OUT}/01-callouts-gallery-page.png`,
+  animations: "disabled",
+  fullPage: false,
+});
+
+// 2. Tight crop of the six callouts. A single bounding box covering all
+// six produces one frame, not six.
+async function clipBox(extractor, name) {
+  const box = await page.evaluate(extractor);
+  if (!box) return false;
+  await page.screenshot({
+    path: `${OUT}/${name}.png`,
+    animations: "disabled",
+    clip: box,
+  });
+  return true;
+}
+
+await clipBox(() => {
+  const callouts = Array.from(document.querySelectorAll(".wk-callout"));
+  if (callouts.length < 6) return null;
+  const first = callouts[0].getBoundingClientRect();
+  const last = callouts[5].getBoundingClientRect();
+  return {
+    x: Math.max(0, Math.floor(first.left - 12)),
+    y: Math.max(0, Math.floor(first.top - 12)),
+    width: Math.ceil(Math.max(first.width, last.width) + 24),
+    height: Math.ceil(last.bottom - first.top + 24),
+  };
+}, "02-callouts-six-types");
+
+// 3. Folded callouts — closed (info-) and open (warning+).
+await page.locator("h2:has-text('Folded callouts')").scrollIntoViewIfNeeded();
+await page.waitForTimeout(200);
+await clipBox(() => {
+  const heading = Array.from(document.querySelectorAll("h2"))
+    .find((h) => h.textContent?.includes("Folded callouts"));
+  if (!heading) return null;
+  const callouts = [];
+  let el = heading.nextElementSibling;
+  while (el && el.tagName !== "H2") {
+    if (el.classList?.contains("wk-callout")) callouts.push(el);
+    el = el.nextElementSibling;
+  }
+  if (callouts.length === 0) return null;
+  const first = callouts[0].getBoundingClientRect();
+  const last = callouts[callouts.length - 1].getBoundingClientRect();
+  return {
+    x: Math.max(0, Math.floor(first.left - 12)),
+    y: Math.max(0, Math.floor(first.top - 12)),
+    width: Math.ceil(Math.max(first.width, last.width) + 24),
+    height: Math.ceil(last.bottom - first.top + 24),
+  };
+}, "03-callouts-folded");
+
+// 4. Single callout close-up showing wikilinks inside its body — the
+// "cross-references survive the callout boundary" proof point.
+await page.locator("h2:has-text('Wikilinks survive inside callouts')").scrollIntoViewIfNeeded();
+await page.waitForTimeout(200);
+await clipBox(() => {
+  const heading = Array.from(document.querySelectorAll("h2"))
+    .find((h) => h.textContent?.includes("Wikilinks survive"));
+  if (!heading) return null;
+  let el = heading.nextElementSibling;
+  while (el && !el.classList?.contains("wk-callout")) el = el.nextElementSibling;
+  if (!el) return null;
+  const box = el.getBoundingClientRect();
+  return {
+    x: Math.max(0, Math.floor(box.left - 12)),
+    y: Math.max(0, Math.floor(box.top - 12)),
+    width: Math.ceil(box.width + 24),
+    height: Math.ceil(box.height + 24),
+  };
+}, "04-callout-with-wikilinks");
+
+console.log("captured callout screenshots to", OUT);
+await browser.close();

--- a/web/src/components/wiki/Callout.test.tsx
+++ b/web/src/components/wiki/Callout.test.tsx
@@ -1,0 +1,134 @@
+import type { ReactElement } from "react";
+import ReactMarkdown from "react-markdown";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMarkdownComponents,
+  buildRemarkPlugins,
+} from "../../lib/wikiMarkdownConfig";
+import Callout, { CalloutBlockquote } from "./Callout";
+
+describe("<Callout>", () => {
+  it("renders the type label, title, and body", () => {
+    render(
+      <Callout type="info" title="Heads up" folded={false} defaultOpen={false}>
+        <p>Body content</p>
+      </Callout>,
+    );
+    expect(screen.getByText("Info")).toBeInTheDocument();
+    expect(screen.getByText("Heads up")).toBeInTheDocument();
+    expect(screen.getByText("Body content")).toBeInTheDocument();
+  });
+
+  it("renders without a title when none is provided", () => {
+    render(
+      <Callout type="note" title="" folded={false} defaultOpen={false}>
+        <p>Just body</p>
+      </Callout>,
+    );
+    expect(screen.getByText("Note")).toBeInTheDocument();
+    expect(screen.getByText("Just body")).toBeInTheDocument();
+  });
+
+  it("uses <details>/<summary> for folded variants", () => {
+    const { container } = render(
+      <Callout type="warning" title="" folded={true} defaultOpen={true}>
+        <p>Expanded body</p>
+      </Callout>,
+    );
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details).toHaveAttribute("open");
+    expect(container.querySelector("summary")).not.toBeNull();
+  });
+
+  it("renders closed by default when defaultOpen=false", () => {
+    const { container } = render(
+      <Callout type="caution" title="" folded={true} defaultOpen={false}>
+        <p>Hidden body</p>
+      </Callout>,
+    );
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("applies the type-specific css class", () => {
+    const { container } = render(
+      <Callout type="caution" title="" folded={false} defaultOpen={false}>
+        <p>x</p>
+      </Callout>,
+    );
+    expect(container.querySelector(".wk-callout-caution")).not.toBeNull();
+  });
+});
+
+describe("<CalloutBlockquote>", () => {
+  it("falls through to a plain blockquote when not tagged as a callout", () => {
+    const props = {
+      children: "ordinary quote",
+    } as unknown as Parameters<typeof CalloutBlockquote>[0];
+    const el = CalloutBlockquote(props) as ReactElement;
+    expect(el.type).toBe("blockquote");
+  });
+});
+
+describe("Callout integration with the wiki markdown pipeline", () => {
+  function renderWiki(source: string, slugs: string[] = []) {
+    const known = new Set(slugs);
+    const remarkPlugins = buildRemarkPlugins((s: string) => known.has(s));
+    const components = buildMarkdownComponents({
+      resolver: (s: string) => known.has(s),
+    });
+    return render(
+      <ReactMarkdown remarkPlugins={remarkPlugins} components={components}>
+        {source}
+      </ReactMarkdown>,
+    );
+  }
+
+  it("renders a `> [!note]` blockquote as a callout with title and body markdown", () => {
+    const { container } = renderWiki(
+      "> [!note] Heads up\n> Body has **bold** text\n",
+    );
+    expect(container.querySelector(".wk-callout-note")).not.toBeNull();
+    expect(screen.getByText("Note")).toBeInTheDocument();
+    expect(screen.getByText("Heads up")).toBeInTheDocument();
+    const strong = container.querySelector("strong");
+    expect(strong).not.toBeNull();
+    expect(strong?.textContent).toBe("bold");
+  });
+
+  it("renders `> [!warning]+` as a folded callout open by default", () => {
+    const { container } = renderWiki("> [!warning]+\n> Expanded body\n");
+    expect(container.querySelector(".wk-callout-warning")).not.toBeNull();
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details).toHaveAttribute("open");
+  });
+
+  it("renders `> [!caution]-` as a folded callout closed by default", () => {
+    const { container } = renderWiki("> [!caution]-\n> Collapsed body\n");
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("keeps wikilinks inside the callout body rendered as wikilinks", () => {
+    const { container } = renderWiki(
+      "> [!info]\n> See [[people/nazz]] for more.\n",
+      ["people/nazz"],
+    );
+    const link = container.querySelector("a[data-wikilink='true']");
+    expect(link).not.toBeNull();
+    expect(link).toHaveAttribute("data-slug", "people/nazz");
+    expect(link?.textContent).toBe("people/nazz");
+  });
+
+  it("leaves a regular blockquote rendered as a plain blockquote", () => {
+    const { container } = renderWiki("> just an ordinary quote\n");
+    expect(container.querySelector(".wk-callout")).toBeNull();
+    expect(container.querySelector("blockquote")).not.toBeNull();
+  });
+});

--- a/web/src/components/wiki/Callout.tsx
+++ b/web/src/components/wiki/Callout.tsx
@@ -47,8 +47,7 @@ function resolveType(raw: unknown): CalloutType {
 export function CalloutBlockquote(props: BlockquoteProps): ReactElement {
   const record = props as Record<string, unknown>;
   if (record["data-callout"] !== "true") {
-    const { children, className } = props;
-    return <blockquote className={className}>{children}</blockquote>;
+    return <blockquote {...props} />;
   }
   const type = resolveType(record["data-callout-type"]);
   const title =

--- a/web/src/components/wiki/Callout.tsx
+++ b/web/src/components/wiki/Callout.tsx
@@ -1,0 +1,121 @@
+import type { ComponentProps, ReactElement, ReactNode } from "react";
+
+import type { CalloutType } from "./parseCallout";
+
+/**
+ * Renders an Obsidian-flavored callout block.
+ *
+ * The actual detection lives in `parseCallout.ts`'s remark plugin, which
+ * tags blockquote nodes with `data-callout-*` properties. This component
+ * is wired in via the react-markdown `blockquote` override and renders
+ * a callout when those data attributes are present, falling through to
+ * a plain blockquote otherwise.
+ */
+
+const TYPE_LABELS: Record<CalloutType, string> = {
+  note: "Note",
+  info: "Info",
+  tip: "Tip",
+  important: "Important",
+  warning: "Warning",
+  caution: "Caution",
+};
+
+const KNOWN_TYPES: ReadonlySet<string> = new Set<CalloutType>([
+  "note",
+  "info",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+]);
+
+type BlockquoteProps = ComponentProps<"blockquote">;
+
+function resolveType(raw: unknown): CalloutType {
+  if (typeof raw === "string" && KNOWN_TYPES.has(raw)) {
+    return raw as CalloutType;
+  }
+  return "note";
+}
+
+/**
+ * react-markdown blockquote override. Detects the `data-callout` attribute
+ * (set by `calloutRemarkPlugin`) and renders a `<Callout>` aside; otherwise
+ * renders a plain `<blockquote>` so non-callout quotes are unaffected.
+ */
+export function CalloutBlockquote(props: BlockquoteProps): ReactElement {
+  const record = props as Record<string, unknown>;
+  if (record["data-callout"] !== "true") {
+    const { children, className } = props;
+    return <blockquote className={className}>{children}</blockquote>;
+  }
+  const type = resolveType(record["data-callout-type"]);
+  const title =
+    typeof record["data-callout-title"] === "string"
+      ? (record["data-callout-title"] as string)
+      : "";
+  const fold = record["data-callout-fold"];
+  const folded = fold === "open" || fold === "closed";
+  const defaultOpen = fold === "open";
+  return (
+    <Callout
+      type={type}
+      title={title}
+      folded={folded}
+      defaultOpen={defaultOpen}
+    >
+      {props.children}
+    </Callout>
+  );
+}
+
+interface CalloutProps {
+  type: CalloutType;
+  title: string;
+  folded: boolean;
+  defaultOpen: boolean;
+  children: ReactNode;
+}
+
+export default function Callout({
+  type,
+  title,
+  folded,
+  defaultOpen,
+  children,
+}: CalloutProps): ReactElement {
+  const label = TYPE_LABELS[type];
+  const headerClass = "wk-callout-header";
+  const bodyClass = "wk-callout-body";
+  const headerInner = (
+    <>
+      <span className="wk-callout-label">{label}</span>
+      {title ? <span className="wk-callout-title">{title}</span> : null}
+    </>
+  );
+  if (folded) {
+    return (
+      <aside
+        className={`wk-callout wk-callout-${type} wk-callout-folded`}
+        data-callout-type={type}
+        aria-label={`${label} callout`}
+      >
+        <details open={defaultOpen}>
+          <summary className={headerClass}>{headerInner}</summary>
+          <div className={bodyClass}>{children}</div>
+        </details>
+      </aside>
+    );
+  }
+  return (
+    <aside
+      className={`wk-callout wk-callout-${type}`}
+      data-callout-type={type}
+      aria-label={`${label} callout`}
+    >
+      <div className={headerClass}>{headerInner}</div>
+      <div className={bodyClass}>{children}</div>
+    </aside>
+  );
+}

--- a/web/src/components/wiki/parseCallout.test.ts
+++ b/web/src/components/wiki/parseCallout.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+
+import { calloutRemarkPlugin, parseCalloutMarker } from "./parseCallout";
+
+describe("parseCalloutMarker", () => {
+  it("parses `[!note] Title` with body", () => {
+    const result = parseCalloutMarker("[!note] Title\nbody");
+    expect(result).toEqual({
+      type: "note",
+      title: "Title",
+      body: "body",
+      defaultOpen: undefined,
+    });
+  });
+
+  it("parses `[!warning]+` as defaultOpen=true", () => {
+    const result = parseCalloutMarker("[!warning]+\nbody");
+    expect(result).toMatchObject({
+      type: "warning",
+      title: "",
+      defaultOpen: true,
+    });
+  });
+
+  it("parses `[!caution]-` as defaultOpen=false", () => {
+    const result = parseCalloutMarker("[!caution]-\nbody");
+    expect(result).toMatchObject({
+      type: "caution",
+      title: "",
+      defaultOpen: false,
+    });
+  });
+
+  it("returns null for a regular blockquote with no marker", () => {
+    expect(parseCalloutMarker("just a quote\nwith two lines")).toBeNull();
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseCalloutMarker("")).toBeNull();
+  });
+
+  it("returns null for non-string input", () => {
+    // @ts-expect-error intentional misuse
+    expect(parseCalloutMarker(null)).toBeNull();
+    // @ts-expect-error intentional misuse
+    expect(parseCalloutMarker(undefined)).toBeNull();
+  });
+
+  it("falls back to `note` for unknown types", () => {
+    const result = parseCalloutMarker("[!frobnicate] Something\nbody");
+    expect(result).toMatchObject({
+      type: "note",
+      title: "Something",
+    });
+  });
+
+  it("normalizes type casing to lowercase", () => {
+    const result = parseCalloutMarker("[!WARNING] Heads up\nbody");
+    expect(result).toMatchObject({
+      type: "warning",
+      title: "Heads up",
+    });
+  });
+
+  it("handles `[!type]` with no title and no body", () => {
+    const result = parseCalloutMarker("[!tip]");
+    expect(result).toEqual({
+      type: "tip",
+      title: "",
+      body: "",
+      defaultOpen: undefined,
+    });
+  });
+
+  it("handles `[!type]+` with a title on the same line", () => {
+    const result = parseCalloutMarker("[!important]+ Read this\nbody line");
+    expect(result).toMatchObject({
+      type: "important",
+      title: "Read this",
+      body: "body line",
+      defaultOpen: true,
+    });
+  });
+});
+
+describe("calloutRemarkPlugin", () => {
+  function build() {
+    return calloutRemarkPlugin()();
+  }
+
+  it("tags a callout-shaped blockquote with data attributes and strips the marker", () => {
+    const transformer = build();
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "blockquote",
+          children: [
+            {
+              type: "paragraph",
+              children: [
+                { type: "text", value: "[!warning]+ Heads up\nBody line" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    transformer(tree);
+    const bq = tree.children[0] as {
+      data?: { hProperties?: Record<string, string> };
+      children: Array<{ type: string; children: Array<{ value: string }> }>;
+    };
+    expect(bq.data?.hProperties).toMatchObject({
+      "data-callout": "true",
+      "data-callout-type": "warning",
+      "data-callout-title": "Heads up",
+      "data-callout-fold": "open",
+    });
+    const firstParaText = bq.children[0].children[0].value;
+    expect(firstParaText).toBe("Body line");
+  });
+
+  it("leaves a regular blockquote untouched", () => {
+    const transformer = build();
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "blockquote",
+          children: [
+            {
+              type: "paragraph",
+              children: [{ type: "text", value: "just a quote" }],
+            },
+          ],
+        },
+      ],
+    };
+    transformer(tree);
+    const bq = tree.children[0] as {
+      data?: unknown;
+      children: Array<{ type: string }>;
+    };
+    expect(bq.data).toBeUndefined();
+    expect(bq.children).toHaveLength(1);
+  });
+
+  it("drops the first paragraph when only the marker line was present", () => {
+    const transformer = build();
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "blockquote",
+          children: [
+            {
+              type: "paragraph",
+              children: [{ type: "text", value: "[!info]" }],
+            },
+            {
+              type: "paragraph",
+              children: [{ type: "text", value: "Body paragraph" }],
+            },
+          ],
+        },
+      ],
+    };
+    transformer(tree);
+    const bq = tree.children[0] as {
+      data?: { hProperties?: Record<string, string> };
+      children: Array<{ type: string }>;
+    };
+    expect(bq.data?.hProperties).toMatchObject({
+      "data-callout": "true",
+      "data-callout-type": "info",
+    });
+    expect(bq.children).toHaveLength(1);
+  });
+
+  it("falls back to `note` for unknown types", () => {
+    const transformer = build();
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "blockquote",
+          children: [
+            {
+              type: "paragraph",
+              children: [{ type: "text", value: "[!frobnicate]" }],
+            },
+          ],
+        },
+      ],
+    };
+    transformer(tree);
+    const bq = tree.children[0] as {
+      data?: { hProperties?: Record<string, string> };
+    };
+    expect(bq.data?.hProperties?.["data-callout-type"]).toBe("note");
+  });
+});

--- a/web/src/components/wiki/parseCallout.ts
+++ b/web/src/components/wiki/parseCallout.ts
@@ -1,0 +1,225 @@
+/**
+ * Obsidian-flavored callout detection.
+ *
+ * A callout is a markdown blockquote whose first line starts with
+ * `[!type]` optionally followed by `+` (start expanded) or `-` (start
+ * collapsed), and optionally followed by a single-line title:
+ *
+ *   > [!note] Optional title
+ *   > Body content
+ *
+ *   > [!warning]+
+ *   > Expanded by default
+ *
+ *   > [!caution]-
+ *   > Collapsed by default
+ *
+ * The renderer in `Callout.tsx` consumes the data attributes attached
+ * by `calloutRemarkPlugin` below.
+ *
+ * Phase 4 of `docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md` §7.1.
+ */
+
+export type CalloutType =
+  | "note"
+  | "info"
+  | "tip"
+  | "important"
+  | "warning"
+  | "caution";
+
+const KNOWN_TYPES: ReadonlySet<string> = new Set<CalloutType>([
+  "note",
+  "info",
+  "tip",
+  "important",
+  "warning",
+  "caution",
+]);
+
+export interface CalloutMarker {
+  type: CalloutType;
+  title: string;
+  /** Markdown source of the body, with the marker line stripped. May be empty. */
+  body: string;
+  /**
+   * `undefined` for the bare `[!type]` form (renders as a non-folding block),
+   * `true` for `[!type]+` (folded, start expanded),
+   * `false` for `[!type]-` (folded, start collapsed).
+   */
+  defaultOpen: boolean | undefined;
+}
+
+const MARKER_RE = /^\[!([a-zA-Z]+)\]([+-]?)[ \t]*(.*?)\s*$/;
+
+/**
+ * Parse the leading marker line of a callout from a string containing
+ * the blockquote's contents (i.e. with the `> ` prefixes already removed).
+ *
+ * Returns null if the input does not start with a recognized callout marker.
+ * Unknown types fall back to `note`.
+ */
+export function parseCalloutMarker(input: string): CalloutMarker | null {
+  if (typeof input !== "string" || input.length === 0) return null;
+  const newlineIdx = input.indexOf("\n");
+  const firstLine = newlineIdx === -1 ? input : input.slice(0, newlineIdx);
+  const rest = newlineIdx === -1 ? "" : input.slice(newlineIdx + 1);
+  const match = firstLine.match(MARKER_RE);
+  if (!match) return null;
+  const [, rawTypeRaw, foldMark, title] = match;
+  const rawType = rawTypeRaw.toLowerCase();
+  const type: CalloutType = (
+    KNOWN_TYPES.has(rawType) ? rawType : "note"
+  ) as CalloutType;
+  let defaultOpen: boolean | undefined;
+  if (foldMark === "+") defaultOpen = true;
+  else if (foldMark === "-") defaultOpen = false;
+  else defaultOpen = undefined;
+  return { type, title, body: rest, defaultOpen };
+}
+
+// ── Remark plugin: detect callout-shaped blockquotes and tag them ──
+
+interface MdTextNode {
+  type: "text";
+  value: string;
+}
+
+interface MdParagraph {
+  type: "paragraph";
+  children: MdInlineNode[];
+}
+
+type MdInlineNode = MdTextNode | { type: string; children?: MdInlineNode[] };
+
+interface MdBlockquote {
+  type: "blockquote";
+  children: MdBlockNode[];
+  data?: { hProperties?: Record<string, string> };
+}
+
+type MdBlockNode =
+  | MdParagraph
+  | MdBlockquote
+  | { type: string; children?: unknown };
+
+interface MdRoot {
+  type: string;
+  children?: MdBlockNode[];
+}
+
+function isTextNode(n: MdInlineNode): n is MdTextNode {
+  return n.type === "text" && typeof (n as MdTextNode).value === "string";
+}
+
+function isParagraph(n: MdBlockNode): n is MdParagraph {
+  return n.type === "paragraph" && Array.isArray((n as MdParagraph).children);
+}
+
+function isBlockquote(n: MdBlockNode): n is MdBlockquote {
+  return n.type === "blockquote" && Array.isArray((n as MdBlockquote).children);
+}
+
+/**
+ * Walk the mdast tree and rewrite callout-shaped blockquotes so the
+ * react-markdown blockquote override (`Callout.tsx`) can render them.
+ *
+ * Detection: the blockquote's first child is a paragraph whose first
+ * inline child is a text node beginning with `[!type]...`.
+ *
+ * Rewrite: strip the marker (and any title text on the same line) from
+ * the first text node, and attach `data-callout-*` hProperties to the
+ * blockquote so the React layer can pick them up. Non-callout
+ * blockquotes are left untouched.
+ */
+export function calloutRemarkPlugin() {
+  return function plugin() {
+    return function transformer(tree: unknown) {
+      visitBlockquotes(tree as MdRoot, transformBlockquote);
+    };
+  };
+}
+
+function visitBlockquotes(
+  node: MdRoot | MdBlockNode,
+  visit: (bq: MdBlockquote) => void,
+) {
+  const { children } = node as { children?: MdBlockNode[] };
+  if (!Array.isArray(children)) return;
+  for (const child of children) {
+    if (isBlockquote(child)) {
+      visit(child);
+    }
+    // Recurse so nested callouts (callouts inside list items, etc.) still
+    // get detected. Cheap because the wiki uses short articles.
+    visitBlockquotes(child as MdBlockNode, visit);
+  }
+}
+
+interface DetectedMarker {
+  type: CalloutType;
+  title: string;
+  foldMark: string;
+}
+
+function detectMarker(text: string): {
+  marker: DetectedMarker;
+  remainder: string;
+} | null {
+  if (!text.startsWith("[!")) return null;
+  const newlineIdx = text.indexOf("\n");
+  const firstLine = newlineIdx === -1 ? text : text.slice(0, newlineIdx);
+  const remainder = newlineIdx === -1 ? "" : text.slice(newlineIdx + 1);
+  const match = firstLine.match(MARKER_RE);
+  if (!match) return null;
+  const [, rawTypeRaw, foldMark, title] = match;
+  const rawType = rawTypeRaw.toLowerCase();
+  const type: CalloutType = (
+    KNOWN_TYPES.has(rawType) ? rawType : "note"
+  ) as CalloutType;
+  return { marker: { type, title, foldMark }, remainder };
+}
+
+function stripMarkerLine(
+  bq: MdBlockquote,
+  firstBlock: MdParagraph,
+  firstInline: MdTextNode,
+  remainder: string,
+): void {
+  if (remainder.length === 0 && firstBlock.children.length === 1) {
+    bq.children.shift();
+    return;
+  }
+  firstInline.value = remainder;
+  if (remainder.length === 0) {
+    // Drop the now-empty leading text node so the paragraph can start
+    // with an inline element (e.g. a wikilink) cleanly.
+    firstBlock.children.shift();
+  }
+  if (firstBlock.children.length === 0) {
+    bq.children.shift();
+  }
+}
+
+function attachCalloutData(bq: MdBlockquote, marker: DetectedMarker): void {
+  const data = bq.data ?? {};
+  const hProperties = data.hProperties ?? {};
+  hProperties["data-callout"] = "true";
+  hProperties["data-callout-type"] = marker.type;
+  if (marker.title) hProperties["data-callout-title"] = marker.title;
+  if (marker.foldMark === "+") hProperties["data-callout-fold"] = "open";
+  else if (marker.foldMark === "-") hProperties["data-callout-fold"] = "closed";
+  data.hProperties = hProperties;
+  bq.data = data;
+}
+
+function transformBlockquote(bq: MdBlockquote) {
+  const [firstBlock] = bq.children;
+  if (!(firstBlock && isParagraph(firstBlock))) return;
+  const [firstInline] = firstBlock.children;
+  if (!(firstInline && isTextNode(firstInline))) return;
+  const detected = detectMarker(firstInline.value);
+  if (!detected) return;
+  stripMarkerLine(bq, firstBlock, firstInline, detected.remainder);
+  attachCalloutData(bq, detected.marker);
+}

--- a/web/src/lib/wikiMarkdownConfig.tsx
+++ b/web/src/lib/wikiMarkdownConfig.tsx
@@ -15,7 +15,9 @@ import rehypeSlug from "rehype-slug";
 import remarkGfm from "remark-gfm";
 import type { PluggableList } from "unified";
 
+import { CalloutBlockquote } from "../components/wiki/Callout";
 import ImageEmbed from "../components/wiki/ImageEmbed";
+import { calloutRemarkPlugin } from "../components/wiki/parseCallout";
 import { wikiLinkRemarkPlugin } from "./wikilink";
 
 export interface WikiMarkdownOptions {
@@ -32,11 +34,11 @@ export interface WikiMarkdownOptions {
   onNavigate?: (slug: string) => void;
 }
 
-/** Remark plugins — remark-gfm + wikilinks. */
+/** Remark plugins — remark-gfm + wikilinks + Obsidian callouts. */
 export function buildRemarkPlugins(
   resolver: (slug: string) => boolean,
 ): PluggableList {
-  return [remarkGfm, wikiLinkRemarkPlugin(resolver)];
+  return [remarkGfm, wikiLinkRemarkPlugin(resolver), calloutRemarkPlugin()];
 }
 
 /** Rehype plugins — slug + autolink headings for TOC anchors. */
@@ -57,6 +59,7 @@ export function buildMarkdownComponents(
 ): Partial<Components> {
   const { onNavigate } = options;
   return {
+    blockquote: CalloutBlockquote,
     a: (props: AnchorProps): ReactElement => {
       const record = props as Record<string, unknown>;
       const isWikilink = record["data-wikilink"] === "true";

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -368,6 +368,82 @@
   color: var(--wk-text);
 }
 
+/* ─── Obsidian-flavored callouts (WIKI-OBSIDIAN-COMPATIBILITY §7.1) ─── */
+.wk-callout {
+  margin: 0 0 20px;
+  padding: 12px 14px 12px 16px;
+  background: var(--wk-paper-dark);
+  border: 1px solid var(--wk-border);
+  border-left: 3px solid var(--wk-border-strong);
+  border-radius: 3px;
+  font-family: var(--wk-body-serif);
+  color: var(--wk-text);
+}
+.wk-callout-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wk-text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+.wk-callout-title {
+  font-family: var(--wk-chrome);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--wk-text-muted);
+}
+.wk-callout-body {
+  font-family: var(--wk-body-serif);
+  font-size: 16px;
+  line-height: 1.6;
+}
+.wk-callout-body > :last-child {
+  margin-bottom: 0;
+}
+.wk-callout-folded > details > summary {
+  cursor: pointer;
+  list-style: none;
+}
+.wk-callout-folded > details > summary::-webkit-details-marker {
+  display: none;
+}
+.wk-callout-folded > details > summary::before {
+  content: "▸";
+  display: inline-block;
+  font-family: var(--wk-chrome);
+  font-size: 11px;
+  color: var(--wk-text-muted);
+  margin-right: 6px;
+  transition: transform 120ms ease;
+}
+.wk-callout-folded > details[open] > summary::before {
+  transform: rotate(90deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .wk-callout-folded > details > summary::before {
+    transition: none;
+  }
+}
+/* Per-type left-border tints. `--amber` is reserved for the live-edit pulse,
+ * so `warning` falls back to a darker neutral instead. `caution` uses the
+ * broken-wikilink red family. All other types share the calm slate border
+ * picked up from the base `.wk-callout` rule above. */
+.wk-callout-warning {
+  border-left-color: var(--wk-text-muted);
+}
+.wk-callout-important {
+  border-left-color: var(--wk-text);
+}
+.wk-callout-caution {
+  border-left-color: var(--wk-wikilink-broken);
+}
+
 /* ─── Hatnote ─── */
 .wk-hatnote {
   font-family: var(--wk-body-serif);


### PR DESCRIPTION
## Summary

Establish the contract for opening WUPHF's wiki as an Obsidian vault. This is Phase 1 of the Obsidian integration work: document the design, fix schema-doc drift, and add regression tests for the basename-collision guard that makes Obsidian's wikilink resolver safe.

## Changes

- **New spec: `docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md`**
  - Defines vault root at `team/` (not wiki root) for correct wikilink resolution and noise suppression
  - Documents layout invariants, `.obsidian/` bootstrap strategy, and the kinded wikilink form (`[[kind/slug]]`) as canonical
  - Specifies round-trip write coexistence with the single-writer invariant via fsnotify watcher, advisory locks, and `last_human_edit_ts` sentinel
  - Covers Obsidian-native primitives (callouts, image embeds, frontmatter tags) and non-goals
  - Phases the work into four reviewable PRs; this commit is Phase 1
  - Flags open items (insights drift, graph file relationship, structured callouts, per-vault identity) for future rounds

- **Schema doc fix: `docs/specs/WIKI-SCHEMA.md`**
  - Corrects playbook paths from `wiki/playbooks/` to `team/playbooks/` to match the vault-root decision and actual code layout

- **Regression test: `internal/team/entity_graph_test.go`**
  - `TestExtractRefs_BasenameCollisionAcrossKinds` pins the Obsidian basename-collision guard
  - Verifies that bare `[[acme]]` does not resolve when the slug exists under multiple kinds (e.g., both `people/acme` and `companies/acme`)
  - Confirms kinded forms (`[[people/acme]]`, `[[companies/acme]]`) remain unambiguous and resolve to distinct entities
  - Guards against silent graph poisoning if a future change relaxes the `known()` contract

## Implementation notes

- The spec is the source of truth; code must match it (not vice versa)
- Phase 2 will implement `.obsidian/` bootstrap in `Repo.ensureLayoutLocked`
- Phase 3 will add the fsnotify watcher, advisory locks, and synthesizer guards
- Phase 4 will implement loose-link normalization, callout rendering, and image embed ingestion
- The basename-collision test is strict by design — it is the Obsidian-compatibility seam and must not be relaxed without explicit review

https://claude.ai/code/session_01Ntdewy7tu1ysB4XYiso8ao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Obsidian vault support: team/ vault root, canonical wikilinks ([[kind/slug]]), image attachment handling, tag projection, idempotent .obsidian/app.json and .gitignore bootstrap, stable JSON output.
  * Brief synthesis sentinel & tags: preserve recent human edits, append "What we've learned" section, derive/merge normalized tags.

* **New Features — Sync/Integration**
  * Filesystem watcher: detect external markdown edits, debounce/coalesce commits, avoid feedback loops, identity/logging hooks.

* **New Features — Editor/Rendering**
  * Obsidian-flavored callouts: parsing, folding, titles, styling, preserved wikilinks.

* **Documentation**
  * Added Obsidian compatibility spec; updated playbook schema paths.

* **Tests**
  * New tests for link disambiguation, bootstrap, callouts, watcher, and synthesizer sentinel/tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/905?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->