### PR TITLE
feat(layout): shrink sidebar default + add drag-to-resize panes

### DIFF
--- a/web/e2e/screenshots/resize-panes.mjs
+++ b/web/e2e/screenshots/resize-panes.mjs
@@ -1,0 +1,62 @@
+// Capture the resizable sidebar + thread panel: default narrow widths,
+// drag-resize states, and the new resize handle affordance.
+//
+// Run via:
+//   web/e2e/screenshots/publish.sh resize-panes <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const { browser, context, page } = await launchBrowser();
+await installCommonMocks(context);
+
+// 1. Default narrower sidebar (220px instead of the prior 260px).
+await bootShell(page, { afterFlipSelector: ".sidebar" });
+await shotPage(page, OUT, "01-sidebar-default-width");
+
+// 2. Sidebar widened to ~360px via dragging the handle.
+const sidebar = page.locator(".sidebar");
+const sidebarBox = await sidebar.boundingBox();
+if (sidebarBox) {
+  const handleX = sidebarBox.x + sidebarBox.width - 1;
+  const handleY = sidebarBox.y + sidebarBox.height / 2;
+  await page.mouse.move(handleX, handleY);
+  await page.mouse.down();
+  await page.mouse.move(handleX + 140, handleY, { steps: 12 });
+  await page.mouse.up();
+}
+await shotPage(page, OUT, "02-sidebar-dragged-wider");
+
+// 3. Sidebar shrunk to the floor (~180px).
+const sidebarBox2 = await sidebar.boundingBox();
+if (sidebarBox2) {
+  const handleX = sidebarBox2.x + sidebarBox2.width - 1;
+  const handleY = sidebarBox2.y + sidebarBox2.height / 2;
+  await page.mouse.move(handleX, handleY);
+  await page.mouse.down();
+  await page.mouse.move(handleX - 300, handleY, { steps: 12 });
+  await page.mouse.up();
+}
+await shotElement(page, ".sidebar", OUT, "03-sidebar-min-width");
+
+// 4. Close-up of the resize handle on hover.
+await sidebar.evaluate((el) => {
+  const handle = el.querySelector(".pane-resize-handle");
+  if (handle instanceof HTMLElement) handle.focus();
+});
+await shotElement(page, ".sidebar", OUT, "04-sidebar-handle-focused");
+
+await browser.close();

--- a/web/e2e/screenshots/resize-panes.mjs
+++ b/web/e2e/screenshots/resize-panes.mjs
@@ -29,27 +29,26 @@ await shotPage(page, OUT, "01-sidebar-default-width");
 
 // 2. Sidebar widened to ~360px via dragging the handle.
 const sidebar = page.locator(".sidebar");
-const sidebarBox = await sidebar.boundingBox();
-if (sidebarBox) {
-  const handleX = sidebarBox.x + sidebarBox.width - 1;
-  const handleY = sidebarBox.y + sidebarBox.height / 2;
+async function dragSidebar(deltaX, reason) {
+  const box = await sidebar.boundingBox();
+  if (!box) {
+    // Fail loudly. Silent fallback would write a "dragged" screenshot
+    // with no drag, masking a real regression in the layout.
+    throw new Error(`Cannot drag sidebar (${reason}) — .sidebar has no bounding box.`);
+  }
+  const handleX = box.x + box.width - 1;
+  const handleY = box.y + box.height / 2;
   await page.mouse.move(handleX, handleY);
   await page.mouse.down();
-  await page.mouse.move(handleX + 140, handleY, { steps: 12 });
+  await page.mouse.move(handleX + deltaX, handleY, { steps: 12 });
   await page.mouse.up();
 }
+
+await dragSidebar(140, "widen");
 await shotPage(page, OUT, "02-sidebar-dragged-wider");
 
 // 3. Sidebar shrunk to the floor (~180px).
-const sidebarBox2 = await sidebar.boundingBox();
-if (sidebarBox2) {
-  const handleX = sidebarBox2.x + sidebarBox2.width - 1;
-  const handleY = sidebarBox2.y + sidebarBox2.height / 2;
-  await page.mouse.move(handleX, handleY);
-  await page.mouse.down();
-  await page.mouse.move(handleX - 300, handleY, { steps: 12 });
-  await page.mouse.up();
-}
+await dragSidebar(-300, "shrink");
 await shotElement(page, ".sidebar", OUT, "03-sidebar-min-width");
 
 // 4. Close-up of the resize handle on hover.

--- a/web/src/components/layout/PaneResizeHandle.test.tsx
+++ b/web/src/components/layout/PaneResizeHandle.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { PaneResizeHandle } from "./PaneResizeHandle";
@@ -28,11 +28,7 @@ function setup(edge: "right" | "left", isResizing = false): Captured {
 }
 
 afterEach(() => {
-  // Clear the DOM between tests without resorting to innerHTML
-  // assignment, which security tooling rightly flags as a sink.
-  while (document.body.firstChild) {
-    document.body.removeChild(document.body.firstChild);
-  }
+  cleanup();
 });
 
 describe("<PaneResizeHandle> keyboard", () => {
@@ -61,6 +57,12 @@ describe("<PaneResizeHandle> keyboard", () => {
     const { step } = setup("left");
     fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
     expect(step).toHaveBeenCalledWith(-16);
+  });
+
+  it("ArrowLeft widens a left-edge pane (+16px)", () => {
+    const { step } = setup("left");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowLeft" });
+    expect(step).toHaveBeenCalledWith(16);
   });
 
   it("Home snaps to the minimum", () => {

--- a/web/src/components/layout/PaneResizeHandle.test.tsx
+++ b/web/src/components/layout/PaneResizeHandle.test.tsx
@@ -1,0 +1,97 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PaneResizeHandle } from "./PaneResizeHandle";
+
+interface Captured {
+  reset: ReturnType<typeof vi.fn>;
+  step: ReturnType<typeof vi.fn>;
+}
+
+function setup(edge: "right" | "left", isResizing = false): Captured {
+  const reset = vi.fn();
+  const step = vi.fn();
+  render(
+    <PaneResizeHandle
+      edge={edge}
+      ariaLabel={`Resize ${edge} pane`}
+      onPointerDown={() => {}}
+      isResizing={isResizing}
+      onReset={reset}
+      onStepResize={step}
+      valueNow={220}
+      valueMin={180}
+      valueMax={420}
+    />,
+  );
+  return { reset, step };
+}
+
+afterEach(() => {
+  // Clear the DOM between tests without resorting to innerHTML
+  // assignment, which security tooling rightly flags as a sink.
+  while (document.body.firstChild) {
+    document.body.removeChild(document.body.firstChild);
+  }
+});
+
+describe("<PaneResizeHandle> keyboard", () => {
+  it("ArrowRight widens a right-edge pane (+16px)", () => {
+    const { step } = setup("right");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
+    expect(step).toHaveBeenCalledWith(16);
+  });
+
+  it("ArrowLeft narrows a right-edge pane (-16px)", () => {
+    const { step } = setup("right");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowLeft" });
+    expect(step).toHaveBeenCalledWith(-16);
+  });
+
+  it("Shift+Arrow uses the coarse step (64px)", () => {
+    const { step } = setup("right");
+    fireEvent.keyDown(screen.getByRole("separator"), {
+      key: "ArrowRight",
+      shiftKey: true,
+    });
+    expect(step).toHaveBeenCalledWith(64);
+  });
+
+  it("ArrowRight narrows a left-edge pane (the user's left widens)", () => {
+    const { step } = setup("left");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "ArrowRight" });
+    expect(step).toHaveBeenCalledWith(-16);
+  });
+
+  it("Home snaps to the minimum", () => {
+    const { step } = setup("right");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "Home" });
+    expect(step).toHaveBeenCalledWith(Number.NEGATIVE_INFINITY);
+  });
+
+  it("End snaps to the maximum", () => {
+    const { step } = setup("right");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "End" });
+    expect(step).toHaveBeenCalledWith(Number.POSITIVE_INFINITY);
+  });
+
+  it("Enter resets to the default", () => {
+    const { reset, step } = setup("right");
+    fireEvent.keyDown(screen.getByRole("separator"), { key: "Enter" });
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(step).not.toHaveBeenCalled();
+  });
+
+  it("exposes aria-valuenow/min/max", () => {
+    setup("right");
+    const sep = screen.getByRole("separator");
+    expect(sep.getAttribute("aria-valuenow")).toBe("220");
+    expect(sep.getAttribute("aria-valuemin")).toBe("180");
+    expect(sep.getAttribute("aria-valuemax")).toBe("420");
+  });
+
+  it("applies is-active class while resizing", () => {
+    setup("right", true);
+    expect(screen.getByRole("separator").className).toMatch(/is-active/);
+  });
+});

