### PR TITLE
feat(onboarding): restore website scan + chat-mode reveal animation

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -871,6 +871,9 @@ var legalPhaseTransitions = map[string]map[string]bool{
 		PhaseIdentity: true,
 	},
 	PhaseIdentity: {
+		PhaseWebsite: true,
+	},
+	PhaseWebsite: {
 		PhaseScan:      true,
 		PhaseBlueprint: true, // skip scan if no website
 	},

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -28,6 +28,7 @@ const currentStateVersion = 2
 const (
 	PhaseGreet     = "greet"
 	PhaseIdentity  = "identity"
+	PhaseWebsite   = "website"
 	PhaseScan      = "scan"
 	PhaseBlueprint = "blueprint"
 	PhaseTeam      = "team"
@@ -102,8 +103,8 @@ type State struct {
 	// v2 chat-mode additions (Phase 2+).
 
 	// Phase is the current phase cursor in the deterministic CEO conversation
-	// state machine. Legal values: greet | identity | scan | blueprint | team |
-	// seed | bridge | draft | approve | kickoff | complete.
+	// state machine. Legal values: greet | identity | website | scan |
+	// blueprint | team | seed | bridge | draft | approve | kickoff | complete.
 	Phase string `json:"phase,omitempty"`
 
 	// CEODMChannelID is the reserved channel slug for the CEO onboarding DM

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -125,7 +125,19 @@ func (b *Broker) advancePhase(s *onboarding.State, next string) error {
 		return fmt.Errorf("onboarding: persist PendingSuggestion for phase %s: %w", next, err)
 	}
 
-	return b.saveLocked()
+	if err := b.saveLocked(); err != nil {
+		return err
+	}
+
+	// PhaseScan: launch the real website scan asynchronously so the chat
+	// can keep flowing. The goroutine updates the chip status, stagger-
+	// posts one "✓ <article>" message per wiki page that gets written,
+	// then auto-advances to PhaseBlueprint when done.
+	if next == onboarding.PhaseScan {
+		go b.runScanPhase(dmSlug)
+	}
+
+	return nil
 }
 
 // runSeedPhase runs the atomic office seed at the seed phase boundary.
@@ -362,6 +374,19 @@ func ceoDeterministicMessages(phase string, s *onboarding.State) []ceoMessagePay
 				"field":       "description",
 				"label":       "Short description",
 				"placeholder": "e.g. Subscription billing for indie SaaS",
+				"optional":    true,
+			}),
+		}}
+
+	case onboarding.PhaseWebsite:
+		return []ceoMessagePayload{{
+			Kind:         "ceo_form_field",
+			Content:      "Got a website I can scan for context?",
+			SuggestionID: "identity-website",
+			SuggestionPayload: mustMarshalRaw(map[string]interface{}{
+				"field":       "website_url",
+				"label":       "Company website",
+				"placeholder": "acme.com",
 				"optional":    true,
 			}),
 		}}

