### PR TITLE
fix(broker): land missing #916 final-triangulation fix round

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,10 @@ jobs:
         if: ${{ steps.broker-changes.outputs.changed == 'true' }}
         working-directory: packages/broker
         run: bun run test
+      - name: Vitest coverage gate
+        if: ${{ steps.broker-changes.outputs.changed == 'true' }}
+        working-directory: packages/broker
+        run: bun run test:coverage
       - name: Broker invariant checks
         # No non-loopback bind constants, no electron imports, all
         # @wuphf/protocol imports go through the package root, etc.

--- a/packages/broker/scripts/branch-10-demo.ts
+++ b/packages/broker/scripts/branch-10-demo.ts
@@ -47,10 +47,12 @@ const db = new BetterSqlite3(dbPath);
 runMigrations(db);
 const eventLog = createEventLog(db);
 const approvalProjection = createApprovalProjection(db);
-const approvalAppender = createApprovalAppender(db, eventLog, approvalProjection);
 const agentProviderRoutingStore = createAgentProviderRoutingStore(db);
 const receiptStore = SqliteReceiptStore.fromDatabase(db, eventLog);
 const threads = createThreadSubsystem(db, eventLog, receiptStore);
+const approvalAppender = createApprovalAppender(db, eventLog, approvalProjection, {
+  threadRefValidator: (threadId) => threads.state.getById(threadId) !== null,
+});
 
 const token = asApiToken("demo-token-with-enough-entropy-AAAAAAAAA");
 const agentId = asAgentId("agent_alice_001");