--- a/web/src/components/layout/PaneResizeHandle.tsx
+++ b/web/src/components/layout/PaneResizeHandle.tsx
@@ -1,5 +1,8 @@
 import { useCallback } from "react";
 
+const STEP_PX = 16;
+const STEP_PX_LARGE = 64;
+
 interface PaneResizeHandleProps {
   /** Pointer-down from useResizablePane(). */
   onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
@@ -7,6 +10,8 @@ interface PaneResizeHandleProps {
   isResizing: boolean;
   /** Double-click target — reset pane to its default width. */
   onReset: () => void;
+  /** Keyboard step resize — positive widens the pane from the user's POV. */
+  onStepResize: (signedDelta: number) => void;
   /** Which edge of the parent pane this handle anchors to. */
   edge: "right" | "left";
   /** Accessibility label, e.g. "Resize sidebar". */
@@ -23,11 +28,18 @@ interface PaneResizeHandleProps {
  * Thin draggable splitter rendered on the edge of a resizable pane. The
  * pane element positions this absolutely; the handle expands its hit area
  * via a pseudo-element so the visible 1px rule is still easy to grab.
+ *
+ * Keyboard map (mirrors the WAI-ARIA separator pattern):
+ *   ArrowLeft / ArrowRight  → ±16px from the user's viewpoint
+ *   Shift + Arrow           → ±64px (coarse step)
+ *   Home / End              → snap to min / max
+ *   Enter                   → reset to default width
  */
 export function PaneResizeHandle({
   onPointerDown,
   isResizing,
   onReset,
+  onStepResize,
   edge,
   ariaLabel,
   valueNow,
@@ -36,14 +48,38 @@ export function PaneResizeHandle({
 }: PaneResizeHandleProps) {
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      // Double-tap Enter / Space to reset is unusual; expose plain Enter
-      // because there's no good keyboard-driven width-set affordance.
-      if (e.key === "Enter") {
-        e.preventDefault();
-        onReset();
+      // Resolve direction from the user's perspective: pressing ArrowRight
+      // should widen a right-edge pane and narrow a left-edge pane. The
+      // hook expects a signed delta where positive = widen, so we flip
+      // the arrow sign for left-edge handles.
+      const stepBase = e.shiftKey ? STEP_PX_LARGE : STEP_PX;
+      const widen = edge === "right" ? stepBase : -stepBase;
+      const narrow = -widen;
+
+      switch (e.key) {
+        case "ArrowRight":
+          e.preventDefault();
+          onStepResize(widen);
+          return;
+        case "ArrowLeft":
+          e.preventDefault();
+          onStepResize(narrow);
+          return;
+        case "Home":
+          e.preventDefault();
+          onStepResize(Number.NEGATIVE_INFINITY);
+          return;
+        case "End":
+          e.preventDefault();
+          onStepResize(Number.POSITIVE_INFINITY);
+          return;
+        case "Enter":
+          e.preventDefault();
+          onReset();
+          return;
       }
     },
-    [onReset],
+    [edge, onReset, onStepResize],
   );
 
   return (

--- a/web/src/components/layout/PaneResizeHandle.tsx
+++ b/web/src/components/layout/PaneResizeHandle.tsx
@@ -1,0 +1,66 @@
+import { useCallback } from "react";
+
+interface PaneResizeHandleProps {
+  /** Pointer-down from useResizablePane(). */
+  onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
+  /** True while the user is actively dragging. Adds an "is-active" hook. */
+  isResizing: boolean;
+  /** Double-click target — reset pane to its default width. */
+  onReset: () => void;
+  /** Which edge of the parent pane this handle anchors to. */
+  edge: "right" | "left";
+  /** Accessibility label, e.g. "Resize sidebar". */
+  ariaLabel: string;
+  /** Current pane width — surfaced to assistive tech via aria-valuenow. */
+  valueNow: number;
+  /** Minimum pane width — surfaced to assistive tech via aria-valuemin. */
+  valueMin: number;
+  /** Maximum pane width — surfaced to assistive tech via aria-valuemax. */
+  valueMax: number;
+}
+
+/**
+ * Thin draggable splitter rendered on the edge of a resizable pane. The
+ * pane element positions this absolutely; the handle expands its hit area
+ * via a pseudo-element so the visible 1px rule is still easy to grab.
+ */
+export function PaneResizeHandle({
+  onPointerDown,
+  isResizing,
+  onReset,
+  edge,
+  ariaLabel,
+  valueNow,
+  valueMin,
+  valueMax,
+}: PaneResizeHandleProps) {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      // Double-tap Enter / Space to reset is unusual; expose plain Enter
+      // because there's no good keyboard-driven width-set affordance.
+      if (e.key === "Enter") {
+        e.preventDefault();
+        onReset();
+      }
+    },
+    [onReset],
+  );
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      aria-valuenow={Math.round(valueNow)}
+      aria-valuemin={valueMin}
+      aria-valuemax={valueMax}
+      tabIndex={0}
+      className={`pane-resize-handle pane-resize-handle--${edge}${
+        isResizing ? " is-active" : ""
+      }`}
+      onPointerDown={onPointerDown}
+      onDoubleClick={onReset}
+      onKeyDown={handleKeyDown}
+    />
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -86,12 +86,16 @@ export function Sidebar() {
   });
 
   // Collapsed rail keeps its fixed CSS width; only the expanded sidebar
-  // honors the user's drag. Inline width overrides the stylesheet so the
-  // CSS rule remains the default for the collapsed state.
-  const asideStyle: React.CSSProperties = {
+  // honors the user's drag. We hand the dragged width to CSS as a custom
+  // property rather than `width:` directly so the mobile media queries
+  // (which clamp the sidebar to 240px / full overlay) can still win
+  // — inline `width` would beat them with normal cascade rules.
+  const asideStyle = {
     ...(sidebarBg ? { background: sidebarBg } : null),
-    ...(sidebarCollapsed ? null : { width: resize.width }),
-  };
+    ...(sidebarCollapsed
+      ? null
+      : { "--sidebar-resize-width": `${resize.width}px` }),
+  } as React.CSSProperties;
 
   return (
     <aside

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import { Settings as SettingsIcon, SidebarCollapse } from "iconoir-react";
 
+import { useResizablePane } from "../../hooks/useResizablePane";
 import { router } from "../../lib/router";
 import { useCurrentApp } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
@@ -15,6 +16,12 @@ import { SidebarColorPicker } from "../sidebar/SidebarColorPicker";
 import { UsagePanel } from "../sidebar/UsagePanel";
 import { WorkspaceSummary } from "../sidebar/WorkspaceSummary";
 import { CollapsedSidebar } from "./CollapsedSidebar";
+import { PaneResizeHandle } from "./PaneResizeHandle";
+
+export const SIDEBAR_DEFAULT_WIDTH = 220;
+export const SIDEBAR_MIN_WIDTH = 180;
+export const SIDEBAR_MAX_WIDTH = 420;
+export const SIDEBAR_WIDTH_STORAGE_KEY = "wuphf-sidebar-width";
 
 function SectionToggle({
   label,
@@ -70,7 +77,21 @@ export function Sidebar() {
   const sidebarBg = useAppStore((s) => s.sidebarBg);
   const currentApp = useCurrentApp();
 
-  const asideStyle = sidebarBg ? { background: sidebarBg } : undefined;
+  const resize = useResizablePane({
+    storageKey: SIDEBAR_WIDTH_STORAGE_KEY,
+    defaultWidth: SIDEBAR_DEFAULT_WIDTH,
+    minWidth: SIDEBAR_MIN_WIDTH,
+    maxWidth: SIDEBAR_MAX_WIDTH,
+    edge: "right",
+  });
+
+  // Collapsed rail keeps its fixed CSS width; only the expanded sidebar
+  // honors the user's drag. Inline width overrides the stylesheet so the
+  // CSS rule remains the default for the collapsed state.
+  const asideStyle: React.CSSProperties = {
+    ...(sidebarBg ? { background: sidebarBg } : null),
+    ...(sidebarCollapsed ? null : { width: resize.width }),
+  };
 
   return (
     <aside
@@ -184,6 +205,18 @@ export function Sidebar() {
           <UsagePanel />
           <SidebarColorPicker />
         </>
+      )}
+      {!sidebarCollapsed && (
+        <PaneResizeHandle
+          edge="right"
+          ariaLabel="Resize sidebar"
+          onPointerDown={resize.onPointerDown}
+          isResizing={resize.isResizing}
+          onReset={resize.reset}
+          valueNow={resize.width}
+          valueMin={SIDEBAR_MIN_WIDTH}
+          valueMax={SIDEBAR_MAX_WIDTH}
+        />
       )}
     </aside>
   );

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -213,6 +213,7 @@ export function Sidebar() {
           onPointerDown={resize.onPointerDown}
           isResizing={resize.isResizing}
           onReset={resize.reset}
+          onStepResize={resize.stepResize}
           valueNow={resize.width}
           valueMin={SIDEBAR_MIN_WIDTH}
           valueMax={SIDEBAR_MAX_WIDTH}

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -10,9 +10,11 @@ import { getConfig, type Message, postMessage } from "../../api/client";
 import { useCommands } from "../../hooks/useCommands";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { useThreadMessages } from "../../hooks/useMessages";
+import { useResizablePane } from "../../hooks/useResizablePane";
 import { extractTaggedMentions } from "../../lib/mentions";
 import { handleSlashCommand, resolveLeadSlug } from "../../lib/slashCommands";
 import { useAppStore } from "../../stores/app";
+import { PaneResizeHandle } from "../layout/PaneResizeHandle";
 import { showNotice } from "../ui/Toast";
 import {
   Autocomplete,
@@ -20,6 +22,11 @@ import {
   applyAutocomplete,
 } from "./Autocomplete";
 import { MessageBubble } from "./MessageBubble";
+
+export const THREAD_PANEL_DEFAULT_WIDTH = 340;
+export const THREAD_PANEL_MIN_WIDTH = 280;
+export const THREAD_PANEL_MAX_WIDTH = 560;
+export const THREAD_PANEL_WIDTH_STORAGE_KEY = "wuphf-thread-panel-width";
 
 interface MessagesQueryData {
   messages?: Message[];
@@ -57,6 +64,13 @@ export function ThreadPanel() {
   const setActiveThread = useAppStore((s) => s.setActiveThread);
   const setLastMessageId = useAppStore((s) => s.setLastMessageId);
   const setChannelClearMarker = useAppStore((s) => s.setChannelClearMarker);
+  const resize = useResizablePane({
+    storageKey: THREAD_PANEL_WIDTH_STORAGE_KEY,
+    defaultWidth: THREAD_PANEL_DEFAULT_WIDTH,
+    minWidth: THREAD_PANEL_MIN_WIDTH,
+    maxWidth: THREAD_PANEL_MAX_WIDTH,
+    edge: "left",
+  });
   // Channel is captured at thread-open time and stored on activeThread so
   // replies posted while the user has navigated away from the originating
   // channel still land in the right place. Reading useChannelSlug() here
@@ -313,7 +327,21 @@ export function ThreadPanel() {
   if (!activeThreadId) return null;
 
   return (
-    <aside className="thread-panel open" aria-label="Thread">
+    <aside
+      className="thread-panel open"
+      aria-label="Thread"
+      style={{ width: resize.width }}
+    >
+      <PaneResizeHandle
+        edge="left"
+        ariaLabel="Resize thread panel"
+        onPointerDown={resize.onPointerDown}
+        isResizing={resize.isResizing}
+        onReset={resize.reset}
+        valueNow={resize.width}
+        valueMin={THREAD_PANEL_MIN_WIDTH}
+        valueMax={THREAD_PANEL_MAX_WIDTH}
+      />
       <div className="thread-panel-header">
         <div className="thread-panel-title-group">
           <span className="thread-panel-title">Thread</span>

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -338,6 +338,7 @@ export function ThreadPanel() {
         onPointerDown={resize.onPointerDown}
         isResizing={resize.isResizing}
         onReset={resize.reset}
+        onStepResize={resize.stepResize}
         valueNow={resize.width}
         valueMin={THREAD_PANEL_MIN_WIDTH}
         valueMax={THREAD_PANEL_MAX_WIDTH}

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -330,7 +330,14 @@ export function ThreadPanel() {
     <aside
       className="thread-panel open"
       aria-label="Thread"
-      style={{ width: resize.width }}
+      // CSS variable rather than `width:` directly so the mobile
+      // media query (which sets the panel to 100% as an overlay)
+      // still wins over a persisted desktop drag width.
+      style={
+        {
+          "--thread-panel-resize-width": `${resize.width}px`,
+        } as React.CSSProperties
+      }
     >
       <PaneResizeHandle
         edge="left"

--- a/web/src/hooks/useResizablePane.test.ts
+++ b/web/src/hooks/useResizablePane.test.ts
@@ -66,12 +66,14 @@ describe("useResizablePane", () => {
   });
 
   it("persists width changes to localStorage", () => {
-    const { result, rerender } = renderHook(() => useResizablePane(baseOpts));
+    // Drive a real width update — the mount-time write already stores
+    // the default, so an assertion against "220" after reset() would
+    // pass even if change-driven persistence regressed.
+    const { result } = renderHook(() => useResizablePane(baseOpts));
     act(() => {
-      result.current.reset();
+      result.current.stepResize(17);
     });
-    rerender();
-    expect(store.get(STORAGE_KEY)).toBe("220");
+    expect(store.get(STORAGE_KEY)).toBe("237");
   });
 
   it("reset() restores the default width within bounds", () => {
@@ -214,6 +216,38 @@ describe("useResizablePane", () => {
       result.current.stepResize(-10_000);
     });
     expect(result.current.width).toBe(180);
+  });
+
+  it("ignores pointer events from a pointer other than the one that started the drag", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      startDrag(result.current.onPointerDown, 100);
+    });
+    expect(result.current.isResizing).toBe(true);
+
+    // Stray pointer move must not change width.
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: 9999, pointerId: 99 }),
+      );
+    });
+    expect(result.current.width).toBe(220);
+
+    // Stray pointerup must not end the drag.
+    act(() => {
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 99 }));
+    });
+    expect(result.current.isResizing).toBe(true);
+
+    // The real pointer can still complete the drag.
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: 150, pointerId: 1 }),
+      );
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+    });
+    expect(result.current.width).toBe(270);
+    expect(result.current.isResizing).toBe(false);
   });
 });
 