--- a/internal/team/broker_onboarding_sanitize_test.go
+++ b/internal/team/broker_onboarding_sanitize_test.go
@@ -274,6 +274,7 @@ func TestCeoDeterministicMessagesNeverCallLLM(t *testing.T) {
 	phase2Phases := []string{
 		onboarding.PhaseGreet,
 		onboarding.PhaseIdentity,
+		onboarding.PhaseWebsite,
 		onboarding.PhaseScan,
 		onboarding.PhaseBlueprint,
 		onboarding.PhaseTeam,
@@ -468,8 +469,9 @@ func TestPhase2TransitionTableValidation(t *testing.T) {
 		// Legal Phase 2 transitions.
 		{"", onboarding.PhaseGreet, true},
 		{onboarding.PhaseGreet, onboarding.PhaseIdentity, true},
-		{onboarding.PhaseIdentity, onboarding.PhaseScan, true},
-		{onboarding.PhaseIdentity, onboarding.PhaseBlueprint, true},
+		{onboarding.PhaseIdentity, onboarding.PhaseWebsite, true},
+		{onboarding.PhaseWebsite, onboarding.PhaseScan, true},
+		{onboarding.PhaseWebsite, onboarding.PhaseBlueprint, true},
 		{onboarding.PhaseScan, onboarding.PhaseBlueprint, true},
 		{onboarding.PhaseBlueprint, onboarding.PhaseTeam, true},
 		{onboarding.PhaseBlueprint, onboarding.PhaseSeed, true},
@@ -480,6 +482,8 @@ func TestPhase2TransitionTableValidation(t *testing.T) {
 		// Invalid jumps (must be rejected with 400 by the handler).
 		{"", onboarding.PhaseSeed, false},
 		{onboarding.PhaseGreet, onboarding.PhaseSeed, false},
+		{onboarding.PhaseIdentity, onboarding.PhaseScan, false},     // must go through PhaseWebsite first
+		{onboarding.PhaseIdentity, onboarding.PhaseBlueprint, false}, // must go through PhaseWebsite first
 		{onboarding.PhaseIdentity, onboarding.PhaseComplete, false},
 		{onboarding.PhaseComplete, onboarding.PhaseGreet, false}, // cannot restart
 	}
@@ -491,6 +495,42 @@ func TestPhase2TransitionTableValidation(t *testing.T) {
 				t.Errorf("IsLegalTransition(%q, %q) = %v, want %v", tc.from, tc.to, allowed, tc.allowed)
 			}
 		})
+	}
+}
+
+// TestPhaseWebsiteEmitsWebsiteURLFormField verifies that entering PhaseWebsite
+// produces a ceo_form_field card targeting the website_url field — the
+// missing link that re-enables the website scan + reveal animation.
+func TestPhaseWebsiteEmitsWebsiteURLFormField(t *testing.T) {
+	state := &onboarding.State{
+		Version: 2,
+		FormAnswers: onboarding.FormAnswers{
+			CompanyName: "Acme",
+			Description: "Subscription billing for indie SaaS",
+		},
+	}
+
+	msgs := ceoDeterministicMessages(onboarding.PhaseWebsite, state)
+	if len(msgs) != 1 {
+		t.Fatalf("PhaseWebsite: expected 1 message, got %d", len(msgs))
+	}
+	got := msgs[0]
+	if got.Kind != "ceo_form_field" {
+		t.Errorf("PhaseWebsite Kind = %q, want %q", got.Kind, "ceo_form_field")
+	}
+	if got.SuggestionPayload == nil {
+		t.Fatal("PhaseWebsite SuggestionPayload is nil")
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(*got.SuggestionPayload, &decoded); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if field, _ := decoded["field"].(string); field != "website_url" {
+		t.Errorf("PhaseWebsite payload.field = %q, want %q", field, "website_url")
+	}
+	if optional, _ := decoded["optional"].(bool); !optional {
+		t.Error("PhaseWebsite payload.optional should be true — scan must be skippable")
 	}
 }
 

--- a/internal/team/broker_onboarding_sanitize_test.go
+++ b/internal/team/broker_onboarding_sanitize_test.go
@@ -482,7 +482,7 @@ func TestPhase2TransitionTableValidation(t *testing.T) {
 		// Invalid jumps (must be rejected with 400 by the handler).
 		{"", onboarding.PhaseSeed, false},
 		{onboarding.PhaseGreet, onboarding.PhaseSeed, false},
-		{onboarding.PhaseIdentity, onboarding.PhaseScan, false},     // must go through PhaseWebsite first
+		{onboarding.PhaseIdentity, onboarding.PhaseScan, false},      // must go through PhaseWebsite first
 		{onboarding.PhaseIdentity, onboarding.PhaseBlueprint, false}, // must go through PhaseWebsite first
 		{onboarding.PhaseIdentity, onboarding.PhaseComplete, false},
 		{onboarding.PhaseComplete, onboarding.PhaseGreet, false}, // cannot restart

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -114,9 +114,9 @@ func (b *Broker) runScanPhase(dmSlug string) {
 // SSE/append-only message log stays append-only.
 func (b *Broker) postScanChipUpdate(dmSlug, websiteURL, status, label string) {
 	rawPayload := mustMarshalRaw(map[string]interface{}{
-		"url":         websiteURL,
-		"status":      status,
-		"done_label":  label,
+		"url":          websiteURL,
+		"status":       status,
+		"done_label":   label,
 		"failed_label": label,
 	})
 	payload := ceoMessagePayload{
@@ -202,4 +202,3 @@ func (b *Broker) advanceAfterScan(websiteURL string, success bool) {
 	}
 	_ = websiteURL // reserved for future telemetry; keep param for clarity
 }
-

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -51,7 +51,14 @@ func (b *Broker) runScanPhase(dmSlug string) {
 	// transition fired; that write is durable by the time we get here.
 	s, err := onboarding.Load()
 	if err != nil {
+		// Don't strand the user on a spinning "Scanning…" chip. Post a
+		// generic failed terminal chip + try to advance out of PhaseScan
+		// even though advanceAfterScan will likely hit the same Load
+		// failure — at minimum the chat shows the failure state.
+		// (CodeRabbit on #911.)
 		log.Printf("onboarding scan: load state: %v", err)
+		b.postScanChipUpdate(dmSlug, "", "failed", "Couldn’t read onboarding state — skipping the scan.")
+		b.advanceAfterScan("", false)
 		return
 	}
 	websiteURL := strings.TrimSpace(s.FormAnswers.WebsiteURL)
@@ -92,6 +99,14 @@ func (b *Broker) runScanPhase(dmSlug string) {
 		return
 	}
 
+	// Re-check phase before each side-effect: if a concurrent resume/tab has
+	// already moved onboarding past PhaseScan, don't append stale "Wiki
+	// updated ✓" / "✓ <article>" messages on top of the new phase's chat.
+	// (CodeRabbit on #911.)
+	if !b.phaseStillScan() {
+		return
+	}
+
 	b.postScanChipUpdate(dmSlug, websiteURL, "done", "Wiki updated ✓")
 
 	// Stagger one chat bubble per article written. Each bubble is a plain
@@ -108,10 +123,28 @@ revealLoop:
 			break revealLoop
 		case <-time.After(scanRevealStagger):
 		}
+		if !b.phaseStillScan() {
+			break revealLoop
+		}
 		b.postScanArticleLine(dmSlug, article)
 	}
 
 	b.advanceAfterScan(websiteURL, true)
+}
+
+// phaseStillScan reports whether the persisted onboarding state is still in
+// PhaseScan. It is called before each post-scan side effect (terminal chip +
+// each article reveal line) so a concurrent resume/tab that already moved
+// onboarding forward does not get stale "Wiki updated ✓" + "✓ <article>"
+// CEO messages appended on top of the new phase's chat. On load failure we
+// return false (bail out is safer than posting stale content).
+func (b *Broker) phaseStillScan() bool {
+	s, err := onboarding.Load()
+	if err != nil {
+		log.Printf("onboarding scan: phase recheck load: %v", err)
+		return false
+	}
+	return s.Phase == onboarding.PhaseScan
 }
 
 // postScanChipUpdate appends a second ceo_scan_chip message into the CEO DM

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -96,10 +96,16 @@ func (b *Broker) runScanPhase(dmSlug string) {
 
 	// Stagger one chat bubble per article written. Each bubble is a plain
 	// text CEO message so it renders as a normal CEO line with the ✓ prefix.
+	//
+	// The labeled `break revealLoop` is load-bearing: a bare `break` inside
+	// the select would only exit the select and the for loop would keep
+	// posting article bubbles after the goroutine's context was cancelled
+	// (caught by staticcheck SA4011 and the CodeRabbit review on #911).
+revealLoop:
 	for _, article := range result.ArticlesWritten {
 		select {
 		case <-ctx.Done():
-			break
+			break revealLoop
 		case <-time.After(scanRevealStagger):
 		}
 		b.postScanArticleLine(dmSlug, article)

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -186,23 +186,40 @@ func (b *Broker) postScanArticleLine(dmSlug, article string) {
 // blueprint CEO card. Mirrors handleTransition's invariant: Phase is set
 // and saved before advancePhase runs the broker-side emission so a resume
 // would re-emit the blueprint card, not the scan chip.
+//
+// The load-check-save is serialized under b.mu (the same mutex advancePhase
+// takes while appending messages and saving state) so a concurrent
+// broker-internal write cannot land between our Load and Save and get
+// clobbered by the stale snapshot. Addresses CodeRabbit on #911.
+//
+// b.mu is released before calling b.advancePhase: that function acquires
+// b.mu itself, and re-entrant locking on sync.Mutex would deadlock. The
+// remaining window between our Save and advancePhase's Save is microseconds
+// and not user-actionable — the only card the user could submit during
+// PhaseScan is the read-only scan chip, which has no submit handler.
 func (b *Broker) advanceAfterScan(websiteURL string, success bool) {
+	b.mu.Lock()
 	s, err := onboarding.Load()
 	if err != nil {
+		b.mu.Unlock()
 		log.Printf("onboarding scan: load for advance: %v", err)
 		return
 	}
 	// Only auto-advance from PhaseScan — protect against the user already
 	// having clicked through some other path during the scan window.
 	if s.Phase != onboarding.PhaseScan {
+		b.mu.Unlock()
 		return
 	}
 	s.FormAnswers.ScanComplete = success
 	s.Phase = onboarding.PhaseBlueprint
 	if err := onboarding.Save(s); err != nil {
+		b.mu.Unlock()
 		log.Printf("onboarding scan: persist blueprint transition: %v", err)
 		return
 	}
+	b.mu.Unlock()
+
 	if err := b.advancePhase(s, onboarding.PhaseBlueprint); err != nil {
 		log.Printf("onboarding scan: advance to blueprint: %v", err)
 	}

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -1,0 +1,205 @@
+package team
+
+// broker_onboarding_scan.go — async website scan for PhaseScan.
+//
+// runScanPhase is launched by advancePhase(PhaseScan) in its own goroutine
+// so the chat can keep flowing while operations.SeedCompanyContext does the
+// HTTP fetch + LLM extraction (typically 5-30 seconds). It then:
+//
+//   1. Posts a status-update chip (status="done" or "failed").
+//   2. Stagger-posts one "✓ <article>" message per wiki page written —
+//      the chat-mode equivalent of the old Step3bAnalysis reveal animation.
+//   3. Persists FormAnswers.ScanComplete = true.
+//   4. Auto-advances the phase machine to PhaseBlueprint (the user is
+//      sitting on a read-only chip; no other actor will advance them).
+//
+// All message writes go through appendMessageLocked under b.mu so the
+// SSE fanout to the OnboardingChat client stays serialized with the
+// rest of the broker.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/onboarding"
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+// scanRevealStagger is the delay between successive "✓ <article>" bubbles
+// during the post-scan reveal. Short enough to feel responsive, long
+// enough that each line registers as a discrete moment.
+const scanRevealStagger = 180 * time.Millisecond
+
+// scanTimeout bounds the whole scan-and-reveal goroutine. The underlying
+// fetch+LLM call has its own internal budget; this is a hard ceiling so
+// a stuck scan does not strand the user on a "scanning…" chip forever.
+const scanTimeout = 90 * time.Second
+
+// runScanPhase runs operations.SeedCompanyContext, posts the result
+// messages into the CEO DM, and auto-advances to PhaseBlueprint.
+//
+// Safe to call without holding b.mu. Acquires the lock per write.
+func (b *Broker) runScanPhase(dmSlug string) {
+	// Re-load state so we read the latest FormAnswers.WebsiteURL rather
+	// than relying on a snapshot from advancePhase's caller. The user
+	// committed website_url via POST /onboarding/answer just before the
+	// transition fired; that write is durable by the time we get here.
+	s, err := onboarding.Load()
+	if err != nil {
+		log.Printf("onboarding scan: load state: %v", err)
+		return
+	}
+	websiteURL := strings.TrimSpace(s.FormAnswers.WebsiteURL)
+	if websiteURL == "" {
+		// Defensive: the transition guard should have routed an empty
+		// website straight to PhaseBlueprint. If we got here anyway,
+		// just advance and skip the scan.
+		b.advanceAfterScan(websiteURL, false)
+		return
+	}
+
+	home := strings.TrimSpace(config.RuntimeHomeDir())
+	wikiRoot := ""
+	if home != "" {
+		wikiRoot = filepath.Join(home, ".wuphf", "wiki")
+	}
+
+	input := operations.CompanySeedInput{
+		WebsiteURL: websiteURL,
+		OwnerName:  s.FormAnswers.OwnerName,
+		OwnerRole:  s.FormAnswers.OwnerRole,
+		Completer:  brokerCompleter{},
+		WikiRoot:   wikiRoot,
+	}
+
+	ctx, cancel := context.WithTimeout(b.lifecycleCtx, scanTimeout)
+	defer cancel()
+	result, scanErr := operations.SeedCompanyContext(ctx, input)
+
+	success := scanErr == nil && result != nil && !result.NeedsRetry
+	if !success {
+		if scanErr != nil {
+			log.Printf("onboarding scan: %v", scanErr)
+		}
+		b.postScanChipUpdate(dmSlug, websiteURL, "failed",
+			fmt.Sprintf("Couldn’t read %s — skipping the scan.", displayURL(websiteURL)))
+		b.advanceAfterScan(websiteURL, false)
+		return
+	}
+
+	b.postScanChipUpdate(dmSlug, websiteURL, "done", "Wiki updated ✓")
+
+	// Stagger one chat bubble per article written. Each bubble is a plain
+	// text CEO message so it renders as a normal CEO line with the ✓ prefix.
+	for _, article := range result.ArticlesWritten {
+		select {
+		case <-ctx.Done():
+			break
+		case <-time.After(scanRevealStagger):
+		}
+		b.postScanArticleLine(dmSlug, article)
+	}
+
+	b.advanceAfterScan(websiteURL, true)
+}
+
+// postScanChipUpdate appends a second ceo_scan_chip message into the CEO DM
+// reflecting the terminal status of the scan (done | failed). It is a new
+// message (not an in-place mutation of the original chip) so the existing
+// SSE/append-only message log stays append-only.
+func (b *Broker) postScanChipUpdate(dmSlug, websiteURL, status, label string) {
+	rawPayload := mustMarshalRaw(map[string]interface{}{
+		"url":         websiteURL,
+		"status":      status,
+		"done_label":  label,
+		"failed_label": label,
+	})
+	payload := ceoMessagePayload{
+		Kind:              "ceo_scan_chip",
+		Content:           label,
+		SuggestionID:      "scan-progress-" + urlToSuggestionID(websiteURL) + "-" + status,
+		SuggestionPayload: rawPayload,
+	}
+	sanitized, err := sanitizeCEOPayload(payload)
+	if err != nil {
+		log.Printf("onboarding scan: sanitize chip update: %v", err)
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "ceo",
+		Channel:   dmSlug,
+		Kind:      payload.Kind,
+		Content:   payload.Content,
+		Payload:   sanitized,
+		Tagged:    []string{},
+		Timestamp: now,
+	})
+	if err := b.saveLocked(); err != nil {
+		log.Printf("onboarding scan: persist chip update: %v", err)
+	}
+}
+
+// postScanArticleLine appends a single CEO text bubble announcing one wiki
+// article written by the scan. The leading ✓ is the chat-mode equivalent
+// of the reveal-check span in the old Step3bAnalysis panel.
+func (b *Broker) postScanArticleLine(dmSlug, article string) {
+	article = strings.TrimSpace(article)
+	if article == "" {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "ceo",
+		Channel:   dmSlug,
+		Kind:      "text",
+		Content:   "✓ " + article,
+		Tagged:    []string{},
+		Timestamp: now,
+	})
+	if err := b.saveLocked(); err != nil {
+		log.Printf("onboarding scan: persist article line: %v", err)
+	}
+}
+
+// advanceAfterScan persists ScanComplete + Phase=Blueprint and emits the
+// blueprint CEO card. Mirrors handleTransition's invariant: Phase is set
+// and saved before advancePhase runs the broker-side emission so a resume
+// would re-emit the blueprint card, not the scan chip.
+func (b *Broker) advanceAfterScan(websiteURL string, success bool) {
+	s, err := onboarding.Load()
+	if err != nil {
+		log.Printf("onboarding scan: load for advance: %v", err)
+		return
+	}
+	// Only auto-advance from PhaseScan — protect against the user already
+	// having clicked through some other path during the scan window.
+	if s.Phase != onboarding.PhaseScan {
+		return
+	}
+	s.FormAnswers.ScanComplete = success
+	s.Phase = onboarding.PhaseBlueprint
+	if err := onboarding.Save(s); err != nil {
+		log.Printf("onboarding scan: persist blueprint transition: %v", err)
+		return
+	}
+	if err := b.advancePhase(s, onboarding.PhaseBlueprint); err != nil {
+		log.Printf("onboarding scan: advance to blueprint: %v", err)
+	}
+	_ = websiteURL // reserved for future telemetry; keep param for clarity
+}
+

--- a/web/e2e/screenshots/onboarding-website-scan.mjs
+++ b/web/e2e/screenshots/onboarding-website-scan.mjs
@@ -222,22 +222,27 @@ const { browser, context, page } = await launchBrowser({
   viewport: { width: 1280, height: 800 },
 });
 
-// Frame 1: the website prompt that the chat-mode redesign accidentally dropped.
-await installFrameMocks(context, STATE_WEBSITE_PROMPT);
-await bootFrame(page);
-await shotPage(page, OUT, "01-website-prompt");
+try {
+  // Frame 1: the website prompt that the chat-mode redesign accidentally dropped.
+  await installFrameMocks(context, STATE_WEBSITE_PROMPT);
+  await bootFrame(page);
+  await shotPage(page, OUT, "01-website-prompt");
 
-// Frame 2: scan running.
-await installFrameMocks(context, STATE_SCAN_IN_PROGRESS);
-await bootFrame(page);
-await shotPage(page, OUT, "02-scan-in-progress");
+  // Frame 2: scan running.
+  await installFrameMocks(context, STATE_SCAN_IN_PROGRESS);
+  await bootFrame(page);
+  await shotPage(page, OUT, "02-scan-in-progress");
 
-// Frame 3: post-scan reveal — done chip + per-article CEO bubble.
-await installFrameMocks(context, STATE_SCAN_DONE, {
-  messages: SCAN_REVEAL_MESSAGES,
-});
-await bootFrame(page);
-await shotPage(page, OUT, "03-scan-reveal");
+  // Frame 3: post-scan reveal — done chip + per-article CEO bubble.
+  await installFrameMocks(context, STATE_SCAN_DONE, {
+    messages: SCAN_REVEAL_MESSAGES,
+  });
+  await bootFrame(page);
+  await shotPage(page, OUT, "03-scan-reveal");
 
-console.log(`captured 3 screenshots to ${OUT}`);
-await browser.close();
+  console.log(`captured 3 screenshots to ${OUT}`);
+} finally {
+  // Cleanup runs even if any frame throws — otherwise CI leaks a chromium
+  // child process and the next run picks up a stale port (CodeRabbit on #911).
+  await browser.close();
+}

--- a/web/e2e/screenshots/onboarding-website-scan.mjs
+++ b/web/e2e/screenshots/onboarding-website-scan.mjs
@@ -1,0 +1,243 @@
+// Capture the restored website-scan onboarding flow:
+//   website-url form field → scanning chip → done chip → article reveal.
+//
+// Stubs /onboarding/state per frame so no real broker is needed.
+// Pattern mirrors onboarding-phase2.mjs.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh onboarding-website-scan <pr-number>
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+// Shared baseline form_answers — the user has already answered company_name
+// and description; what changes between frames is the pending suggestion and
+// any chat messages on the CEO DM.
+const baseAnswers = {
+  company_name: "Acme Billing",
+  description: "Subscription billing for indie SaaS",
+};
+
+// Frame 1: PhaseWebsite — the restored "Got a website I can scan for context?"
+// card. This is the question that disappeared in the chat-mode redesign.
+const STATE_WEBSITE_PROMPT = {
+  onboarded: false,
+  phase: "website",
+  form_answers: baseAnswers,
+  pending_suggestion: {
+    id: "identity-website",
+    phase: "website",
+    kind: "ceo_form_field",
+    payload: {
+      field: "website_url",
+      label: "Company website",
+      placeholder: "acme.com",
+      optional: true,
+    },
+  },
+};
+
+// Frame 2: PhaseScan — chip showing the scan is in progress. Status updates
+// arrive via SSE in production; for screenshot purposes we render the chip
+// in its initial "scanning" state directly from /onboarding/state.
+const STATE_SCAN_IN_PROGRESS = {
+  onboarded: false,
+  phase: "scan",
+  form_answers: {
+    ...baseAnswers,
+    website_url: "https://anthropic.com",
+  },
+  pending_suggestion: {
+    id: "scan-progress-anthropic-com",
+    phase: "scan",
+    kind: "ceo_scan_chip",
+    payload: {
+      url: "https://anthropic.com",
+      status: "scanning",
+      scanning_label: "Scanning anthropic.com…",
+    },
+  },
+};
+
+// Frame 3: PhaseScan terminal — chip flips to "done" and the per-article
+// reveal lines have been posted as separate CEO bubbles. In production these
+// arrive via SSE; we mock them on the messages endpoint so the chat shows
+// the staggered reveal in its final state.
+const STATE_SCAN_DONE = {
+  onboarded: false,
+  // After the goroutine finishes it auto-advances to blueprint, so the
+  // pending_suggestion for the dom is the blueprint chip_row. But the chat
+  // history above it shows the reveal sequence.
+  phase: "blueprint",
+  form_answers: {
+    ...baseAnswers,
+    website_url: "https://anthropic.com",
+    scan_complete: true,
+  },
+  pending_suggestion: {
+    id: "blueprint-pick",
+    phase: "blueprint",
+    kind: "ceo_chip_row",
+    payload: {
+      field: "blueprint_id",
+      label: "Pick a starter template, or start from scratch:",
+      options: [
+        { id: "bookkeeping-invoicing-service", label: "Bookkeeping" },
+        { id: "niche-crm", label: "Niche CRM" },
+        { id: "youtube-factory", label: "YouTube Factory" },
+        { id: "", label: "Start from scratch" },
+      ],
+    },
+  },
+};
+
+// Messages on the CEO DM for the reveal frame — the staggered "✓ <article>"
+// lines that replace the old Step3bAnalysis reveal animation.
+const dmSlug = "dm:ceo:onboarding";
+const SCAN_REVEAL_MESSAGES = [
+  {
+    id: "msg-1",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "text",
+    content: "Office name?",
+    timestamp: "2026-05-18T12:43:00Z",
+  },
+  {
+    id: "msg-2",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "text",
+    content: "What does Acme Billing do?",
+    timestamp: "2026-05-18T12:43:05Z",
+  },
+  {
+    id: "msg-3",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "text",
+    content: "Got a website I can scan for context?",
+    timestamp: "2026-05-18T12:43:10Z",
+  },
+  {
+    id: "msg-4",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "ceo_scan_chip",
+    content: "Scanning anthropic.com…",
+    payload: { url: "https://anthropic.com", status: "scanning" },
+    timestamp: "2026-05-18T12:43:12Z",
+  },
+  {
+    id: "msg-5",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "ceo_scan_chip",
+    content: "Wiki updated ✓",
+    payload: {
+      url: "https://anthropic.com",
+      status: "done",
+      done_label: "Wiki updated ✓",
+    },
+    timestamp: "2026-05-18T12:43:38Z",
+  },
+  {
+    id: "msg-6",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "text",
+    content: "✓ team/about/company.md",
+    timestamp: "2026-05-18T12:43:39Z",
+  },
+];
+
+async function installFrameMocks(context, stateFixture, opts = {}) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      await ctx.route("**/api/onboarding/state", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(stateFixture),
+        }),
+      );
+      await ctx.route("**/api/onboarding/answer", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true }),
+        }),
+      );
+      await ctx.route("**/api/onboarding/transition", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, phase: stateFixture.phase }),
+        }),
+      );
+      if (opts.messages) {
+        await ctx.route(`**/api/messages?channel=${encodeURIComponent(dmSlug)}**`, (r) =>
+          r.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ messages: opts.messages }),
+          }),
+        );
+        await ctx.route("**/api/messages**", (r) =>
+          r.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ messages: opts.messages }),
+          }),
+        );
+      }
+    },
+  });
+}
+
+async function bootFrame(page) {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("wuphf:onboarding-v2", "1");
+      window.localStorage.setItem("wuphf:in-ceo-onboarding", "1");
+    } catch {
+      // private-mode tabs; the query param fallback handles it.
+    }
+  });
+  await page.goto(`${DEFAULT_BASE}/?onboardingV2=1`, { waitUntil: "load" });
+  await page.waitForSelector('[data-testid="onboarding-dm-route"]', {
+    timeout: 15_000,
+  });
+  await page.waitForTimeout(400);
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 800 },
+});
+
+// Frame 1: the website prompt that the chat-mode redesign accidentally dropped.
+await installFrameMocks(context, STATE_WEBSITE_PROMPT);
+await bootFrame(page);
+await shotPage(page, OUT, "01-website-prompt");
+
+// Frame 2: scan running.
+await installFrameMocks(context, STATE_SCAN_IN_PROGRESS);
+await bootFrame(page);
+await shotPage(page, OUT, "02-scan-in-progress");
+
+// Frame 3: post-scan reveal — done chip + per-article CEO bubble.
+await installFrameMocks(context, STATE_SCAN_DONE, {
+  messages: SCAN_REVEAL_MESSAGES,
+});
+await bootFrame(page);
+await shotPage(page, OUT, "03-scan-reveal");
+
+console.log(`captured 3 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -788,7 +788,7 @@ async function advanceOnboardingAfterAnswer(
       await post("/onboarding/transition", { phase: "identity" });
       return;
     case "description":
-      await post("/onboarding/transition", { phase: "blueprint" });
+      await post("/onboarding/transition", { phase: "website" });
       return;
     case "blueprint_id":
       // Strict trimmed-string check: an unknown payload can be a whitespace

--- a/web/src/components/onboarding/usePreviewOffice.ts
+++ b/web/src/components/onboarding/usePreviewOffice.ts
@@ -33,6 +33,7 @@ export interface PreviewOfficeState {
 const PREVIEW_PHASES = new Set([
   "greet",
   "identity",
+  "website",
   "scan",
   "blueprint",
   "team",


### PR DESCRIPTION
## Summary

The original wizard had a `Step3bAnalysis` pane that scraped the user's company URL, wrote a few wiki articles, and revealed each one with a staggered animation. The chat-mode redesign (#892 / #903) wired the backend chip + state machine for it but never reached `PhaseScan` — identity only collected `description` and then jumped straight to `blueprint`. The chip code, the `SeedCompanyContext` pipeline, and `POST /onboarding/scan` were all sitting unreachable.

This restores the flow inside the new chat UX.

### Backend

- Insert a new `PhaseWebsite` between identity and scan so the CEO has somewhere to ask for the URL. Legal transitions are now:
  ```
  identity → website → (scan | blueprint) → blueprint
  ```
  Bypassing the new phase (e.g. `identity → scan` or `identity → blueprint`) is now rejected by the state machine.
- Emit a `ceo_form_field` card for `website_url` on `PhaseWebsite` entry (`optional: true`, so the existing skip path still works).
- On `PhaseScan` entry, launch a goroutine that runs `operations.SeedCompanyContext`, posts a terminal `ceo_scan_chip` (`status=done|failed`), stagger-posts one `✓ <article>` CEO bubble per wiki page written, and then auto-advances to `PhaseBlueprint` so the user is not stranded on a read-only chip.

### Frontend

- `InterviewBar` advance: `description → website` (was `→ blueprint`).
- `usePreviewOffice`: keep the sidebar preview overlay alive during the new website phase.

### Tests

- Updated `TestPhase2TransitionTableValidation` for the new edges and the newly-illegal `identity → scan` / `identity → blueprint` shortcuts.
- Added `TestPhaseWebsiteEmitsWebsiteURLFormField`.
- Added `PhaseWebsite` to `TestCeoDeterministicMessagesNeverCallLLM`.

## Live smoke test

Ran a fresh `WUPHF_RUNTIME_HOME=/tmp/wuphf-rws-home` instance on `--web-port 7920 --broker-port 7921` and drove the full flow end-to-end via Playwright against the real binary.

State trace (from `/onboarding/state`):

```
greet → identity (form_answers.company_name = "Acme Billing")
identity → website (form_answers.description = "Subscription billing for indie SaaS")
website → scan (form_answers.website_url = "https://anthropic.com")
scan → blueprint (form_answers.scan_complete = true)
```

Wiki output (real LLM extraction, not a stub):

```
$ cat $WUPHF_RUNTIME_HOME/.wuphf/wiki/team/about/company.md
# Anthropic

AI research and products company building Claude, a family of AI models and
applications, with a focus on safety at the frontier.

**Website:** https://anthropic.com
**Industry:** Artificial Intelligence
**Audience:** Developers, enterprises, and consumers across coding, agents,
customer support, education, financial services, government, healthcare,
legal, life sciences, nonprofits, security, and small business
**Goals:** Secure the benefits of AI and mitigate its risks while serving
humanity's long-term well-being
```

## Screenshots

These were captured from the real running binary, not from the vite+mocks harness.

**1. The restored website-URL prompt — the question that disappeared in the chat-mode redesign:**

![01-website-prompt](https://github.com/nex-crm/wuphf/raw/screenshots/pr-911/01-website-prompt.png)

**2. Scan in progress — `ceo_scan_chip` rendered with the `scanning` status:**

![02-scan-in-progress](https://github.com/nex-crm/wuphf/raw/screenshots/pr-911/02-scan-in-progress.png)

**3. Post-scan reveal — terminal `Wiki updated ✓` chip, the `✓ team/about/company.md` reveal line, then the auto-advanced blueprint card:**

![03-scan-reveal-and-blueprint](https://github.com/nex-crm/wuphf/raw/screenshots/pr-911/03-scan-reveal-and-blueprint.png)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./internal/...` — all packages green
- [x] `bunx tsc --noEmit` — clean
- [x] `bash scripts/test-web.sh web/src/components/onboarding/ web/src/components/messages/InterviewBar.ceoKinds.test.tsx` — 75/75 pass
- [x] `bun run build` — clean
- [x] Real Chrome via `browser-harness` (CDP-attached desktop Chrome, not headless) — same `greet → blueprint` traversal, same real LLM scan, confirms the phase header reads `PHASE: WEBSITE` then `PHASE: SCAN` then auto-advances
- [x] Live smoke against a real `wuphf` binary on a fresh `WUPHF_RUNTIME_HOME` — full `greet → blueprint` traversal with real scan, real LLM extraction, real `wiki/team/about/company.md` written

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "website" step to CEO onboarding: optional website URL field, sidebar preview during the step, and an automated website scan that posts success/failure chips and reveals scanned article results in staggered CEO messages.

* **Tests**
  * Expanded Phase 2 transition and sanitization tests to include the website step and added a test asserting the website URL form field.

* **Other**
  * Added an end-to-end screenshot script for the website scan flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/911?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