--- a/packages/broker/src/approvals/appender.ts
+++ b/packages/broker/src/approvals/appender.ts
@@ -66,12 +66,15 @@ export interface IdempotentApprovalDecisionArgs {
 
 export interface ApprovalAppender {
   sharesProvenance(db: Database.Database, eventLog: EventLog): boolean;
-  enableThreadReferenceValidation(): void;
   requestApproval(payload: ApprovalRequestedAuditPayload): ApprovalAppendResult;
   decideApproval(payload: ApprovalDecidedAuditPayload): ApprovalAppendResult;
   requestApprovalIdempotent(args: IdempotentApprovalRequestArgs): IdempotentApprovalAppendResult;
   decideApprovalIdempotent(args: IdempotentApprovalDecisionArgs): IdempotentApprovalAppendResult;
   pruneIdempotencyOlderThan(cutoffMs: number): number;
+}
+
+export interface ApprovalAppenderOptions {
+  readonly threadRefValidator?: (threadId: ThreadId) => boolean;
 }
 
 export class ApprovalRequestAlreadyExistsError extends Error {
@@ -139,14 +142,11 @@ interface TokenUsageRow {
   readonly approvalId: string;
 }
 
-interface ExistsRow {
-  readonly present: 1;
-}
-
 export function createApprovalAppender(
   db: Database.Database,
   eventLog: EventLog,
   projection: ApprovalProjection,
+  options: ApprovalAppenderOptions = {},
 ): ApprovalAppender {
   const tokenUsageStmt = db.prepare<[string, string], TokenUsageRow>(
     `SELECT approval_id AS approvalId
@@ -173,10 +173,7 @@ export function createApprovalAppender(
      WHERE created_at_ms < ?
        AND command IN ('approval.requested', 'approval.decided')`,
   );
-  const threadExistsStmt = db.prepare<[ThreadId], ExistsRow>(
-    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
-  );
-  let enforceThreadReferences = false;
+  const threadRefValidator = options.threadRefValidator ?? null;
 
   const assertApprovalTokenUnused = (payload: ApprovalDecidedAuditPayload): void => {
     const suppliedApprovalToken = payload.decision === "approve" ? payload.token : undefined;
@@ -188,8 +185,8 @@ export function createApprovalAppender(
   };
 
   const assertThreadReferenceExists = (payload: ApprovalRequestedAuditPayload): void => {
-    if (!enforceThreadReferences || payload.threadId === undefined) return;
-    if (threadExistsStmt.get(payload.threadId) === undefined) {
+    if (payload.threadId === undefined) return;
+    if (threadRefValidator === null || !threadRefValidator(payload.threadId)) {
       throw new ApprovalThreadNotFoundError(payload.threadId);
     }
   };
@@ -335,9 +332,6 @@ export function createApprovalAppender(
   return {
     sharesProvenance(candidateDb: Database.Database, candidateEventLog: EventLog): boolean {
       return candidateDb === db && candidateEventLog === eventLog;
-    },
-    enableThreadReferenceValidation(): void {
-      enforceThreadReferences = true;
     },
     requestApproval(payload: ApprovalRequestedAuditPayload): ApprovalAppendResult {
       return requestApprovalTransaction.immediate(payload);

--- a/packages/broker/src/approvals/appender.ts
+++ b/packages/broker/src/approvals/appender.ts
@@ -66,6 +66,7 @@ export interface IdempotentApprovalDecisionArgs {
 
 export interface ApprovalAppender {
   sharesProvenance(db: Database.Database, eventLog: EventLog): boolean;
+  enableThreadReferenceValidation(): void;
   requestApproval(payload: ApprovalRequestedAuditPayload): ApprovalAppendResult;
   decideApproval(payload: ApprovalDecidedAuditPayload): ApprovalAppendResult;
   requestApprovalIdempotent(args: IdempotentApprovalRequestArgs): IdempotentApprovalAppendResult;
@@ -175,7 +176,7 @@ export function createApprovalAppender(
   const threadExistsStmt = db.prepare<[ThreadId], ExistsRow>(
     "SELECT 1 AS present FROM threads WHERE thread_id = ?",
   );
-  const enforceThreadReferences = false;
+  let enforceThreadReferences = false;
 
   const assertApprovalTokenUnused = (payload: ApprovalDecidedAuditPayload): void => {
     const suppliedApprovalToken = payload.decision === "approve" ? payload.token : undefined;
@@ -244,6 +245,7 @@ export function createApprovalAppender(
       throw new Error("approval decision did not produce a terminal status");
     }
     assertApprovalTokenUnused(payload);
+    assertApprovalTokenIssuedToDecider(payload);
     try {
       approvalRequestToJson(folded);
     } catch (err) {
@@ -331,6 +333,9 @@ export function createApprovalAppender(
   return {
     sharesProvenance(candidateDb: Database.Database, candidateEventLog: EventLog): boolean {
       return candidateDb === db && candidateEventLog === eventLog;
+    },
+    enableThreadReferenceValidation(): void {
+      enforceThreadReferences = true;
     },
     requestApproval(payload: ApprovalRequestedAuditPayload): ApprovalAppendResult {
       return requestApprovalTransaction.immediate(payload);

--- a/packages/broker/src/approvals/appender.ts
+++ b/packages/broker/src/approvals/appender.ts
@@ -213,6 +213,8 @@ export function createApprovalAppender(
       );
     }
     assertThreadReferenceExists(payload);
+    // TODO(approval-overcap-repair): add repair or quarantine for upgraded DBs
+    // already over this cap; pinned snapshots fail closed until then.
     if (
       payload.threadId !== undefined &&
       projection.countPendingByThread(payload.threadId) >= MAX_ROUTE_APPROVAL_LIST_ITEMS

--- a/packages/broker/src/approvals/appender.ts
+++ b/packages/broker/src/approvals/appender.ts
@@ -15,7 +15,9 @@ import {
   approvalRequestToJson,
   type EventLsn,
   lsnFromV1Number,
+  MAX_ROUTE_APPROVAL_LIST_ITEMS,
   parseLsn,
+  type ThreadId,
 } from "@wuphf/protocol";
 import type Database from "better-sqlite3";
 
@@ -86,8 +88,32 @@ export class ApprovalRequestAlreadyDecidedError extends Error {
   }
 }
 
+export class ApprovalPendingLimitExceededError extends Error {
+  override readonly name = "ApprovalPendingLimitExceededError";
+  constructor(readonly threadId: ThreadId) {
+    super(`thread ${threadId} already has ${MAX_ROUTE_APPROVAL_LIST_ITEMS} pending approvals`);
+  }
+}
+
+export class ApprovalThreadNotFoundError extends Error {
+  override readonly name = "ApprovalThreadNotFoundError";
+  constructor(readonly threadId: ThreadId) {
+    super(`thread not found: ${threadId}`);
+  }
+}
+
 export class ApprovalDecisionInvalidError extends Error {
   override readonly name = "ApprovalDecisionInvalidError";
+}
+
+export class ApprovalTokenIssuedToMismatchError extends Error {
+  override readonly name = "ApprovalTokenIssuedToMismatchError";
+  constructor(
+    readonly issuedTo: string,
+    readonly decidedBy: string,
+  ) {
+    super(`approval token issued to ${issuedTo}, not ${decidedBy}`);
+  }
 }
 
 export class ApprovalTokenAlreadyUsedError extends Error {
@@ -110,6 +136,10 @@ interface IdempotencyRow {
 
 interface TokenUsageRow {
   readonly approvalId: string;
+}
+
+interface ExistsRow {
+  readonly present: 1;
 }
 
 export function createApprovalAppender(
@@ -142,6 +172,10 @@ export function createApprovalAppender(
      WHERE created_at_ms < ?
        AND command IN ('approval.requested', 'approval.decided')`,
   );
+  const threadExistsStmt = db.prepare<[ThreadId], ExistsRow>(
+    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
+  );
+  const enforceThreadReferences = false;
 
   const assertApprovalTokenUnused = (payload: ApprovalDecidedAuditPayload): void => {
     const suppliedApprovalToken = payload.decision === "approve" ? payload.token : undefined;
@@ -152,12 +186,37 @@ export function createApprovalAppender(
     }
   };
 
+  const assertThreadReferenceExists = (payload: ApprovalRequestedAuditPayload): void => {
+    if (!enforceThreadReferences || payload.threadId === undefined) return;
+    if (threadExistsStmt.get(payload.threadId) === undefined) {
+      throw new ApprovalThreadNotFoundError(payload.threadId);
+    }
+  };
+
+  const assertApprovalTokenIssuedToDecider = (payload: ApprovalDecidedAuditPayload): void => {
+    const suppliedApprovalToken = payload.decision === "approve" ? payload.token : undefined;
+    if (suppliedApprovalToken === undefined) return;
+    if (String(suppliedApprovalToken.issuedTo) !== String(payload.decidedBy)) {
+      throw new ApprovalTokenIssuedToMismatchError(
+        String(suppliedApprovalToken.issuedTo),
+        String(payload.decidedBy),
+      );
+    }
+  };
+
   const requestApprovalInner = (payload: ApprovalRequestedAuditPayload): ApprovalAppendResult => {
     const existing = projection.getById(payload.requestId);
     if (existing !== null) {
       throw new ApprovalRequestAlreadyExistsError(
         `approval request already exists: ${payload.requestId}`,
       );
+    }
+    assertThreadReferenceExists(payload);
+    if (
+      payload.threadId !== undefined &&
+      projection.countPendingByThread(payload.threadId) >= MAX_ROUTE_APPROVAL_LIST_ITEMS
+    ) {
+      throw new ApprovalPendingLimitExceededError(payload.threadId);
     }
     const bytes = approvalAuditPayloadToBytes("approval_requested", payload);
     const lsn = eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });

--- a/packages/broker/src/approvals/index.ts
+++ b/packages/broker/src/approvals/index.ts
@@ -102,4 +102,7 @@ export {
   foldApprovalFromLog,
   statusForDecision,
 } from "./projections.ts";
-export { rebuildApprovalsProjectionFromLog } from "./rebuild/index.ts";
+export {
+  ApprovalRebuildThreadProjectionNotReadyError,
+  rebuildApprovalsProjectionFromLog,
+} from "./rebuild/index.ts";

--- a/packages/broker/src/approvals/index.ts
+++ b/packages/broker/src/approvals/index.ts
@@ -52,10 +52,13 @@ export type {
 export {
   ApprovalDecisionInvalidError,
   ApprovalIdempotencyConflictError,
+  ApprovalPendingLimitExceededError,
   ApprovalRequestAlreadyDecidedError,
   ApprovalRequestAlreadyExistsError,
   ApprovalRequestNotFoundError,
+  ApprovalThreadNotFoundError,
   ApprovalTokenAlreadyUsedError,
+  ApprovalTokenIssuedToMismatchError,
   createApprovalAppender,
 } from "./appender.ts";
 export type {
@@ -72,6 +75,7 @@ export type {
   ApprovalListFilter,
   ApprovalListPage,
   ApprovalListPageOptions,
+  ApprovalPendingByThreadSnapshot,
   ApprovalProjection,
   ApprovalProjectionEvent,
   ApprovalProjectionRebuildResult,

--- a/packages/broker/src/approvals/index.ts
+++ b/packages/broker/src/approvals/index.ts
@@ -82,6 +82,7 @@ export type {
   FoldedApprovalRow,
 } from "./projections.ts";
 export {
+  ApprovalPendingSnapshotOverflowError,
   approvalFromRequested,
   approvalWithDecision,
   createApprovalProjection,

--- a/packages/broker/src/approvals/index.ts
+++ b/packages/broker/src/approvals/index.ts
@@ -5,6 +5,7 @@ import type Database from "better-sqlite3";
 import type { EventLog as ApprovalEventLog } from "../event-log/index.ts";
 import {
   type ApprovalAppender as ApprovalAppenderInstance,
+  type ApprovalAppenderOptions,
   createApprovalAppender,
 } from "./appender.ts";
 import {
@@ -31,19 +32,29 @@ export interface ApprovalSubsystem {
   readonly projection: ApprovalProjectionInstance;
 }
 
+export interface ApprovalSubsystemOptions {
+  readonly threadRefValidator?: ApprovalAppenderOptions["threadRefValidator"];
+}
+
 export function createApprovalSubsystem(
   db: Database.Database,
   eventLog: ApprovalEventLog,
+  options: ApprovalSubsystemOptions = {},
 ): ApprovalSubsystem {
   const projection = createApprovalProjection(db);
   return {
-    appender: createApprovalAppender(db, eventLog, projection),
+    appender: createApprovalAppender(db, eventLog, projection, {
+      ...(options.threadRefValidator === undefined
+        ? {}
+        : { threadRefValidator: options.threadRefValidator }),
+    }),
     projection,
   };
 }
 
 export type {
   ApprovalAppender,
+  ApprovalAppenderOptions,
   ApprovalAppendResult,
   IdempotentApprovalAppendResult,
   IdempotentApprovalDecisionArgs,

--- a/packages/broker/src/approvals/index.ts
+++ b/packages/broker/src/approvals/index.ts
@@ -83,6 +83,8 @@ export type {
 } from "./projections.ts";
 export {
   ApprovalPendingSnapshotOverflowError,
+  ApprovalReplayPendingLimitExceededError,
+  ApprovalReplayThreadNotFoundError,
   approvalFromRequested,
   approvalWithDecision,
   createApprovalProjection,

--- a/packages/broker/src/approvals/projections.ts
+++ b/packages/broker/src/approvals/projections.ts
@@ -51,6 +51,11 @@ export interface ApprovalListPage {
   readonly nextCursor?: EventLsn;
 }
 
+export interface ApprovalPendingByThreadSnapshot {
+  readonly rows: readonly FoldedApprovalRow[];
+  readonly headLsn: EventLsn | null;
+}
+
 export interface ApprovalProjectionEvent {
   readonly lsn: number;
   readonly type: EventType | string;
@@ -72,6 +77,7 @@ export interface ApprovalProjection {
   countPendingByThread(threadId: ThreadId): number;
   listPendingByThread(threadId: ThreadId): readonly FoldedApprovalRow[];
   latestHeadLsnByThread(threadId: ThreadId): EventLsn | null;
+  pendingByThreadSnapshot(threadId: ThreadId): ApprovalPendingByThreadSnapshot;
 }
 
 interface ApprovalDbRow {
@@ -266,6 +272,22 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       return { eventsApplied, highestLsn: lsnFromV1Number(highestLsn) };
     },
   );
+  const pendingByThreadSnapshotTransaction = db.transaction(
+    (threadId: ThreadId): ApprovalPendingByThreadSnapshot => {
+      const rows = listRows(
+        db,
+        { threadId, status: "pending" },
+        {
+          limit: MAX_ROUTE_APPROVAL_LIST_ITEMS,
+        },
+      ).map(rowToFolded);
+      const headLsn = latestHeadLsnByThreadStmt.get(threadId)?.headLsn ?? null;
+      return {
+        rows,
+        headLsn: headLsn === null ? null : lsnFromV1Number(headLsn),
+      };
+    },
+  );
 
   return {
     sharesProvenance(candidateDb: Database.Database, _eventLog: EventLog): boolean {
@@ -321,6 +343,9 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       const row = latestHeadLsnByThreadStmt.get(threadId);
       if (row === undefined || row.headLsn === null) return null;
       return lsnFromV1Number(row.headLsn);
+    },
+    pendingByThreadSnapshot(threadId: ThreadId): ApprovalPendingByThreadSnapshot {
+      return pendingByThreadSnapshotTransaction.deferred(threadId);
     },
   };
 }

--- a/packages/broker/src/approvals/projections.ts
+++ b/packages/broker/src/approvals/projections.ts
@@ -75,7 +75,6 @@ export interface ApprovalProjection {
   list(filter?: ApprovalListFilter): readonly FoldedApprovalRow[];
   listPage(filter: ApprovalListFilter | undefined, page: ApprovalListPageOptions): ApprovalListPage;
   countPendingByThread(threadId: ThreadId): number;
-  listPendingByThread(threadId: ThreadId): readonly FoldedApprovalRow[];
   latestHeadLsnByThread(threadId: ThreadId): EventLsn | null;
   pendingByThreadSnapshot(threadId: ThreadId): ApprovalPendingByThreadSnapshot;
 }
@@ -413,15 +412,6 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
     },
     countPendingByThread(threadId: ThreadId): number {
       return pendingCountByThread(threadId);
-    },
-    listPendingByThread(threadId: ThreadId): readonly FoldedApprovalRow[] {
-      return listRows(
-        db,
-        { threadId, status: "pending" },
-        {
-          limit: MAX_ROUTE_APPROVAL_LIST_ITEMS,
-        },
-      ).map(rowToFolded);
     },
     latestHeadLsnByThread(threadId: ThreadId): EventLsn | null {
       const row = latestHeadLsnByThreadStmt.get(threadId);

--- a/packages/broker/src/approvals/projections.ts
+++ b/packages/broker/src/approvals/projections.ts
@@ -80,6 +80,20 @@ export interface ApprovalProjection {
   pendingByThreadSnapshot(threadId: ThreadId): ApprovalPendingByThreadSnapshot;
 }
 
+export class ApprovalPendingSnapshotOverflowError extends Error {
+  readonly threadId: ThreadId;
+  readonly count: number;
+
+  constructor(threadId: ThreadId, count: number) {
+    super(
+      `thread ${threadId} has ${count} pending approvals; refusing partial pinned approvals snapshot`,
+    );
+    this.name = "ApprovalPendingSnapshotOverflowError";
+    this.threadId = threadId;
+    this.count = count;
+  }
+}
+
 interface ApprovalDbRow {
   readonly approvalId: string;
   readonly status: string;
@@ -278,12 +292,16 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
         db,
         { threadId, status: "pending" },
         {
-          limit: MAX_ROUTE_APPROVAL_LIST_ITEMS,
+          limit: MAX_ROUTE_APPROVAL_LIST_ITEMS + 1,
         },
-      ).map(rowToFolded);
+      );
+      if (rows.length > MAX_ROUTE_APPROVAL_LIST_ITEMS) {
+        const count = countPendingByThreadStmt.get(threadId)?.count ?? rows.length;
+        throw new ApprovalPendingSnapshotOverflowError(threadId, count);
+      }
       const headLsn = latestHeadLsnByThreadStmt.get(threadId)?.headLsn ?? null;
       return {
-        rows,
+        rows: rows.map(rowToFolded),
         headLsn: headLsn === null ? null : lsnFromV1Number(headLsn),
       };
     },

--- a/packages/broker/src/approvals/projections.ts
+++ b/packages/broker/src/approvals/projections.ts
@@ -20,6 +20,7 @@ import {
   canonicalJSON,
   type EventLsn,
   lsnFromV1Number,
+  MAX_ROUTE_APPROVAL_LIST_ITEMS,
   type TaskId,
   type ThreadId,
 } from "@wuphf/protocol";
@@ -308,7 +309,13 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       return row.count;
     },
     listPendingByThread(threadId: ThreadId): readonly FoldedApprovalRow[] {
-      return listRows(db, { threadId, status: "pending" }).map(rowToFolded);
+      return listRows(
+        db,
+        { threadId, status: "pending" },
+        {
+          limit: MAX_ROUTE_APPROVAL_LIST_ITEMS,
+        },
+      ).map(rowToFolded);
     },
     latestHeadLsnByThread(threadId: ThreadId): EventLsn | null {
       const row = latestHeadLsnByThreadStmt.get(threadId);

--- a/packages/broker/src/approvals/projections.ts
+++ b/packages/broker/src/approvals/projections.ts
@@ -94,6 +94,32 @@ export class ApprovalPendingSnapshotOverflowError extends Error {
   }
 }
 
+export class ApprovalReplayThreadNotFoundError extends Error {
+  readonly threadId: ThreadId;
+  readonly lsn: number;
+
+  constructor(threadId: ThreadId, lsn: number) {
+    super(`approval.requested at ${lsnFromV1Number(lsn)} references missing thread ${threadId}`);
+    this.name = "ApprovalReplayThreadNotFoundError";
+    this.threadId = threadId;
+    this.lsn = lsn;
+  }
+}
+
+export class ApprovalReplayPendingLimitExceededError extends Error {
+  readonly threadId: ThreadId;
+  readonly lsn: number;
+
+  constructor(threadId: ThreadId, lsn: number) {
+    super(
+      `approval.requested at ${lsnFromV1Number(lsn)} exceeds ${MAX_ROUTE_APPROVAL_LIST_ITEMS} pending approvals for thread ${threadId}`,
+    );
+    this.name = "ApprovalReplayPendingLimitExceededError";
+    this.threadId = threadId;
+    this.lsn = lsn;
+  }
+}
+
 interface ApprovalDbRow {
   readonly approvalId: string;
   readonly status: string;
@@ -125,6 +151,10 @@ interface CountRow {
 
 interface MaxLsnRow {
   readonly headLsn: number | null;
+}
+
+interface ExistsRow {
+  readonly present: 1;
 }
 
 interface ApprovalRequestJsonFields {
@@ -206,11 +236,40 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
   const latestHeadLsnByThreadStmt = db.prepare<[string], MaxLsnRow>(
     "SELECT MAX(head_lsn) AS headLsn FROM pending_approvals WHERE thread_id = ?",
   );
+  const threadExistsStmt = db.prepare<[string], ExistsRow>(
+    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
+  );
+
+  const pendingCountByThread = (threadId: ThreadId): number => {
+    const row = countPendingByThreadStmt.get(threadId);
+    if (row === undefined) {
+      throw new Error(`pending approval count query returned no row for ${threadId}`);
+    }
+    return row.count;
+  };
+
+  const assertReplayRequestedInvariants = (
+    payload: ApprovalRequestedAuditPayload,
+    lsn: number,
+  ): void => {
+    const threadId = payload.threadId;
+    if (threadId === undefined) return;
+    if (threadExistsStmt.get(threadId) === undefined) {
+      throw new ApprovalReplayThreadNotFoundError(threadId, lsn);
+    }
+    if (pendingCountByThread(threadId) >= MAX_ROUTE_APPROVAL_LIST_ITEMS) {
+      throw new ApprovalReplayPendingLimitExceededError(threadId, lsn);
+    }
+  };
 
   const applyRequested = (
     payload: ApprovalRequestedAuditPayload,
     lsn: number,
+    options: { readonly replay: boolean },
   ): FoldedApprovalRow => {
+    if (options.replay) {
+      assertReplayRequestedInvariants(payload, lsn);
+    }
     const approval = approvalFromRequested(payload);
     const wire = approvalRequestToJsonValue(approval) as unknown as ApprovalRequestJsonFields;
     insertRequestedStmt.run(
@@ -260,7 +319,16 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
     const decoded = parseApprovalEvent(event);
     if (decoded === null) return null;
     if (decoded.kind === "approval_requested") {
-      return applyRequested(decoded.payload, event.lsn);
+      return applyRequested(decoded.payload, event.lsn, { replay: false });
+    }
+    return applyDecided(decoded.payload, event.lsn);
+  };
+
+  const applyReplayEvent = (event: ApprovalProjectionEvent): FoldedApprovalRow | null => {
+    const decoded = parseApprovalEvent(event);
+    if (decoded === null) return null;
+    if (decoded.kind === "approval_requested") {
+      return applyRequested(decoded.payload, event.lsn, { replay: true });
     }
     return applyDecided(decoded.payload, event.lsn);
   };
@@ -271,13 +339,15 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       let cursor = 0;
       let eventsApplied = 0;
       let highestLsn = 0;
+      // TODO(approval-replay-repair): add offline repair or quarantine for
+      // logs that fail replay-time approval invariants.
       for (;;) {
         const rows = eventLog.readFromLsn(cursor, APPROVAL_EVENT_BATCH_SIZE);
         if (rows.length === 0) break;
         for (const row of rows) {
           cursor = row.lsn;
           highestLsn = Math.max(highestLsn, row.lsn);
-          if (applyEvent(row) !== null) {
+          if (applyReplayEvent(row) !== null) {
             eventsApplied += 1;
           }
         }
@@ -296,7 +366,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
         },
       );
       if (rows.length > MAX_ROUTE_APPROVAL_LIST_ITEMS) {
-        const count = countPendingByThreadStmt.get(threadId)?.count ?? rows.length;
+        const count = pendingCountByThread(threadId);
         throw new ApprovalPendingSnapshotOverflowError(threadId, count);
       }
       const headLsn = latestHeadLsnByThreadStmt.get(threadId)?.headLsn ?? null;
@@ -342,11 +412,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       };
     },
     countPendingByThread(threadId: ThreadId): number {
-      const row = countPendingByThreadStmt.get(threadId);
-      if (row === undefined) {
-        throw new Error(`pending approval count query returned no row for ${threadId}`);
-      }
-      return row.count;
+      return pendingCountByThread(threadId);
     },
     listPendingByThread(threadId: ThreadId): readonly FoldedApprovalRow[] {
       return listRows(

--- a/packages/broker/src/approvals/rebuild/index.ts
+++ b/packages/broker/src/approvals/rebuild/index.ts
@@ -1,13 +1,93 @@
+import {
+  type EventLsn,
+  lsnFromV1Number,
+  parseLsn,
+  type ThreadCreatedAuditPayload,
+  type ThreadId,
+  threadAuditPayloadFromJsonValue,
+} from "@wuphf/protocol";
 import type Database from "better-sqlite3";
 
 import type { EventLog } from "../../event-log/index.ts";
+import { type ThreadStateStore, threadAuditKindForEventType } from "../../threads/projections.ts";
 import { type ApprovalProjectionRebuildResult, createApprovalProjection } from "../projections.ts";
 
 export type { ApprovalProjectionRebuildResult } from "../projections.ts";
 
+const THREAD_PROJECTION_CHECK_BATCH_SIZE = 500;
+
+export interface ApprovalRebuildThreadProjectionNotReadyArgs {
+  readonly expectedThreadCount: number;
+  readonly actualThreadCount: number;
+  readonly expectedHeadLsn: EventLsn;
+  readonly actualHeadLsn: EventLsn;
+}
+
+export class ApprovalRebuildThreadProjectionNotReadyError extends Error {
+  override readonly name = "ApprovalRebuildThreadProjectionNotReadyError";
+  readonly expectedThreadCount: number;
+  readonly actualThreadCount: number;
+  readonly expectedHeadLsn: EventLsn;
+  readonly actualHeadLsn: EventLsn;
+
+  constructor(args: ApprovalRebuildThreadProjectionNotReadyArgs) {
+    super(
+      `approval rebuild requires rebuilt threads projection: expected ${args.expectedThreadCount} threads through ${args.expectedHeadLsn}, got ${args.actualThreadCount} through ${args.actualHeadLsn}`,
+    );
+    this.expectedThreadCount = args.expectedThreadCount;
+    this.actualThreadCount = args.actualThreadCount;
+    this.expectedHeadLsn = args.expectedHeadLsn;
+    this.actualHeadLsn = args.actualHeadLsn;
+  }
+}
+
 export function rebuildApprovalsProjectionFromLog(
   db: Database.Database,
   eventLog: EventLog,
+  threadStateStore: ThreadStateStore,
 ): ApprovalProjectionRebuildResult {
+  assertThreadProjectionReady(eventLog, threadStateStore);
   return createApprovalProjection(db).rebuildFromLog(eventLog);
+}
+
+function assertThreadProjectionReady(eventLog: EventLog, threadStateStore: ThreadStateStore): void {
+  const expected = expectedThreadProjectionState(eventLog);
+  const rows = threadStateStore.list();
+  const actualHeadLsn = rows.reduce((max, row) => Math.max(max, parseLsn(row.headLsn).localLsn), 0);
+  if (rows.length !== expected.threadCount || actualHeadLsn !== expected.headLsn) {
+    throw new ApprovalRebuildThreadProjectionNotReadyError({
+      expectedThreadCount: expected.threadCount,
+      actualThreadCount: rows.length,
+      expectedHeadLsn: lsnFromV1Number(expected.headLsn),
+      actualHeadLsn: lsnFromV1Number(actualHeadLsn),
+    });
+  }
+}
+
+function expectedThreadProjectionState(eventLog: EventLog): {
+  readonly threadCount: number;
+  readonly headLsn: number;
+} {
+  const threadIds = new Set<ThreadId>();
+  let headLsn = 0;
+  let cursor = 0;
+  for (;;) {
+    const batch = eventLog.readFromLsn(cursor, THREAD_PROJECTION_CHECK_BATCH_SIZE);
+    if (batch.length === 0) break;
+    for (const record of batch) {
+      const kind = threadAuditKindForEventType(record.type);
+      if (kind === null) continue;
+      headLsn = record.lsn;
+      if (kind === "thread_created") {
+        const parsed = JSON.parse(record.payload.toString("utf8")) as unknown;
+        const payload = threadAuditPayloadFromJsonValue(kind, parsed) as ThreadCreatedAuditPayload;
+        threadIds.add(payload.threadId);
+      }
+    }
+    const last = batch.at(-1);
+    if (last === undefined) break;
+    cursor = last.lsn;
+    if (batch.length < THREAD_PROJECTION_CHECK_BATCH_SIZE) break;
+  }
+  return { threadCount: threadIds.size, headLsn };
 }

--- a/packages/broker/src/approvals/routes.ts
+++ b/packages/broker/src/approvals/routes.ts
@@ -19,7 +19,6 @@ import {
   type ApprovalRequestId,
   type ApprovalRequestStatus,
   type ApprovalStreamEvent,
-  type ApprovalView,
   approvalDecisionRequestFromJson,
   approvalDecisionRequestToJsonValue,
   approvalDecisionResponseToJsonValue,
@@ -61,6 +60,7 @@ import {
 } from "./appender.ts";
 import type { ApprovalCommand, ParsedApprovalIdempotencyKey } from "./idempotency.ts";
 import type { ApprovalListFilter, ApprovalProjection } from "./projections.ts";
+import { approvalViewFromApproval } from "./view.ts";
 
 const MAX_APPROVAL_BODY_BYTES = 256 * 1024;
 const APPROVAL_STATUS_SET: ReadonlySet<string> = new Set<string>(APPROVAL_REQUEST_STATUS_VALUES);
@@ -100,7 +100,7 @@ export async function handleApprovalRoute(
       handleApprovalList(req, res, deps);
       return true;
     }
-    methodNotAllowed(res, "GET, POST");
+    methodNotAllowed(res, "GET, HEAD, POST");
     return true;
   }
 
@@ -121,7 +121,7 @@ export async function handleApprovalRoute(
       return true;
     }
     if (req.method !== "GET" && req.method !== "HEAD") {
-      methodNotAllowed(res, "GET");
+      methodNotAllowed(res, "GET, HEAD");
       return true;
     }
     handleApprovalGet(res, deps, id);
@@ -569,31 +569,6 @@ function emitThreadPinnedApprovalsInvalidation(
   });
 }
 
-function approvalViewFromApproval(approval: ApprovalRequest): ApprovalView {
-  return {
-    id: approval.id,
-    claim: approval.claim,
-    scope: approval.scope,
-    riskClass: approval.riskClass,
-    ...(approval.threadId === undefined ? {} : { threadId: approval.threadId }),
-    ...(approval.taskId === undefined ? {} : { taskId: approval.taskId }),
-    ...(approval.receiptId === undefined ? {} : { receiptId: approval.receiptId }),
-    requestedBy: approval.requestedBy,
-    requestedAt: approval.requestedAt,
-    status: approval.status,
-    ...(approval.decision === undefined
-      ? {}
-      : {
-          decisionSummary: {
-            decision: approval.decision.decision,
-            decidedBy: approval.decision.decidedBy,
-            decidedAt: approval.decision.decidedAt,
-          },
-        }),
-    schemaVersion: 1,
-  };
-}
-
 function invalidPayload(
   res: ServerResponse,
   deps: Pick<ApprovalRouteDeps, "logger">,
@@ -611,9 +586,9 @@ function malformedJson(
   routeName: string,
   err: unknown,
 ): void {
-  const reason = err instanceof Error ? err.message : "malformed_json";
-  deps.logger.warn(`${routeName}_rejected`, { reason: "malformed_json" });
-  writeRouteError(res, 400, { error: "malformed_json", message: reason });
+  const reason = err instanceof Error ? err.message : "invalid_json";
+  deps.logger.warn(`${routeName}_rejected`, { reason: "invalid_json" });
+  writeRouteError(res, 400, { error: "invalid_json", message: reason });
 }
 
 function parseJsonBody(

--- a/packages/broker/src/approvals/routes.ts
+++ b/packages/broker/src/approvals/routes.ts
@@ -51,9 +51,11 @@ import {
   type ApprovalAppender,
   ApprovalDecisionInvalidError,
   ApprovalIdempotencyConflictError,
+  ApprovalPendingLimitExceededError,
   ApprovalRequestAlreadyDecidedError,
   ApprovalRequestAlreadyExistsError,
   ApprovalRequestNotFoundError,
+  ApprovalThreadNotFoundError,
   ApprovalTokenAlreadyUsedError,
 } from "./appender.ts";
 import type { ApprovalCommand, ParsedApprovalIdempotencyKey } from "./idempotency.ts";
@@ -185,6 +187,14 @@ async function handleApprovalRequestPost(
   } catch (err) {
     if (err instanceof ApprovalRequestAlreadyExistsError) {
       writeRouteError(res, 409, { error: "approval_request_exists" });
+      return;
+    }
+    if (err instanceof ApprovalPendingLimitExceededError) {
+      writeRouteError(res, 409, { error: "pending_approval_limit_exceeded" });
+      return;
+    }
+    if (err instanceof ApprovalThreadNotFoundError) {
+      writeRouteError(res, 400, { error: "thread_not_found" });
       return;
     }
     if (err instanceof ApprovalIdempotencyConflictError) {

--- a/packages/broker/src/approvals/routes.ts
+++ b/packages/broker/src/approvals/routes.ts
@@ -57,6 +57,7 @@ import {
   ApprovalRequestNotFoundError,
   ApprovalThreadNotFoundError,
   ApprovalTokenAlreadyUsedError,
+  ApprovalTokenIssuedToMismatchError,
 } from "./appender.ts";
 import type { ApprovalCommand, ParsedApprovalIdempotencyKey } from "./idempotency.ts";
 import type { ApprovalListFilter, ApprovalProjection } from "./projections.ts";
@@ -281,6 +282,10 @@ async function handleApprovalDecisionPost(
     }
     if (err instanceof ApprovalTokenAlreadyUsedError) {
       writeRouteError(res, 409, { error: "approval_token_reused" });
+      return;
+    }
+    if (err instanceof ApprovalTokenIssuedToMismatchError) {
+      writeRouteError(res, 403, { error: "approval_token_actor_mismatch" });
       return;
     }
     if (err instanceof ApprovalIdempotencyConflictError) {

--- a/packages/broker/src/approvals/routes.ts
+++ b/packages/broker/src/approvals/routes.ts
@@ -539,9 +539,8 @@ function emitApprovalInvalidation(
   headLsn: EventLsn,
   deps: ApprovalRouteDeps,
 ): void {
-  const localLsn = parseLsn(headLsn).localLsn;
   const event: ApprovalStreamEvent = {
-    id: `approval_${localLsn}`,
+    id: headLsn,
     kind,
     emittedAt: new Date(deps.nowMs()).toISOString(),
     payload: {

--- a/packages/broker/src/approvals/view.ts
+++ b/packages/broker/src/approvals/view.ts
@@ -1,0 +1,26 @@
+import type { ApprovalRequest, ApprovalView } from "@wuphf/protocol";
+
+export function approvalViewFromApproval(approval: ApprovalRequest): ApprovalView {
+  return {
+    id: approval.id,
+    claim: approval.claim,
+    scope: approval.scope,
+    riskClass: approval.riskClass,
+    ...(approval.threadId === undefined ? {} : { threadId: approval.threadId }),
+    ...(approval.taskId === undefined ? {} : { taskId: approval.taskId }),
+    ...(approval.receiptId === undefined ? {} : { receiptId: approval.receiptId }),
+    requestedBy: approval.requestedBy,
+    requestedAt: approval.requestedAt,
+    status: approval.status,
+    ...(approval.decision === undefined
+      ? {}
+      : {
+          decisionSummary: {
+            decision: approval.decision.decision,
+            decidedBy: approval.decision.decidedBy,
+            decidedAt: approval.decision.decidedAt,
+          },
+        }),
+    schemaVersion: 1,
+  };
+}

--- a/packages/broker/src/cost-ledger/projections.ts
+++ b/packages/broker/src/cost-ledger/projections.ts
@@ -273,7 +273,9 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
      VALUES (?, ?, ?, ?, ?, ?)`,
   );
   const pruneIdempotencyStmt = db.prepare<[number]>(
-    `DELETE FROM command_idempotency WHERE created_at_ms < ?`,
+    `DELETE FROM command_idempotency
+     WHERE created_at_ms < ?
+       AND command IN ('cost.event', 'cost.budget.set', 'cost.budget.tombstone')`,
   );
 
   // Inner (non-transactional) append helpers. The public `appendX`

--- a/packages/broker/src/event-log/007_approvals.sql
+++ b/packages/broker/src/event-log/007_approvals.sql
@@ -50,8 +50,8 @@ CREATE TABLE pending_approvals (
 CREATE INDEX pending_approvals_status
   ON pending_approvals(status);
 
--- TODO(PR3): add a thread FK once the thread_state table lands. In this PR,
--- thread/task/receipt ids are opaque optional references.
+-- Thread/task/receipt ids are optional cross-subsystem references. The
+-- approval appender validates thread_id when thread state shares provenance.
 CREATE INDEX pending_approvals_thread
   ON pending_approvals(thread_id)
   WHERE thread_id IS NOT NULL;

--- a/packages/broker/src/event-log/009_pending_approvals_thread_fk.sql
+++ b/packages/broker/src/event-log/009_pending_approvals_thread_fk.sql
@@ -1,0 +1,103 @@
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE pending_approvals RENAME TO pending_approvals_old;
+
+CREATE TABLE pending_approvals (
+  approval_id      TEXT PRIMARY KEY,
+  status           TEXT NOT NULL,
+  head_lsn         INTEGER NOT NULL,
+  claim            TEXT NOT NULL,
+  scope            TEXT NOT NULL,
+  risk_class       TEXT NOT NULL,
+  thread_id        TEXT,
+  task_id          TEXT,
+  receipt_id       TEXT,
+  requested_by     TEXT NOT NULL,
+  requested_at_ms  INTEGER NOT NULL,
+  decided_by       TEXT,
+  decided_at_ms    INTEGER,
+  decision         TEXT,
+  token            TEXT,
+  token_id         TEXT,
+  FOREIGN KEY (head_lsn) REFERENCES event_log(lsn) ON DELETE RESTRICT,
+  FOREIGN KEY (thread_id) REFERENCES threads(thread_id) ON DELETE RESTRICT,
+  CHECK (token_id IS NULL OR (length(token_id) = 26 AND token_id NOT GLOB '*[^0-9A-HJKMNP-TV-Z]*')),
+  CHECK (status IN ('pending', 'approved', 'rejected', 'abstained')),
+  CHECK (
+    (status = 'pending' AND decided_by IS NULL AND decided_at_ms IS NULL AND decision IS NULL)
+    OR
+    (status != 'pending' AND decided_by IS NOT NULL AND decided_at_ms IS NOT NULL AND decision IS NOT NULL)
+  ),
+  CHECK (
+    (decision IS NULL AND status = 'pending')
+    OR (decision = 'approve' AND status = 'approved')
+    OR (decision = 'reject' AND status = 'rejected')
+    OR (decision = 'abstain' AND status = 'abstained')
+  ),
+  CHECK (
+    (decision IS NULL AND token IS NULL AND token_id IS NULL)
+    OR (decision = 'approve' AND token IS NOT NULL AND token_id IS NOT NULL)
+    OR (decision IN ('reject', 'abstain') AND token IS NULL AND token_id IS NULL)
+  )
+) STRICT, WITHOUT ROWID;
+
+INSERT INTO pending_approvals (
+  approval_id,
+  status,
+  head_lsn,
+  claim,
+  scope,
+  risk_class,
+  thread_id,
+  task_id,
+  receipt_id,
+  requested_by,
+  requested_at_ms,
+  decided_by,
+  decided_at_ms,
+  decision,
+  token,
+  token_id
+)
+SELECT
+  approval_id,
+  status,
+  head_lsn,
+  claim,
+  scope,
+  risk_class,
+  thread_id,
+  task_id,
+  receipt_id,
+  requested_by,
+  requested_at_ms,
+  decided_by,
+  decided_at_ms,
+  decision,
+  token,
+  token_id
+FROM pending_approvals_old;
+
+DROP TABLE pending_approvals_old;
+
+CREATE INDEX pending_approvals_status
+  ON pending_approvals(status);
+
+CREATE INDEX pending_approvals_thread
+  ON pending_approvals(thread_id)
+  WHERE thread_id IS NOT NULL;
+
+CREATE INDEX pending_approvals_task
+  ON pending_approvals(task_id)
+  WHERE task_id IS NOT NULL;
+
+CREATE UNIQUE INDEX pending_approvals_token_id
+  ON pending_approvals(token_id)
+  WHERE token_id IS NOT NULL;
+
+CREATE INDEX pending_approvals_thread_status
+  ON pending_approvals(thread_id, status)
+  WHERE thread_id IS NOT NULL;
+
+PRAGMA foreign_key_check;
+PRAGMA user_version = 9;

--- a/packages/broker/src/event-log/migrations.ts
+++ b/packages/broker/src/event-log/migrations.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 
 import type Database from "better-sqlite3";
 
-export const CURRENT_SCHEMA_VERSION = 8;
+export const CURRENT_SCHEMA_VERSION = 9;
 
 interface Migration {
   readonly version: number;
@@ -44,6 +44,10 @@ const MIGRATIONS: readonly Migration[] = [
       new URL("./008_pending_approvals_thread_status_index.sql", import.meta.url),
       "utf8",
     ),
+  },
+  {
+    version: 9,
+    sql: readFileSync(new URL("./009_pending_approvals_thread_fk.sql", import.meta.url), "utf8"),
   },
 ];
 

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -283,6 +283,7 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
           appender: config.threads.appender,
           state: config.threads.state,
           receiptIndex: config.threads.receiptIndex,
+          views: config.threads.views,
           approvals: config.approvals?.projection ?? null,
           logger,
           nowMs: () => readBrokerClock(clock),

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -122,6 +122,9 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
   ) {
     throw new Error("createBroker: approvals must share threads storage provenance");
   }
+  if (config.threads !== undefined && config.approvals !== undefined) {
+    config.approvals.appender.enableThreadReferenceValidation();
+  }
   // Default to an in-memory store when the host doesn't supply one. Thread
   // routes carry their own cohesive store handle so receipt indexing cannot
   // be wired to a different database from the thread projection.

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -452,6 +452,7 @@ async function routeRequest(
       receiptStore: deps.receiptStore,
       webauthnStore: deps.webauthn?.store ?? null,
       logger: deps.logger,
+      emitThreadEvent: (event) => deps.sseHub.emitThreadEvent(event),
     });
     return;
   }

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -151,9 +151,6 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
   ) {
     throw new Error("createBroker: approvals must share threads storage provenance");
   }
-  if (config.threads !== undefined && config.approvals !== undefined) {
-    config.approvals.appender.enableThreadReferenceValidation();
-  }
   // Default to an in-memory store when the host doesn't supply one. Thread
   // routes carry their own cohesive store handle so receipt indexing cannot
   // be wired to a different database from the thread projection.

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -60,6 +60,7 @@ import {
   type BrokerPort,
   isApprovalRole,
   MAX_APPROVAL_TOKEN_LIFETIME_MS,
+  type ReceiptSnapshot,
 } from "@wuphf/protocol";
 import { WebSocketServer } from "ws";
 
@@ -75,7 +76,7 @@ import { InMemoryReceiptStore, type ReceiptStore } from "./receipt-store.ts";
 import { handleReceiptCreate, handleReceiptGet, handleThreadReceiptsList } from "./receipts.ts";
 import { createRunnerRouteState, type RunnerRouteState } from "./runners/route.ts";
 import { createStaticHandler, type StaticHandler } from "./serve-static.ts";
-import { createSseHub, type SseHub } from "./sse.ts";
+import { createSseHub, type SseHub, type ThreadSseEmitArgs } from "./sse.ts";
 import { attachTerminalUpgrade } from "./terminal-ws.ts";
 import { handleThreadRoute, type ThreadRouteDeps } from "./threads/routes.ts";
 import { generateApiToken } from "./token.ts";
@@ -100,6 +101,34 @@ import {
 
 const LOOPBACK_HOST = "127.0.0.1";
 const BROWSER_WEBAUTHN_HOST = "localhost";
+
+function withThreadReceiptInvalidations(
+  receiptStore: ReceiptStore,
+  emitThreadEvent: (event: ThreadSseEmitArgs) => void,
+): ReceiptStore {
+  return {
+    async put(receipt: ReceiptSnapshot) {
+      const result = await receiptStore.put(receipt);
+      if (!result.existed && receipt.schemaVersion === 2 && receipt.threadId !== undefined) {
+        emitThreadEvent({
+          kind: "thread.updated",
+          threadId: receipt.threadId,
+          headLsn: result.lsn,
+        });
+      }
+      return result;
+    },
+    get(id) {
+      return receiptStore.get(id);
+    },
+    list(filter) {
+      return receiptStore.list(filter);
+    },
+    size() {
+      return receiptStore.size();
+    },
+  };
+}
 
 export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHandle> {
   const logger: BrokerLogger = config.logger ?? NOOP_LOGGER;
@@ -128,8 +157,11 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
   // Default to an in-memory store when the host doesn't supply one. Thread
   // routes carry their own cohesive store handle so receipt indexing cannot
   // be wired to a different database from the thread projection.
-  const receiptStore: ReceiptStore =
+  const baseReceiptStore: ReceiptStore =
     config.threads?.receiptStore ?? config.receiptStore ?? new InMemoryReceiptStore();
+  const receiptStore = withThreadReceiptInvalidations(baseReceiptStore, (event) =>
+    sseHub.emitThreadEvent(event),
+  );
   const agentProviderRoutingStore = config.runners?.agentProviderRoutingStore ?? null;
   // Reuse the same bearer→agent binding map that runner spawn uses so a
   // bearer pinned to agent_alpha cannot read or PUT agent_beta's routing.
@@ -452,7 +484,6 @@ async function routeRequest(
       receiptStore: deps.receiptStore,
       webauthnStore: deps.webauthn?.store ?? null,
       logger: deps.logger,
-      emitThreadEvent: (event) => deps.sseHub.emitThreadEvent(event),
     });
     return;
   }

--- a/packages/broker/src/listener.ts
+++ b/packages/broker/src/listener.ts
@@ -156,9 +156,10 @@ export async function createBroker(config: BrokerConfig = {}): Promise<BrokerHan
   // be wired to a different database from the thread projection.
   const baseReceiptStore: ReceiptStore =
     config.threads?.receiptStore ?? config.receiptStore ?? new InMemoryReceiptStore();
-  const receiptStore = withThreadReceiptInvalidations(baseReceiptStore, (event) =>
-    sseHub.emitThreadEvent(event),
-  );
+  const receiptStore =
+    config.threads === undefined
+      ? baseReceiptStore
+      : withThreadReceiptInvalidations(baseReceiptStore, (event) => sseHub.emitThreadEvent(event));
   const agentProviderRoutingStore = config.runners?.agentProviderRoutingStore ?? null;
   // Reuse the same bearer→agent binding map that runner spawn uses so a
   // bearer pinned to agent_alpha cannot read or PUT agent_beta's routing.

--- a/packages/broker/src/receipt-store.ts
+++ b/packages/broker/src/receipt-store.ts
@@ -28,7 +28,13 @@
 // to honor this rule. `SqliteReceiptStore` sidesteps this by storing
 // canonical bytes and re-parsing on read.
 
-import type { ReceiptId, ReceiptSnapshot, ThreadId } from "@wuphf/protocol";
+import {
+  type EventLsn,
+  lsnFromV1Number,
+  type ReceiptId,
+  type ReceiptSnapshot,
+  type ThreadId,
+} from "@wuphf/protocol";
 
 /**
  * Filter + pagination arguments for `ReceiptStore.list`.
@@ -79,7 +85,7 @@ export interface ReceiptStore {
    * HTTP `201 Location:` contract promises an immediately fetchable
    * receipt, and clients race the 201 response against follow-up reads.
    */
-  put(receipt: ReceiptSnapshot): Promise<{ readonly existed: boolean }>;
+  put(receipt: ReceiptSnapshot): Promise<ReceiptPutResult>;
   /**
    * Read by id. Returns null when not found.
    */
@@ -102,6 +108,10 @@ export interface ReceiptStore {
    */
   size(): number;
 }
+
+export type ReceiptPutResult =
+  | { readonly existed: true; readonly lsn: null }
+  | { readonly existed: false; readonly lsn: EventLsn };
 
 /**
  * Error thrown when the store has reached its configured receipt cap or
@@ -308,9 +318,9 @@ export class InMemoryReceiptStore implements ReceiptStore {
     this.maxReceipts = requested;
   }
 
-  async put(receipt: ReceiptSnapshot): Promise<{ readonly existed: boolean }> {
+  async put(receipt: ReceiptSnapshot): Promise<ReceiptPutResult> {
     if (this.byId.has(receipt.id)) {
-      return { existed: true };
+      return { existed: true, lsn: null };
     }
     // Cap check runs AFTER the `has` check so a duplicate POST against a
     // store at capacity still returns 409 (the correct semantic) rather
@@ -328,7 +338,7 @@ export class InMemoryReceiptStore implements ReceiptStore {
         existing.add(receipt.id);
       }
     }
-    return { existed: false };
+    return { existed: false, lsn: lsnFromV1Number(lsn) };
   }
 
   async get(id: ReceiptId): Promise<ReceiptSnapshot | null> {

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -19,7 +19,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   asReceiptId,
   asThreadId,
-  type EventLsn,
   type ReceiptId,
   type ReceiptSnapshot,
   receiptFromJson,
@@ -68,13 +67,6 @@ interface ReceiptRouteDeps {
   readonly receiptStore: ReceiptStore;
   readonly webauthnStore: WebAuthnStore | null;
   readonly logger: BrokerLogger;
-  readonly emitThreadEvent?: (event: ReceiptThreadStreamEvent) => void;
-}
-
-interface ReceiptThreadStreamEvent {
-  readonly kind: "thread.updated";
-  readonly threadId: ThreadId;
-  readonly headLsn: EventLsn;
 }
 
 export async function handleReceiptCreate(
@@ -215,14 +207,6 @@ export async function handleReceiptCreate(
     writeJsonResponse(res, 409, JSON.stringify({ error: "receipt_id_exists", id: receipt.id }));
     return;
   }
-  if (receipt.schemaVersion === 2 && receipt.threadId !== undefined) {
-    deps.emitThreadEvent?.({
-      kind: "thread.updated",
-      threadId: receipt.threadId,
-      headLsn: result.lsn,
-    });
-  }
-
   deps.logger.info("receipt_put_ok", { receiptId: receipt.id });
   writeJsonResponse(res, 201, receiptToJson(receipt), {
     Location: `/api/receipts/${encodeURIComponent(receipt.id)}`,

--- a/packages/broker/src/receipts.ts
+++ b/packages/broker/src/receipts.ts
@@ -19,6 +19,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import {
   asReceiptId,
   asThreadId,
+  type EventLsn,
   type ReceiptId,
   type ReceiptSnapshot,
   receiptFromJson,
@@ -30,6 +31,7 @@ import {
   InvalidListCursorError,
   InvalidListLimitError,
   MAX_LIST_LIMIT,
+  type ReceiptPutResult,
   type ReceiptStore,
   ReceiptStoreBusyError,
   ReceiptStoreFullError,
@@ -66,6 +68,13 @@ interface ReceiptRouteDeps {
   readonly receiptStore: ReceiptStore;
   readonly webauthnStore: WebAuthnStore | null;
   readonly logger: BrokerLogger;
+  readonly emitThreadEvent?: (event: ReceiptThreadStreamEvent) => void;
+}
+
+interface ReceiptThreadStreamEvent {
+  readonly kind: "thread.updated";
+  readonly threadId: ThreadId;
+  readonly headLsn: EventLsn;
 }
 
 export async function handleReceiptCreate(
@@ -182,7 +191,7 @@ export async function handleReceiptCreate(
     throw err;
   }
 
-  let result: { readonly existed: boolean };
+  let result: ReceiptPutResult;
   try {
     result = await deps.receiptStore.put(receipt);
   } catch (err) {
@@ -205,6 +214,13 @@ export async function handleReceiptCreate(
     deps.logger.info("receipt_put_conflict", { receiptId: receipt.id });
     writeJsonResponse(res, 409, JSON.stringify({ error: "receipt_id_exists", id: receipt.id }));
     return;
+  }
+  if (receipt.schemaVersion === 2 && receipt.threadId !== undefined) {
+    deps.emitThreadEvent?.({
+      kind: "thread.updated",
+      threadId: receipt.threadId,
+      headLsn: result.lsn,
+    });
   }
 
   deps.logger.info("receipt_put_ok", { receiptId: receipt.id });

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -1,4 +1,5 @@
 import {
+  lsnFromV1Number,
   type ReceiptId,
   type ReceiptSnapshot,
   receiptFromJson,
@@ -14,6 +15,7 @@ import {
   encodeListCursor,
   type ListFilter,
   type ListPage,
+  type ReceiptPutResult,
   type ReceiptStore,
   ReceiptStoreBusyError,
   ReceiptStoreFullError,
@@ -78,7 +80,7 @@ export class SqliteReceiptStore implements ReceiptStore {
   >;
   private readonly countStmt: Database.Statement<[], CountRow>;
   private readonly putTransaction: Database.Transaction<
-    (receipt: ReceiptSnapshot) => { readonly existed: boolean }
+    (receipt: ReceiptSnapshot) => ReceiptPutResult
   >;
   private closed = false;
 
@@ -139,7 +141,7 @@ export class SqliteReceiptStore implements ReceiptStore {
     this.countStmt = db.prepare<[], CountRow>("SELECT COUNT(*) AS count FROM receipts_projection");
     this.putTransaction = db.transaction((receipt: ReceiptSnapshot) => {
       if (this.receiptExistsStmt.get(receipt.id) !== undefined) {
-        return { existed: true };
+        return { existed: true, lsn: null };
       }
       // Cap check runs AFTER the existence check (mirrors the in-memory
       // store): a duplicate POST against a store at capacity still
@@ -162,7 +164,7 @@ export class SqliteReceiptStore implements ReceiptStore {
       if (threadId !== null) {
         this.insertThreadReceiptStmt.run(threadId, receipt.id, receipt.taskId, lsn);
       }
-      return { existed: false };
+      return { existed: false, lsn: lsnFromV1Number(lsn) };
     });
   }
 
@@ -170,12 +172,12 @@ export class SqliteReceiptStore implements ReceiptStore {
     return this.db === db && this.eventLog === eventLog;
   }
 
-  async put(receipt: ReceiptSnapshot): Promise<{ readonly existed: boolean }> {
+  async put(receipt: ReceiptSnapshot): Promise<ReceiptPutResult> {
     try {
       return this.putTransaction.immediate(receipt);
     } catch (err) {
       if (isReceiptIdConstraintError(err)) {
-        return { existed: true };
+        return { existed: true, lsn: null };
       }
       // SQLITE_FULL = filesystem out of space (or page-cache limit hit).
       // Surface as `ReceiptStoreFullError` so the HTTP route reuses the

--- a/packages/broker/src/threads/index.ts
+++ b/packages/broker/src/threads/index.ts
@@ -44,3 +44,18 @@ export type { ThreadProjectionSnapshotRow } from "./replay-check/index.ts";
 export { snapshotThreadProjection } from "./replay-check/index.ts";
 export type { ThreadSubsystem } from "./subsystem.ts";
 export { createThreadSubsystem, SYSTEM_INBOX_THREAD_ID } from "./subsystem.ts";
+export type {
+  ThreadApprovalQuery,
+  ThreadApprovalQueryRow,
+  ThreadApprovalQuerySnapshot,
+  ThreadListViewArgs,
+  ThreadListViewPage,
+  ThreadStatusFilter,
+  ThreadViewStore,
+} from "./views.ts";
+export {
+  createThreadViewStore,
+  THREAD_BOARD_COLUMN_SET,
+  THREAD_EFFECTIVE_STATUS_SET,
+  threadViewFromRow,
+} from "./views.ts";

--- a/packages/broker/src/threads/index.ts
+++ b/packages/broker/src/threads/index.ts
@@ -22,7 +22,12 @@ export {
 } from "./effective-status.ts";
 export type { ParsedIdempotencyKey, ThreadCommand } from "./idempotency.ts";
 export { parseThreadIdempotencyKey, THREAD_COMMAND_VALUES } from "./idempotency.ts";
-export type { ThreadStateRow, ThreadStateStore } from "./projections.ts";
+export type {
+  ThreadStatePage,
+  ThreadStatePageOptions,
+  ThreadStateRow,
+  ThreadStateStore,
+} from "./projections.ts";
 export {
   createThreadStateStore,
   threadAuditKindForEventType,

--- a/packages/broker/src/threads/index.ts
+++ b/packages/broker/src/threads/index.ts
@@ -23,8 +23,6 @@ export {
 export type { ParsedIdempotencyKey, ThreadCommand } from "./idempotency.ts";
 export { parseThreadIdempotencyKey, THREAD_COMMAND_VALUES } from "./idempotency.ts";
 export type {
-  ThreadStatePage,
-  ThreadStatePageOptions,
   ThreadStateRow,
   ThreadStateStore,
 } from "./projections.ts";

--- a/packages/broker/src/threads/projections.ts
+++ b/packages/broker/src/threads/projections.ts
@@ -50,17 +50,6 @@ export interface ThreadStateStore {
   getById(threadId: ThreadId): ThreadStateRow | null;
   hasSpecRevision(revisionId: string): boolean;
   list(filter?: { readonly status?: ThreadStatus }): readonly ThreadStateRow[];
-  listPage(page: ThreadStatePageOptions): ThreadStatePage;
-}
-
-export interface ThreadStatePageOptions {
-  readonly limit: number;
-  readonly afterHeadLsn?: number;
-}
-
-export interface ThreadStatePage {
-  readonly rows: readonly ThreadStateRow[];
-  readonly nextCursor?: EventLsn;
 }
 
 interface ThreadDbRow {
@@ -171,24 +160,6 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
             spec_authored_at_ms AS specAuthoredAtMs,
             external_refs AS externalRefs
      FROM threads ORDER BY head_lsn ASC`,
-  );
-  const listPageStmt = db.prepare<[number, number], ThreadDbRow>(
-    `SELECT thread_id AS threadId,
-            title,
-            status,
-            head_lsn AS headLsn,
-            created_by AS createdBy,
-            created_at_ms AS createdAtMs,
-            updated_at_ms AS updatedAtMs,
-            closed_at_ms AS closedAtMs,
-            spec_revision_id AS specRevisionId,
-            spec_base_revision_id AS specBaseRevisionId,
-            spec_content AS specContent,
-            spec_content_hash AS specContentHash,
-            spec_authored_by AS specAuthoredBy,
-            spec_authored_at_ms AS specAuthoredAtMs,
-            external_refs AS externalRefs
-     FROM threads WHERE head_lsn > ? ORDER BY head_lsn ASC LIMIT ?`,
   );
   const listByStatusStmt = db.prepare<[string], ThreadDbRow>(
     `SELECT thread_id AS threadId,
@@ -307,20 +278,6 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
       const rows =
         filter?.status === undefined ? listAllStmt.all() : listByStatusStmt.all(filter.status);
       return rows.map(toThreadStateRow);
-    },
-    listPage(page: ThreadStatePageOptions): ThreadStatePage {
-      if (!Number.isSafeInteger(page.limit) || page.limit < 1) {
-        throw new Error("thread state page limit must be a positive safe integer");
-      }
-      const rows = listPageStmt.all(page.afterHeadLsn ?? 0, page.limit + 1);
-      const selectedRows = rows.length > page.limit ? rows.slice(0, page.limit) : rows;
-      const lastRow = selectedRows.at(-1);
-      return {
-        rows: selectedRows.map(toThreadStateRow),
-        ...(rows.length > page.limit && lastRow !== undefined
-          ? { nextCursor: lsnFromV1Number(lastRow.headLsn) }
-          : {}),
-      };
     },
   };
 }

--- a/packages/broker/src/threads/projections.ts
+++ b/packages/broker/src/threads/projections.ts
@@ -49,6 +49,17 @@ export interface ThreadStateStore {
   getById(threadId: ThreadId): ThreadStateRow | null;
   hasSpecRevision(revisionId: string): boolean;
   list(filter?: { readonly status?: ThreadStatus }): readonly ThreadStateRow[];
+  listPage(page: ThreadStatePageOptions): ThreadStatePage;
+}
+
+export interface ThreadStatePageOptions {
+  readonly limit: number;
+  readonly afterHeadLsn?: number;
+}
+
+export interface ThreadStatePage {
+  readonly rows: readonly ThreadStateRow[];
+  readonly nextCursor?: EventLsn;
 }
 
 interface ThreadDbRow {
@@ -159,6 +170,24 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
             spec_authored_at_ms AS specAuthoredAtMs,
             external_refs AS externalRefs
      FROM threads ORDER BY head_lsn ASC`,
+  );
+  const listPageStmt = db.prepare<[number, number], ThreadDbRow>(
+    `SELECT thread_id AS threadId,
+            title,
+            status,
+            head_lsn AS headLsn,
+            created_by AS createdBy,
+            created_at_ms AS createdAtMs,
+            updated_at_ms AS updatedAtMs,
+            closed_at_ms AS closedAtMs,
+            spec_revision_id AS specRevisionId,
+            spec_base_revision_id AS specBaseRevisionId,
+            spec_content AS specContent,
+            spec_content_hash AS specContentHash,
+            spec_authored_by AS specAuthoredBy,
+            spec_authored_at_ms AS specAuthoredAtMs,
+            external_refs AS externalRefs
+     FROM threads WHERE head_lsn > ? ORDER BY head_lsn ASC LIMIT ?`,
   );
   const listByStatusStmt = db.prepare<[string], ThreadDbRow>(
     `SELECT thread_id AS threadId,
@@ -273,6 +302,20 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
       const rows =
         filter?.status === undefined ? listAllStmt.all() : listByStatusStmt.all(filter.status);
       return rows.map(toThreadStateRow);
+    },
+    listPage(page: ThreadStatePageOptions): ThreadStatePage {
+      if (!Number.isSafeInteger(page.limit) || page.limit < 1) {
+        throw new Error("thread state page limit must be a positive safe integer");
+      }
+      const rows = listPageStmt.all(page.afterHeadLsn ?? 0, page.limit + 1);
+      const selectedRows = rows.length > page.limit ? rows.slice(0, page.limit) : rows;
+      const lastRow = selectedRows.at(-1);
+      return {
+        rows: selectedRows.map(toThreadStateRow),
+        ...(rows.length > page.limit && lastRow !== undefined
+          ? { nextCursor: lsnFromV1Number(lastRow.headLsn) }
+          : {}),
+      };
     },
   };
 }

--- a/packages/broker/src/threads/projections.ts
+++ b/packages/broker/src/threads/projections.ts
@@ -45,6 +45,7 @@ export interface ThreadStateRow {
 
 export interface ThreadStateStore {
   applyEvent(record: EventLogRecord): void;
+  clear(): void;
   rebuildFromLog(eventLog: EventLog, fromLsn?: number): void;
   getById(threadId: ThreadId): ThreadStateRow | null;
   hasSpecRevision(revisionId: string): boolean;
@@ -287,6 +288,10 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
   return {
     applyEvent(record: EventLogRecord): void {
       applyEventInner(record);
+    },
+    clear(): void {
+      clearSpecRevisionsStmt.run();
+      clearThreadsStmt.run();
     },
     rebuildFromLog(eventLog: EventLog, fromLsn = 0): void {
       rebuildTransaction.immediate(eventLog, fromLsn);

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -39,6 +39,7 @@ import {
   validateThread,
 } from "@wuphf/protocol";
 import BetterSqlite3 from "better-sqlite3";
+import { ApprovalPendingSnapshotOverflowError } from "../approvals/index.ts";
 import { approvalViewFromApproval } from "../approvals/view.ts";
 import {
   InvalidListCursorError,
@@ -266,6 +267,15 @@ function handleThreadPinnedApprovalsGet(
       }),
     );
   } catch (err) {
+    if (err instanceof ApprovalPendingSnapshotOverflowError) {
+      deps.logger.error("thread_pinned_approvals_rejected", {
+        reason: "pinned_approvals_overflow",
+        threadId: err.threadId,
+        count: err.count,
+      });
+      writeRouteError(res, 500, "pinned_approvals_overflow", err.message);
+      return;
+    }
     if (writeStorageErrorResponse(res, err, deps.logger, "thread_pinned_approvals_rejected")) {
       return;
     }

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -10,6 +10,7 @@ import {
   canonicalJSON,
   type EventLsn,
   lsnFromV1Number,
+  MAX_ROUTE_THREAD_LIST_ITEMS,
   parseLsn,
   routeErrorToJsonValue,
   type Sha256Hex,
@@ -71,6 +72,7 @@ import {
 import type { ThreadReceiptIndexStore } from "./receipt-index.ts";
 
 const MAX_THREAD_BODY_BYTES = 512 * 1_024;
+const DEFAULT_THREAD_LIST_LIMIT = MAX_ROUTE_THREAD_LIST_ITEMS;
 const THREAD_EFFECTIVE_STATUS_SET: ReadonlySet<string> = new Set<string>(
   THREAD_EFFECTIVE_STATUS_VALUES,
 );
@@ -170,17 +172,24 @@ export async function handleThreadRoute(
 
 function handleThreadList(req: IncomingMessage, res: ServerResponse, deps: ThreadRouteDeps): void {
   const url = new URL(req.url ?? "/", "http://127.0.0.1");
-  const filter = parseStatusFilter(url.searchParams);
-  if (!filter.ok) {
-    writeRouteError(res, 400, "invalid_status", filter.reason);
+  const query = parseThreadListQuery(url.searchParams);
+  if (!query.ok) {
+    writeRouteError(res, 400, query.error, query.reason);
     return;
   }
   try {
-    const rows = deps.state.list();
-    const threads = rows
+    const page = deps.state.listPage({
+      limit: query.limit,
+      ...(query.afterHeadLsn === undefined ? {} : { afterHeadLsn: query.afterHeadLsn }),
+    });
+    const threads = page.rows
       .map((row) => threadViewFromRow(row, deps))
-      .filter((thread) => threadMatchesStatusFilter(thread, filter.filter));
-    writeJsonValue(res, 200, threadListResponseToJsonValue({ threads }));
+      .filter((thread) => threadMatchesStatusFilter(thread, query.filter));
+    writeJsonValue(
+      res,
+      200,
+      threadListResponseToJsonValue({ threads, nextCursor: page.nextCursor }),
+    );
   } catch (err) {
     if (writeStorageErrorResponse(res, err, deps.logger, "thread_list_rejected")) return;
     throw err;
@@ -523,14 +532,63 @@ function assertThreadValid(thread: Thread): void {
   }
 }
 
+function parseThreadListQuery(params: URLSearchParams):
+  | {
+      readonly ok: true;
+      readonly filter?: ThreadStatusFilter;
+      readonly limit: number;
+      readonly afterHeadLsn?: number;
+    }
+  | { readonly ok: false; readonly error: string; readonly reason?: string } {
+  const status = parseStatusFilter(params);
+  if (!status.ok) return status;
+
+  const limitParam = singleQueryParam(params, "limit");
+  if (limitParam === "multiple") {
+    return { ok: false, error: "invalid_limit", reason: "limit may appear only once" };
+  }
+  let limit = DEFAULT_THREAD_LIST_LIMIT;
+  if (limitParam !== undefined) {
+    if (!/^\d+$/.test(limitParam)) {
+      return { ok: false, error: "invalid_limit", reason: "limit must be a positive integer" };
+    }
+    const parsedLimit = Number.parseInt(limitParam, 10);
+    if (!Number.isSafeInteger(parsedLimit) || parsedLimit < 1) {
+      return { ok: false, error: "invalid_limit", reason: "limit must be a positive integer" };
+    }
+    limit = Math.min(parsedLimit, MAX_ROUTE_THREAD_LIST_ITEMS);
+  }
+
+  const cursor = singleQueryParam(params, "cursor");
+  if (cursor === "multiple") {
+    return { ok: false, error: "invalid_cursor", reason: "cursor may appear only once" };
+  }
+  if (cursor !== undefined) {
+    try {
+      return {
+        ok: true,
+        ...(status.filter === undefined ? {} : { filter: status.filter }),
+        limit,
+        afterHeadLsn: parseLsn(cursor as EventLsn).localLsn,
+      };
+    } catch {
+      return { ok: false, error: "invalid_cursor", reason: "cursor must be an EventLsn" };
+    }
+  }
+
+  return { ok: true, ...(status.filter === undefined ? {} : { filter: status.filter }), limit };
+}
+
 function parseStatusFilter(
   params: URLSearchParams,
 ):
   | { readonly ok: true; readonly filter?: ThreadStatusFilter }
-  | { readonly ok: false; readonly reason: string } {
+  | { readonly ok: false; readonly error: string; readonly reason: string } {
   const values = params.getAll("status");
   if (values.length === 0) return { ok: true };
-  if (values.length > 1) return { ok: false, reason: "status may appear only once" };
+  if (values.length > 1) {
+    return { ok: false, error: "invalid_status", reason: "status may appear only once" };
+  }
   const raw = values[0] ?? "";
   if (THREAD_EFFECTIVE_STATUS_SET.has(raw)) {
     return {
@@ -541,7 +599,18 @@ function parseStatusFilter(
   if (THREAD_BOARD_COLUMN_SET.has(raw)) {
     return { ok: true, filter: { kind: "board_column", value: raw as ThreadBoardColumn } };
   }
-  return { ok: false, reason: "unknown thread status, effective status, or board column" };
+  return {
+    ok: false,
+    error: "invalid_status",
+    reason: "unknown thread status, effective status, or board column",
+  };
+}
+
+function singleQueryParam(params: URLSearchParams, key: string): string | "multiple" | undefined {
+  const values = params.getAll(key);
+  if (values.length === 0) return undefined;
+  if (values.length > 1) return "multiple";
+  return values[0] ?? "";
 }
 
 type ThreadStatusFilter =

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -1,7 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
 import {
-  type ApprovalRequest,
   asIdempotencyKey,
   asSignerIdentity,
   asThreadId,
@@ -14,9 +13,6 @@ import {
   routeErrorToJsonValue,
   type Sha256Hex,
   type SignerIdentity,
-  THREAD_BOARD_COLUMN_VALUES,
-  THREAD_EFFECTIVE_STATUS_VALUES,
-  type Thread,
   type ThreadBoardColumn,
   type ThreadCreateCommand,
   type ThreadEffectiveStatus,
@@ -24,7 +20,6 @@ import {
   type ThreadId,
   type ThreadSpecEditCommand,
   type ThreadStatusChangeCommand,
-  type ThreadView,
   threadCreateRequestFromJson,
   threadCreateRequestToJsonValue,
   threadGetResponseToJsonValue,
@@ -36,7 +31,6 @@ import {
   threadSpecEditRequestToJsonValue,
   threadStatusChangeRequestFromJson,
   threadStatusChangeRequestToJsonValue,
-  validateThread,
 } from "@wuphf/protocol";
 import BetterSqlite3 from "better-sqlite3";
 import { ApprovalPendingSnapshotOverflowError } from "../approvals/index.ts";
@@ -57,26 +51,26 @@ import {
   ThreadNotFoundError,
   ThreadTerminalTransitionError,
 } from "./appender.ts";
-import { deriveThreadEffectiveStatus } from "./effective-status.ts";
 import {
   type IdempotencyParseError,
   type ParsedIdempotencyKey,
   parseThreadIdempotencyKey,
   type ThreadCommand,
 } from "./idempotency.ts";
-import {
-  type ThreadStateRow,
-  type ThreadStateStore,
-  threadStateRowToThread,
-} from "./projections.ts";
+import type { ThreadStateStore } from "./projections.ts";
 import type { ThreadReceiptIndexStore } from "./receipt-index.ts";
+import {
+  THREAD_BOARD_COLUMN_SET,
+  THREAD_EFFECTIVE_STATUS_SET,
+  type ThreadApprovalQuery,
+  type ThreadApprovalQueryRow,
+  type ThreadStatusFilter,
+  type ThreadViewStore,
+  threadViewFromRow,
+} from "./views.ts";
 
 const MAX_THREAD_BODY_BYTES = 512 * 1_024;
 const DEFAULT_THREAD_LIST_LIMIT = MAX_ROUTE_THREAD_LIST_ITEMS;
-const THREAD_EFFECTIVE_STATUS_SET: ReadonlySet<string> = new Set<string>(
-  THREAD_EFFECTIVE_STATUS_VALUES,
-);
-const THREAD_BOARD_COLUMN_SET: ReadonlySet<string> = new Set<string>(THREAD_BOARD_COLUMN_VALUES);
 const ROUTE_SIGNER: SignerIdentity = asSignerIdentity("broker");
 const EMPTY_EXTERNAL_REFS: ThreadExternalRefs = Object.freeze({
   sourceUrls: Object.freeze([]),
@@ -87,43 +81,17 @@ export interface ThreadRouteDeps {
   readonly appender: ThreadAppender;
   readonly state: ThreadStateStore;
   readonly receiptIndex: ThreadReceiptIndexStore;
+  readonly views: ThreadViewStore;
   readonly approvals: ThreadApprovalQuery | null;
   readonly logger: BrokerLogger;
   readonly nowMs: () => number;
   readonly emitThreadEvent: (event: ThreadRouteStreamEvent) => void;
 }
 
-export interface ThreadApprovalQuery {
-  countPendingByThread(threadId: ThreadId): number;
-  listPendingByThread(threadId: ThreadId): readonly ThreadApprovalQueryRow[];
-  latestHeadLsnByThread(threadId: ThreadId): EventLsn | null;
-  pendingByThreadSnapshot(threadId: ThreadId): ThreadApprovalQuerySnapshot;
-}
-
-export interface ThreadApprovalQueryRow {
-  readonly approval: ApprovalRequest;
-  readonly headLsn: EventLsn;
-}
-
-export interface ThreadApprovalQuerySnapshot {
-  readonly rows: readonly ThreadApprovalQueryRow[];
-  readonly headLsn: EventLsn | null;
-}
-
 export interface ThreadRouteStreamEvent {
   readonly kind: "thread.created" | "thread.updated" | "thread.pinned_approvals.changed";
   readonly threadId: ThreadId;
   readonly headLsn: EventLsn;
-}
-
-interface ThreadListViewPage {
-  readonly threads: readonly ThreadView[];
-  readonly nextCursor?: EventLsn;
-}
-
-interface ThreadListViewItem {
-  readonly thread: ThreadView;
-  readonly viewLsn: number;
 }
 
 export async function handleThreadRoute(
@@ -194,8 +162,9 @@ function handleThreadList(req: IncomingMessage, res: ServerResponse, deps: Threa
     return;
   }
   try {
-    const page = listThreadViewPage(deps, {
+    const page = deps.views.listThreadViews({
       limit: query.limit,
+      approvals: deps.approvals,
       ...(query.filter === undefined ? {} : { filter: query.filter }),
       ...(query.afterViewLsn === undefined ? {} : { afterViewLsn: query.afterViewLsn }),
     });
@@ -529,75 +498,6 @@ function threadRouteStreamEventFromApplied(applied: {
   };
 }
 
-function threadViewFromRow(row: ThreadStateRow, deps: ThreadRouteDeps): ThreadView {
-  return threadViewItemFromRow(row, deps).thread;
-}
-
-function listThreadViewPage(
-  deps: ThreadRouteDeps,
-  args: {
-    readonly limit: number;
-    readonly filter?: ThreadStatusFilter;
-    readonly afterViewLsn?: number;
-  },
-): ThreadListViewPage {
-  if (!Number.isSafeInteger(args.limit) || args.limit < 1) {
-    throw new Error("thread view page limit must be a positive safe integer");
-  }
-  const afterViewLsn = args.afterViewLsn ?? 0;
-  const candidates = deps.state
-    .list()
-    .map((row) => threadViewItemFromRow(row, deps))
-    .filter((item) => item.viewLsn > afterViewLsn)
-    .filter((item) => threadMatchesStatusFilter(item.thread, args.filter))
-    .sort((left, right) => left.viewLsn - right.viewLsn);
-  const visibleItems = candidates.slice(0, args.limit);
-  const last = visibleItems.at(-1);
-  return {
-    threads: visibleItems.map((item) => item.thread),
-    ...(candidates.length > args.limit && last !== undefined
-      ? { nextCursor: lsnFromV1Number(last.viewLsn) }
-      : {}),
-  };
-}
-
-function threadViewItemFromRow(row: ThreadStateRow, deps: ThreadRouteDeps): ThreadListViewItem {
-  const refs = deps.receiptIndex.refsForThread(row.id);
-  const thread = threadStateRowToThread(row, refs.taskIds);
-  assertThreadValid(thread);
-  const pendingApprovalCount = deps.approvals?.countPendingByThread(row.id) ?? 0;
-  const latestReceipt = deps.receiptIndex.latestForThread(row.id);
-  const approvalHeadLsn = deps.approvals?.latestHeadLsnByThread(row.id) ?? null;
-  const viewLsn = Math.max(
-    parseLsn(row.headLsn).localLsn,
-    latestReceipt?.lsn ?? 0,
-    approvalHeadLsn === null ? 0 : parseLsn(approvalHeadLsn).localLsn,
-  );
-  return {
-    viewLsn,
-    thread: {
-      ...thread,
-      ...deriveThreadEffectiveStatus({
-        storedStatus: row.status,
-        pendingApprovalCount,
-        latestReceiptStatus: latestReceipt?.status,
-      }),
-      pendingApprovalCount,
-    },
-  };
-}
-
-function assertThreadValid(thread: Thread): void {
-  const threadValidation = validateThread(thread);
-  if (!threadValidation.ok) {
-    throw new Error(
-      `thread projection failed validation: ${threadValidation.errors
-        .map((error) => `${error.path}: ${error.message}`)
-        .join("; ")}`,
-    );
-  }
-}
-
 function parseThreadListQuery(params: URLSearchParams):
   | {
       readonly ok: true;
@@ -677,16 +577,6 @@ function singleQueryParam(params: URLSearchParams, key: string): string | "multi
   if (values.length === 0) return undefined;
   if (values.length > 1) return "multiple";
   return values[0] ?? "";
-}
-
-type ThreadStatusFilter =
-  | { readonly kind: "effective_status"; readonly value: ThreadEffectiveStatus }
-  | { readonly kind: "board_column"; readonly value: ThreadBoardColumn };
-
-function threadMatchesStatusFilter(thread: ThreadView, filter: ThreadStatusFilter | undefined) {
-  if (filter === undefined) return true;
-  if (filter.kind === "effective_status") return thread.effectiveStatus === filter.value;
-  return thread.boardColumn === filter.value;
 }
 
 function maxHeadLsn(

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -97,11 +97,17 @@ export interface ThreadApprovalQuery {
   countPendingByThread(threadId: ThreadId): number;
   listPendingByThread(threadId: ThreadId): readonly ThreadApprovalQueryRow[];
   latestHeadLsnByThread(threadId: ThreadId): EventLsn | null;
+  pendingByThreadSnapshot(threadId: ThreadId): ThreadApprovalQuerySnapshot;
 }
 
 export interface ThreadApprovalQueryRow {
   readonly approval: ApprovalRequest;
   readonly headLsn: EventLsn;
+}
+
+export interface ThreadApprovalQuerySnapshot {
+  readonly rows: readonly ThreadApprovalQueryRow[];
+  readonly headLsn: EventLsn | null;
 }
 
 export interface ThreadRouteStreamEvent {
@@ -239,15 +245,17 @@ function handleThreadPinnedApprovalsGet(
     return;
   }
   try {
-    const approvals = deps.approvals?.listPendingByThread(threadId) ?? [];
-    const approvalHeadLsn = deps.approvals?.latestHeadLsnByThread(threadId) ?? null;
+    const snapshot = deps.approvals?.pendingByThreadSnapshot(threadId) ?? {
+      rows: [],
+      headLsn: null,
+    };
     writeJsonValue(
       res,
       200,
       threadPinnedApprovalsResponseToJsonValue({
         threadId,
-        headLsn: maxHeadLsn(row.headLsn, approvals, approvalHeadLsn),
-        approvals: approvals.map((approval) => approvalViewFromApproval(approval.approval)),
+        headLsn: maxHeadLsn(row.headLsn, snapshot.rows, snapshot.headLsn),
+        approvals: snapshot.rows.map((approval) => approvalViewFromApproval(approval.approval)),
       }),
     );
   } catch (err) {

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -2,7 +2,6 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 
 import {
   type ApprovalRequest,
-  type ApprovalView,
   asIdempotencyKey,
   asSignerIdentity,
   asThreadId,
@@ -40,7 +39,7 @@ import {
   validateThread,
 } from "@wuphf/protocol";
 import BetterSqlite3 from "better-sqlite3";
-
+import { approvalViewFromApproval } from "../approvals/view.ts";
 import {
   InvalidListCursorError,
   InvalidListLimitError,
@@ -310,7 +309,7 @@ async function handleThreadCreate(
       content: request.specContent,
     };
   } catch (err) {
-    writeRouteError(res, 400, "invalid_thread_command", errorMessage(err));
+    writeRouteError(res, 422, "invalid_payload", errorMessage(err));
     return;
   }
 
@@ -383,7 +382,7 @@ async function handleThreadSpecPatch(
     };
     baseContentHash = request.baseContentHash;
   } catch (err) {
-    writeRouteError(res, 400, "invalid_thread_command", errorMessage(err));
+    writeRouteError(res, 422, "invalid_payload", errorMessage(err));
     return;
   }
 
@@ -454,7 +453,7 @@ async function handleThreadStatusPatch(
       changedAt: routeDate(deps.nowMs()),
     };
   } catch (err) {
-    writeRouteError(res, 400, "invalid_thread_command", errorMessage(err));
+    writeRouteError(res, 422, "invalid_payload", errorMessage(err));
     return;
   }
 
@@ -646,31 +645,6 @@ function maxHeadLsn(
   return lsnFromV1Number(max);
 }
 
-function approvalViewFromApproval(approval: ApprovalRequest): ApprovalView {
-  return {
-    id: approval.id,
-    claim: approval.claim,
-    scope: approval.scope,
-    riskClass: approval.riskClass,
-    ...(approval.threadId === undefined ? {} : { threadId: approval.threadId }),
-    ...(approval.taskId === undefined ? {} : { taskId: approval.taskId }),
-    ...(approval.receiptId === undefined ? {} : { receiptId: approval.receiptId }),
-    requestedBy: approval.requestedBy,
-    requestedAt: approval.requestedAt,
-    status: approval.status,
-    ...(approval.decision === undefined
-      ? {}
-      : {
-          decisionSummary: {
-            decision: approval.decision.decision,
-            decidedBy: approval.decision.decidedBy,
-            decidedAt: approval.decision.decidedAt,
-          },
-        }),
-    schemaVersion: 1,
-  };
-}
-
 function parseThreadIdPath(encoded: string): ThreadId | null {
   if (encoded.length === 0 || encoded.includes("/")) return null;
   try {
@@ -688,7 +662,7 @@ function writeThreadAppenderError(
 ): void {
   if (err instanceof ThreadCommandValidationError) {
     logger.warn(rejectedEvent, { reason: "invalid_command" });
-    writeRouteError(res, 400, "invalid_thread_command", err.message);
+    writeRouteError(res, 422, "invalid_payload", err.message);
     return;
   }
   if (err instanceof ThreadNotFoundError) {

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -115,6 +115,16 @@ export interface ThreadRouteStreamEvent {
   readonly headLsn: EventLsn;
 }
 
+interface ThreadListViewPage {
+  readonly threads: readonly ThreadView[];
+  readonly nextCursor?: EventLsn;
+}
+
+interface ThreadListViewItem {
+  readonly thread: ThreadView;
+  readonly viewLsn: number;
+}
+
 export async function handleThreadRoute(
   req: IncomingMessage,
   res: ServerResponse,
@@ -183,17 +193,15 @@ function handleThreadList(req: IncomingMessage, res: ServerResponse, deps: Threa
     return;
   }
   try {
-    const page = deps.state.listPage({
+    const page = listThreadViewPage(deps, {
       limit: query.limit,
-      ...(query.afterHeadLsn === undefined ? {} : { afterHeadLsn: query.afterHeadLsn }),
+      ...(query.filter === undefined ? {} : { filter: query.filter }),
+      ...(query.afterViewLsn === undefined ? {} : { afterViewLsn: query.afterViewLsn }),
     });
-    const threads = page.rows
-      .map((row) => threadViewFromRow(row, deps))
-      .filter((thread) => threadMatchesStatusFilter(thread, query.filter));
     writeJsonValue(
       res,
       200,
-      threadListResponseToJsonValue({ threads, nextCursor: page.nextCursor }),
+      threadListResponseToJsonValue({ threads: page.threads, nextCursor: page.nextCursor }),
     );
   } catch (err) {
     if (writeStorageErrorResponse(res, err, deps.logger, "thread_list_rejected")) return;
@@ -512,19 +520,60 @@ function threadRouteStreamEventFromApplied(applied: {
 }
 
 function threadViewFromRow(row: ThreadStateRow, deps: ThreadRouteDeps): ThreadView {
+  return threadViewItemFromRow(row, deps).thread;
+}
+
+function listThreadViewPage(
+  deps: ThreadRouteDeps,
+  args: {
+    readonly limit: number;
+    readonly filter?: ThreadStatusFilter;
+    readonly afterViewLsn?: number;
+  },
+): ThreadListViewPage {
+  if (!Number.isSafeInteger(args.limit) || args.limit < 1) {
+    throw new Error("thread view page limit must be a positive safe integer");
+  }
+  const afterViewLsn = args.afterViewLsn ?? 0;
+  const candidates = deps.state
+    .list()
+    .map((row) => threadViewItemFromRow(row, deps))
+    .filter((item) => item.viewLsn > afterViewLsn)
+    .filter((item) => threadMatchesStatusFilter(item.thread, args.filter))
+    .sort((left, right) => left.viewLsn - right.viewLsn);
+  const visibleItems = candidates.slice(0, args.limit);
+  const last = visibleItems.at(-1);
+  return {
+    threads: visibleItems.map((item) => item.thread),
+    ...(candidates.length > args.limit && last !== undefined
+      ? { nextCursor: lsnFromV1Number(last.viewLsn) }
+      : {}),
+  };
+}
+
+function threadViewItemFromRow(row: ThreadStateRow, deps: ThreadRouteDeps): ThreadListViewItem {
   const refs = deps.receiptIndex.refsForThread(row.id);
   const thread = threadStateRowToThread(row, refs.taskIds);
   assertThreadValid(thread);
   const pendingApprovalCount = deps.approvals?.countPendingByThread(row.id) ?? 0;
   const latestReceipt = deps.receiptIndex.latestForThread(row.id);
+  const approvalHeadLsn = deps.approvals?.latestHeadLsnByThread(row.id) ?? null;
+  const viewLsn = Math.max(
+    parseLsn(row.headLsn).localLsn,
+    latestReceipt?.lsn ?? 0,
+    approvalHeadLsn === null ? 0 : parseLsn(approvalHeadLsn).localLsn,
+  );
   return {
-    ...thread,
-    ...deriveThreadEffectiveStatus({
-      storedStatus: row.status,
+    viewLsn,
+    thread: {
+      ...thread,
+      ...deriveThreadEffectiveStatus({
+        storedStatus: row.status,
+        pendingApprovalCount,
+        latestReceiptStatus: latestReceipt?.status,
+      }),
       pendingApprovalCount,
-      latestReceiptStatus: latestReceipt?.status,
-    }),
-    pendingApprovalCount,
+    },
   };
 }
 
@@ -544,7 +593,7 @@ function parseThreadListQuery(params: URLSearchParams):
       readonly ok: true;
       readonly filter?: ThreadStatusFilter;
       readonly limit: number;
-      readonly afterHeadLsn?: number;
+      readonly afterViewLsn?: number;
     }
   | { readonly ok: false; readonly error: string; readonly reason?: string } {
   const status = parseStatusFilter(params);
@@ -576,7 +625,7 @@ function parseThreadListQuery(params: URLSearchParams):
         ok: true,
         ...(status.filter === undefined ? {} : { filter: status.filter }),
         limit,
-        afterHeadLsn: parseLsn(cursor as EventLsn).localLsn,
+        afterViewLsn: parseLsn(cursor as EventLsn).localLsn,
       };
     } catch {
       return { ok: false, error: "invalid_cursor", reason: "cursor must be an EventLsn" };

--- a/packages/broker/src/threads/subsystem.ts
+++ b/packages/broker/src/threads/subsystem.ts
@@ -16,6 +16,7 @@ import { createThreadAppender, type ThreadAppender } from "./appender.ts";
 import type { ParsedIdempotencyKey } from "./idempotency.ts";
 import { createThreadStateStore, type ThreadStateStore } from "./projections.ts";
 import { createThreadReceiptIndexStore, type ThreadReceiptIndexStore } from "./receipt-index.ts";
+import { createThreadViewStore, type ThreadViewStore } from "./views.ts";
 
 export const SYSTEM_INBOX_THREAD_ID: ThreadId = asThreadId("00000000000000000000000001");
 
@@ -35,6 +36,7 @@ export interface ThreadSubsystem {
   readonly appender: ThreadAppender;
   readonly state: ThreadStateStore;
   readonly receiptIndex: ThreadReceiptIndexStore;
+  readonly views: ThreadViewStore;
   readonly receiptStore: SqliteReceiptStore;
   readonly inboxThreadId: ThreadId;
   sharesApprovalProvenance(appender: ApprovalAppender, projection: ApprovalProjection): boolean;
@@ -51,6 +53,7 @@ export function createThreadSubsystem(
   }
   const state = createThreadStateStore(db);
   const receiptIndex = createThreadReceiptIndexStore(db);
+  const views = createThreadViewStore(db, state, receiptIndex);
   const appender = createThreadAppender(db, eventLog, state);
   ensureSystemInboxThread(appender, state);
   const rebuildTransaction = db.transaction((fromLsn: number): void => {
@@ -81,6 +84,7 @@ export function createThreadSubsystem(
     appender,
     state,
     receiptIndex,
+    views,
     receiptStore,
     inboxThreadId: SYSTEM_INBOX_THREAD_ID,
     sharesApprovalProvenance(appender: ApprovalAppender, projection: ApprovalProjection): boolean {

--- a/packages/broker/src/threads/subsystem.ts
+++ b/packages/broker/src/threads/subsystem.ts
@@ -29,6 +29,7 @@ const SYSTEM_INBOX_EXTERNAL_REFS: ThreadExternalRefs = Object.freeze({
   sourceUrls: Object.freeze([]),
   entityIds: Object.freeze([]),
 });
+const THREAD_REBUILD_BATCH_SIZE = 500;
 
 export interface ThreadSubsystem {
   readonly appender: ThreadAppender;
@@ -52,6 +53,30 @@ export function createThreadSubsystem(
   const receiptIndex = createThreadReceiptIndexStore(db);
   const appender = createThreadAppender(db, eventLog, state);
   ensureSystemInboxThread(appender, state);
+  const rebuildTransaction = db.transaction((fromLsn: number): void => {
+    if (!Number.isSafeInteger(fromLsn) || fromLsn < 0) {
+      throw new Error(
+        `rebuildFromLog: fromLsn must be a non-negative safe integer, got ${fromLsn}`,
+      );
+    }
+    if (fromLsn === 0) {
+      receiptIndex.clear();
+      state.clear();
+    }
+    let cursor = fromLsn;
+    for (;;) {
+      const batch = eventLog.readFromLsn(cursor, THREAD_REBUILD_BATCH_SIZE);
+      if (batch.length === 0) break;
+      for (const record of batch) {
+        state.applyEvent(record);
+        receiptIndex.applyEvent(record);
+      }
+      const last = batch.at(-1);
+      if (last === undefined) break;
+      cursor = last.lsn;
+      if (batch.length < THREAD_REBUILD_BATCH_SIZE) break;
+    }
+  });
   return {
     appender,
     state,
@@ -62,11 +87,7 @@ export function createThreadSubsystem(
       return appender.sharesProvenance(db, eventLog) && projection.sharesProvenance(db, eventLog);
     },
     rebuildFromLog(fromLsn = 0): void {
-      if (fromLsn === 0) {
-        receiptIndex.clear();
-      }
-      state.rebuildFromLog(eventLog, fromLsn);
-      receiptIndex.rebuildFromLog(eventLog, fromLsn);
+      rebuildTransaction.immediate(fromLsn);
       ensureSystemInboxThread(appender, state);
     },
   };

--- a/packages/broker/src/threads/views.ts
+++ b/packages/broker/src/threads/views.ts
@@ -31,7 +31,6 @@ export const THREAD_BOARD_COLUMN_SET: ReadonlySet<string> = new Set<string>(
 
 export interface ThreadApprovalQuery {
   countPendingByThread(threadId: ThreadId): number;
-  listPendingByThread(threadId: ThreadId): readonly ThreadApprovalQueryRow[];
   latestHeadLsnByThread(threadId: ThreadId): EventLsn | null;
   pendingByThreadSnapshot(threadId: ThreadId): ThreadApprovalQuerySnapshot;
 }

--- a/packages/broker/src/threads/views.ts
+++ b/packages/broker/src/threads/views.ts
@@ -1,0 +1,166 @@
+import {
+  type ApprovalRequest,
+  type EventLsn,
+  lsnFromV1Number,
+  parseLsn,
+  THREAD_BOARD_COLUMN_VALUES,
+  THREAD_EFFECTIVE_STATUS_VALUES,
+  type Thread,
+  type ThreadBoardColumn,
+  type ThreadEffectiveStatus,
+  type ThreadId,
+  type ThreadView,
+  validateThread,
+} from "@wuphf/protocol";
+import type Database from "better-sqlite3";
+
+import { deriveThreadEffectiveStatus } from "./effective-status.ts";
+import {
+  type ThreadStateRow,
+  type ThreadStateStore,
+  threadStateRowToThread,
+} from "./projections.ts";
+import type { ThreadReceiptIndexStore } from "./receipt-index.ts";
+
+export const THREAD_EFFECTIVE_STATUS_SET: ReadonlySet<string> = new Set<string>(
+  THREAD_EFFECTIVE_STATUS_VALUES,
+);
+export const THREAD_BOARD_COLUMN_SET: ReadonlySet<string> = new Set<string>(
+  THREAD_BOARD_COLUMN_VALUES,
+);
+
+export interface ThreadApprovalQuery {
+  countPendingByThread(threadId: ThreadId): number;
+  listPendingByThread(threadId: ThreadId): readonly ThreadApprovalQueryRow[];
+  latestHeadLsnByThread(threadId: ThreadId): EventLsn | null;
+  pendingByThreadSnapshot(threadId: ThreadId): ThreadApprovalQuerySnapshot;
+}
+
+export interface ThreadApprovalQueryRow {
+  readonly approval: ApprovalRequest;
+  readonly headLsn: EventLsn;
+}
+
+export interface ThreadApprovalQuerySnapshot {
+  readonly rows: readonly ThreadApprovalQueryRow[];
+  readonly headLsn: EventLsn | null;
+}
+
+export type ThreadStatusFilter =
+  | { readonly kind: "effective_status"; readonly value: ThreadEffectiveStatus }
+  | { readonly kind: "board_column"; readonly value: ThreadBoardColumn };
+
+export interface ThreadListViewArgs {
+  readonly limit: number;
+  readonly filter?: ThreadStatusFilter;
+  readonly afterViewLsn?: number;
+  readonly approvals: ThreadApprovalQuery | null;
+}
+
+export interface ThreadListViewPage {
+  readonly threads: readonly ThreadView[];
+  readonly nextCursor?: EventLsn;
+}
+
+export interface ThreadViewStore {
+  listThreadViews(args: ThreadListViewArgs): ThreadListViewPage;
+}
+
+interface ThreadListViewItem {
+  readonly thread: ThreadView;
+  readonly viewLsn: number;
+}
+
+interface ThreadViewDeps {
+  readonly receiptIndex: ThreadReceiptIndexStore;
+  readonly approvals: ThreadApprovalQuery | null;
+}
+
+export function createThreadViewStore(
+  db: Database.Database,
+  state: ThreadStateStore,
+  receiptIndex: ThreadReceiptIndexStore,
+): ThreadViewStore {
+  const listThreadViewsTransaction = db.transaction((args: ThreadListViewArgs) =>
+    listThreadViewPage(state, receiptIndex, args),
+  );
+
+  return {
+    listThreadViews(args: ThreadListViewArgs): ThreadListViewPage {
+      return listThreadViewsTransaction.deferred(args);
+    },
+  };
+}
+
+export function threadViewFromRow(row: ThreadStateRow, deps: ThreadViewDeps): ThreadView {
+  return threadViewItemFromRow(row, deps).thread;
+}
+
+function listThreadViewPage(
+  state: ThreadStateStore,
+  receiptIndex: ThreadReceiptIndexStore,
+  args: ThreadListViewArgs,
+): ThreadListViewPage {
+  if (!Number.isSafeInteger(args.limit) || args.limit < 1) {
+    throw new Error("thread view page limit must be a positive safe integer");
+  }
+  const afterViewLsn = args.afterViewLsn ?? 0;
+  const deps = { receiptIndex, approvals: args.approvals };
+  const candidates = state
+    .list()
+    .map((row) => threadViewItemFromRow(row, deps))
+    .filter((item) => item.viewLsn > afterViewLsn)
+    .filter((item) => threadMatchesStatusFilter(item.thread, args.filter))
+    .sort((left, right) => left.viewLsn - right.viewLsn);
+  const visibleItems = candidates.slice(0, args.limit);
+  const last = visibleItems.at(-1);
+  return {
+    threads: visibleItems.map((item) => item.thread),
+    ...(candidates.length > args.limit && last !== undefined
+      ? { nextCursor: lsnFromV1Number(last.viewLsn) }
+      : {}),
+  };
+}
+
+function threadViewItemFromRow(row: ThreadStateRow, deps: ThreadViewDeps): ThreadListViewItem {
+  const refs = deps.receiptIndex.refsForThread(row.id);
+  const thread = threadStateRowToThread(row, refs.taskIds);
+  assertThreadValid(thread);
+  const pendingApprovalCount = deps.approvals?.countPendingByThread(row.id) ?? 0;
+  const latestReceipt = deps.receiptIndex.latestForThread(row.id);
+  const approvalHeadLsn = deps.approvals?.latestHeadLsnByThread(row.id) ?? null;
+  const viewLsn = Math.max(
+    parseLsn(row.headLsn).localLsn,
+    latestReceipt?.lsn ?? 0,
+    approvalHeadLsn === null ? 0 : parseLsn(approvalHeadLsn).localLsn,
+  );
+  return {
+    viewLsn,
+    thread: {
+      ...thread,
+      ...deriveThreadEffectiveStatus({
+        storedStatus: row.status,
+        pendingApprovalCount,
+        latestReceiptStatus: latestReceipt?.status,
+      }),
+      pendingApprovalCount,
+    },
+  };
+}
+
+function assertThreadValid(thread: Thread): void {
+  const threadValidation = validateThread(thread);
+  if (!threadValidation.ok) {
+    throw new Error(
+      `thread projection failed validation: ${threadValidation.errors
+        .map((error) => `${error.path}: ${error.message}`)
+        .join("; ")}`,
+    );
+  }
+}
+
+function threadMatchesStatusFilter(thread: ThreadView, filter: ThreadStatusFilter | undefined) {
+  if (filter === undefined) return true;
+  if (filter.kind === "effective_status") return thread.effectiveStatus === filter.value;
+  return thread.boardColumn === filter.value;
+}

--- a/packages/broker/src/types.ts
+++ b/packages/broker/src/types.ts
@@ -122,7 +122,8 @@ export interface BrokerConfig {
   /**
    * Optional explicit approvals feature. When supplied,
    * `/api/v1/approvals` routes are mounted. Hosts construct these deps via
-   * `createApprovalSubsystem(db, eventLog)`.
+   * `createApprovalSubsystem(db, eventLog, { threadRefValidator })` when
+   * approvals can name threads.
    * Decisions are attributed to the bearer-bound agent in `tokenAgentIds`;
    * when omitted, the listener falls back to the runner bearer map if one
    * is configured.

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -14,6 +14,7 @@ import {
   asThreadId,
   asTimestampMs,
   canonicalJSON,
+  MAX_ROUTE_APPROVAL_LIST_ITEMS,
   type SignedApprovalToken,
   signedApprovalTokenFromJson,
   signedApprovalTokenToJsonValue,
@@ -22,6 +23,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   ApprovalIdempotencyConflictError,
+  ApprovalReplayPendingLimitExceededError,
+  ApprovalReplayThreadNotFoundError,
   ApprovalRequestAlreadyDecidedError,
   ApprovalTokenAlreadyUsedError,
   createApprovalAppender,
@@ -37,6 +40,8 @@ const RECEIPT_ID = asReceiptId("01BRZ3NDEKTSV4RRFFQ69G5FA0");
 const THREAD_ID = asThreadId("01CRZ3NDEKTSV4RRFFQ69G5FA1");
 const TASK_ID = asTaskId("01DRZ3NDEKTSV4RRFFQ69G5FA2");
 const OPERATOR = asSignerIdentity("operator@example.com");
+const ULID_TIME_PREFIX = "01ZRZ3NDEK";
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
 function setup() {
   const db = openDatabase({ path: ":memory:" });
@@ -135,6 +140,30 @@ function eventCount(db: ReturnType<typeof openDatabase>, type: string): number {
       )
       .get(type)?.n ?? 0
   );
+}
+
+function indexedApprovalRequestId(index: number): ReturnType<typeof asApprovalRequestId> {
+  let value = index;
+  let suffix = "";
+  for (let i = 0; i < 16; i += 1) {
+    suffix = ULID_ALPHABET[value % ULID_ALPHABET.length] + suffix;
+    value = Math.floor(value / ULID_ALPHABET.length);
+  }
+  return asApprovalRequestId(`${ULID_TIME_PREFIX}${suffix}`);
+}
+
+function insertThreadProjectionRow(
+  db: ReturnType<typeof openDatabase>,
+  eventLog: ReturnType<typeof createEventLog>,
+  threadId = THREAD_ID,
+): void {
+  const lsn = eventLog.append({ type: "thread.created", payload: Buffer.from("{}") });
+  db.prepare<[string, number, string, string], void>(
+    `INSERT INTO threads
+       (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms,
+        external_refs)
+     VALUES (?, 'Replay thread', 'open', ?, ?, 0, 0, ?)`,
+  ).run(threadId, lsn, OPERATOR, canonicalJSON({ source_urls: [], entity_ids: [] }));
 }
 
 function projectionSnapshot(db: ReturnType<typeof openDatabase>): string {
@@ -416,7 +445,7 @@ describe("approval projection and appender", () => {
   it("rebuilds pending_approvals from the event log byte-equivalent to live projection", () => {
     const { db, eventLog, projection, appender } = setup();
     try {
-      appender.requestApproval(requestedPayload(REQUEST_ID));
+      appender.requestApproval(requestedPayload(REQUEST_ID, { thread: false, task: false }));
       appender.decideApproval(decidedPayload("abstain", REQUEST_ID));
       appender.requestApproval(requestedPayload(SECOND_REQUEST_ID, { thread: false, task: false }));
 
@@ -433,10 +462,49 @@ describe("approval projection and appender", () => {
     }
   });
 
+  it("projection replay rejects requested events for missing threads", () => {
+    const { db, eventLog, projection, appender } = setup();
+    try {
+      appender.requestApproval(requestedPayload(REQUEST_ID, { thread: false, task: false }));
+      const live = projectionSnapshot(db);
+      const bytes = approvalAuditPayloadToBytes(
+        "approval_requested",
+        requestedPayload(SECOND_REQUEST_ID, { task: false }),
+      );
+      eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
+
+      expect(() => projection.rebuildFromLog(eventLog)).toThrow(ApprovalReplayThreadNotFoundError);
+      expect(projectionSnapshot(db)).toBe(live);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("projection replay rejects per-thread pending approval overflow", () => {
+    const { db, eventLog, projection } = setup();
+    try {
+      insertThreadProjectionRow(db, eventLog);
+      for (let index = 0; index <= MAX_ROUTE_APPROVAL_LIST_ITEMS; index += 1) {
+        const bytes = approvalAuditPayloadToBytes(
+          "approval_requested",
+          requestedPayload(indexedApprovalRequestId(index), { task: false }),
+        );
+        eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
+      }
+
+      expect(() => projection.rebuildFromLog(eventLog)).toThrow(
+        ApprovalReplayPendingLimitExceededError,
+      );
+      expect(projection.countPendingByThread(THREAD_ID)).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
   it("projection replay rejects forged duplicate decision events", () => {
     const { db, eventLog, projection, appender } = setup();
     try {
-      appender.requestApproval(requestedPayload());
+      appender.requestApproval(requestedPayload(REQUEST_ID, { thread: false, task: false }));
       const rejectBytes = approvalAuditPayloadToBytes("approval_decided", decidedPayload("reject"));
       const approveBytes = approvalAuditPayloadToBytes(
         "approval_decided",
@@ -455,7 +523,10 @@ describe("approval projection and appender", () => {
   it("projection replay rejects duplicate requested events", () => {
     const { db, eventLog, projection } = setup();
     try {
-      const bytes = approvalAuditPayloadToBytes("approval_requested", requestedPayload());
+      const bytes = approvalAuditPayloadToBytes(
+        "approval_requested",
+        requestedPayload(REQUEST_ID, { thread: false, task: false }),
+      );
       eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
       eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
 

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -508,14 +508,14 @@ describe("approval projection and appender", () => {
         threadId: otherThreadId,
       });
       expect(projection.countPendingByThread(THREAD_ID)).toBe(1);
-      expect(projection.listPendingByThread(THREAD_ID).map((row) => row.approval.id)).toEqual([
-        REQUEST_ID,
-      ]);
+      expect(
+        projection.pendingByThreadSnapshot(THREAD_ID).rows.map((row) => row.approval.id),
+      ).toEqual([REQUEST_ID]);
       expect(projection.latestHeadLsnByThread(THREAD_ID)).toBe("v1:3");
 
       appender.decideApproval(decidedPayload("reject", REQUEST_ID));
       expect(projection.countPendingByThread(THREAD_ID)).toBe(0);
-      expect(projection.listPendingByThread(THREAD_ID)).toEqual([]);
+      expect(projection.pendingByThreadSnapshot(THREAD_ID).rows).toEqual([]);
       expect(projection.latestHeadLsnByThread(THREAD_ID)).toBe("v1:5");
       expect(projection.countPendingByThread(otherThreadId)).toBe(1);
 

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -26,6 +26,7 @@ import {
   ApprovalReplayPendingLimitExceededError,
   ApprovalReplayThreadNotFoundError,
   ApprovalRequestAlreadyDecidedError,
+  ApprovalThreadNotFoundError,
   ApprovalTokenAlreadyUsedError,
   ApprovalTokenIssuedToMismatchError,
   createApprovalAppender,
@@ -53,9 +54,28 @@ function setup() {
   return { db, eventLog, projection, appender };
 }
 
+function setupWithThreadValidator(
+  threadIds: readonly ReturnType<typeof asThreadId>[] = [THREAD_ID],
+) {
+  const db = openDatabase({ path: ":memory:" });
+  runMigrations(db);
+  const eventLog = createEventLog(db);
+  for (const threadId of threadIds) {
+    insertThreadProjectionRow(db, eventLog, threadId);
+  }
+  const threadExistsStmt = db.prepare<[string], { readonly present: 1 }>(
+    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
+  );
+  const projection = createApprovalProjection(db);
+  const appender = createApprovalAppender(db, eventLog, projection, {
+    threadRefValidator: (threadId) => threadExistsStmt.get(threadId) !== undefined,
+  });
+  return { db, eventLog, projection, appender };
+}
+
 function requestedPayload(
   requestId = REQUEST_ID,
-  opts: { readonly thread?: boolean; readonly task?: boolean } = { thread: true, task: true },
+  opts: { readonly thread?: boolean; readonly task?: boolean } = { thread: false, task: true },
 ): ApprovalRequestedAuditPayload {
   const claimId = asApprovalClaimId(`claim_${requestId.slice(-6).toLowerCase()}`);
   const claim = {
@@ -217,6 +237,18 @@ function requestFingerprint(
 }
 
 describe("approval projection and appender", () => {
+  it("rejects explicit thread references when constructed without a thread validator", () => {
+    const { db, appender } = setup();
+    try {
+      expect(() =>
+        appender.requestApproval(requestedPayload(REQUEST_ID, { thread: true, task: false })),
+      ).toThrow(ApprovalThreadNotFoundError);
+      expect(eventCount(db, "approval.requested")).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
   it("folds request then decision in LSN order and rejects a second decision", () => {
     const { db, projection, appender } = setup();
     try {
@@ -469,24 +501,24 @@ describe("approval projection and appender", () => {
   });
 
   it("queries pinned approvals as pending rows scoped to a thread", () => {
-    const { db, projection, appender } = setup();
+    const otherThreadId = asThreadId("01FRZ3NDEKTSV4RRFFQ69G5FA4");
+    const { db, projection, appender } = setupWithThreadValidator([THREAD_ID, otherThreadId]);
     try {
-      const otherThreadId = asThreadId("01FRZ3NDEKTSV4RRFFQ69G5FA4");
-      appender.requestApproval(requestedPayload(REQUEST_ID));
+      appender.requestApproval(requestedPayload(REQUEST_ID, { thread: true }));
       appender.requestApproval({
-        ...requestedPayload(SECOND_REQUEST_ID),
+        ...requestedPayload(SECOND_REQUEST_ID, { thread: true }),
         threadId: otherThreadId,
       });
       expect(projection.countPendingByThread(THREAD_ID)).toBe(1);
       expect(projection.listPendingByThread(THREAD_ID).map((row) => row.approval.id)).toEqual([
         REQUEST_ID,
       ]);
-      expect(projection.latestHeadLsnByThread(THREAD_ID)).toBe("v1:1");
+      expect(projection.latestHeadLsnByThread(THREAD_ID)).toBe("v1:3");
 
       appender.decideApproval(decidedPayload("reject", REQUEST_ID));
       expect(projection.countPendingByThread(THREAD_ID)).toBe(0);
       expect(projection.listPendingByThread(THREAD_ID)).toEqual([]);
-      expect(projection.latestHeadLsnByThread(THREAD_ID)).toBe("v1:3");
+      expect(projection.latestHeadLsnByThread(THREAD_ID)).toBe("v1:5");
       expect(projection.countPendingByThread(otherThreadId)).toBe(1);
 
       const indexes = db
@@ -527,7 +559,7 @@ describe("approval projection and appender", () => {
       const live = projectionSnapshot(db);
       const bytes = approvalAuditPayloadToBytes(
         "approval_requested",
-        requestedPayload(SECOND_REQUEST_ID, { task: false }),
+        requestedPayload(SECOND_REQUEST_ID, { thread: true, task: false }),
       );
       eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
 
@@ -545,7 +577,7 @@ describe("approval projection and appender", () => {
       for (let index = 0; index <= MAX_ROUTE_APPROVAL_LIST_ITEMS; index += 1) {
         const bytes = approvalAuditPayloadToBytes(
           "approval_requested",
-          requestedPayload(indexedApprovalRequestId(index), { task: false }),
+          requestedPayload(indexedApprovalRequestId(index), { thread: true, task: false }),
         );
         eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
       }

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -27,6 +27,7 @@ import {
   ApprovalReplayThreadNotFoundError,
   ApprovalRequestAlreadyDecidedError,
   ApprovalTokenAlreadyUsedError,
+  ApprovalTokenIssuedToMismatchError,
   createApprovalAppender,
   createApprovalProjection,
   parseApprovalIdempotencyKey,
@@ -107,6 +108,13 @@ function decidedPayloadWithToken(): ApprovalDecidedAuditPayload {
   return {
     ...decidedPayload("approve"),
     token: signedApprovalTokenFixture(requested),
+  };
+}
+
+function mismatchedTokenDecisionPayload(): ApprovalDecidedAuditPayload {
+  return {
+    ...decidedPayloadWithToken(),
+    decidedBy: asSignerIdentity("agent_beta"),
   };
 }
 
@@ -271,6 +279,56 @@ describe("approval projection and appender", () => {
 
       expect(eventCount(db, "approval.decided")).toBe(1);
       expect(projection.getById(SECOND_REQUEST_ID)?.approval.status).toBe("pending");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects direct approval decisions when the token was issued to a different actor", () => {
+    const { db, projection, appender } = setup();
+    try {
+      appender.requestApproval(requestedPayload());
+      const before = projectionSnapshot(db);
+
+      expect(() => appender.decideApproval(mismatchedTokenDecisionPayload())).toThrow(
+        ApprovalTokenIssuedToMismatchError,
+      );
+
+      expect(eventCount(db, "approval.decided")).toBe(0);
+      expect(projectionSnapshot(db)).toBe(before);
+      expect(projection.getById(REQUEST_ID)?.approval.status).toBe("pending");
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rejects idempotent approval decisions when the token was issued to a different actor", () => {
+    const { db, projection, appender } = setup();
+    try {
+      appender.requestApproval(requestedPayload());
+      const before = projectionSnapshot(db);
+      const decisionKey = parseApprovalIdempotencyKey(
+        "cmd_approval.decided_01ARZ3NDEKTSV4RRFFQ69G5FAW",
+        "approval.decided",
+      );
+      expect(decisionKey.ok).toBe(true);
+      if (!decisionKey.ok) return;
+
+      expect(() =>
+        appender.decideApprovalIdempotent({
+          payload: mismatchedTokenDecisionPayload(),
+          idempotency: decisionKey.key,
+          requestFingerprint: requestFingerprint("approval.decided"),
+          nowMs: 1_700_000_000_000,
+          render: () => {
+            throw new Error("decision render must not run when token actor mismatches");
+          },
+        }),
+      ).toThrow(ApprovalTokenIssuedToMismatchError);
+
+      expect(eventCount(db, "approval.decided")).toBe(0);
+      expect(projectionSnapshot(db)).toBe(before);
+      expect(projection.getById(REQUEST_ID)?.approval.status).toBe("pending");
     } finally {
       db.close();
     }

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -91,7 +91,7 @@ function decidedPayload(
   return {
     requestId,
     decision,
-    decidedBy: asSignerIdentity("approver@example.com"),
+    decidedBy: asSignerIdentity("agent_alpha"),
     decidedAt: new Date("2026-05-18T10:01:00.000Z"),
     ...(token === undefined ? {} : { token }),
   };

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -23,8 +23,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   ApprovalIdempotencyConflictError,
-  ApprovalReplayPendingLimitExceededError,
-  ApprovalReplayThreadNotFoundError,
   ApprovalRequestAlreadyDecidedError,
   ApprovalThreadNotFoundError,
   ApprovalTokenAlreadyUsedError,
@@ -561,9 +559,11 @@ describe("approval projection and appender", () => {
         "approval_requested",
         requestedPayload(SECOND_REQUEST_ID, { thread: true, task: false }),
       );
-      eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
+      const lsn = eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
 
-      expect(() => projection.rebuildFromLog(eventLog)).toThrow(ApprovalReplayThreadNotFoundError);
+      expect(() => projection.rebuildFromLog(eventLog)).toThrowError(
+        expect.objectContaining({ name: "ApprovalReplayThreadNotFoundError", lsn }),
+      );
       expect(projectionSnapshot(db)).toBe(live);
     } finally {
       db.close();
@@ -574,16 +574,24 @@ describe("approval projection and appender", () => {
     const { db, eventLog, projection } = setup();
     try {
       insertThreadProjectionRow(db, eventLog);
+      let overflowLsn: number | null = null;
       for (let index = 0; index <= MAX_ROUTE_APPROVAL_LIST_ITEMS; index += 1) {
         const bytes = approvalAuditPayloadToBytes(
           "approval_requested",
           requestedPayload(indexedApprovalRequestId(index), { thread: true, task: false }),
         );
-        eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
+        const lsn = eventLog.append({ type: "approval.requested", payload: Buffer.from(bytes) });
+        if (index === MAX_ROUTE_APPROVAL_LIST_ITEMS) {
+          overflowLsn = lsn;
+        }
       }
+      if (overflowLsn === null) throw new Error("overflow event was not appended");
 
-      expect(() => projection.rebuildFromLog(eventLog)).toThrow(
-        ApprovalReplayPendingLimitExceededError,
+      expect(() => projection.rebuildFromLog(eventLog)).toThrowError(
+        expect.objectContaining({
+          name: "ApprovalReplayPendingLimitExceededError",
+          lsn: overflowLsn,
+        }),
       );
       expect(projection.countPendingByThread(THREAD_ID)).toBe(0);
     } finally {

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -18,11 +18,13 @@ import {
   type SignedApprovalToken,
   signedApprovalTokenFromJson,
   signedApprovalTokenToJsonValue,
+  threadAuditPayloadToBytes,
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
 
 import {
   ApprovalIdempotencyConflictError,
+  ApprovalRebuildThreadProjectionNotReadyError,
   ApprovalRequestAlreadyDecidedError,
   ApprovalThreadNotFoundError,
   ApprovalTokenAlreadyUsedError,
@@ -33,6 +35,7 @@ import {
   rebuildApprovalsProjectionFromLog,
 } from "../../src/approvals/index.ts";
 import { createEventLog, openDatabase, runMigrations } from "../../src/event-log/index.ts";
+import { createThreadStateStore } from "../../src/threads/index.ts";
 
 const REQUEST_ID = asApprovalRequestId("01ARZ3NDEKTSV4RRFFQ69G5FAV");
 const SECOND_REQUEST_ID = asApprovalRequestId("01ARZ3NDEKTSV4RRFFQ69G5FAW");
@@ -183,13 +186,27 @@ function insertThreadProjectionRow(
   eventLog: ReturnType<typeof createEventLog>,
   threadId = THREAD_ID,
 ): void {
-  const lsn = eventLog.append({ type: "thread.created", payload: Buffer.from("{}") });
+  const lsn = appendThreadCreatedEvent(eventLog, threadId);
   db.prepare<[string, number, string, string], void>(
     `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms,
         external_refs)
      VALUES (?, 'Replay thread', 'open', ?, ?, 0, 0, ?)`,
   ).run(threadId, lsn, OPERATOR, canonicalJSON({ source_urls: [], entity_ids: [] }));
+}
+
+function appendThreadCreatedEvent(
+  eventLog: ReturnType<typeof createEventLog>,
+  threadId = THREAD_ID,
+): number {
+  const bytes = threadAuditPayloadToBytes("thread_created", {
+    threadId,
+    title: "Replay thread",
+    createdBy: OPERATOR,
+    createdAt: new Date("2026-05-18T09:00:00.000Z"),
+    externalRefs: { sourceUrls: [], entityIds: [] },
+  });
+  return eventLog.append({ type: "thread.created", payload: Buffer.from(bytes) });
 }
 
 function projectionSnapshot(db: ReturnType<typeof openDatabase>): string {
@@ -539,12 +556,41 @@ describe("approval projection and appender", () => {
 
       const live = projectionSnapshot(db);
       db.exec("DELETE FROM pending_approvals");
-      const rebuilt = rebuildApprovalsProjectionFromLog(db, eventLog);
+      const rebuilt = rebuildApprovalsProjectionFromLog(db, eventLog, createThreadStateStore(db));
       expect(rebuilt.eventsApplied).toBe(3);
       expect(projectionSnapshot(db)).toBe(live);
       expect(projection.list({ status: "pending" }).map((row) => row.approval.id)).toEqual([
         SECOND_REQUEST_ID,
       ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rebuild helper requires the thread projection to be rebuilt first", () => {
+    const { db, eventLog } = setup();
+    try {
+      const threadLsn = appendThreadCreatedEvent(eventLog);
+      const approvalBytes = approvalAuditPayloadToBytes(
+        "approval_requested",
+        requestedPayload(REQUEST_ID, { thread: true, task: false }),
+      );
+      eventLog.append({ type: "approval.requested", payload: Buffer.from(approvalBytes) });
+
+      expect(() =>
+        rebuildApprovalsProjectionFromLog(db, eventLog, createThreadStateStore(db)),
+      ).toThrowError(
+        expect.objectContaining({
+          name: "ApprovalRebuildThreadProjectionNotReadyError",
+          expectedThreadCount: 1,
+          actualThreadCount: 0,
+          expectedHeadLsn: `v1:${threadLsn}`,
+          actualHeadLsn: "v1:0",
+        }),
+      );
+      expect(() =>
+        rebuildApprovalsProjectionFromLog(db, eventLog, createThreadStateStore(db)),
+      ).toThrow(ApprovalRebuildThreadProjectionNotReadyError);
     } finally {
       db.close();
     }

--- a/packages/broker/tests/approvals/routes.spec.ts
+++ b/packages/broker/tests/approvals/routes.spec.ts
@@ -654,6 +654,27 @@ describe("/api/v1/approvals routes", () => {
     expect(fix.projection.getById(second.id)?.approval.status).toBe("pending");
   });
 
+  it("rejects approve tokens issued to a different bearer-bound agent", async () => {
+    await teardown(fix);
+    fix = await buildFixture({
+      tokenAgentIds: new Map([[TOKEN, asAgentId("agent_beta")]]),
+    });
+    const created = approvalRequestCreateResponseFromJson(
+      (await (await postApproval(fix)).json()) as unknown,
+    ).approvalRequest;
+
+    const decided = await fetch(`${fix.broker.url}/api/v1/approvals/${created.id}/decision`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: decisionBody(decidedPayload("approve", created.id)),
+    });
+
+    expect(decided.status).toBe(403);
+    expect(await decided.json()).toEqual({ error: "approval_token_actor_mismatch" });
+    expect(eventCount(fix.db, "approval.decided")).toBe(0);
+    expect(fix.projection.getById(created.id)?.approval.status).toBe("pending");
+  });
+
   it("rejects decisions when the bearer cannot be resolved to an agent", async () => {
     await teardown(fix);
     fix = await buildFixture({ tokenAgentIds: new Map() });

--- a/packages/broker/tests/approvals/routes.spec.ts
+++ b/packages/broker/tests/approvals/routes.spec.ts
@@ -1,4 +1,8 @@
-import { request as httpRequest, type OutgoingHttpHeaders } from "node:http";
+import {
+  request as httpRequest,
+  type IncomingHttpHeaders,
+  type OutgoingHttpHeaders,
+} from "node:http";
 
 import {
   type ApprovalDecidedAuditPayload,
@@ -241,7 +245,11 @@ function rawRequest(args: {
   readonly path: string;
   readonly headers?: OutgoingHttpHeaders;
   readonly body?: string;
-}): Promise<{ readonly status: number; readonly body: string }> {
+}): Promise<{
+  readonly status: number;
+  readonly body: string;
+  readonly headers: IncomingHttpHeaders;
+}> {
   return new Promise((resolveFn, rejectFn) => {
     const req = httpRequest(
       {
@@ -258,6 +266,7 @@ function rawRequest(args: {
           resolveFn({
             status: res.statusCode ?? 0,
             body: Buffer.concat(chunks).toString("utf8"),
+            headers: res.headers,
           }),
         );
       },
@@ -377,6 +386,27 @@ describe("/api/v1/approvals routes", () => {
     const secondPageBody = approvalListResponseFromJson((await secondPage.json()) as unknown);
     expect(secondPageBody.approvals.map((approval) => approval.id)).toEqual([third.id]);
     expect(secondPageBody.nextCursor).toBeUndefined();
+  });
+
+  it.each([
+    ["invalid status", "status=not_a_status", "invalid_status"],
+    ["duplicate status", "status=pending&status=approved", "invalid_status"],
+    ["invalid thread", "threadId=not-a-thread", "invalid_thread_id"],
+    ["duplicate thread", `threadId=${THREAD_ID}&threadId=${OTHER_THREAD_ID}`, "invalid_thread_id"],
+    ["invalid task", "taskId=not-a-task", "invalid_task_id"],
+    ["duplicate task", `taskId=${TASK_ID}&taskId=${OTHER_TASK_ID}`, "invalid_task_id"],
+    ["invalid limit", "limit=abc", "invalid_limit"],
+    ["zero limit", "limit=0", "invalid_limit"],
+    ["duplicate limit", "limit=1&limit=2", "invalid_limit"],
+    ["invalid cursor", "cursor=not-an-lsn", "invalid_cursor"],
+    ["duplicate cursor", "cursor=v1:1&cursor=v1:2", "invalid_cursor"],
+  ])("rejects %s on the approval list route", async (_name, query, error) => {
+    if (fix === null) throw new Error("fixture missing");
+    const res = await fetch(`${fix.broker.url}/api/v1/approvals?${query}`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(400);
+    expect(routeErrorFromJson((await res.json()) as unknown).error).toBe(error);
   });
 
   it("filters approvals by status, thread, and task across mixed rows", async () => {
@@ -753,7 +783,7 @@ describe("/api/v1/approvals routes", () => {
     });
 
     expect(malformed.status).toBe(400);
-    expect(routeErrorFromJson((await malformed.json()) as unknown).error).toBe("malformed_json");
+    expect(routeErrorFromJson((await malformed.json()) as unknown).error).toBe("invalid_json");
   });
 
   it("returns 422 route errors for semantic approval command validation failures", async () => {
@@ -820,6 +850,27 @@ describe("/api/v1/approvals routes", () => {
       });
       expect(badHost.status).toBe(403);
     }
+  });
+
+  it("includes HEAD in approval read-route Allow headers", async () => {
+    if (fix === null) throw new Error("fixture missing");
+    const list = await rawRequest({
+      port: fix.broker.port,
+      method: "PUT",
+      path: "/api/v1/approvals",
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(list.status).toBe(405);
+    expect(list.headers.allow).toBe("GET, HEAD, POST");
+
+    const get = await rawRequest({
+      port: fix.broker.port,
+      method: "POST",
+      path: `/api/v1/approvals/${REQUEST_ID}`,
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(get.status).toBe(405);
+    expect(get.headers.allow).toBe("GET, HEAD");
   });
 });
 

--- a/packages/broker/tests/approvals/routes.spec.ts
+++ b/packages/broker/tests/approvals/routes.spec.ts
@@ -486,6 +486,7 @@ describe("/api/v1/approvals routes", () => {
     const requestedText = await readUntil(reader, "event: approval.requested");
     const requestedEvent = parseApprovalSse(requestedText, "approval.requested");
     expect(validateApprovalStreamEvent(requestedEvent).ok).toBe(true);
+    expect(requestedEvent.id).toBe("v1:1");
     expect(requestedEvent.payload.requestId).toBe(createdApproval.id);
     expect(requestedEvent.payload.threadId).toBe(THREAD_ID);
     expect(requestedEvent.payload.headLsn).toBe("v1:1");
@@ -502,6 +503,7 @@ describe("/api/v1/approvals routes", () => {
     const decidedText = await readUntil(reader, "event: approval.decided");
     const decidedEvent = parseApprovalSse(decidedText, "approval.decided");
     expect(validateApprovalStreamEvent(decidedEvent).ok).toBe(true);
+    expect(decidedEvent.id).toBe("v1:2");
     expect(decidedEvent.payload.headLsn).toBe("v1:2");
     controller.abort();
   });

--- a/packages/broker/tests/approvals/routes.spec.ts
+++ b/packages/broker/tests/approvals/routes.spec.ts
@@ -27,6 +27,7 @@ import {
   asTaskId,
   asThreadId,
   asTimestampMs,
+  canonicalJSON,
   routeErrorFromJson,
   type SignedApprovalToken,
   signedApprovalTokenFromJson,
@@ -61,6 +62,7 @@ interface FixtureOverrides {
   readonly appender?: (base: ApprovalAppender) => ApprovalAppender;
   readonly projection?: (base: ApprovalProjection) => ApprovalProjection;
   readonly tokenAgentIds?: ReadonlyMap<typeof TOKEN, ReturnType<typeof asAgentId>>;
+  readonly threadIds?: readonly ReturnType<typeof asThreadId>[];
 }
 
 interface Fixture {
@@ -101,7 +103,7 @@ function requestedPayload(
     claim,
     scope,
     riskClass: "critical",
-    threadId: overrides.threadId ?? THREAD_ID,
+    ...(overrides.threadId === undefined ? {} : { threadId: overrides.threadId }),
     taskId: overrides.taskId ?? TASK_ID,
     receiptId: RECEIPT_ID,
     requestedBy: asSignerIdentity("operator@example.com"),
@@ -150,9 +152,19 @@ async function buildFixture(overrides?: FixtureOverrides): Promise<Fixture> {
   const db = openDatabase({ path: ":memory:" });
   runMigrations(db);
   const eventLog = createEventLog(db);
+  const threadIds = overrides?.threadIds ?? [];
+  for (const threadId of threadIds) {
+    insertThreadProjectionRow(db, eventLog, threadId);
+  }
+  const threadExistsStmt = db.prepare<[string], { readonly present: 1 }>(
+    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
+  );
   const { appender: baseAppender, projection: baseProjection } = createApprovalSubsystem(
     db,
     eventLog,
+    threadIds.length === 0
+      ? {}
+      : { threadRefValidator: (threadId) => threadExistsStmt.get(threadId) !== undefined },
   );
   const projection = overrides?.projection?.(baseProjection) ?? baseProjection;
   const appender = overrides?.appender?.(baseAppender) ?? baseAppender;
@@ -167,6 +179,25 @@ async function buildFixture(overrides?: FixtureOverrides): Promise<Fixture> {
     },
   });
   return { db, broker, appender, projection };
+}
+
+function insertThreadProjectionRow(
+  db: ReturnType<typeof openDatabase>,
+  eventLog: ReturnType<typeof createEventLog>,
+  threadId: ReturnType<typeof asThreadId>,
+): void {
+  const lsn = eventLog.append({ type: "thread.created", payload: Buffer.from("{}") });
+  db.prepare<[string, number, string, string], void>(
+    `INSERT INTO threads
+       (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms,
+        external_refs)
+     VALUES (?, 'Approval route thread', 'open', ?, ?, 0, 0, ?)`,
+  ).run(
+    threadId,
+    lsn,
+    asSignerIdentity("operator@example.com"),
+    canonicalJSON({ source_urls: [], entity_ids: [] }),
+  );
 }
 
 async function teardown(fix: Fixture | null): Promise<void> {
@@ -410,6 +441,8 @@ describe("/api/v1/approvals routes", () => {
   });
 
   it("filters approvals by status, thread, and task across mixed rows", async () => {
+    await teardown(fix);
+    fix = await buildFixture({ threadIds: [THREAD_ID, OTHER_THREAD_ID] });
     if (fix === null) throw new Error("fixture missing");
     const fixture = fix;
     const firstPayload = requestedPayload(FILTER_REQUEST_ID_1, {
@@ -485,6 +518,19 @@ describe("/api/v1/approvals routes", () => {
     ).toEqual([first.id, second.id]);
   });
 
+  it("rejects explicit thread IDs when the appender has no thread validator", async () => {
+    if (fix === null) throw new Error("fixture missing");
+    const res = await fetch(`${fix.broker.url}/api/v1/approvals`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: requestBody(requestedPayload(REQUEST_ID, { threadId: THREAD_ID })),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "thread_not_found" });
+    expect(eventCount(fix.db, "approval.requested")).toBe(0);
+  });
+
   it("uses a ULID create idempotency key as the approval request id", async () => {
     if (fix === null) throw new Error("fixture missing");
 
@@ -518,7 +564,7 @@ describe("/api/v1/approvals routes", () => {
     expect(validateApprovalStreamEvent(requestedEvent).ok).toBe(true);
     expect(requestedEvent.id).toBe("v1:1");
     expect(requestedEvent.payload.requestId).toBe(createdApproval.id);
-    expect(requestedEvent.payload.threadId).toBe(THREAD_ID);
+    expect(requestedEvent.payload.threadId).toBeUndefined();
     expect(requestedEvent.payload.headLsn).toBe("v1:1");
 
     const decided = await fetch(

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -366,6 +366,16 @@ describe("idempotency", () => {
         payload: Buffer.from(JSON.stringify({ lsn: applied.lsn }), "utf8"),
       }),
     });
+    db.prepare<[string, string, number], void>(
+      `INSERT INTO command_idempotency
+         (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms)
+       VALUES (?, ?, 201, x'7B7D', NULL, ?)`,
+    ).run("old-approval", "approval.requested", 1_000);
+    db.prepare<[string, string, number], void>(
+      `INSERT INTO command_idempotency
+         (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms)
+       VALUES (?, ?, 201, x'7B7D', NULL, ?)`,
+    ).run("old-thread", "thread.create", 1_000);
 
     expect(ledger.pruneIdempotencyOlderThan(3_000)).toBe(1);
 
@@ -374,7 +384,11 @@ describe("idempotency", () => {
         "SELECT idempotency_key AS idempotencyKey FROM command_idempotency ORDER BY idempotency_key ASC",
       )
       .all();
-    expect(idempotencyRows).toEqual([{ idempotencyKey: freshKey.key.raw }]);
+    expect(idempotencyRows).toEqual([
+      { idempotencyKey: freshKey.key.raw },
+      { idempotencyKey: "old-approval" },
+      { idempotencyKey: "old-thread" },
+    ]);
 
     const eventCountAfterPrune = db
       .prepare<[], { readonly n: number }>(

--- a/packages/broker/tests/cost-routes.spec.ts
+++ b/packages/broker/tests/cost-routes.spec.ts
@@ -233,6 +233,103 @@ describe("/api/v1/cost routes", () => {
     expect(postBody.limitMicroUsd).toBe(0);
   });
 
+  it("GET /budgets lists current budgets", async () => {
+    if (fix === null) throw new Error("fixture missing");
+    const setRes = await fetch(`${fix.broker.url}/api/v1/cost/budgets`, {
+      method: "POST",
+      headers: mutationHeaders({
+        "Idempotency-Key": `cmd_cost.budget.set_${RECEIPT_ID}`,
+      }),
+      body: JSON.stringify(budgetSetJson(5_000_000)),
+    });
+    expect(setRes.status).toBe(201);
+
+    const list = await fetch(`${fix.broker.url}/api/v1/cost/budgets`, {
+      headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+    });
+    expect(list.status).toBe(200);
+    const body = (await list.json()) as {
+      readonly budgets: readonly { readonly budgetId: string; readonly thresholdsBps: number[] }[];
+    };
+    expect(body.budgets).toEqual([
+      expect.objectContaining({
+        budgetId: BUDGET_ID,
+        scope: "global",
+        limitMicroUsd: 5_000_000,
+        thresholdsBps: [5_000, 10_000],
+        tombstoned: false,
+      }),
+    ]);
+  });
+
+  it("returns structured errors for unsupported cost methods and bad budget ids", async () => {
+    if (fix === null) throw new Error("fixture missing");
+    const checks = await Promise.all([
+      fetch(`${fix.broker.url}/api/v1/cost/events`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+      fetch(`${fix.broker.url}/api/v1/cost/budgets`, {
+        method: "PUT",
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+      fetch(`${fix.broker.url}/api/v1/cost/budgets/not-a-budget`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+      fetch(`${fix.broker.url}/api/v1/cost/budgets/not-a-budget`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+      fetch(`${fix.broker.url}/api/v1/cost/summary`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+      fetch(`${fix.broker.url}/api/v1/cost/replay-check`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+      fetch(`${fix.broker.url}/api/v1/cost/idempotency/prune`, {
+        headers: { Authorization: `Bearer ${FIXED_TOKEN}` },
+      }),
+    ]);
+    expect(checks.map((response) => response.status)).toEqual([405, 405, 404, 405, 405, 405, 405]);
+  });
+
+  it("rejects malformed cost mutation envelopes before appending", async () => {
+    if (fix === null) throw new Error("fixture missing");
+    const unsupported = await fetch(`${fix.broker.url}/api/v1/cost/events`, {
+      method: "POST",
+      headers: mutationHeaders({
+        "Content-Type": "text/plain",
+        "Idempotency-Key": `cmd_cost.event_${RECEIPT_ID}`,
+      }),
+      body: JSON.stringify(costEventJson(1_000_000)),
+    });
+    expect(unsupported.status).toBe(415);
+    expect(((await unsupported.json()) as { readonly error: string }).error).toBe(
+      "unsupported_media_type",
+    );
+
+    const invalidEvent = await fetch(`${fix.broker.url}/api/v1/cost/events`, {
+      method: "POST",
+      headers: mutationHeaders({ "Idempotency-Key": `cmd_cost.event_${RECEIPT_ID}` }),
+      body: "{",
+    });
+    expect(invalidEvent.status).toBe(400);
+    expect(((await invalidEvent.json()) as { readonly error: string }).error).toBe(
+      "invalid_payload",
+    );
+
+    const invalidBudget = await fetch(`${fix.broker.url}/api/v1/cost/budgets`, {
+      method: "POST",
+      headers: mutationHeaders({ "Idempotency-Key": `cmd_cost.budget.set_${RECEIPT_ID}` }),
+      body: JSON.stringify([]),
+    });
+    expect(invalidBudget.status).toBe(400);
+    expect(((await invalidBudget.json()) as { readonly error: string }).error).toBe(
+      "invalid_payload",
+    );
+  });
+
   it("DELETE without X-Operator-Identity returns 400", async () => {
     if (fix === null) throw new Error("fixture missing");
     // Seed a budget so the DELETE has a real row to act on.

--- a/packages/broker/tests/event-log.spec.ts
+++ b/packages/broker/tests/event-log.spec.ts
@@ -142,6 +142,14 @@ describe("event log", () => {
           )
           .get()?.name,
       ).toBe("webauthn_consumed_tokens_expires_at_ms_idx");
+      expect(
+        second
+          .prepare<[], { readonly table: string; readonly from: string; readonly to: string }>(
+            "PRAGMA foreign_key_list('pending_approvals')",
+          )
+          .all()
+          .map((row) => ({ table: row.table, from: row.from, to: row.to })),
+      ).toContainEqual({ table: "threads", from: "thread_id", to: "thread_id" });
     } finally {
       second.close();
     }

--- a/packages/broker/tests/receipt-store-parity.spec.ts
+++ b/packages/broker/tests/receipt-store-parity.spec.ts
@@ -96,7 +96,7 @@ function runReceiptStoreContractTests(
     try {
       const receipt = minimalReceiptV1(receiptIdAt(1));
 
-      expect(await store.put(receipt)).toEqual({ existed: false });
+      expect(await store.put(receipt)).toMatchObject({ existed: false });
       expect(await store.get(receipt.id)).toEqual(receipt);
     } finally {
       closeStore(store);
@@ -110,7 +110,7 @@ function runReceiptStoreContractTests(
       const second = { ...first, model: "different" };
 
       await store.put(first);
-      expect(await store.put(second)).toEqual({ existed: true });
+      expect(await store.put(second)).toEqual({ existed: true, lsn: null });
       expect(await store.get(first.id)).toEqual(first);
     } finally {
       closeStore(store);

--- a/packages/broker/tests/receipt-store.spec.ts
+++ b/packages/broker/tests/receipt-store.spec.ts
@@ -65,7 +65,7 @@ describe("InMemoryReceiptStore", () => {
     const store = new InMemoryReceiptStore();
     const r = minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAV");
     const result = await store.put(r);
-    expect(result).toEqual({ existed: false });
+    expect(result).toMatchObject({ existed: false });
     expect(await store.get(r.id)).toBe(r);
   });
 
@@ -75,7 +75,7 @@ describe("InMemoryReceiptStore", () => {
     const r2 = { ...r1, model: "different" };
     await store.put(r1);
     const second = await store.put(r2);
-    expect(second).toEqual({ existed: true });
+    expect(second).toEqual({ existed: true, lsn: null });
     expect(await store.get(r1.id)).toBe(r1);
   });
 
@@ -275,7 +275,7 @@ describe("InMemoryReceiptStore", () => {
     const store = new InMemoryReceiptStore({ maxReceipts: 1 });
     const r = minimalReceiptV1("01ARZ3NDEKTSV4RRFFQ69G5FAV");
     await store.put(r);
-    expect(await store.put(r)).toEqual({ existed: true });
+    expect(await store.put(r)).toEqual({ existed: true, lsn: null });
   });
 
   it("rejects non-positive or non-integer maxReceipts at construction", () => {

--- a/packages/broker/tests/receipts.spec.ts
+++ b/packages/broker/tests/receipts.spec.ts
@@ -22,6 +22,7 @@ import {
   canonicalJSON,
   FrozenArgs,
   type JsonValue,
+  lsnFromV1Number,
   type ReceiptSnapshot,
   receiptToJson,
   SanitizedString,
@@ -1140,7 +1141,7 @@ describe("receipts API", () => {
     it("GET /api/receipts/:id maps ReceiptStoreBusyError to 503 + Retry-After", async () => {
       const store: ReceiptStore = {
         async put() {
-          return { existed: false };
+          return { existed: false, lsn: lsnFromV1Number(1) };
         },
         async get() {
           throw new ReceiptStoreBusyError("test busy");
@@ -1166,7 +1167,7 @@ describe("receipts API", () => {
     it("GET /api/receipts/:id maps ReceiptStoreUnavailableError to 503 storage_error", async () => {
       const store: ReceiptStore = {
         async put() {
-          return { existed: false };
+          return { existed: false, lsn: lsnFromV1Number(1) };
         },
         async get() {
           throw new ReceiptStoreUnavailableError("test readonly");
@@ -1192,7 +1193,7 @@ describe("receipts API", () => {
     it("GET /api/threads/:tid/receipts maps storage errors to 503", async () => {
       const store: ReceiptStore = {
         async put() {
-          return { existed: false };
+          return { existed: false, lsn: lsnFromV1Number(1) };
         },
         async get() {
           return null;

--- a/packages/broker/tests/runners/factory.spec.ts
+++ b/packages/broker/tests/runners/factory.spec.ts
@@ -325,6 +325,7 @@ describe("createAgentRunnerForBroker", () => {
       "https://eastus.openai.azure.com/openai/deployments/demo/chat/completions",
       ["https://*.openai.azure.com"],
     ],
+    ["exact private origin", "https://192.168.1.10/v1/chat/completions", ["https://192.168.1.10"]],
   ])("allows openai-compatible endpoints that match the %s allowlist", async (_name, endpoint, endpointAllowlist) => {
     const runner = await createAgentRunnerForBroker(
       openAICompatRequest(endpoint),
@@ -345,7 +346,28 @@ describe("createAgentRunnerForBroker", () => {
 
   it.each([
     ["not allowlisted", "https://evil.test/v1/chat/completions", ["https://api.openai.com"]],
+    ["malformed endpoint", "not a url", ["https://api.openai.com"]],
     ["loopback wildcard", "http://127.0.0.1:8080/v1/chat/completions", ["http://*"]],
+    ["ftp scheme", "ftp://api.openai.com/v1/chat/completions", ["ftp://api.openai.com"]],
+    ["invalid exact allowlist entry", "https://api.openai.com/v1/chat/completions", ["not a url"]],
+    [
+      "overlong wildcard pattern",
+      "https://api.openai.com/v1/chat/completions",
+      [`https://${"*".repeat(257)}.example.com`],
+    ],
+    [
+      "too many wildcard segments",
+      "https://api.openai.com/v1/chat/completions",
+      [`https://${Array.from({ length: 11 }, () => "*").join(".")}.example.com`],
+    ],
+    ["private ipv4 wildcard", "https://192.168.1.10/v1/chat/completions", ["https://*"]],
+    ["link-local ipv4 wildcard", "https://169.254.1.2/v1/chat/completions", ["https://*"]],
+    ["ula ipv6 wildcard", "https://[fc00::1]/v1/chat/completions", ["https://*"]],
+    [
+      "ipv4-mapped private ipv6 wildcard",
+      "https://[::ffff:192.168.1.10]/v1/chat/completions",
+      ["https://*"],
+    ],
     ["file scheme", "file:///etc/passwd", ["file://*"]],
   ])("rejects openai-compatible endpoints: %s", async (_name, endpoint, endpointAllowlist) => {
     await expect(

--- a/packages/broker/tests/runners/route.spec.ts
+++ b/packages/broker/tests/runners/route.spec.ts
@@ -6,13 +6,21 @@ import { createFakeAgentRunner, type FakeAgentRunner } from "@wuphf/agent-runner
 import { forBrokerTests } from "@wuphf/credentials/testing";
 import {
   asAgentId,
+  asAgentSlug,
   asApiToken,
   asCredentialHandleId,
   asCredentialScope,
   asProviderKind,
+  asReceiptId,
   asRunnerId,
+  asTaskId,
+  asThreadId,
+  type ReceiptSnapshot,
   type RunnerSpawnRequest,
   runnerSpawnRequestToJsonValue,
+  SanitizedString,
+  sha256Hex,
+  validateThreadStreamEvent,
 } from "@wuphf/protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -24,6 +32,8 @@ const otherAgentId = asAgentId("agent_beta");
 const runnerId = asRunnerId("run_0123456789ABCDEFGHIJKLMNOPQRSTUV");
 const runnerId2 = asRunnerId("run_1123456789ABCDEFGHIJKLMNOPQRSTUV");
 const runnerId3 = asRunnerId("run_2123456789ABCDEFGHIJKLMNOPQRSTUV");
+const runnerThreadId = asThreadId("01TRZ3NDEKTSV4RRFFQ69G5FT0");
+const runnerTaskId = asTaskId("01TRZ3NDEKTSV4RRFFQ69G5FT1");
 
 function spawnRequest(agent = agentId): RunnerSpawnRequest {
   return {
@@ -42,6 +52,7 @@ describe("runner routes", () => {
   let terminateCount = 0;
   let terminatedRunnerIds = new Set<string>();
   let tempDirs: string[] = [];
+  let receiptToWriteOnSpawn: ReceiptSnapshot | null = null;
 
   afterEach(async () => {
     for (const item of runners) {
@@ -52,6 +63,7 @@ describe("runner routes", () => {
     spawnedRequest = null;
     terminateCount = 0;
     terminatedRunnerIds = new Set<string>();
+    receiptToWriteOnSpawn = null;
     if (broker !== null) {
       await broker.stop();
       broker = null;
@@ -92,8 +104,12 @@ describe("runner routes", () => {
         },
         costLedger: { record: async () => undefined },
         eventLog: { append: async () => 1 },
-        spawnRunner: async (request) => {
+        spawnRunner: async (request, deps) => {
           spawnedRequest = request;
+          if (receiptToWriteOnSpawn !== null) {
+            const result = await deps.receiptStore.put(receiptToWriteOnSpawn);
+            expect(result.stored).toBe(true);
+          }
           const fake = createFakeAgentRunner({
             id: [runnerId, runnerId2, runnerId3][runners.length] ?? runnerId,
             kind: request.kind,
@@ -136,6 +152,44 @@ describe("runner routes", () => {
     await expect(res.json()).resolves.toEqual({ runnerId });
     expect(runner?.agentId).toBe(agentId);
     expect(spawnedRequest?.cwd).toBe(await realpath(projectDir));
+  });
+
+  it("emits thread.updated invalidations for runner-written threaded receipts", async () => {
+    receiptToWriteOnSpawn = minimalReceiptV2("01VRZ3NDEKTSV4RRFFQ69G5FV0", runnerTaskId, "ok");
+    const workspaceRoot = await makeWorkspaceRoot();
+    const handle = await startBroker(workspaceRoot);
+    const controller = new AbortController();
+    const events = await fetch(`${handle.url}/api/events`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "text/event-stream",
+      },
+      signal: controller.signal,
+    });
+    expect(events.status).toBe(200);
+    const reader = events.body?.getReader();
+    if (reader === undefined) throw new Error("missing SSE body");
+    await readUntil(reader, "event: ready");
+
+    const res = await fetch(`${handle.url}/api/runners`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(runnerSpawnRequestToJsonValue(spawnRequest())),
+    });
+
+    expect(res.status).toBe(201);
+    const text = await readUntil(reader, "event: thread.updated");
+    controller.abort();
+    const event = parseThreadSse(text, "thread.updated");
+    expect(validateThreadStreamEvent(event).ok).toBe(true);
+    expect(event).toMatchObject({
+      id: "v1:1",
+      kind: "thread.updated",
+      payload: { threadId: runnerThreadId, headLsn: "v1:1" },
+    });
   });
 
   it.each([
@@ -524,4 +578,90 @@ function openAICompatSpawnRequest(endpoint: string): RunnerSpawnRequest {
       endpoint,
     },
   };
+}
+
+function minimalReceiptV2(
+  id: string,
+  taskId: ReturnType<typeof asTaskId>,
+  status: ReceiptSnapshot["status"],
+): ReceiptSnapshot {
+  return {
+    id: asReceiptId(id),
+    agentSlug: asAgentSlug("agent"),
+    taskId,
+    triggerKind: "human_message",
+    triggerRef: "message",
+    startedAt: new Date("2026-05-18T09:00:00.000Z"),
+    finishedAt: new Date("2026-05-18T09:01:00.000Z"),
+    status,
+    providerKind: asProviderKind("anthropic"),
+    model: "claude-opus-4-7",
+    promptHash: sha256Hex("prompt"),
+    toolManifest: sha256Hex("tools"),
+    toolCalls: [],
+    approvals: [],
+    filesChanged: [],
+    commits: [],
+    sourceReads: [],
+    writes: [],
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    finalMessage: SanitizedString.fromUnknown(""),
+    error: SanitizedString.fromUnknown(status === "error" ? "receipt failed" : ""),
+    notebookWrites: [],
+    wikiWrites: [],
+    schemaVersion: 2,
+    threadId: runnerThreadId,
+  };
+}
+
+const sseReaderBuffers = new WeakMap<ReadableStreamDefaultReader<Uint8Array>, string>();
+
+async function readUntil(reader: ReadableStreamDefaultReader<Uint8Array>, needle: string) {
+  let text = sseReaderBuffers.get(reader) ?? "";
+  for (let i = 0; i < 20; i += 1) {
+    const buffered = takeBufferedSse(text, needle);
+    text = buffered.remaining;
+    if (buffered.match !== null) {
+      sseReaderBuffers.set(reader, buffered.remaining);
+      return buffered.match;
+    }
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    text += new TextDecoder().decode(chunk.value);
+  }
+  sseReaderBuffers.set(reader, text);
+  throw new Error(`SSE stream did not include ${needle}`);
+}
+
+function takeBufferedSse(
+  text: string,
+  needle: string,
+): { readonly match: string | null; readonly remaining: string } {
+  let cursor = 0;
+  for (;;) {
+    const blockEnd = text.indexOf("\n\n", cursor);
+    if (blockEnd === -1) {
+      return { match: null, remaining: text.slice(cursor) };
+    }
+    const nextCursor = blockEnd + 2;
+    if (text.slice(cursor, nextCursor).includes(needle)) {
+      return { match: text.slice(0, nextCursor), remaining: text.slice(nextCursor) };
+    }
+    cursor = nextCursor;
+  }
+}
+
+function parseThreadSse(text: string, kind: "thread.updated") {
+  const blocks = text.split("\n\n");
+  for (const block of blocks) {
+    if (!block.includes(`event: ${kind}`)) continue;
+    const dataLine = block.split("\n").find((line) => line.startsWith("data: "));
+    if (dataLine === undefined) throw new Error(`missing data line for ${kind}`);
+    return JSON.parse(dataLine.slice("data: ".length)) as unknown;
+  }
+  throw new Error(`missing SSE event ${kind}`);
 }

--- a/packages/broker/tests/runners/route.spec.ts
+++ b/packages/broker/tests/runners/route.spec.ts
@@ -20,7 +20,6 @@ import {
   runnerSpawnRequestToJsonValue,
   SanitizedString,
   sha256Hex,
-  validateThreadStreamEvent,
 } from "@wuphf/protocol";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -34,6 +33,7 @@ const runnerId2 = asRunnerId("run_1123456789ABCDEFGHIJKLMNOPQRSTUV");
 const runnerId3 = asRunnerId("run_2123456789ABCDEFGHIJKLMNOPQRSTUV");
 const runnerThreadId = asThreadId("01TRZ3NDEKTSV4RRFFQ69G5FT0");
 const runnerTaskId = asTaskId("01TRZ3NDEKTSV4RRFFQ69G5FT1");
+const SSE_NEGATIVE_TIMEOUT_MS = 100;
 
 function spawnRequest(agent = agentId): RunnerSpawnRequest {
   return {
@@ -154,42 +154,38 @@ describe("runner routes", () => {
     expect(spawnedRequest?.cwd).toBe(await realpath(projectDir));
   });
 
-  it("emits thread.updated invalidations for runner-written threaded receipts", async () => {
+  it("does not emit thread.updated invalidations for runner-written threaded receipts without threads", async () => {
     receiptToWriteOnSpawn = minimalReceiptV2("01VRZ3NDEKTSV4RRFFQ69G5FV0", runnerTaskId, "ok");
     const workspaceRoot = await makeWorkspaceRoot();
     const handle = await startBroker(workspaceRoot);
     const controller = new AbortController();
-    const events = await fetch(`${handle.url}/api/events`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        Accept: "text/event-stream",
-      },
-      signal: controller.signal,
-    });
-    expect(events.status).toBe(200);
-    const reader = events.body?.getReader();
-    if (reader === undefined) throw new Error("missing SSE body");
-    await readUntil(reader, "event: ready");
+    try {
+      const events = await fetch(`${handle.url}/api/events`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: "text/event-stream",
+        },
+        signal: controller.signal,
+      });
+      expect(events.status).toBe(200);
+      const reader = events.body?.getReader();
+      if (reader === undefined) throw new Error("missing SSE body");
+      await readUntil(reader, "event: ready");
 
-    const res = await fetch(`${handle.url}/api/runners`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(runnerSpawnRequestToJsonValue(spawnRequest())),
-    });
+      const res = await fetch(`${handle.url}/api/runners`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(runnerSpawnRequestToJsonValue(spawnRequest())),
+      });
 
-    expect(res.status).toBe(201);
-    const text = await readUntil(reader, "event: thread.updated");
-    controller.abort();
-    const event = parseThreadSse(text, "thread.updated");
-    expect(validateThreadStreamEvent(event).ok).toBe(true);
-    expect(event).toMatchObject({
-      id: "v1:1",
-      kind: "thread.updated",
-      payload: { threadId: runnerThreadId, headLsn: "v1:1" },
-    });
+      expect(res.status).toBe(201);
+      await expectNoThreadUpdated(reader);
+    } finally {
+      controller.abort();
+    }
   });
 
   it.each([
@@ -637,6 +633,38 @@ async function readUntil(reader: ReadableStreamDefaultReader<Uint8Array>, needle
   throw new Error(`SSE stream did not include ${needle}`);
 }
 
+async function readUntilWithin(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  needle: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      resolve(null);
+    }, timeoutMs);
+  });
+  const readPromise = readUntil(reader, needle).catch((err: unknown) => {
+    if (timedOut) return null;
+    throw err;
+  });
+  try {
+    return await Promise.race([readPromise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+async function expectNoThreadUpdated(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+  await expect(
+    readUntilWithin(reader, "event: thread.updated", SSE_NEGATIVE_TIMEOUT_MS),
+  ).resolves.toBeNull();
+}
+
 function takeBufferedSse(
   text: string,
   needle: string,
@@ -653,15 +681,4 @@ function takeBufferedSse(
     }
     cursor = nextCursor;
   }
-}
-
-function parseThreadSse(text: string, kind: "thread.updated") {
-  const blocks = text.split("\n\n");
-  for (const block of blocks) {
-    if (!block.includes(`event: ${kind}`)) continue;
-    const dataLine = block.split("\n").find((line) => line.startsWith("data: "));
-    if (dataLine === undefined) throw new Error(`missing data line for ${kind}`);
-    return JSON.parse(dataLine.slice("data: ".length)) as unknown;
-  }
-  throw new Error(`missing SSE event ${kind}`);
 }

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -163,7 +163,9 @@ describe("SqliteReceiptStore", () => {
     try {
       const receipt = minimalReceiptV2(receiptIdAt(1), THREAD_A);
 
-      await expect(store.put(receipt)).resolves.toMatchObject({ existed: false });
+      const inserted = await store.put(receipt);
+      expect(inserted).toMatchObject({ existed: false });
+      expect(inserted.lsn).not.toBeNull();
       await expect(store.get(receipt.id)).resolves.toEqual(receipt);
       await expect(store.list({ threadId: asThreadId(THREAD_A) })).resolves.toMatchObject({
         items: [receipt],
@@ -193,7 +195,9 @@ describe("SqliteReceiptStore", () => {
       const first = minimalReceiptV1(receiptIdAt(1));
       const second = { ...first, model: "different" };
 
-      expect(await store.put(first)).toMatchObject({ existed: false });
+      const firstInsert = await store.put(first);
+      expect(firstInsert).toMatchObject({ existed: false });
+      expect(firstInsert.lsn).not.toBeNull();
       expect(await store.put(second)).toEqual({ existed: true, lsn: null });
 
       expect(await store.get(first.id)).toEqual(first);
@@ -336,7 +340,9 @@ describe("SqliteReceiptStore", () => {
       const second = minimalReceiptV2(receiptIdAt(2), THREAD_A);
 
       expect(await secondStore.get(first.id)).toEqual(first);
-      expect(await secondStore.put(second)).toMatchObject({ existed: false });
+      const secondInsert = await secondStore.put(second);
+      expect(secondInsert).toMatchObject({ existed: false });
+      expect(secondInsert.lsn).not.toBeNull();
       expect(maxEventLogLsn(secondDb)).toBe(4);
       expect((await secondStore.list()).items.map((receipt) => receipt.id)).toEqual([
         first.id,

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -163,7 +163,7 @@ describe("SqliteReceiptStore", () => {
     try {
       const receipt = minimalReceiptV2(receiptIdAt(1), THREAD_A);
 
-      await expect(store.put(receipt)).resolves.toEqual({ existed: false });
+      await expect(store.put(receipt)).resolves.toMatchObject({ existed: false });
       await expect(store.get(receipt.id)).resolves.toEqual(receipt);
       await expect(store.list({ threadId: asThreadId(THREAD_A) })).resolves.toMatchObject({
         items: [receipt],
@@ -193,8 +193,8 @@ describe("SqliteReceiptStore", () => {
       const first = minimalReceiptV1(receiptIdAt(1));
       const second = { ...first, model: "different" };
 
-      expect(await store.put(first)).toEqual({ existed: false });
-      expect(await store.put(second)).toEqual({ existed: true });
+      expect(await store.put(first)).toMatchObject({ existed: false });
+      expect(await store.put(second)).toEqual({ existed: true, lsn: null });
 
       expect(await store.get(first.id)).toEqual(first);
       expect(countRows(db, "event_log")).toBe(1);
@@ -336,7 +336,7 @@ describe("SqliteReceiptStore", () => {
       const second = minimalReceiptV2(receiptIdAt(2), THREAD_A);
 
       expect(await secondStore.get(first.id)).toEqual(first);
-      expect(await secondStore.put(second)).toEqual({ existed: false });
+      expect(await secondStore.put(second)).toMatchObject({ existed: false });
       expect(maxEventLogLsn(secondDb)).toBe(4);
       expect((await secondStore.list()).items.map((receipt) => receipt.id)).toEqual([
         first.id,
@@ -398,7 +398,7 @@ describe("SqliteReceiptStore", () => {
     try {
       const r = minimalReceiptV1(receiptIdAt(1));
       await store.put(r);
-      expect(await store.put(r)).toEqual({ existed: true });
+      expect(await store.put(r)).toEqual({ existed: true, lsn: null });
     } finally {
       store.close();
     }

--- a/packages/broker/tests/threads/thread-routes.spec.ts
+++ b/packages/broker/tests/threads/thread-routes.spec.ts
@@ -25,6 +25,7 @@ import {
   sha256Hex,
   threadGetResponseFromJson,
   threadListResponseFromJson,
+  threadMutationResponseFromJson,
   threadPinnedApprovalsResponseFromJson,
   threadSpecContentHash,
   validateThreadStreamEvent,
@@ -251,11 +252,9 @@ async function createThread(fix: Fixture): Promise<{ readonly headLsn: EventLsn 
     body: JSON.stringify(createBody()),
   });
   expect(res.status).toBe(201);
-  const body = (await res.json()) as {
-    readonly headLsn: EventLsn;
-    readonly revisionId: string;
-    readonly contentHash: string;
-  };
+  const body = threadMutationResponseFromJson((await res.json()) as unknown);
+  expect(body.threadId).toBe(THREAD_ID);
+  expect(body.headLsn).toBe("v1:4");
   expect(body.revisionId).toBe(CREATE_REVISION_ID);
   expect(body.contentHash).toBe(threadSpecContentHash(INITIAL_CONTENT));
   return body;
@@ -511,6 +510,107 @@ describe("/api/v1/threads routes", () => {
     expect(checks.map((res) => res.status)).toEqual([403, 403, 403, 403, 403, 403, 403]);
   });
 
+  it("returns structured errors for unsupported thread methods and bad paths", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    const checks = await Promise.all([
+      rawRequest({
+        port: fixture.broker.port,
+        path: "/api/v1/threads",
+        method: "PUT",
+        authorization: `Bearer ${TOKEN}`,
+      }),
+      rawRequest({
+        port: fixture.broker.port,
+        path: `/api/v1/threads/${THREAD_ID}`,
+        method: "POST",
+        authorization: `Bearer ${TOKEN}`,
+      }),
+      rawRequest({
+        port: fixture.broker.port,
+        path: `/api/v1/threads/${THREAD_ID}/pinned-approvals`,
+        method: "POST",
+        authorization: `Bearer ${TOKEN}`,
+      }),
+      rawRequest({
+        port: fixture.broker.port,
+        path: `/api/v1/threads/${THREAD_ID}/spec`,
+        method: "GET",
+        authorization: `Bearer ${TOKEN}`,
+      }),
+      rawRequest({
+        port: fixture.broker.port,
+        path: `/api/v1/threads/${THREAD_ID}/status`,
+        method: "GET",
+        authorization: `Bearer ${TOKEN}`,
+      }),
+      rawRequest({
+        port: fixture.broker.port,
+        path: `/api/v1/threads/${THREAD_ID}/unknown`,
+        method: "GET",
+        authorization: `Bearer ${TOKEN}`,
+      }),
+    ]);
+    expect(checks.map((res) => res.status)).toEqual([405, 405, 405, 405, 405, 404]);
+    expect(checks.map((res) => routeErrorFromJson(JSON.parse(res.body) as unknown).error)).toEqual([
+      "method_not_allowed",
+      "method_not_allowed",
+      "method_not_allowed",
+      "method_not_allowed",
+      "method_not_allowed",
+      "not_found",
+    ]);
+  });
+
+  it("returns the unified v1 route validation contract for thread mutations", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    const unsupportedMedia = await fetch(`${fixture.broker.url}/api/v1/threads`, {
+      method: "POST",
+      headers: authHeaders({ "Content-Type": "text/plain" }),
+      body: JSON.stringify(createBody()),
+    });
+    expect(unsupportedMedia.status).toBe(415);
+    expect(routeErrorFromJson((await unsupportedMedia.json()) as unknown).error).toBe(
+      "unsupported_media_type",
+    );
+
+    const malformedJson = await fetch(`${fixture.broker.url}/api/v1/threads`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: "{",
+    });
+    expect(malformedJson.status).toBe(400);
+    expect(routeErrorFromJson((await malformedJson.json()) as unknown).error).toBe("invalid_json");
+
+    const invalidCreate = await fetch(`${fixture.broker.url}/api/v1/threads`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...createBody(), title: "" }),
+    });
+    expect(invalidCreate.status).toBe(422);
+    expect(routeErrorFromJson((await invalidCreate.json()) as unknown).error).toBe(
+      "invalid_payload",
+    );
+
+    await createThread(fixture);
+    const invalidSpec = await fetch(`${fixture.broker.url}/api/v1/threads/${THREAD_ID}/spec`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...specBody(), baseRevisionId: "not-a-revision" }),
+    });
+    expect(invalidSpec.status).toBe(422);
+    expect(routeErrorFromJson((await invalidSpec.json()) as unknown).error).toBe("invalid_payload");
+
+    const invalidStatus = await fetch(`${fixture.broker.url}/api/v1/threads/${THREAD_ID}/status`, {
+      method: "PATCH",
+      headers: jsonHeaders(),
+      body: JSON.stringify({ ...statusBody(), toStatus: "not-a-status" }),
+    });
+    expect(invalidStatus.status).toBe(422);
+    expect(routeErrorFromJson((await invalidStatus.json()) as unknown).error).toBe(
+      "invalid_payload",
+    );
+  });
+
   it("rejects approval deps that do not share thread storage provenance", async () => {
     const db = openDatabase({ path: ":memory:" });
     runMigrations(db);
@@ -581,9 +681,14 @@ describe("/api/v1/threads routes", () => {
       body: JSON.stringify(specBody()),
     });
     expect(spec.status).toBe(200);
-    expect((await spec.json()) as unknown).toMatchObject({
+    const specMutation = threadMutationResponseFromJson((await spec.json()) as unknown);
+    const editedContentHash = threadSpecContentHash({ goal: "route threads", version: 2 });
+    expect(specMutation).toEqual({
+      schemaVersion: 1,
+      threadId: asThreadId(THREAD_ID),
+      headLsn: "v1:8",
       revisionId: SPEC_REVISION_ID,
-      contentHash: threadSpecContentHash({ goal: "route threads", version: 2 }),
+      contentHash: editedContentHash,
     });
 
     const status = await fetch(`${fixture.broker.url}/api/v1/threads/${THREAD_ID}/status`, {
@@ -592,6 +697,13 @@ describe("/api/v1/threads routes", () => {
       body: JSON.stringify(statusBody("open", "closed")),
     });
     expect(status.status).toBe(200);
+    expect(threadMutationResponseFromJson((await status.json()) as unknown)).toEqual({
+      schemaVersion: 1,
+      threadId: asThreadId(THREAD_ID),
+      headLsn: "v1:9",
+      revisionId: SPEC_REVISION_ID,
+      contentHash: editedContentHash,
+    });
 
     const closed = await fetch(`${fixture.broker.url}/api/v1/threads?status=closed`, {
       headers: authHeaders(),

--- a/packages/broker/tests/threads/thread-routes.spec.ts
+++ b/packages/broker/tests/threads/thread-routes.spec.ts
@@ -1,6 +1,8 @@
 import { request as httpRequest, type OutgoingHttpHeaders } from "node:http";
 
 import {
+  type ApprovalRequestedAuditPayload,
+  approvalAuditPayloadToBytes,
   approvalDecisionRequestToJsonValue,
   approvalDecisionResponseFromJson,
   approvalRequestCreateRequestToJsonValue,
@@ -14,6 +16,7 @@ import {
   asIdempotencyKey,
   asProviderKind,
   asReceiptId,
+  asSignerIdentity,
   asTaskId,
   asThreadId,
   type EventLsn,
@@ -211,6 +214,41 @@ function approvalRequestBody(args: {
       idempotencyKey: asIdempotencyKey(args.requestId),
     }),
   );
+}
+
+function approvalRequestedPayload(args: {
+  readonly requestId: ReturnType<typeof asApprovalRequestId>;
+  readonly threadId: ReturnType<typeof asThreadId>;
+  readonly taskId?: ReturnType<typeof asTaskId>;
+}): ApprovalRequestedAuditPayload {
+  const claim = {
+    schemaVersion: 1,
+    claimId: APPROVAL_CLAIM_ID,
+    kind: "receipt_co_sign",
+    receiptId: APPROVAL_RECEIPT_ID,
+    frozenArgsHash: APPROVAL_FROZEN_ARGS_HASH,
+    riskClass: "critical",
+  } as const;
+  const scope = {
+    mode: "single_use",
+    claimId: APPROVAL_CLAIM_ID,
+    claimKind: "receipt_co_sign",
+    role: asApprovalRole("approver"),
+    maxUses: 1,
+    receiptId: APPROVAL_RECEIPT_ID,
+    frozenArgsHash: APPROVAL_FROZEN_ARGS_HASH,
+  } as const;
+  return {
+    requestId: args.requestId,
+    claim,
+    scope,
+    riskClass: "critical",
+    threadId: args.threadId,
+    ...(args.taskId === undefined ? {} : { taskId: args.taskId }),
+    receiptId: APPROVAL_RECEIPT_ID,
+    requestedBy: asSignerIdentity("broker"),
+    requestedAt: new Date("2026-05-18T10:00:00.000Z"),
+  };
 }
 
 function approvalDecisionBody(idempotencyKey = APPROVAL_DECISION_KEY): string {
@@ -1103,6 +1141,40 @@ describe("/api/v1/threads routes", () => {
     expect(
       threadPinnedApprovalsResponseFromJson((await pinned.json()) as unknown).approvals,
     ).toHaveLength(MAX_ROUTE_APPROVAL_LIST_ITEMS);
+  });
+
+  it("fails pinned approvals loudly when a rebuilt projection is already over cap", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    await createThread(fixture);
+
+    for (let index = 0; index <= MAX_ROUTE_APPROVAL_LIST_ITEMS; index += 1) {
+      const payload = approvalRequestedPayload({
+        requestId: indexedApprovalRequestId(5_000 + index),
+        threadId: asThreadId(THREAD_ID),
+        taskId: APPROVAL_TASK_ID,
+      });
+      const bytes = Buffer.from(approvalAuditPayloadToBytes("approval_requested", payload));
+      const lsn = fixture.eventLog.append({ type: "approval.requested", payload: bytes });
+      fixture.approvalProjection.applyEvent({
+        lsn,
+        type: "approval.requested",
+        payload: bytes,
+      });
+    }
+    expect(fixture.approvalProjection.countPendingByThread(asThreadId(THREAD_ID))).toBe(
+      MAX_ROUTE_APPROVAL_LIST_ITEMS + 1,
+    );
+
+    const pinned = await fetch(
+      `${fixture.broker.url}/api/v1/threads/${THREAD_ID}/pinned-approvals`,
+      {
+        headers: authHeaders(),
+      },
+    );
+    expect(pinned.status).toBe(500);
+    expect(routeErrorFromJson((await pinned.json()) as unknown).error).toBe(
+      "pinned_approvals_overflow",
+    );
   });
 
   it("rejects approval requests for missing threads when approval storage is shared", async () => {

--- a/packages/broker/tests/threads/thread-routes.spec.ts
+++ b/packages/broker/tests/threads/thread-routes.spec.ts
@@ -117,7 +117,9 @@ async function setup(): Promise<Fixture> {
   const eventLog = createEventLog(db);
   const receiptStore = constructSqliteReceiptStoreForTesting(db, eventLog);
   const subsystem = createThreadSubsystem(db, eventLog, receiptStore);
-  const approvals = createApprovalSubsystem(db, eventLog);
+  const approvals = createApprovalSubsystem(db, eventLog, {
+    threadRefValidator: (threadId) => subsystem.state.getById(threadId) !== null,
+  });
   const { state, appender } = subsystem;
   const broker = await createBroker({
     port: 0,
@@ -1009,8 +1011,9 @@ describe("/api/v1/threads routes", () => {
       currentSeat: attentionBody.currentSeat,
       pendingApprovalCount: attentionBody.pendingApprovalCount,
     };
-    fixture.approvalProjection.rebuildFromLog(fixture.eventLog);
+    fixture.db.exec("DELETE FROM pending_approvals");
     fixture.subsystem.rebuildFromLog(0);
+    fixture.approvalProjection.rebuildFromLog(fixture.eventLog);
     const replayed = await fetch(`${fixture.broker.url}/api/v1/threads/${THREAD_ID}`, {
       headers: authHeaders(),
     });

--- a/packages/broker/tests/threads/thread-routes.spec.ts
+++ b/packages/broker/tests/threads/thread-routes.spec.ts
@@ -17,7 +17,10 @@ import {
   asTaskId,
   asThreadId,
   type EventLsn,
+  MAX_ROUTE_APPROVAL_LIST_ITEMS,
   type ReceiptSnapshot,
+  receiptToJson,
+  routeErrorFromJson,
   SanitizedString,
   sha256Hex,
   threadGetResponseFromJson,
@@ -356,6 +359,10 @@ function indexedReceiptId(index: number): string {
     value = Math.floor(value / ULID_ALPHABET.length);
   }
   return `${ULID_TIME_PREFIX}${suffix}`;
+}
+
+function indexedApprovalRequestId(index: number): ReturnType<typeof asApprovalRequestId> {
+  return asApprovalRequestId(indexedReceiptId(index));
 }
 
 const sseReaderBuffers = new WeakMap<ReadableStreamDefaultReader<Uint8Array>, string>();
@@ -899,6 +906,110 @@ describe("/api/v1/threads routes", () => {
     expect(clearedThread.pendingApprovalCount).toBe(0);
   });
 
+  it("paginates thread lists by scanned rows before applying read-time filters", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    await createThread(fixture);
+    await createApproval(fixture, {
+      threadId: asThreadId(THREAD_ID),
+      taskId: APPROVAL_TASK_ID,
+    });
+
+    const first = await fetch(
+      `${fixture.broker.url}/api/v1/threads?status=needs_attention&limit=1`,
+      {
+        headers: authHeaders(),
+      },
+    );
+    expect(first.status).toBe(200);
+    const firstBody = threadListResponseFromJson((await first.json()) as unknown);
+    expect(firstBody.threads).toEqual([]);
+    expect(firstBody.nextCursor).toBeDefined();
+
+    const second = await fetch(
+      `${fixture.broker.url}/api/v1/threads?status=needs_attention&limit=1&cursor=${firstBody.nextCursor}`,
+      {
+        headers: authHeaders(),
+      },
+    );
+    expect(second.status).toBe(200);
+    const secondBody = threadListResponseFromJson((await second.json()) as unknown);
+    expect(secondBody.threads.map((thread) => thread.id)).toEqual([THREAD_ID]);
+    expect(secondBody.nextCursor).toBeUndefined();
+  });
+
+  it.each([
+    ["invalid status", "status=not_a_status", "invalid_status"],
+    ["duplicate status", "status=open&status=closed", "invalid_status"],
+    ["invalid limit", "limit=abc", "invalid_limit"],
+    ["zero limit", "limit=0", "invalid_limit"],
+    ["duplicate limit", "limit=1&limit=2", "invalid_limit"],
+    ["invalid cursor", "cursor=not-an-lsn", "invalid_cursor"],
+    ["duplicate cursor", "cursor=v1:1&cursor=v1:2", "invalid_cursor"],
+  ])("rejects %s on the thread list route", async (_name, query, error) => {
+    if (fixture === null) throw new Error("fixture missing");
+    const res = await fetch(`${fixture.broker.url}/api/v1/threads?${query}`, {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+    expect(routeErrorFromJson((await res.json()) as unknown).error).toBe(error);
+  });
+
+  it("rejects approval requests once a thread reaches the pinned approvals cap", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    await createThread(fixture);
+
+    for (let index = 0; index < MAX_ROUTE_APPROVAL_LIST_ITEMS; index += 1) {
+      await createApproval(fixture, {
+        requestId: indexedApprovalRequestId(2_000 + index),
+        threadId: asThreadId(THREAD_ID),
+        taskId: APPROVAL_TASK_ID,
+      });
+    }
+
+    const overCap = await fetch(`${fixture.broker.url}/api/v1/approvals`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: approvalRequestBody({
+        requestId: indexedApprovalRequestId(3_000),
+        threadId: asThreadId(THREAD_ID),
+        taskId: APPROVAL_TASK_ID,
+      }),
+    });
+    expect(overCap.status).toBe(409);
+    expect(await overCap.json()).toEqual({ error: "pending_approval_limit_exceeded" });
+    expect(fixture.approvalProjection.countPendingByThread(asThreadId(THREAD_ID))).toBe(
+      MAX_ROUTE_APPROVAL_LIST_ITEMS,
+    );
+
+    const pinned = await fetch(
+      `${fixture.broker.url}/api/v1/threads/${THREAD_ID}/pinned-approvals`,
+      {
+        headers: authHeaders(),
+      },
+    );
+    expect(pinned.status).toBe(200);
+    expect(
+      threadPinnedApprovalsResponseFromJson((await pinned.json()) as unknown).approvals,
+    ).toHaveLength(MAX_ROUTE_APPROVAL_LIST_ITEMS);
+  });
+
+  it("rejects approval requests for missing threads when approval storage is shared", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    const missingThreadId = asThreadId("01YRZ3NDEKTSV4RRFFQ69G5FY0");
+    const res = await fetch(`${fixture.broker.url}/api/v1/approvals`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: approvalRequestBody({
+        requestId: indexedApprovalRequestId(4_000),
+        threadId: missingThreadId,
+        taskId: APPROVAL_TASK_ID,
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(routeErrorFromJson((await res.json()) as unknown).error).toBe("thread_not_found");
+    expect(fixture.approvalProjection.countPendingByThread(missingThreadId)).toBe(0);
+  });
+
   it("defaults threadless approval requests to the system inbox thread", async () => {
     if (fixture === null) throw new Error("fixture missing");
     const created = await createApproval(fixture, {
@@ -994,6 +1105,39 @@ describe("/api/v1/threads routes", () => {
     const updatedEvent = JSON.parse(updatedDataLine.slice("data: ".length)) as unknown;
     expect(validateThreadStreamEvent(updatedEvent).ok).toBe(true);
     expect(updatedEvent).toMatchObject({
+      id: "v1:5",
+      kind: "thread.updated",
+      payload: { threadId: THREAD_ID, headLsn: "v1:5" },
+    });
+  });
+
+  it("emits thread.updated invalidations for new threaded receipts", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    const controller = new AbortController();
+    const events = await fetch(`${fixture.broker.url}/api/events`, {
+      headers: { Authorization: `Bearer ${TOKEN}`, Accept: "text/event-stream" },
+      signal: controller.signal,
+    });
+    expect(events.status).toBe(200);
+    const reader = events.body?.getReader();
+    expect(reader).toBeDefined();
+    if (reader === undefined) throw new Error("missing SSE reader");
+    await readUntil(reader, "event: ready");
+
+    await createThread(fixture);
+    await readUntil(reader, "event: thread.created");
+    const receipt = minimalReceiptV2("01YRZ3NDEKTSV4RRFFQ69G5FY0", APPROVAL_TASK_ID, "error");
+    const posted = await fetch(`${fixture.broker.url}/api/receipts`, {
+      method: "POST",
+      headers: jsonHeaders(),
+      body: receiptToJson(receipt),
+    });
+    expect(posted.status).toBe(201);
+    const text = await readUntil(reader, "event: thread.updated");
+    controller.abort();
+    const event = parseThreadSse(text, "thread.updated");
+    expect(validateThreadStreamEvent(event).ok).toBe(true);
+    expect(event).toMatchObject({
       id: "v1:5",
       kind: "thread.updated",
       payload: { threadId: THREAD_ID, headLsn: "v1:5" },

--- a/packages/broker/tests/threads/thread-routes.spec.ts
+++ b/packages/broker/tests/threads/thread-routes.spec.ts
@@ -1018,9 +1018,9 @@ describe("/api/v1/threads routes", () => {
     expect(clearedThread.pendingApprovalCount).toBe(0);
   });
 
-  it("paginates thread lists by scanned rows before applying read-time filters", async () => {
+  it("paginates thread lists by the filtered effective view LSN", async () => {
     if (fixture === null) throw new Error("fixture missing");
-    await createThread(fixture);
+    const created = await createThread(fixture);
     await createApproval(fixture, {
       threadId: asThreadId(THREAD_ID),
       taskId: APPROVAL_TASK_ID,
@@ -1034,11 +1034,11 @@ describe("/api/v1/threads routes", () => {
     );
     expect(first.status).toBe(200);
     const firstBody = threadListResponseFromJson((await first.json()) as unknown);
-    expect(firstBody.threads).toEqual([]);
-    expect(firstBody.nextCursor).toBeDefined();
+    expect(firstBody.threads.map((thread) => thread.id)).toEqual([THREAD_ID]);
+    expect(firstBody.nextCursor).toBeUndefined();
 
     const second = await fetch(
-      `${fixture.broker.url}/api/v1/threads?status=needs_attention&limit=1&cursor=${firstBody.nextCursor}`,
+      `${fixture.broker.url}/api/v1/threads?status=needs_attention&limit=1&cursor=${created.headLsn}`,
       {
         headers: authHeaders(),
       },

--- a/packages/broker/tests/threads/thread-state.spec.ts
+++ b/packages/broker/tests/threads/thread-state.spec.ts
@@ -305,9 +305,6 @@ describe("thread appender and projection", () => {
         record("state.list");
         return fix.state.list(filter);
       },
-      listPage(page) {
-        return fix.state.listPage(page);
-      },
     };
     const receiptIndex: ThreadReceiptIndexStore = {
       applyEvent(recordEvent) {

--- a/packages/broker/tests/threads/thread-state.spec.ts
+++ b/packages/broker/tests/threads/thread-state.spec.ts
@@ -550,11 +550,13 @@ describe("thread appender and projection", () => {
     });
 
     const live = snapshotThreadProjection(fix.db);
+    fix.state.rebuildFromLog(fix.eventLog);
+    expect(snapshotThreadProjection(fix.db)).toEqual(live);
     fix.subsystem.rebuildFromLog(0);
     expect(snapshotThreadProjection(fix.db)).toEqual(live);
   });
 
-  it("receipt list order provides the deterministic thread receipt index source", async () => {
+  it("paginates and rebuilds the direct thread receipt index", async () => {
     const fix = setup();
     appendCreate(fix);
     const taskA = "01MRZ3NDEKTSV4RRFFQ69G5FM0";
@@ -578,7 +580,59 @@ describe("thread appender and projection", () => {
       taskIds: [taskA, taskB],
     };
     expect(fix.subsystem.receiptIndex.refsForThread(asThreadId(THREAD_ID))).toEqual(liveRefs);
+    const first = fix.subsystem.receiptIndex.list(asThreadId(THREAD_ID), { limit: 2 });
+    expect(first.items.map((item) => item.receiptId)).toEqual([
+      "01PRZ3NDEKTSV4RRFFQ69G5FP0",
+      "01QRZ3NDEKTSV4RRFFQ69G5FQ0",
+    ]);
+    expect(first.nextCursor).not.toBeNull();
+    if (first.nextCursor === null) throw new Error("missing receipt index cursor");
+    const second = fix.subsystem.receiptIndex.list(asThreadId(THREAD_ID), {
+      cursor: first.nextCursor,
+      limit: 2,
+    });
+    expect(second.items.map((item) => item.receiptId)).toEqual(["01RRZ3NDEKTSV4RRFFQ69G5FR0"]);
+    expect(fix.subsystem.receiptIndex.latestForThread(asThreadId(THREAD_ID))?.receiptId).toBe(
+      "01RRZ3NDEKTSV4RRFFQ69G5FR0",
+    );
+    fix.subsystem.receiptIndex.rebuildFromLog(fix.eventLog, 0);
+    expect(fix.subsystem.receiptIndex.refsForThread(asThreadId(THREAD_ID))).toEqual(liveRefs);
     fix.subsystem.rebuildFromLog(0);
     expect(fix.subsystem.receiptIndex.refsForThread(asThreadId(THREAD_ID))).toEqual(liveRefs);
+  });
+
+  it("keeps thread state and receipt index intact when full rebuild replay fails", async () => {
+    const fix = setup();
+    appendCreate(fix);
+    await fix.receiptStore.put(
+      minimalReceiptV2("01PRZ3NDEKTSV4RRFFQ69G5FP0", "01MRZ3NDEKTSV4RRFFQ69G5FM0"),
+    );
+    const live = snapshotThreadProjection(fix.db);
+    const liveReceiptRows = fix.db
+      .prepare<[], { readonly count: number }>("SELECT COUNT(*) AS count FROM thread_receipts")
+      .get()?.count;
+
+    fix.eventLog.append({
+      type: "thread.status_changed",
+      payload: Buffer.from(
+        threadAuditPayloadToBytes("thread_status_changed", {
+          threadId: asThreadId(OTHER_THREAD_ID),
+          fromStatus: "open",
+          toStatus: "closed",
+          changedBy: SIGNER,
+          changedAt: new Date("2026-05-18T10:30:00.000Z"),
+        }),
+      ),
+    });
+
+    expect(() => fix.subsystem.rebuildFromLog(0)).toThrow(
+      /thread projection status change referenced a missing thread/,
+    );
+    expect(snapshotThreadProjection(fix.db)).toEqual(live);
+    expect(
+      fix.db
+        .prepare<[], { readonly count: number }>("SELECT COUNT(*) AS count FROM thread_receipts")
+        .get()?.count,
+    ).toBe(liveReceiptRows);
   });
 });

--- a/packages/broker/tests/threads/thread-state.spec.ts
+++ b/packages/broker/tests/threads/thread-state.spec.ts
@@ -336,9 +336,6 @@ describe("thread appender and projection", () => {
         record("approvals.countPendingByThread");
         return 0;
       },
-      listPendingByThread() {
-        return [];
-      },
       latestHeadLsnByThread() {
         record("approvals.latestHeadLsnByThread");
         return null;

--- a/packages/broker/tests/threads/thread-state.spec.ts
+++ b/packages/broker/tests/threads/thread-state.spec.ts
@@ -29,14 +29,17 @@ import { constructSqliteReceiptStoreForTesting } from "../../src/internal/sqlite
 import type { SqliteReceiptStore } from "../../src/sqlite-receipt-store.ts";
 import {
   createThreadSubsystem,
+  createThreadViewStore,
   parseThreadIdempotencyKey,
   SYSTEM_INBOX_THREAD_ID,
   snapshotThreadProjection,
   type ThreadAppender,
+  type ThreadApprovalQuery,
   type ThreadCommand,
   ThreadConflictError,
   ThreadIdempotencyConflictError,
   ThreadNotFoundError,
+  type ThreadReceiptIndexStore,
   type ThreadStateStore,
   type ThreadSubsystem,
   ThreadTerminalTransitionError,
@@ -276,6 +279,91 @@ function minimalReceiptV2(id: string, taskId: string, threadId = THREAD_ID): Rec
 }
 
 describe("thread appender and projection", () => {
+  it("derives thread list views inside one read transaction", () => {
+    const fix = setup();
+    const observed: { readonly name: string; readonly inTransaction: boolean }[] = [];
+    const record = (name: string): void => {
+      observed.push({ name, inTransaction: fix.db.inTransaction });
+    };
+    const state: ThreadStateStore = {
+      applyEvent(recordEvent) {
+        fix.state.applyEvent(recordEvent);
+      },
+      clear() {
+        fix.state.clear();
+      },
+      rebuildFromLog(eventLog, fromLsn) {
+        fix.state.rebuildFromLog(eventLog, fromLsn);
+      },
+      getById(threadId) {
+        return fix.state.getById(threadId);
+      },
+      hasSpecRevision(revisionId) {
+        return fix.state.hasSpecRevision(revisionId);
+      },
+      list(filter) {
+        record("state.list");
+        return fix.state.list(filter);
+      },
+      listPage(page) {
+        return fix.state.listPage(page);
+      },
+    };
+    const receiptIndex: ThreadReceiptIndexStore = {
+      applyEvent(recordEvent) {
+        fix.subsystem.receiptIndex.applyEvent(recordEvent);
+      },
+      clear() {
+        fix.subsystem.receiptIndex.clear();
+      },
+      rebuildFromLog(eventLog, fromLsn) {
+        fix.subsystem.receiptIndex.rebuildFromLog(eventLog, fromLsn);
+      },
+      list(threadId, filter) {
+        return fix.subsystem.receiptIndex.list(threadId, filter);
+      },
+      refsForThread(threadId) {
+        record("receiptIndex.refsForThread");
+        return fix.subsystem.receiptIndex.refsForThread(threadId);
+      },
+      latestForThread(threadId) {
+        record("receiptIndex.latestForThread");
+        return fix.subsystem.receiptIndex.latestForThread(threadId);
+      },
+    };
+    const approvals: ThreadApprovalQuery = {
+      countPendingByThread() {
+        record("approvals.countPendingByThread");
+        return 0;
+      },
+      listPendingByThread() {
+        return [];
+      },
+      latestHeadLsnByThread() {
+        record("approvals.latestHeadLsnByThread");
+        return null;
+      },
+      pendingByThreadSnapshot() {
+        return { rows: [], headLsn: null };
+      },
+    };
+    const views = createThreadViewStore(fix.db, state, receiptIndex);
+
+    const page = views.listThreadViews({ limit: 10, approvals });
+
+    expect(page.threads.map((thread) => thread.id)).toContain(SYSTEM_INBOX_THREAD_ID);
+    expect(observed.map((entry) => entry.name)).toEqual(
+      expect.arrayContaining([
+        "state.list",
+        "receiptIndex.refsForThread",
+        "receiptIndex.latestForThread",
+        "approvals.countPendingByThread",
+        "approvals.latestHeadLsnByThread",
+      ]),
+    );
+    expect(observed.every((entry) => entry.inTransaction)).toBe(true);
+  });
+
   it("stores spec content hash from canonical content and replays latest spec payload bytes", () => {
     const fix = setup();
     appendCreate(fix);

--- a/packages/broker/tests/threads/thread-triangulation.spec.ts
+++ b/packages/broker/tests/threads/thread-triangulation.spec.ts
@@ -4,7 +4,7 @@ import {
   asProviderKind,
   asReceiptId,
   asTaskId,
-  type asThreadId,
+  asThreadId,
   type EventLsn,
   MAX_ROUTE_THREAD_LIST_ITEMS,
   type ReceiptSnapshot,
@@ -261,7 +261,11 @@ async function expectNoThreadUpdated(
 }
 
 async function openSse(fix: Fixture, controller: AbortController) {
-  const events = await fetch(`${fix.broker.url}/api/events`, {
+  return await openSseForBroker(fix.broker, controller);
+}
+
+async function openSseForBroker(broker: BrokerHandle, controller: AbortController) {
+  const events = await fetch(`${broker.url}/api/events`, {
     headers: { Authorization: `Bearer ${TOKEN}`, Accept: "text/event-stream" },
     signal: controller.signal,
   });
@@ -389,6 +393,31 @@ describe("thread triangulation route coverage", () => {
       await expectNoThreadUpdated(reader);
     } finally {
       controller.abort();
+    }
+  });
+
+  it("does not emit thread.updated invalidations for threaded V2 receipts without threads mounted", async () => {
+    const broker = await createBroker({ port: 0, token: TOKEN });
+    const controller = new AbortController();
+    try {
+      const reader = await openSseForBroker(broker, controller);
+      const receipt = minimalReceiptV2(
+        indexedUlid(50_000),
+        asThreadId(indexedUlid(50_001)),
+        asTaskId(indexedUlid(50_002)),
+        "ok",
+      );
+
+      const created = await fetch(`${broker.url}/api/receipts`, {
+        method: "POST",
+        headers: jsonHeaders(),
+        body: receiptToJson(receipt),
+      });
+      expect(created.status).toBe(201);
+      await expectNoThreadUpdated(reader);
+    } finally {
+      controller.abort();
+      await broker.stop();
     }
   });
 });

--- a/packages/broker/tests/threads/thread-triangulation.spec.ts
+++ b/packages/broker/tests/threads/thread-triangulation.spec.ts
@@ -1,0 +1,394 @@
+import {
+  asAgentSlug,
+  asApiToken,
+  asProviderKind,
+  asReceiptId,
+  asTaskId,
+  type asThreadId,
+  type EventLsn,
+  MAX_ROUTE_THREAD_LIST_ITEMS,
+  type ReceiptSnapshot,
+  receiptToJson,
+  SanitizedString,
+  sha256Hex,
+  threadListResponseFromJson,
+  threadMutationResponseFromJson,
+  validateThreadStreamEvent,
+} from "@wuphf/protocol";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createEventLog, openDatabase, runMigrations } from "../../src/event-log/index.ts";
+import { type BrokerHandle, createBroker } from "../../src/index.ts";
+import { constructSqliteReceiptStoreForTesting } from "../../src/internal/sqlite-receipt-store-testing.ts";
+import type { SqliteReceiptStore } from "../../src/sqlite-receipt-store.ts";
+import { createThreadSubsystem, SYSTEM_INBOX_THREAD_ID } from "../../src/threads/index.ts";
+
+const TOKEN = asApiToken("thread-triangulation-test-token-AAAAA");
+const ULID_TIME_PREFIX = "01ZRZ3NDEK";
+const ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+const SSE_NEGATIVE_TIMEOUT_MS = 100;
+
+interface Fixture {
+  readonly broker: BrokerHandle;
+  readonly db: ReturnType<typeof openDatabase>;
+  readonly receiptStore: SqliteReceiptStore;
+}
+
+let fixture: Fixture | null = null;
+
+beforeEach(async () => {
+  fixture = await setup();
+});
+
+afterEach(async () => {
+  if (fixture !== null) {
+    await fixture.broker.stop();
+    fixture.receiptStore.close();
+    fixture = null;
+  }
+});
+
+async function setup(): Promise<Fixture> {
+  const db = openDatabase({ path: ":memory:" });
+  runMigrations(db);
+  const eventLog = createEventLog(db);
+  const receiptStore = constructSqliteReceiptStoreForTesting(db, eventLog);
+  const threads = createThreadSubsystem(db, eventLog, receiptStore);
+  const broker = await createBroker({
+    port: 0,
+    token: TOKEN,
+    threads,
+  });
+  return { broker, db, receiptStore };
+}
+
+function authHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    Authorization: `Bearer ${TOKEN}`,
+    ...extra,
+  };
+}
+
+function jsonHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return authHeaders({ "Content-Type": "application/json", ...extra });
+}
+
+function indexedUlid(index: number): string {
+  let value = index;
+  let suffix = "";
+  for (let i = 0; i < 16; i += 1) {
+    suffix = ULID_ALPHABET[value % ULID_ALPHABET.length] + suffix;
+    value = Math.floor(value / ULID_ALPHABET.length);
+  }
+  return `${ULID_TIME_PREFIX}${suffix}`;
+}
+
+function threadCreateBody(index: number) {
+  const idempotencyKey = indexedUlid(10_000 + index);
+  return {
+    title: `Thread cap ${index}`,
+    specContent: { goal: "prove route cap", index },
+    externalRefs: { source_urls: [], entity_ids: [] },
+    idempotencyKey,
+  };
+}
+
+async function createThread(fix: Fixture, index: number): Promise<ReturnType<typeof asThreadId>> {
+  const body = threadCreateBody(index);
+  const response = await fetch(`${fix.broker.url}/api/v1/threads`, {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+  expect(response.status).toBe(201);
+  const created = threadMutationResponseFromJson((await response.json()) as unknown);
+  expect(created.threadId).toBe(body.idempotencyKey);
+  return created.threadId;
+}
+
+function minimalReceiptV1(
+  id: string,
+  taskId: ReturnType<typeof asTaskId>,
+  status: ReceiptSnapshot["status"] = "ok",
+): ReceiptSnapshot {
+  return {
+    id: asReceiptId(id),
+    agentSlug: asAgentSlug("agent"),
+    taskId,
+    triggerKind: "human_message",
+    triggerRef: "message",
+    startedAt: new Date("2026-05-18T09:00:00.000Z"),
+    finishedAt: new Date("2026-05-18T09:01:00.000Z"),
+    status,
+    providerKind: asProviderKind("anthropic"),
+    model: "claude-opus-4-7",
+    promptHash: sha256Hex("prompt"),
+    toolManifest: sha256Hex("tools"),
+    toolCalls: [],
+    approvals: [],
+    filesChanged: [],
+    commits: [],
+    sourceReads: [],
+    writes: [],
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+    finalMessage: SanitizedString.fromUnknown(""),
+    error: SanitizedString.fromUnknown(status === "error" ? "receipt failed" : ""),
+    notebookWrites: [],
+    wikiWrites: [],
+    schemaVersion: 1,
+  };
+}
+
+function minimalReceiptV2(
+  id: string,
+  threadId: ReturnType<typeof asThreadId>,
+  taskId: ReturnType<typeof asTaskId>,
+  status: ReceiptSnapshot["status"] = "ok",
+): ReceiptSnapshot {
+  return {
+    ...minimalReceiptV1(id, taskId, status),
+    schemaVersion: 2,
+    threadId,
+  };
+}
+
+const sseReaderBuffers = new WeakMap<ReadableStreamDefaultReader<Uint8Array>, string>();
+
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  needle: string,
+): Promise<string> {
+  let text = sseReaderBuffers.get(reader) ?? "";
+  for (let i = 0; i < 20; i += 1) {
+    const buffered = takeBufferedSse(text, needle);
+    text = buffered.remaining;
+    if (buffered.match !== null) {
+      sseReaderBuffers.set(reader, buffered.remaining);
+      return buffered.match;
+    }
+    const chunk = await reader.read();
+    if (chunk.done) break;
+    text += new TextDecoder().decode(chunk.value);
+  }
+  sseReaderBuffers.set(reader, text);
+  throw new Error(`SSE stream did not include ${needle}`);
+}
+
+async function readUntilWithin(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  needle: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  let timedOut = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      resolve(null);
+    }, timeoutMs);
+  });
+  const readPromise = readUntil(reader, needle).catch((err: unknown) => {
+    if (timedOut) return null;
+    throw err;
+  });
+  try {
+    return await Promise.race([readPromise, timeoutPromise]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+function takeBufferedSse(
+  text: string,
+  needle: string,
+): { readonly match: string | null; readonly remaining: string } {
+  let cursor = 0;
+  for (;;) {
+    const blockEnd = text.indexOf("\n\n", cursor);
+    if (blockEnd === -1) {
+      return { match: null, remaining: text.slice(cursor) };
+    }
+    const nextCursor = blockEnd + 2;
+    if (text.slice(cursor, nextCursor).includes(needle)) {
+      return { match: text.slice(0, nextCursor), remaining: text.slice(nextCursor) };
+    }
+    cursor = nextCursor;
+  }
+}
+
+function parseThreadSse(
+  text: string,
+  kind: "thread.created" | "thread.updated" | "thread.pinned_approvals.changed",
+) {
+  const blocks = text.split("\n\n");
+  for (const block of blocks) {
+    if (!block.includes(`event: ${kind}`)) continue;
+    const dataLine = block.split("\n").find((line) => line.startsWith("data: "));
+    if (dataLine === undefined) throw new Error(`missing data line for ${kind}`);
+    return JSON.parse(dataLine.slice("data: ".length)) as unknown;
+  }
+  throw new Error(`missing SSE event ${kind}`);
+}
+
+async function postReceipt(fix: Fixture, receipt: ReceiptSnapshot): Promise<Response> {
+  return await fetch(`${fix.broker.url}/api/receipts`, {
+    method: "POST",
+    headers: jsonHeaders(),
+    body: receiptToJson(receipt),
+  });
+}
+
+function latestReceiptPutLsn(fix: Fixture): EventLsn {
+  const row = fix.db
+    .prepare<[], { readonly lsn: number }>(
+      "SELECT lsn FROM event_log WHERE type = 'receipt.put' ORDER BY lsn DESC LIMIT 1",
+    )
+    .get();
+  if (row === undefined) throw new Error("missing receipt.put event");
+  return `v1:${row.lsn}` as EventLsn;
+}
+
+async function expectNoThreadUpdated(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): Promise<void> {
+  await expect(
+    readUntilWithin(reader, "event: thread.updated", SSE_NEGATIVE_TIMEOUT_MS),
+  ).resolves.toBeNull();
+}
+
+async function openSse(fix: Fixture, controller: AbortController) {
+  const events = await fetch(`${fix.broker.url}/api/events`, {
+    headers: { Authorization: `Bearer ${TOKEN}`, Accept: "text/event-stream" },
+    signal: controller.signal,
+  });
+  expect(events.status).toBe(200);
+  const reader = events.body?.getReader();
+  expect(reader).toBeDefined();
+  if (reader === undefined) throw new Error("missing SSE reader");
+  await readUntil(reader, "event: ready");
+  return reader;
+}
+
+describe("thread triangulation route coverage", () => {
+  it("clamps thread list pages to MAX_ROUTE_THREAD_LIST_ITEMS before encoding", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    const createdThreadIds: string[] = [];
+    for (let index = 0; index < MAX_ROUTE_THREAD_LIST_ITEMS + 1; index += 1) {
+      createdThreadIds.push(await createThread(fixture, index));
+    }
+
+    const defaultResponse = await fetch(`${fixture.broker.url}/api/v1/threads`, {
+      headers: authHeaders(),
+    });
+    expect(defaultResponse.status).toBe(200);
+    const defaultBody = threadListResponseFromJson((await defaultResponse.json()) as unknown);
+    expect(defaultBody.threads).toHaveLength(MAX_ROUTE_THREAD_LIST_ITEMS);
+    expect(defaultBody.nextCursor).toBeDefined();
+
+    const highLimitResponse = await fetch(`${fixture.broker.url}/api/v1/threads?limit=9999`, {
+      headers: authHeaders(),
+    });
+    expect(highLimitResponse.status).toBe(200);
+    const highLimitBody = threadListResponseFromJson((await highLimitResponse.json()) as unknown);
+    expect(highLimitBody.threads).toHaveLength(MAX_ROUTE_THREAD_LIST_ITEMS);
+    expect(highLimitBody.threads.map((thread) => thread.id)).toEqual(
+      defaultBody.threads.map((thread) => thread.id),
+    );
+    expect(highLimitBody.nextCursor).toBe(defaultBody.nextCursor);
+
+    const cursor = defaultBody.nextCursor;
+    if (cursor === undefined) throw new Error("missing default nextCursor");
+    const defaultRemainderResponse = await fetch(
+      `${fixture.broker.url}/api/v1/threads?cursor=${encodeURIComponent(cursor)}`,
+      { headers: authHeaders() },
+    );
+    expect(defaultRemainderResponse.status).toBe(200);
+    const defaultRemainderBody = threadListResponseFromJson(
+      (await defaultRemainderResponse.json()) as unknown,
+    );
+    expect(defaultRemainderBody.threads).toHaveLength(2);
+    expect(defaultRemainderBody.nextCursor).toBeUndefined();
+
+    const highLimitCursor = highLimitBody.nextCursor;
+    if (highLimitCursor === undefined) throw new Error("missing high-limit nextCursor");
+    const highLimitRemainderResponse = await fetch(
+      `${fixture.broker.url}/api/v1/threads?limit=9999&cursor=${encodeURIComponent(
+        highLimitCursor,
+      )}`,
+      { headers: authHeaders() },
+    );
+    expect(highLimitRemainderResponse.status).toBe(200);
+    const highLimitRemainderBody = threadListResponseFromJson(
+      (await highLimitRemainderResponse.json()) as unknown,
+    );
+    expect(highLimitRemainderBody.threads.map((thread) => thread.id)).toEqual(
+      defaultRemainderBody.threads.map((thread) => thread.id),
+    );
+    expect(highLimitRemainderBody.nextCursor).toBeUndefined();
+
+    const listedIds = [
+      ...defaultBody.threads.map((thread) => thread.id),
+      ...defaultRemainderBody.threads.map((thread) => thread.id),
+    ];
+    expect(new Set(listedIds).size).toBe(MAX_ROUTE_THREAD_LIST_ITEMS + 2);
+    expect(listedIds).toEqual([SYSTEM_INBOX_THREAD_ID, ...createdThreadIds]);
+  });
+
+  it.each([
+    "error",
+    "stalled",
+    "ok",
+  ] as const)("emits exactly one receipt-backed thread.updated invalidation for %s receipts", async (status) => {
+    if (fixture === null) throw new Error("fixture missing");
+    const controller = new AbortController();
+    try {
+      const reader = await openSse(fixture, controller);
+      const threadId = await createThread(fixture, 30_000);
+      await readUntil(reader, "event: thread.created");
+
+      const receipt = minimalReceiptV2(
+        indexedUlid(31_000),
+        threadId,
+        asTaskId(indexedUlid(32_000)),
+        status,
+      );
+      const created = await postReceipt(fixture, receipt);
+      expect(created.status).toBe(201);
+      const committedLsn = latestReceiptPutLsn(fixture);
+      const text = await readUntil(reader, "event: thread.updated");
+      const event = parseThreadSse(text, "thread.updated");
+      expect(validateThreadStreamEvent(event).ok).toBe(true);
+      expect(event).toMatchObject({
+        id: committedLsn,
+        kind: "thread.updated",
+        payload: { threadId, headLsn: committedLsn },
+      });
+
+      const duplicate = await postReceipt(fixture, receipt);
+      expect(duplicate.status).toBe(409);
+      expect(await duplicate.json()).toEqual({ error: "receipt_id_exists", id: receipt.id });
+      await expectNoThreadUpdated(reader);
+    } finally {
+      controller.abort();
+    }
+  });
+
+  it("does not emit thread.updated invalidations for unthreaded V1 receipts", async () => {
+    if (fixture === null) throw new Error("fixture missing");
+    const controller = new AbortController();
+    try {
+      const reader = await openSse(fixture, controller);
+      const receipt = minimalReceiptV1(indexedUlid(40_000), asTaskId(indexedUlid(41_000)), "ok");
+
+      const created = await postReceipt(fixture, receipt);
+      expect(created.status).toBe(201);
+      await expectNoThreadUpdated(reader);
+    } finally {
+      controller.abort();
+    }
+  });
+});

--- a/packages/broker/tests/threads/triangulation-regression.spec.ts
+++ b/packages/broker/tests/threads/triangulation-regression.spec.ts
@@ -1,0 +1,279 @@
+// Regression gate for the PR #918 triangulation findings. Each test reproduces
+// the exact end-to-end shape of a HIGH/MEDIUM defect a 5-lens review caught
+// on the cherry-picked #916 fix round, and asserts the post-fix invariant.
+// Reverting any of GROUPs 2/3/4 will turn one of these red on `bun run test`.
+
+import {
+  type ApprovalRequestedAuditPayload,
+  approvalAuditPayloadToBytes,
+  approvalRequestCreateRequestToJsonValue,
+  asAgentId,
+  asApiToken,
+  asApprovalClaimId,
+  asApprovalRequestId,
+  asApprovalRole,
+  asIdempotencyKey,
+  asReceiptId,
+  asSignerIdentity,
+  asThreadId,
+  MAX_ROUTE_APPROVAL_LIST_ITEMS,
+  sha256Hex,
+  threadListResponseFromJson,
+  threadMutationResponseFromJson,
+} from "@wuphf/protocol";
+import type Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { type ApprovalProjection, createApprovalSubsystem } from "../../src/approvals/index.ts";
+import {
+  createEventLog,
+  type EventLog,
+  openDatabase,
+  runMigrations,
+} from "../../src/event-log/index.ts";
+import { type BrokerHandle, createBroker } from "../../src/index.ts";
+import { constructSqliteReceiptStoreForTesting } from "../../src/internal/sqlite-receipt-store-testing.ts";
+import type { SqliteReceiptStore } from "../../src/sqlite-receipt-store.ts";
+import { createThreadSubsystem } from "../../src/threads/index.ts";
+
+const TOKEN = asApiToken("triangulation-spec-token-with-entropy-AA");
+const THREAD_A = "01BRZ3NDEKTSV4RRFFQ69G5FA0";
+const THREAD_B = "01BRZ3NDEKTSV4RRFFQ69G5FB0";
+const ORPHAN_THREAD = "01BRZ3NDEKTSV4RRFFQ69G5FX0";
+const APPROVAL_REQUEST_ID = "01MRZ3NDEKTSV4RRFFQ69G5FM0";
+
+interface Fixture {
+  readonly broker: BrokerHandle;
+  readonly db: Database.Database;
+  readonly eventLog: EventLog;
+  readonly approvals: ApprovalProjection;
+  readonly receiptStore: SqliteReceiptStore;
+}
+
+async function setup(): Promise<Fixture> {
+  const db = openDatabase({ path: ":memory:" });
+  runMigrations(db);
+  const eventLog = createEventLog(db);
+  const receiptStore = constructSqliteReceiptStoreForTesting(db, eventLog);
+  const threads = createThreadSubsystem(db, eventLog, receiptStore);
+  const approvals = createApprovalSubsystem(db, eventLog);
+  const broker = await createBroker({
+    port: 0,
+    token: TOKEN,
+    threads,
+    approvals: {
+      appender: approvals.appender,
+      projection: approvals.projection,
+      tokenAgentIds: new Map([[TOKEN, asAgentId("agent_alpha")]]),
+    },
+  });
+  return { broker, db, eventLog, approvals: approvals.projection, receiptStore };
+}
+
+function authJson(): Record<string, string> {
+  return { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" };
+}
+
+async function createThread(
+  fix: Fixture,
+  idempotencyKey: string,
+): Promise<{ readonly id: string; readonly headLsn: string }> {
+  const res = await fetch(`${fix.broker.url}/api/v1/threads`, {
+    method: "POST",
+    headers: authJson(),
+    body: JSON.stringify({
+      title: `triangulation thread ${idempotencyKey}`,
+      specContent: { goal: "triangulation regression", key: idempotencyKey },
+      externalRefs: { source_urls: [], entity_ids: [] },
+      idempotencyKey,
+    }),
+  });
+  expect(res.status).toBe(201);
+  const body = threadMutationResponseFromJson((await res.json()) as unknown);
+  return { id: body.threadId, headLsn: body.headLsn };
+}
+
+async function createApprovalForThread(fix: Fixture, threadId: string): Promise<void> {
+  const claimId = asApprovalClaimId("claim_triangulation");
+  const receiptId = asReceiptId("01PRZ3NDEKTSV4RRFFQ69G5FP0");
+  const frozenArgsHash = sha256Hex("triangulation-spec-frozen-args");
+  const body = approvalRequestCreateRequestToJsonValue({
+    schemaVersion: 1,
+    claim: {
+      schemaVersion: 1,
+      claimId,
+      kind: "receipt_co_sign",
+      receiptId,
+      frozenArgsHash,
+      riskClass: "critical",
+    },
+    scope: {
+      mode: "single_use",
+      claimId,
+      claimKind: "receipt_co_sign",
+      role: asApprovalRole("approver"),
+      maxUses: 1,
+      receiptId,
+      frozenArgsHash,
+    },
+    riskClass: "critical",
+    threadId: asThreadId(threadId),
+    receiptId,
+    idempotencyKey: asIdempotencyKey(APPROVAL_REQUEST_ID),
+  });
+  const res = await fetch(`${fix.broker.url}/api/v1/approvals`, {
+    method: "POST",
+    headers: authJson(),
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(201);
+}
+
+async function listThreads(
+  fix: Fixture,
+  query: string,
+): Promise<{ readonly ids: readonly string[]; readonly nextCursor: string | null }> {
+  const res = await fetch(`${fix.broker.url}/api/v1/threads${query}`, {
+    headers: { Authorization: `Bearer ${TOKEN}` },
+  });
+  expect(res.status).toBe(200);
+  const body = threadListResponseFromJson((await res.json()) as unknown);
+  return { ids: body.threads.map((t) => t.id), nextCursor: body.nextCursor ?? null };
+}
+
+// Build a well-formed ApprovalRequestedAuditPayload that varies per `index`
+// so projection/log inserts don't collide on the primary key.
+function buildApprovalPayload(threadIdStr: string, index: number): ApprovalRequestedAuditPayload {
+  const suffix = index.toString().padStart(7, "0"); // crockford-safe digits
+  const requestIdStr = `01BRZ3NDEKTSV4RRFFQ${suffix}`;
+  const receiptIdStr = `01PRZ3NDEKTSV4RRFFP${suffix}`;
+  const claimId = asApprovalClaimId(`claim_tri_${index}`);
+  const receiptId = asReceiptId(receiptIdStr);
+  const frozenArgsHash = sha256Hex(`triangulation-spec-frozen-${index}`);
+  return {
+    requestId: asApprovalRequestId(requestIdStr),
+    claim: {
+      schemaVersion: 1,
+      claimId,
+      kind: "receipt_co_sign",
+      receiptId,
+      frozenArgsHash,
+      riskClass: "critical",
+    },
+    scope: {
+      mode: "single_use",
+      claimId,
+      claimKind: "receipt_co_sign",
+      role: asApprovalRole("approver"),
+      maxUses: 1,
+      receiptId,
+      frozenArgsHash,
+    },
+    riskClass: "critical",
+    threadId: asThreadId(threadIdStr),
+    receiptId,
+    requestedBy: asSignerIdentity("broker"),
+    requestedAt: new Date(`2026-05-19T20:00:${(index % 60).toString().padStart(2, "0")}.000Z`),
+  };
+}
+
+function appendApprovalRequestedToLog(
+  eventLog: EventLog,
+  payload: ApprovalRequestedAuditPayload,
+): { readonly lsn: number; readonly bytes: Buffer } {
+  const bytes = Buffer.from(approvalAuditPayloadToBytes("approval_requested", payload));
+  const lsn = eventLog.append({ type: "approval.requested", payload: bytes });
+  return { lsn, bytes };
+}
+
+describe("PR #918 triangulation regressions", () => {
+  let fixture: Fixture | null = null;
+
+  beforeEach(async () => {
+    fixture = await setup();
+  });
+
+  afterEach(async () => {
+    if (fixture !== null) {
+      await fixture.broker.stop();
+      fixture.receiptStore.close();
+      fixture = null;
+    }
+  });
+
+  // GROUP 2 — thread-list cursor stays coherent with the derived
+  // effective_status filter. The list route used to page on
+  // `threads.head_lsn`, derive effective_status from approvals/receipts at
+  // read time, then filter AFTER slicing. A thread paged past while it did
+  // not match could later start matching (a new approval) without its
+  // head_lsn moving — and a client following its cursor would never see it
+  // again. The post-fix list route pages by an effective view LSN
+  // (max of thread/approval/receipt LSNs), so this regression cannot happen.
+  it("thread-list cursor returns a thread that later starts matching the filter", async () => {
+    const fix = fixture as Fixture;
+    const a = await createThread(fix, THREAD_A);
+    await createThread(fix, THREAD_B);
+
+    // A client paged past A while A was 'open' — its cursor is now A.headLsn.
+    // Then A gains a pending approval -> effective_status flips to
+    // needs_attention; A.head_lsn does NOT move.
+    await createApprovalForThread(fix, a.id);
+
+    const cursored = await listThreads(
+      fix,
+      `?status=needs_attention&cursor=${encodeURIComponent(a.headLsn)}`,
+    );
+    const full = await listThreads(fix, "?status=needs_attention");
+
+    expect(full.ids).toContain(a.id);
+    expect(cursored.ids).toContain(a.id);
+  });
+
+  // GROUP 4 — replay invariants per §15.B. The old appender validated
+  // FK/per-thread cap at append time only. Rebuild re-inserted every
+  // approval.requested verbatim, so a historically-bad event silently
+  // reappeared on every restart. The post-fix rebuild asserts the invariants
+  // and fails closed.
+  it("rebuild fails closed on an orphan-thread approval event", async () => {
+    const fix = fixture as Fixture;
+    appendApprovalRequestedToLog(fix.eventLog, buildApprovalPayload(ORPHAN_THREAD, 1));
+    expect(() => fix.approvals.rebuildFromLog(fix.eventLog)).toThrowError(
+      expect.objectContaining({ name: "ApprovalReplayThreadNotFoundError" }),
+    );
+  });
+
+  it("rebuild fails closed on per-thread cap overflow", async () => {
+    const fix = fixture as Fixture;
+    const a = await createThread(fix, THREAD_A);
+    for (let i = 0; i <= MAX_ROUTE_APPROVAL_LIST_ITEMS; i += 1) {
+      appendApprovalRequestedToLog(fix.eventLog, buildApprovalPayload(a.id, 1000 + i));
+    }
+    expect(() => fix.approvals.rebuildFromLog(fix.eventLog)).toThrowError(
+      expect.objectContaining({ name: "ApprovalReplayPendingLimitExceededError" }),
+    );
+  });
+
+  // GROUP 3 — pinned-approvals fails loud instead of silently truncating.
+  // The append-time cap is forward-only; a pre-fix DB can hold >cap rows
+  // per thread. The old read returned 200 with the first cap rows + a
+  // headLsn — clients believed they had the complete set. The post-fix
+  // read returns a 5xx with a structured `pinned_approvals_overflow` error.
+  it("pinned-approvals read fails loud when stored rows exceed the cap", async () => {
+    const fix = fixture as Fixture;
+    const a = await createThread(fix, THREAD_A);
+    const count = MAX_ROUTE_APPROVAL_LIST_ITEMS + 1;
+    for (let i = 0; i < count; i += 1) {
+      const payload = buildApprovalPayload(a.id, 2000 + i);
+      const { lsn, bytes } = appendApprovalRequestedToLog(fix.eventLog, payload);
+      fix.approvals.applyEvent({ lsn, type: "approval.requested", payload: bytes });
+    }
+
+    const res = await fetch(`${fix.broker.url}/api/v1/threads/${a.id}/pinned-approvals`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBeGreaterThanOrEqual(500);
+    expect(res.status).toBeLessThan(600);
+    const body = (await res.json()) as { readonly error?: string };
+    expect(body.error).toBe("pinned_approvals_overflow");
+  });
+});

--- a/packages/broker/tests/threads/triangulation-regression.spec.ts
+++ b/packages/broker/tests/threads/triangulation-regression.spec.ts
@@ -56,7 +56,9 @@ async function setup(): Promise<Fixture> {
   const eventLog = createEventLog(db);
   const receiptStore = constructSqliteReceiptStoreForTesting(db, eventLog);
   const threads = createThreadSubsystem(db, eventLog, receiptStore);
-  const approvals = createApprovalSubsystem(db, eventLog);
+  const approvals = createApprovalSubsystem(db, eventLog, {
+    threadRefValidator: (threadId) => threads.state.getById(threadId) !== null,
+  });
   const broker = await createBroker({
     port: 0,
     token: TOKEN,

--- a/packages/broker/tests/threads/triangulation-regression.spec.ts
+++ b/packages/broker/tests/threads/triangulation-regression.spec.ts
@@ -238,20 +238,34 @@ describe("PR #918 triangulation regressions", () => {
   // and fails closed.
   it("rebuild fails closed on an orphan-thread approval event", async () => {
     const fix = fixture as Fixture;
-    appendApprovalRequestedToLog(fix.eventLog, buildApprovalPayload(ORPHAN_THREAD, 1));
+    const { lsn } = appendApprovalRequestedToLog(
+      fix.eventLog,
+      buildApprovalPayload(ORPHAN_THREAD, 1),
+    );
     expect(() => fix.approvals.rebuildFromLog(fix.eventLog)).toThrowError(
-      expect.objectContaining({ name: "ApprovalReplayThreadNotFoundError" }),
+      expect.objectContaining({ name: "ApprovalReplayThreadNotFoundError", lsn }),
     );
   });
 
   it("rebuild fails closed on per-thread cap overflow", async () => {
     const fix = fixture as Fixture;
     const a = await createThread(fix, THREAD_A);
+    let overflowLsn: number | null = null;
     for (let i = 0; i <= MAX_ROUTE_APPROVAL_LIST_ITEMS; i += 1) {
-      appendApprovalRequestedToLog(fix.eventLog, buildApprovalPayload(a.id, 1000 + i));
+      const { lsn } = appendApprovalRequestedToLog(
+        fix.eventLog,
+        buildApprovalPayload(a.id, 1000 + i),
+      );
+      if (i === MAX_ROUTE_APPROVAL_LIST_ITEMS) {
+        overflowLsn = lsn;
+      }
     }
+    if (overflowLsn === null) throw new Error("overflow event was not appended");
     expect(() => fix.approvals.rebuildFromLog(fix.eventLog)).toThrowError(
-      expect.objectContaining({ name: "ApprovalReplayPendingLimitExceededError" }),
+      expect.objectContaining({
+        name: "ApprovalReplayPendingLimitExceededError",
+        lsn: overflowLsn,
+      }),
     );
   });
 

--- a/packages/protocol/vitest.config.ts
+++ b/packages/protocol/vitest.config.ts
@@ -22,12 +22,12 @@ export default defineConfig({
       reportsDirectory: "coverage",
       thresholds: {
         // Ratcheted up after R11 added 198 spec-driven tests.
-        // Measured: 97.05 lines / 97.05 statements / 99.62 functions / 89.79 branches.
+        // Measured: 98.11 lines / 98.11 statements / 99.74 functions / 90.08 branches.
         // Aspirational target: 98/98/98/98.
         lines: 97,
         statements: 97,
         functions: 99,
-        branches: 89,
+        branches: 90,
       },
     },
   },


### PR DESCRIPTION
## Summary

PR #916 (the thread-as-work-item slice) was **squash-merged without its final
5-lens triangulation fix round**. This PR restores those commits AND addresses
a fresh 5-lens re-review of the diff that found the original fix round was
itself incomplete.

10 commits, broker-only (+ `packages/protocol/vitest.config.ts` ratchet).

## What this fixes — findings live on `main` today

### Original missed fix round (cherry-picked, commits `9ac7d95d`..`3d0fee9a`)

| Severity | Finding |
|---|---|
| **HIGH** | `GET /api/v1/threads` + `/pinned-approvals` throw 500 above the protocol 256-item cap → DoS on the triage endpoint |
| **HIGH** (security) | Approval token `issuedTo` not checked against bearer-resolved decider — a bearer for one agent can submit a token issued to another |
| **HIGH** | `pending_approvals.thread_id` has no FK at append → approvals can commit for nonexistent threads (orphan pins) |
| **HIGH** | Threaded receipt writes emit no SSE invalidation — `/api/events` clients see stale boards |
| MEDIUM/LOW | approval SSE id format, snapshot coherence, rebuild atomicity, cost-prune scoping, unified route error contract, `Allow` headers, dedup, broker coverage CI gate |

### Triangulation re-review (5-lens: security / distsys / api / architecture / coverage)

Running 5 read-only codex agents on the cherry-pick diff caught that the
original fix round was incomplete:

| Severity | Finding | Fix |
|---|---|---|
| **HIGH** | Runner receipt writes still missed thread SSE invalidations — fix only wired the HTTP route, not the runner path that drops `receiptStore.put()`'s LSN | `50888933` centralized invalidation via the shared store, single chokepoint |
| **HIGH** | Thread-list cursor not coherent with derived `effective_status` filter — pages on `head_lsn`, filters after slicing, so a thread paged-past while not matching can later match and be skipped forever | `6069ded8` page by the effective view LSN (max of thread/approval/receipt LSNs); status filter inside the paged query |
| **HIGH** | Pinned-approvals silently truncates pre-cap overflow — cap was append-time only, but `main` already shipped uncapped so existing DBs can hold >256 → false-complete 200 | `f231e4a6` fetch cap+1, fail loud with a structured error on overflow |
| MEDIUM | FK + cap validated at append but not at replay/rebuild (§15.B requires both) | `76ab3a1a` assert FK + per-thread cap on projection rebuild, fail closed on historical violations |
| MEDIUM/LOW | Test gaps: 256-cap boundary untested, token mismatch only route-tested (not appender), receipt-invalidation only `error` tested | `9b665afb` 256-cap boundary route test, appender-level token-mismatch tests referencing `ApprovalTokenIssuedToMismatchError`, receipt-invalidation table test (error/stalled/ok + duplicate + V1 negative) |

## Pre-existing deferral — out of scope

`approvals/appender.ts:256` still records the SignedApprovalToken without
cryptographic verification (WebAuthn assertion check). This is the deliberate
deferral from #916 — the protocol codec enforces structural claim/scope
binding; full WebAuthn assertion verification is the webauthn module's
concern. #918's `issuedTo` check is a net hardening (`main` has zero check
today). To be tracked as a follow-up.

## End-to-end acceptance gate

A smoke test reproduces the HIGH cursor-incoherence defect over real HTTP
against a real broker:

```
BEFORE (no fix):    GET ?status=needs_attention&cursor=<A.head_lsn> -> []
                    GET ?status=needs_attention (no cursor)          -> [thread A]
                    REPRODUCED — thread A invisible despite needing a human

AFTER (this PR):    GET ?status=needs_attention&cursor=<A.head_lsn> -> [thread A]
                    GET ?status=needs_attention (no cursor)          -> [thread A]
                    CLEAN
```

## Test plan

- [x] broker — `typecheck` ✓ · `test` 520 passed ✓ · `test:coverage` ✓ · `check` ✓ · `check:invariants` ✓
- [x] protocol — `tsc --noEmit` ✓ · `test:coverage` ✓ · Go oracle 213 vectors ✓
- [x] `bash scripts/check-file-size.sh` — no failures
- [x] HTTP smoke test reproduces defect 2 against the pre-fix commit and goes CLEAN against the post-fix tip

Broker-only diff; no `web/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Thread-aware approval validation; per-thread pending-approval limits; decision-token actor checks
  - Cursor-based thread listing with pinned-approvals snapshots and thread head tracking
  - Emission of thread.updated SSE events for threaded receipts
  - Approval -> API view conversion helper

* **Improvements**
  - Receipt creation returns richer LSN info
  - HEAD allowed for approvals and thread endpoints
  - Standardized error codes (invalid_json, pending_approval_limit_exceeded, approval_token_actor_mismatch)

* **Bug Fixes**
  - Rebuild/replay rejects orphaned approvals and per-thread overflow

* **Chores**
  - Added Vitest coverage gate in CI (higher branch threshold)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->