### PR TITLE
fix: require text for direct interview answers

### DIFF
--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -65,7 +65,7 @@ func requestOptionDefaults(kind string) ([]interviewOption, string) {
 		}, "balanced"
 	case "interview":
 		return []interviewOption{
-			{ID: "answer_directly", Label: "Answer directly", Description: "Respond in your own words below."},
+			{ID: "answer_directly", Label: "Answer directly", Description: "Respond in your own words below.", RequiresText: true, TextHint: "Type your answer for the team."},
 			{ID: "need_more_context", Label: "Need more context", Description: "Ask the office to bring back more context before you decide.", RequiresText: true, TextHint: "Type what context is missing or what should be clarified next."},
 		}, "answer_directly"
 	case "freeform", "secret":

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -713,6 +713,16 @@ func TestBrokerHumanInterviewDoesNotBlockAndCancelsOnHumanMessage(t *testing.T) 
 	if created.Request.Blocking || created.Request.Required {
 		t.Fatalf("human interviews must be non-blocking, got %+v", created.Request)
 	}
+	var answerDirectly *interviewOption
+	for i := range created.Request.Options {
+		if created.Request.Options[i].ID == "answer_directly" {
+			answerDirectly = &created.Request.Options[i]
+			break
+		}
+	}
+	if answerDirectly == nil || !answerDirectly.RequiresText || strings.TrimSpace(answerDirectly.TextHint) == "" {
+		t.Fatalf("expected answer_directly to require text, got %+v", answerDirectly)
+	}
 	if b.HasBlockingRequest() {
 		t.Fatal("human interview should not count as a blocking request")
 	}

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -621,8 +621,8 @@ function RequestBody({
       <RequestItem
         request={fullRequest}
         isPending={isPending}
-        onAnswer={(choiceId) => {
-          void answerRequest(fullRequest.id, choiceId).then(() => {
+        onAnswer={(choiceId, customText) => {
+          void answerRequest(fullRequest.id, choiceId, customText).then(() => {
             void queryClient.invalidateQueries({ queryKey: ["requests"] });
             void queryClient.invalidateQueries({ queryKey: ["lifecycle"] });
           });

--- a/web/src/components/lifecycle/RequestItem.test.tsx
+++ b/web/src/components/lifecycle/RequestItem.test.tsx
@@ -5,17 +5,26 @@ import type { AgentRequest } from "../../api/client";
 import { RequestItem } from "./RequestItem";
 
 describe("<RequestItem>", () => {
-  it("collects text before answering legacy direct-answer interviews", () => {
-    const request: AgentRequest = {
-      id: "request-200",
+  function makeInterviewRequest(
+    id: string,
+    options: AgentRequest["options"] = [
+      { id: "answer_directly", label: "Answer directly" },
+    ],
+  ): AgentRequest {
+    return {
+      id,
       from: "research",
       question: "What should we ask next?",
       title: "Human interview",
       blocking: false,
       status: "pending",
-      options: [{ id: "answer_directly", label: "Answer directly" }],
+      options,
       kind: "interview",
     };
+  }
+
+  it("collects text before answering legacy direct-answer interviews", () => {
+    const request = makeInterviewRequest("request-200");
     const onAnswer = vi.fn();
 
     render(
@@ -34,5 +43,40 @@ describe("<RequestItem>", () => {
       "answer_directly",
       "Ask whether they already use a workaround.",
     );
+  });
+
+  it("resets text mode when the request changes", () => {
+    const firstRequest = makeInterviewRequest("request-201");
+    const secondRequest = makeInterviewRequest("request-202", [
+      { id: "accept", label: "Accept" },
+    ]);
+    const onAnswer = vi.fn();
+
+    const { rerender } = render(
+      <RequestItem
+        request={firstRequest}
+        isPending={true}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Answer directly/i }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Stale text from the first request." },
+    });
+
+    rerender(
+      <RequestItem
+        request={secondRequest}
+        isPending={true}
+        onAnswer={onAnswer}
+      />,
+    );
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Accept/i }));
+
+    expect(onAnswer).toHaveBeenCalledTimes(1);
+    expect(onAnswer).toHaveBeenCalledWith("accept");
   });
 });

--- a/web/src/components/lifecycle/RequestItem.test.tsx
+++ b/web/src/components/lifecycle/RequestItem.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentRequest } from "../../api/client";
+import { RequestItem } from "./RequestItem";
+
+describe("<RequestItem>", () => {
+  it("collects text before answering legacy direct-answer interviews", () => {
+    const request: AgentRequest = {
+      id: "request-200",
+      from: "research",
+      question: "What should we ask next?",
+      title: "Human interview",
+      blocking: false,
+      status: "pending",
+      options: [{ id: "answer_directly", label: "Answer directly" }],
+      kind: "interview",
+    };
+    const onAnswer = vi.fn();
+
+    render(
+      <RequestItem request={request} isPending={true} onAnswer={onAnswer} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Answer directly/i }));
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Ask whether they already use a workaround." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Send as Answer directly/i }),
+    );
+
+    expect(onAnswer).toHaveBeenCalledWith(
+      "answer_directly",
+      "Ask whether they already use a workaround.",
+    );
+  });
+});

--- a/web/src/components/lifecycle/RequestItem.tsx
+++ b/web/src/components/lifecycle/RequestItem.tsx
@@ -85,6 +85,7 @@ export function RequestItem({
 
       {isPending && options.length > 0 ? (
         <RequestActions
+          key={request.id}
           request={request}
           options={options}
           onAnswer={onAnswer}
@@ -107,8 +108,12 @@ interface RequestActionsProps {
 }
 
 function RequestActions({ request, options, onAnswer }: RequestActionsProps) {
+  // Caller passes `key={request.id}` so the subtree fully remounts on
+  // request switch, so text-entry state can't leak from one request to the
+  // next without us needing an explicit reset effect here.
   const [textOption, setTextOption] = useState<InterviewOption | null>(null);
   const [customText, setCustomText] = useState("");
+
   const submitText = () => {
     const text = customText.trim();
     if (!(textOption && text)) return;

--- a/web/src/components/lifecycle/RequestItem.tsx
+++ b/web/src/components/lifecycle/RequestItem.tsx
@@ -1,11 +1,17 @@
-import type { AgentRequest } from "../../api/client";
+import { useState } from "react";
+
+import type { AgentRequest, InterviewOption } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
+import {
+  requestOptionNeedsText,
+  requestOptionTextHint,
+} from "../../lib/requestOptions";
 import { RedactedBadge } from "../ui/RedactedBadge";
 
 interface RequestItemProps {
   request: AgentRequest;
   isPending: boolean;
-  onAnswer?: (choiceId: string) => void;
+  onAnswer?: (choiceId: string, customText?: string) => void;
 }
 
 /**
@@ -77,27 +83,109 @@ export function RequestItem({
         </div>
       ) : null}
 
-      {isPending && options.length > 0 && (
-        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-          {options.map((opt) => (
-            <button
-              type="button"
-              key={opt.id}
-              className={`btn btn-sm ${opt.id === request.recommended_id ? "btn-primary" : "btn-ghost"}`}
-              title={opt.description}
-              onClick={() => onAnswer?.(opt.id)}
-            >
-              {opt.label}
-            </button>
-          ))}
-        </div>
-      )}
+      {isPending && options.length > 0 ? (
+        <RequestActions
+          request={request}
+          options={options}
+          onAnswer={onAnswer}
+        />
+      ) : null}
 
       {!isPending && (
         <div style={{ fontSize: 12, color: "var(--green)", fontWeight: 500 }}>
           Answered
         </div>
       )}
+    </div>
+  );
+}
+
+interface RequestActionsProps {
+  request: AgentRequest;
+  options: InterviewOption[];
+  onAnswer?: (choiceId: string, customText?: string) => void;
+}
+
+function RequestActions({ request, options, onAnswer }: RequestActionsProps) {
+  const [textOption, setTextOption] = useState<InterviewOption | null>(null);
+  const [customText, setCustomText] = useState("");
+  const submitText = () => {
+    const text = customText.trim();
+    if (!(textOption && text)) return;
+    onAnswer?.(textOption.id, text);
+    setTextOption(null);
+    setCustomText("");
+  };
+
+  if (textOption) {
+    return (
+      <div style={{ display: "grid", gap: 8 }}>
+        <textarea
+          className="interview-bar-textarea"
+          placeholder={requestOptionTextHint(request, textOption)}
+          value={customText}
+          onChange={(e) => setCustomText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setTextOption(null);
+              setCustomText("");
+            }
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              submitText();
+            }
+          }}
+          rows={3}
+        />
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          <button
+            type="button"
+            className="btn btn-sm btn-ghost"
+            onClick={() => {
+              setTextOption(null);
+              setCustomText("");
+            }}
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-primary"
+            disabled={!customText.trim()}
+            onClick={submitText}
+          >
+            Send as {textOption.label}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      {options.map((opt) => {
+        const needsText = requestOptionNeedsText(request, opt);
+        return (
+          <button
+            type="button"
+            key={opt.id}
+            className={`btn btn-sm ${opt.id === request.recommended_id ? "btn-primary" : "btn-ghost"}`}
+            title={opt.description}
+            onClick={() => {
+              if (needsText) {
+                setTextOption(opt);
+                setCustomText("");
+                return;
+              }
+              onAnswer?.(opt.id);
+            }}
+          >
+            {opt.label}
+            {needsText ? " · type" : ""}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/messages/InterviewBar.test.tsx
+++ b/web/src/components/messages/InterviewBar.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AgentRequest } from "../../api/client";
@@ -29,9 +29,11 @@ vi.mock("../../api/client", async () => {
         },
       ],
     }),
+    answerRequest: vi.fn().mockResolvedValue({}),
   };
 });
 
+import * as clientMod from "../../api/client";
 import { InterviewBar } from "./InterviewBar";
 
 function wrap(ui: ReactNode) {
@@ -263,5 +265,41 @@ describe("<InterviewBar> approval UX", () => {
 
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.getByText("Approve the new plan?")).toBeInTheDocument();
+  });
+
+  it("collects text for legacy direct-answer interviews", async () => {
+    const legacyInterview: AgentRequest = {
+      id: "request-legacy-interview",
+      from: "research",
+      channel: "general",
+      kind: "interview",
+      status: "pending",
+      question: "What should we ask next?",
+      options: [{ id: "answer_directly", label: "Answer directly" }],
+      blocking: false,
+      created_at: "2026-05-06T00:00:00Z",
+    };
+    const answerSpy = vi.mocked(clientMod.answerRequest);
+    answerSpy.mockClear();
+
+    setPending([legacyInterview]);
+    render(wrap(<InterviewBar />));
+
+    fireEvent.click(screen.getByRole("button", { name: /Answer directly/i }));
+    const textbox = screen.getByRole("textbox");
+    fireEvent.change(textbox, {
+      target: { value: "Ask whether the buyer has budget authority." },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Send as Answer directly/i }),
+    );
+
+    await waitFor(() => {
+      expect(answerSpy).toHaveBeenCalledWith(
+        "request-legacy-interview",
+        "answer_directly",
+        "Ask whether the buyer has budget authority.",
+      );
+    });
   });
 });

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -15,6 +15,10 @@ import {
 } from "../../api/client";
 import { useRequests } from "../../hooks/useRequests";
 import { parseApprovalContext } from "../../lib/parseApprovalContext";
+import {
+  requestOptionNeedsText,
+  requestOptionTextHint,
+} from "../../lib/requestOptions";
 import { useAppStore } from "../../stores/app";
 import { SkillCompareView } from "../apps/SkillCompareView";
 import { useOnboardingDMContext } from "../onboarding/OnboardingDMRoute";
@@ -203,7 +207,7 @@ export function InterviewBar() {
   };
 
   const handleOption = (option: InterviewOption) => {
-    if (option.requires_text) {
+    if (requestOptionNeedsText(current, option)) {
       setTextMode({ option });
       setCustomText("");
       return;
@@ -345,7 +349,7 @@ export function InterviewBar() {
             <textarea
               ref={textareaRef}
               className="interview-bar-textarea"
-              placeholder={textMode.option.text_hint || "Type your answer..."}
+              placeholder={requestOptionTextHint(current, textMode.option)}
               value={customText}
               onChange={(e) => setCustomText(e.target.value)}
               onKeyDown={(e) => {
@@ -401,7 +405,7 @@ export function InterviewBar() {
               >
                 <span className="interview-bar-opt-num">{i + 1}</span>
                 <span className="interview-bar-opt-label">{opt.label}</span>
-                {opt.requires_text ? (
+                {requestOptionNeedsText(current, opt) ? (
                   <span className="interview-bar-text-hint"> · type</span>
                 ) : null}
               </button>

--- a/web/src/lib/requestOptions.ts
+++ b/web/src/lib/requestOptions.ts
@@ -1,0 +1,22 @@
+import type { AgentRequest, InterviewOption } from "../api/client";
+
+export function requestOptionNeedsText(
+  request: AgentRequest,
+  option: InterviewOption,
+): boolean {
+  return Boolean(
+    option.requires_text ||
+      (request.kind === "interview" && option.id === "answer_directly"),
+  );
+}
+
+export function requestOptionTextHint(
+  request: AgentRequest,
+  option: InterviewOption,
+): string {
+  if (option.text_hint) return option.text_hint;
+  if (request.kind === "interview" && option.id === "answer_directly") {
+    return "Type your answer for the team.";
+  }
+  return "Type your answer...";
+}


### PR DESCRIPTION
## Summary
- require broker-created direct interview answers to include text
- treat legacy direct-answer interview options as text-required in the web UI
- add focused Go and web tests for the fallback behavior

## Verification
- go test ./internal/team -run 'TestBrokerHumanInterviewDoesNotBlockAndCancelsOnHumanMessage|TestRequestAnswerFromHumanSession|TestBrokerRequestAnswerRequiresCustomTextWhenOptionNeedsIt'
- bash scripts/test-web.sh web/src/components/messages/InterviewBar.test.tsx web/src/components/lifecycle/RequestItem.test.tsx
- bash scripts/test-web.sh web/src/api/wiki.test.ts web/src/api/client.test.ts
- go test ./cmd/wuphf -run 'TestShareJoinFlowEndToEnd|TestShareProxyStampsHumanActor|TestShareProxyDoesNotExposeBrokerToken'
- bunx biome check src/lib/requestOptions.ts src/components/messages/InterviewBar.tsx src/components/messages/InterviewBar.test.tsx src/components/lifecycle/RequestItem.tsx src/components/lifecycle/RequestItem.test.tsx
- git diff --check --cached

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Answer directly" interview option now accepts free-text answers with contextual placeholder hints and ensures typed text is submitted.
  * Text entry supports keyboard shortcuts (Ctrl/Meta+Enter to submit, Esc to cancel) and a Send action.
* **Tests**
  * Added UI and unit tests validating the direct-answer text flow, placeholder behavior, and correct submission of typed responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->