--- a/web/src/hooks/useResizablePane.test.ts
+++ b/web/src/hooks/useResizablePane.test.ts
@@ -1,0 +1,199 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useResizablePane } from "./useResizablePane";
+
+const STORAGE_KEY = "test-pane-width";
+
+const baseOpts = {
+  storageKey: STORAGE_KEY,
+  defaultWidth: 220,
+  minWidth: 180,
+  maxWidth: 420,
+  edge: "right" as const,
+};
+
+let store: Map<string, string>;
+beforeEach(() => {
+  store = new Map();
+  vi.stubGlobal("localStorage", {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      store.set(k, v);
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => {
+      store.clear();
+    },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.className = "";
+});
+
+describe("useResizablePane", () => {
+  it("starts at the default width when nothing is stored", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    expect(result.current.width).toBe(220);
+  });
+
+  it("hydrates from localStorage when a value is present", () => {
+    store.set(STORAGE_KEY, "300");
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    expect(result.current.width).toBe(300);
+  });
+
+  it("clamps a hydrated value above the max", () => {
+    store.set(STORAGE_KEY, "9999");
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    expect(result.current.width).toBe(420);
+  });
+
+  it("clamps a hydrated value below the min", () => {
+    store.set(STORAGE_KEY, "50");
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    expect(result.current.width).toBe(180);
+  });
+
+  it("ignores non-numeric stored values", () => {
+    store.set(STORAGE_KEY, "junk");
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    expect(result.current.width).toBe(220);
+  });
+
+  it("persists width changes to localStorage", () => {
+    const { result, rerender } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      result.current.reset();
+    });
+    rerender();
+    expect(store.get(STORAGE_KEY)).toBe("220");
+  });
+
+  it("reset() restores the default width within bounds", () => {
+    store.set(STORAGE_KEY, "300");
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    expect(result.current.width).toBe(300);
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.width).toBe(220);
+  });
+
+  it("drag widens the pane for a right-edge handle when moving right", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      runDrag(result.current.onPointerDown, 100, 150);
+    });
+    expect(result.current.width).toBe(270);
+    expect(result.current.isResizing).toBe(false);
+  });
+
+  it("drag narrows a left-edge pane when the pointer moves right", () => {
+    const { result } = renderHook(() =>
+      useResizablePane({ ...baseOpts, edge: "left", defaultWidth: 340 }),
+    );
+    act(() => {
+      runDrag(result.current.onPointerDown, 500, 560);
+    });
+    // left edge: pointer moving right shrinks (delta sign flipped)
+    expect(result.current.width).toBe(280);
+  });
+
+  it("drag clamps to the configured maximum", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      runDrag(result.current.onPointerDown, 100, 9999);
+    });
+    expect(result.current.width).toBe(420);
+  });
+
+  it("drag clamps to the configured minimum", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      runDrag(result.current.onPointerDown, 1000, 0);
+    });
+    expect(result.current.width).toBe(180);
+  });
+
+  it("non-primary button pointerdown is ignored", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      // Simulate right-click — should not start a drag.
+      const target = makeHandleTarget();
+      const event = {
+        button: 2,
+        clientX: 100,
+        pointerId: 1,
+        currentTarget: target,
+        preventDefault: () => {},
+      } as unknown as React.PointerEvent<HTMLElement>;
+      result.current.onPointerDown(event);
+    });
+    expect(result.current.isResizing).toBe(false);
+    // A subsequent move on window must not change width.
+    act(() => {
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: 9999, pointerId: 1 }),
+      );
+    });
+    expect(result.current.width).toBe(220);
+  });
+
+  it("adds a body class while dragging and removes it on pointerup", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      startDrag(result.current.onPointerDown, 100);
+    });
+    expect(document.body.classList.contains("resizing-pane")).toBe(true);
+    act(() => {
+      finishDrag(1);
+    });
+    expect(document.body.classList.contains("resizing-pane")).toBe(false);
+  });
+});
+
+// Helpers --------------------------------------------------------------------
+
+function makeHandleTarget(): HTMLElement {
+  const el = document.createElement("div");
+  el.setPointerCapture = () => {};
+  el.releasePointerCapture = () => {};
+  return el;
+}
+
+function startDrag(
+  onPointerDown: (e: React.PointerEvent<HTMLElement>) => void,
+  fromX: number,
+): HTMLElement {
+  const target = makeHandleTarget();
+  const event = {
+    button: 0,
+    clientX: fromX,
+    pointerId: 1,
+    currentTarget: target,
+    preventDefault: () => {},
+  } as unknown as React.PointerEvent<HTMLElement>;
+  onPointerDown(event);
+  return target;
+}
+
+function finishDrag(pointerId: number): void {
+  window.dispatchEvent(new PointerEvent("pointerup", { pointerId }));
+}
+
+function runDrag(
+  onPointerDown: (e: React.PointerEvent<HTMLElement>) => void,
+  fromX: number,
+  toX: number,
+): void {
+  startDrag(onPointerDown, fromX);
+  window.dispatchEvent(
+    new PointerEvent("pointermove", { clientX: toX, pointerId: 1 }),
+  );
+  finishDrag(1);
+}

