### PR TITLE
fix(notebook): restore scrolling inside open entries

### DIFF
--- a/web/src/styles/notebook.css
+++ b/web/src/styles/notebook.css
@@ -326,6 +326,35 @@
   position: relative;
 }
 
+/* Inside the two-column layout, `.nb-layout` is `overflow: hidden` and the
+   shelf owns its own scroll. The article column needs to own its own scroll
+   too — otherwise long entries are clipped and the user cannot reach the
+   promote button, review thread, or footer. */
+.notebook-surface .nb-layout > .nb-article {
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.25) transparent;
+}
+.notebook-surface .nb-layout > .nb-article::-webkit-scrollbar {
+  width: 10px;
+}
+.notebook-surface .nb-layout > .nb-article::-webkit-scrollbar-track {
+  background: transparent;
+}
+.notebook-surface .nb-layout > .nb-article::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.22);
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.notebook-surface .nb-layout > .nb-article::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.4);
+  background-clip: padding-box;
+}
+
 /* Breadcrumb */
 .notebook-surface .nb-crumb {
   font-family: var(--nb-chrome);


### PR DESCRIPTION
## Summary

- Open any agent notebook, click an entry, try to scroll the body — nothing happens; the promote button, review thread, and footer are unreachable.
- Cause: `.nb-layout` is `display: grid` with `overflow: hidden` and `height: 100%`. The shelf column already has its own `overflow-y: auto`, but the `.nb-article` column had no scroll rule, so long entries were clipped at the grid cell.
- Fix: give `.nb-layout > .nb-article` its own scroll container (`height: 100%; min-height: 0; overflow-y: auto; overscroll-behavior: contain`) plus matching scrollbar styling. Scoped to the two-column layout so the catalog/error-state uses of `.nb-article` (which rely on `.notebook-surface` to scroll) are not affected.

## Test plan

- [ ] `bash scripts/test-web.sh` — 164/164 file pass, 1561 tests pass locally
- [ ] Open `/notebooks/<agent>/<entry>` for a long entry, confirm body scrolls, promote button + review thread + posterity footer are reachable
- [ ] Open the bookshelf catalog and confirm short error/loading states still render correctly (unchanged path)
- [ ] Shelf column still scrolls independently of the article

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved scrollbar appearance and scrolling behavior in the notebook article section for enhanced visual consistency across browsers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->