### PR TITLE
ci+test: bump golangci-lint pin (root cause) + early-return after t.Fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -536,7 +536,7 @@ jobs:
       # would execute with CI privileges.
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # ratchet:golangci/golangci-lint-action@v9.2.0
         with:
-          version: v2.11.4
+          version: v2.12.2
           args: --timeout=5m
       - name: Cache govulncheck binary
         # The version below is pinned, so the compiled binary at

--- a/tests/e2e/delegation_test.go
+++ b/tests/e2e/delegation_test.go
@@ -58,6 +58,7 @@ func newTestAgentServiceWithStart(t *testing.T, resolver agent.StreamFnResolver,
 	pack := agent.GetPack("founding-team")
 	if pack == nil {
 		t.Fatal("founding-team pack not found")
+		return nil, nil
 	}
 
 	for _, cfg := range pack.Agents {
@@ -275,6 +276,7 @@ func TestDelegationParsing(t *testing.T) {
 	pack := agent.GetPack("founding-team")
 	if pack == nil {
 		t.Fatal("founding-team pack not found")
+		return
 	}
 
 	for _, cfg := range pack.Agents {
@@ -319,6 +321,7 @@ func TestPackBootstrap(t *testing.T) {
 	pack := agent.GetPack("founding-team")
 	if pack == nil {
 		t.Fatal("founding-team pack not found")
+		return
 	}
 
 	svc := agent.NewAgentService()


### PR DESCRIPTION
## Summary

Two-commit fix for the SA5011 false-positive wave that's been blocking
PR #918 (and would block every subsequent PR until cache expiry):

1. **`45f92509` fix(tests): early-return after t.Fatal in delegation_test nil guards** — 3 explicit `return`s after `t.Fatal` in nil-guard blocks. Doesn't change behaviour (`t.Fatal` already calls `runtime.Goexit()`); makes the early-exit visible to any static analyser that doesn't model `t.Fatal` as a terminator.
2. **`30e64ea0` ci: bump golangci-lint pin v2.11.4 -> v2.12.2** — the actual root-cause fix. v2.11.4 ships an older staticcheck that produces 35 SA5011 "possible nil pointer dereference" false positives across 7 v0 test files; v2.12.2 ships the upstream fix and reports `0 issues` locally on the full repo.

## Why this surfaced now

`main`'s last green CI was on `4a0096aa` (PR #905, obsidian-vault wiki) — that run hit the golangci-lint action's cache and silently skipped re-analysing these files. PR #918 brought main into its branch via a merge; the merge-commit CI invalidated the relevant cache slice and produced a fresh analysis that re-surfaced the false positives. Main itself is, by every reasonable definition, broken on the same files — it just wasn't catching it.

## Files affected by the false positive (none touched by this PR's commit #1)

| File | Sites |
|---|---|
| `internal/agent/packs_test.go` | 4 |
| `internal/company/blueprints_permission_test.go` | 3 |
| `internal/company/manifest_test.go` | 2 |
| `internal/orchestration/router_test.go` | 1 |
| `internal/provider/openai_compat_live_test.go` | 4 |
| `internal/provider/openai_compat_test.go` | 2 |
| `internal/scanner/scanner_patterns_test.go` | 2 |
| `tests/e2e/delegation_test.go` | 3 (also fixed in commit `45f92509` for clarity) |

Commit #2 (the version bump) makes all 35 false positives disappear with one line; commit #1 is kept because explicit `return` after `t.Fatal` is a clarity improvement that survives future tool changes.

## Test plan

- [x] `golangci-lint v2.12.2 run ./...` locally: `0 issues.`
- [x] `golangci-lint v2.11.4 run ./...` locally (CI's pre-bump version, against commit #1's file): `0 issues` (the explicit `return` makes v2.11.4 happy on `delegation_test.go`)
- [x] `gofmt -l` clean · `go vet ./...` clean
- [x] No production code touched

`t.Fatal` semantics are unchanged. The unreachable `return` after `t.Fatal` is a no-op at runtime (`runtime.Goexit()` terminates before the `return` executes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test helpers and test flow to stop cleanly when required test resources are missing, preventing spurious execution after failures.
* **Chores**
  * Updated CI linting configuration to a newer lint-action version for more consistent checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/921?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->