--- a/web/src/hooks/useResizablePane.test.ts
+++ b/web/src/hooks/useResizablePane.test.ts
@@ -155,6 +155,66 @@ describe("useResizablePane", () => {
     });
     expect(document.body.classList.contains("resizing-pane")).toBe(false);
   });
+
+  it("cleans drag listeners and body class when unmounted mid-drag", () => {
+    const { result, unmount } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      startDrag(result.current.onPointerDown, 100);
+    });
+    expect(document.body.classList.contains("resizing-pane")).toBe(true);
+
+    const widthBeforeUnmount = result.current.width;
+    unmount();
+    expect(document.body.classList.contains("resizing-pane")).toBe(false);
+
+    // Listeners must have been removed: subsequent pointermove/up events
+    // must not throw or mutate state on the stale hook instance.
+    expect(() => {
+      window.dispatchEvent(
+        new PointerEvent("pointermove", { clientX: 9999, pointerId: 1 }),
+      );
+      window.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+    }).not.toThrow();
+    // The captured value never advanced past mount because the listener
+    // was already torn down before the move arrived.
+    expect(result.current.width).toBe(widthBeforeUnmount);
+  });
+
+  it("stepResize widens a right-edge pane by a positive delta", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      result.current.stepResize(16);
+    });
+    expect(result.current.width).toBe(236);
+  });
+
+  it("stepResize clamps to the max with +Infinity", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      result.current.stepResize(Number.POSITIVE_INFINITY);
+    });
+    expect(result.current.width).toBe(420);
+  });
+
+  it("stepResize clamps to the min with -Infinity", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      result.current.stepResize(Number.NEGATIVE_INFINITY);
+    });
+    expect(result.current.width).toBe(180);
+  });
+
+  it("stepResize never escapes the configured bounds", () => {
+    const { result } = renderHook(() => useResizablePane(baseOpts));
+    act(() => {
+      result.current.stepResize(10_000);
+    });
+    expect(result.current.width).toBe(420);
+    act(() => {
+      result.current.stepResize(-10_000);
+    });
+    expect(result.current.width).toBe(180);
+  });
 });
 
 // Helpers --------------------------------------------------------------------

--- a/web/src/hooks/useResizablePane.ts
+++ b/web/src/hooks/useResizablePane.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type ResizeEdge = "right" | "left";
+
+export interface UseResizablePaneOptions {
+  /** localStorage key used to persist the width across reloads. */
+  storageKey: string;
+  /** Default width in CSS pixels when no persisted value exists. */
+  defaultWidth: number;
+  /** Minimum width in CSS pixels the pane is allowed to be dragged to. */
+  minWidth: number;
+  /** Maximum width in CSS pixels the pane is allowed to be dragged to. */
+  maxWidth: number;
+  /**
+   * Which edge of the pane the resize handle lives on. "right" widens by
+   * dragging away from the pane's left origin (e.g. left sidebar). "left"
+   * widens by dragging towards the pane's right origin (e.g. right thread
+   * panel that anchors to the viewport edge).
+   */
+  edge: ResizeEdge;
+}
+
+interface ResizablePane {
+  /** Current width in CSS pixels. */
+  width: number;
+  /** Pointer-down handler for the resize handle element. */
+  onPointerDown: (event: React.PointerEvent<HTMLElement>) => void;
+  /** True while the user is actively dragging the handle. */
+  isResizing: boolean;
+  /** Reset to the default width (handle double-click target). */
+  reset: () => void;
+}
+
+function readStoredWidth(key: string): number | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistWidth(key: string, value: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, String(Math.round(value)));
+  } catch {
+    /* Safari private mode + sandboxed iframes throw. The width still
+       updates for the live session; only persistence is lost. */
+  }
+}
+
+function clampWidth(width: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, width));
+}
+
+/**
+ * Drives a draggable resize handle for a side pane (sidebar, thread panel,
+ * etc.). The hook owns:
+ *   - persisted width clamped to [minWidth, maxWidth]
+ *   - a pointer-capture drag loop that updates width as the user drags
+ *   - body-level cursor + select-none affordances during the drag
+ *   - a reset() helper for double-click-to-restore-default
+ *
+ * Pass the returned `onPointerDown` to your handle element and apply
+ * `width` to the pane via inline style or a CSS variable.
+ */
+export function useResizablePane({
+  storageKey,
+  defaultWidth,
+  minWidth,
+  maxWidth,
+  edge,
+}: UseResizablePaneOptions): ResizablePane {
+  const [width, setWidth] = useState<number>(() => {
+    const stored = readStoredWidth(storageKey);
+    return clampWidth(stored ?? defaultWidth, minWidth, maxWidth);
+  });
+  const [isResizing, setIsResizing] = useState(false);
+  // Refs keep the drag loop allocation-free and avoid the stale-closure
+  // problem when the pointermove handler reads the starting geometry.
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(width);
+
+  useEffect(() => {
+    persistWidth(storageKey, width);
+  }, [storageKey, width]);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      // Left button only — secondary buttons should fall through so the
+      // browser's context menu / middle-click semantics keep working.
+      if (event.button !== 0) return;
+      event.preventDefault();
+      startXRef.current = event.clientX;
+      startWidthRef.current = width;
+      setIsResizing(true);
+
+      const handle = event.currentTarget;
+      try {
+        handle.setPointerCapture(event.pointerId);
+      } catch {
+        /* setPointerCapture can throw if the pointer was already
+           captured elsewhere; the move/up listeners still fire. */
+      }
+
+      const onMove = (e: PointerEvent) => {
+        const delta = e.clientX - startXRef.current;
+        const signed = edge === "right" ? delta : -delta;
+        const next = clampWidth(
+          startWidthRef.current + signed,
+          minWidth,
+          maxWidth,
+        );
+        setWidth(next);
+      };
+
+      const onUp = (e: PointerEvent) => {
+        try {
+          handle.releasePointerCapture(e.pointerId);
+        } catch {
+          /* Same rationale as setPointerCapture above. */
+        }
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        window.removeEventListener("pointercancel", onUp);
+        setIsResizing(false);
+      };
+
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
+    },
+    [edge, maxWidth, minWidth, width],
+  );
+
+  // Toggle a body-level class so the global cursor + user-select rule
+  // applies across the whole viewport during the drag. Without this,
+  // dragging fast can leave the pointer over the main content where
+  // text gets selected and the cursor reverts to text.
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const cls = "resizing-pane";
+    if (isResizing) {
+      document.body.classList.add(cls);
+    } else {
+      document.body.classList.remove(cls);
+    }
+    return () => {
+      document.body.classList.remove(cls);
+    };
+  }, [isResizing]);
+
+  const reset = useCallback(() => {
+    setWidth(clampWidth(defaultWidth, minWidth, maxWidth));
+  }, [defaultWidth, maxWidth, minWidth]);
+
+  return { width, onPointerDown, isResizing, reset };
+}

--- a/web/src/hooks/useResizablePane.ts
+++ b/web/src/hooks/useResizablePane.ts
@@ -29,6 +29,13 @@ interface ResizablePane {
   isResizing: boolean;
   /** Reset to the default width (handle double-click target). */
   reset: () => void;
+  /**
+   * Apply a signed pixel delta from the user's perspective: positive widens
+   * the pane, negative narrows it. The hook resolves the edge orientation
+   * internally so callers don't need to care. ±Infinity snaps to the
+   * configured bounds (used by Home/End on the keyboard handle).
+   */
+  stepResize: (signedDelta: number) => void;
 }
 
 function readStoredWidth(key: string): number | null {
@@ -84,6 +91,9 @@ export function useResizablePane({
   // problem when the pointermove handler reads the starting geometry.
   const startXRef = useRef(0);
   const startWidthRef = useRef(width);
+  // Held so an unmount mid-drag can tear down the active pointer
+  // listeners and pointer capture, even when onUp never fires.
+  const cleanupDragRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     persistWidth(storageKey, width);
@@ -100,8 +110,9 @@ export function useResizablePane({
       setIsResizing(true);
 
       const handle = event.currentTarget;
+      const pointerId = event.pointerId;
       try {
-        handle.setPointerCapture(event.pointerId);
+        handle.setPointerCapture(pointerId);
       } catch {
         /* setPointerCapture can throw if the pointer was already
            captured elsewhere; the move/up listeners still fire. */
@@ -118,23 +129,55 @@ export function useResizablePane({
         setWidth(next);
       };
 
-      const onUp = (e: PointerEvent) => {
+      const teardown = () => {
         try {
-          handle.releasePointerCapture(e.pointerId);
+          handle.releasePointerCapture(pointerId);
         } catch {
           /* Same rationale as setPointerCapture above. */
         }
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
         window.removeEventListener("pointercancel", onUp);
+        cleanupDragRef.current = null;
+      };
+
+      const onUp = () => {
+        teardown();
         setIsResizing(false);
       };
 
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
       window.addEventListener("pointercancel", onUp);
+      cleanupDragRef.current = teardown;
     },
     [edge, maxWidth, minWidth, width],
+  );
+
+  // Unmount safety: if the component unmounts mid-drag, the user's pointer
+  // is still down somewhere on the page. Removing the listeners here keeps
+  // them from continuing to call setWidth / setIsResizing on a stale
+  // hook instance, and also strips the body class so the cursor returns
+  // to normal even though the consumer disappeared.
+  useEffect(() => {
+    return () => {
+      cleanupDragRef.current?.();
+      cleanupDragRef.current = null;
+      if (typeof document !== "undefined") {
+        document.body.classList.remove("resizing-pane");
+      }
+    };
+  }, []);
+
+  const stepResize = useCallback(
+    (signedDelta: number) => {
+      setWidth((prev) => {
+        if (signedDelta === Number.POSITIVE_INFINITY) return maxWidth;
+        if (signedDelta === Number.NEGATIVE_INFINITY) return minWidth;
+        return clampWidth(prev + signedDelta, minWidth, maxWidth);
+      });
+    },
+    [maxWidth, minWidth],
   );
 
   // Toggle a body-level class so the global cursor + user-select rule
@@ -158,5 +201,5 @@ export function useResizablePane({
     setWidth(clampWidth(defaultWidth, minWidth, maxWidth));
   }, [defaultWidth, maxWidth, minWidth]);
 
-  return { width, onPointerDown, isResizing, reset };
+  return { width, onPointerDown, isResizing, reset, stepResize };
 }

--- a/web/src/hooks/useResizablePane.ts
+++ b/web/src/hooks/useResizablePane.ts
@@ -119,6 +119,10 @@ export function useResizablePane({
       }
 
       const onMove = (e: PointerEvent) => {
+        // Ignore stray pointers — e.g. a second touch or a mouse moving
+        // through while a pen drag is in progress — so they don't drive
+        // width updates that the user didn't initiate.
+        if (e.pointerId !== pointerId) return;
         const delta = e.clientX - startXRef.current;
         const signed = edge === "right" ? delta : -delta;
         const next = clampWidth(
@@ -141,7 +145,11 @@ export function useResizablePane({
         cleanupDragRef.current = null;
       };
 
-      const onUp = () => {
+      const onUp = (e: PointerEvent) => {
+        // Only the pointer that started the drag can end it. Without
+        // this guard, a second pointer's up event would terminate the
+        // active drag prematurely.
+        if (e.pointerId !== pointerId) return;
         teardown();
         setIsResizing(false);
       };

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -11,7 +11,10 @@
 
 /* ─── Sidebar ─── */
 .sidebar {
-  width: 260px;
+  /* Default width is intentionally narrow — most users were left with
+     little room for the main column. The Sidebar component overrides
+     this inline via useResizablePane() so a user-dragged width persists. */
+  width: 220px;
   flex-shrink: 0;
   background: var(--bg-card);
   border-right: 1px solid var(--border);
@@ -22,6 +25,8 @@
      scroll container for windows too short to fit the fixed sidebar chrome. */
   overflow-y: auto;
   overflow-x: hidden;
+  /* Anchor the absolutely-positioned resize handle. */
+  position: relative;
 }
 
 /* ─── Collapsed rail ─── */
@@ -2150,7 +2155,10 @@ html[data-theme="nex"]
 
 /* ─── Thread Panel ─── */
 .thread-panel {
-  width: 380px;
+  /* Default width chosen to leave the main column room on a 13" laptop.
+     ThreadPanel overrides this inline via useResizablePane() so a
+     user-dragged width persists across reloads. */
+  width: 340px;
   flex-shrink: 0;
   background: var(--bg-card);
   border-left: 1px solid var(--border);
@@ -2158,6 +2166,8 @@ html[data-theme="nex"]
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
+  /* Anchor the absolutely-positioned resize handle. */
+  position: relative;
 }
 .thread-panel.open {
   display: flex;
@@ -3453,4 +3463,67 @@ html[data-theme="nex"]
 .workspace-rail-add:active {
   background: rgba(255, 255, 255, 0.1);
   transition-duration: 100ms;
+}
+
+/* ─── Resizable pane drag handle ─────────────────────────────────
+   Thin vertical splitter anchored to a side pane's edge. The visible
+   rule is 1px wide so the layout doesn't shift, while a pseudo-element
+   expands the hit area to ~8px for easy grabbing. */
+.pane-resize-handle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: transparent;
+  cursor: col-resize;
+  z-index: 50;
+  touch-action: none;
+  /* Keep keyboard focus visible without the default outline pushing
+     the rule away from the edge. */
+  outline: none;
+}
+
+.pane-resize-handle--right {
+  right: -1px;
+}
+
+.pane-resize-handle--left {
+  left: -1px;
+}
+
+.pane-resize-handle::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  /* Expand horizontal hit area without nudging the visible rule. */
+  left: -3px;
+  right: -3px;
+}
+
+.pane-resize-handle:hover,
+.pane-resize-handle:focus-visible,
+.pane-resize-handle.is-active {
+  background: var(--cyan-500, #06b6d4);
+}
+
+.pane-resize-handle:focus-visible {
+  /* Visible focus marker without shifting layout. */
+  box-shadow: 0 0 0 1px var(--focus-ring-color, var(--cyan-500, #06b6d4));
+}
+
+/* Globally suppress text selection + force the resize cursor while a
+   drag is in progress, so the cursor doesn't flicker to text-select
+   when the pointer crosses the main content area mid-drag. The
+   high-specificity `*` selector combined with !important is the
+   classic web idiom for this; biome flags it but the override is
+   intentional and scoped to the duration of the drag. */
+body.resizing-pane {
+  cursor: col-resize !important;
+  user-select: none;
+}
+
+body.resizing-pane * {
+  cursor: col-resize !important;
+  user-select: none !important;
 }

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -12,9 +12,13 @@
 /* ─── Sidebar ─── */
 .sidebar {
   /* Default width is intentionally narrow — most users were left with
-     little room for the main column. The Sidebar component overrides
-     this inline via useResizablePane() so a user-dragged width persists. */
-  width: 220px;
+     little room for the main column. The Sidebar component supplies a
+     `--sidebar-resize-width` CSS variable via useResizablePane() so a
+     user-dragged width persists; the variable resolves to 220px when
+     unset. Mobile breakpoints further down override the width directly
+     and intentionally bypass the variable so persisted desktop widths
+     can't leak into the mobile overlay layout. */
+  width: var(--sidebar-resize-width, 220px);
   flex-shrink: 0;
   background: var(--bg-card);
   border-right: 1px solid var(--border);
@@ -2156,9 +2160,12 @@ html[data-theme="nex"]
 /* ─── Thread Panel ─── */
 .thread-panel {
   /* Default width chosen to leave the main column room on a 13" laptop.
-     ThreadPanel overrides this inline via useResizablePane() so a
-     user-dragged width persists across reloads. */
-  width: 340px;
+     ThreadPanel supplies a `--thread-panel-resize-width` variable via
+     useResizablePane(); the variable resolves to 340px when unset. The
+     mobile media query below sets `width: 100%` and intentionally
+     bypasses the variable so a persisted desktop width can't shrink
+     the mobile overlay. */
+  width: var(--thread-panel-resize-width, 340px);
   flex-shrink: 0;
   background: var(--bg-card);
   border-left: 1px solid var(--border);


### PR DESCRIPTION
## Summary

- Reduce the left sidebar's default width 260px → 220px so the main column has room to breathe.
- Add a reusable `useResizablePane()` hook + `PaneResizeHandle` component.
- Wire resize handles to both the left sidebar (right edge) and the right ThreadPanel (left edge); each persists its width to localStorage and supports double-click / Enter to reset.

## Why

The Recents section + the rest of the left sidebar were eating the main column on a 13" laptop — the user reported "other things don't have much space." A narrower default plus a draggable splitter lets each user dial in the layout they want without us guessing for them.

## Behavior

- Sidebar: clamped 180–420px, default 220px, persisted at `wuphf-sidebar-width`.
- ThreadPanel: clamped 280–560px, default 340px (was 380px), persisted at `wuphf-thread-panel-width`.
- Handle is a 1px vertical rule with an 8px hit area; cursor flips to `col-resize` on hover/drag and the body gets `resizing-pane` while dragging so the cursor + selection stay stable across the viewport.
- `role="separator"` with `aria-valuenow/min/max` so screen readers can announce the current width.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bash scripts/test-web.sh` — 165 files, 1574 tests pass
- [x] `bun run build` clean
- [x] New unit tests for `useResizablePane` (hydration, clamping, drag math, reset, body-class lifecycle, non-primary-button ignore)
- [ ] Manually: drag sidebar wider/narrower, refresh, confirm width persists
- [ ] Manually: open a thread, drag thread panel wider/narrower, refresh, confirm width persists
- [ ] Manually: double-click handle restores default; Enter on focused handle does the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-sidebar-default-width](https://github.com/nex-crm/wuphf/raw/screenshots/pr-910/01-sidebar-default-width.png)

![02-sidebar-dragged-wider](https://github.com/nex-crm/wuphf/raw/screenshots/pr-910/02-sidebar-dragged-wider.png)

![03-sidebar-min-width](https://github.com/nex-crm/wuphf/raw/screenshots/pr-910/03-sidebar-min-width.png)

![04-sidebar-handle-focused](https://github.com/nex-crm/wuphf/raw/screenshots/pr-910/04-sidebar-handle-focused.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar and thread panel are now user-resizable with persisted widths, keyboard step/reset controls, accessible separator, and improved drag affordance.
  * Default sidebar and thread-panel sizes reduced to smaller defaults.
* **Tests**
  * Added unit tests for the resizable-pane logic and handle keyboard/drag behavior.
  * Added an E2E screenshot script capturing multiple resize states (default, wider, minimized, focused).
* **Style**
  * CSS for the resize handle, larger hit area, placement, hover/focus/active states, and global drag cursor/selection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->