### PR TITLE
feat(wiki): restore Reviews tab inside the Wiki app

### DIFF
--- a/web/e2e/screenshots/wiki-reviews-tab.mjs
+++ b/web/e2e/screenshots/wiki-reviews-tab.mjs
@@ -5,8 +5,6 @@
 // Run via the wrapper:
 //   web/e2e/screenshots/publish.sh wiki-reviews-tab <pr-number>
 
-import process from "node:process";
-
 import {
   bootShell,
   installCommonMocks,
@@ -14,6 +12,7 @@ import {
   shotElement,
   shotPage,
 } from "./lib.mjs";
+import process from "node:process";
 
 const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
 if (!OUT) {
@@ -43,8 +42,14 @@ await page.evaluate(() => {
 await page.waitForSelector('[data-testid="review-queue-surface"]', {
   timeout: 10_000,
 });
-// Let the wiki-tabs badge fetch settle so the chrome stops flashing.
-await page.waitForTimeout(500);
+// Wait for the fetch to resolve (loading spinner detaches) and the
+// 5-column grid to mount before capturing — avoids transitional
+// frames on slow runners.
+await page.waitForSelector(".nb-loading", {
+  state: "detached",
+  timeout: 10_000,
+});
+await page.waitForSelector(".nb-review-columns", { timeout: 10_000 });
 
 // 1. Full Wiki shell — Reviews tab active, 5-column empty Kanban below.
 await shotPage(page, OUT, "01-wiki-reviews-tab-active");

--- a/web/e2e/screenshots/wiki-reviews-tab.mjs
+++ b/web/e2e/screenshots/wiki-reviews-tab.mjs
@@ -1,0 +1,67 @@
+// Capture the Reviews tab inside Wiki, restored after Phase 2b
+// retired the standalone /reviews surface. Captures the wiki shell with
+// the Reviews tab active, plus the 5-column Kanban empty state.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh wiki-reviews-tab <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1480, height: 980 },
+});
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/review/list*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ reviews: [] }),
+      }),
+    );
+  },
+});
+
+await bootShell(page);
+await page.evaluate(() => {
+  window.location.hash = "#/reviews";
+});
+await page.waitForSelector('[data-testid="review-queue-surface"]', {
+  timeout: 10_000,
+});
+// Let the wiki-tabs badge fetch settle so the chrome stops flashing.
+await page.waitForTimeout(500);
+
+// 1. Full Wiki shell — Reviews tab active, 5-column empty Kanban below.
+await shotPage(page, OUT, "01-wiki-reviews-tab-active");
+
+// 2. Just the wiki-tabs chrome — proves the Reviews tab + badge slot are back.
+await shotElement(page, ".wiki-tabs", OUT, "02-wiki-tabs-bar");
+
+// 3. The Kanban surface alone (5 columns, "Empty" placeholder per column).
+await shotElement(
+  page,
+  '[data-testid="review-queue-surface"]',
+  OUT,
+  "03-reviews-kanban-empty",
+);
+
+console.log(`captured 3 screenshots to ${OUT}`);
+if (errors.length > 0) {
+  console.error("page errors during capture:", errors);
+}
+await browser.close();

--- a/web/e2e/tests/route-matrix.spec.ts
+++ b/web/e2e/tests/route-matrix.spec.ts
@@ -152,11 +152,9 @@ test.describe("canonical route matrix", () => {
       await expect(p.getByTestId("notebook-surface")).toBeVisible();
     });
 
-    // Phase 2b: /#/reviews now redirects to /inbox instead of mounting
-    // ReviewQueueKanban. Verify the URL change, not the briefly-mounted
-    // InboxRedirect testid (it unmounts as soon as the redirect fires).
-    await page.goto("/#/reviews");
-    await expect(page).toHaveURL(/#\/inbox$/, { timeout: 10_000 });
+    await expectCanonicalRoute(page, "/#/reviews", async (p) => {
+      await expect(p.getByTestId("review-queue-surface")).toBeVisible();
+    });
   });
 
   test("dropped legacy aliases and unknown routes render not found", async ({

--- a/web/e2e/tests/route-regressions.spec.ts
+++ b/web/e2e/tests/route-regressions.spec.ts
@@ -94,7 +94,11 @@ test.describe("PR #634 review pins", () => {
     // useEffect fires, so racing toBeVisible against the redirect is
     // flaky. URL change is the stable assertion.
     await expect(page).toHaveURL(/#\/inbox$/, { timeout: 5_000 });
-    await expectNoReactErrors(page, getErrors, "during legacy requests redirect");
+    await expectNoReactErrors(
+      page,
+      getErrors,
+      "during legacy requests redirect",
+    );
   });
 
   test("AgentPanel hides the per-channel toggle when no conversation channel is active", async ({
@@ -258,8 +262,7 @@ test.describe("PR #634 review pins", () => {
       { route: "/#/wiki", label: "Wiki" },
       { route: "/#/wiki/lookup?q=test", label: "Wiki" },
       { route: "/#/notebooks", label: "Notebooks" },
-      // /#/reviews was retired in Phase 2b; the route now redirects to
-      // /inbox so it no longer has its own breadcrumb label.
+      { route: "/#/reviews", label: "Reviews" },
     ];
 
     for (const { route, label } of surfaces) {

--- a/web/src/components/review/ReviewQueueKanban.test.tsx
+++ b/web/src/components/review/ReviewQueueKanban.test.tsx
@@ -42,11 +42,7 @@ describe("<ReviewQueueKanban>", () => {
   it("renders five state columns with their cards", async () => {
     vi.spyOn(api, "fetchReviews").mockResolvedValue(MOCK_REVIEWS);
     render(<ReviewQueueKanban />);
-    await waitFor(() =>
-      expect(
-        screen.getByRole("heading", { name: "Reviews" }),
-      ).toBeInTheDocument(),
-    );
+    await screen.findByText("Pending one");
     expect(
       screen.getByRole("heading", { name: "Pending" }),
     ).toBeInTheDocument();

--- a/web/src/components/review/ReviewQueueKanban.test.tsx
+++ b/web/src/components/review/ReviewQueueKanban.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ReviewItem } from "../../api/notebook";
+import * as api from "../../api/notebook";
+import ReviewQueueKanban from "./ReviewQueueKanban";
+
+function mkReview(
+  id: string,
+  state: ReviewItem["state"],
+  title: string,
+): ReviewItem {
+  return {
+    id,
+    agent_slug: "pm",
+    entry_slug: "e",
+    entry_title: title,
+    proposed_wiki_path: "p/q",
+    excerpt: "x",
+    reviewer_slug: "ceo",
+    state,
+    submitted_ts: new Date().toISOString(),
+    updated_ts: new Date().toISOString(),
+    comments: [],
+  };
+}
+
+const MOCK_REVIEWS: ReviewItem[] = [
+  mkReview("r1", "pending", "Pending one"),
+  mkReview("r2", "in-review", "In review one"),
+  mkReview("r3", "changes-requested", "Changes one"),
+  mkReview("r4", "approved", "Approved one"),
+];
+
+describe("<ReviewQueueKanban>", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, "subscribeNotebookEvents").mockImplementation(() => () => {});
+  });
+
+  it("renders five state columns with their cards", async () => {
+    vi.spyOn(api, "fetchReviews").mockResolvedValue(MOCK_REVIEWS);
+    render(<ReviewQueueKanban />);
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "Reviews" }),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Pending" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "In review" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Changes requested" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Approved" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Archived" }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Pending one")).toBeInTheDocument();
+    expect(screen.getByText("In review one")).toBeInTheDocument();
+  });
+
+  it("opens the detail drawer when a card is clicked", async () => {
+    vi.spyOn(api, "fetchReviews").mockResolvedValue(MOCK_REVIEWS);
+    render(<ReviewQueueKanban />);
+    await waitFor(() =>
+      expect(screen.getByText("Pending one")).toBeInTheDocument(),
+    );
+    await userEvent.setup().click(screen.getByText("Pending one"));
+    await waitFor(() =>
+      expect(screen.getByTestId("nb-review-drawer")).toBeInTheDocument(),
+    );
+  });
+
+  it("optimistically moves a card when approved from the drawer", async () => {
+    vi.spyOn(api, "fetchReviews").mockResolvedValue([
+      mkReview("r1", "pending", "My card"),
+    ]);
+    const updateSpy = vi.spyOn(api, "updateReviewState").mockResolvedValue({
+      ...mkReview("r1", "approved", "My card"),
+    });
+    render(<ReviewQueueKanban />);
+    await waitFor(() =>
+      expect(screen.getByText("My card")).toBeInTheDocument(),
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByText("My card"));
+    await waitFor(() =>
+      expect(screen.getByTestId("nb-review-drawer")).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await waitFor(() => {
+      expect(updateSpy).toHaveBeenCalledWith("r1", "approved");
+    });
+  });
+
+  it("surfaces an error state + Retry button on fetch failure", async () => {
+    vi.spyOn(api, "fetchReviews").mockRejectedValue(new Error("down"));
+    render(<ReviewQueueKanban />);
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("renders the grade badge inside the Kanban for a card aged >= 12 hours", async () => {
+    const oldCard = {
+      ...mkReview("r5", "pending", "Old pending"),
+      submitted_ts: new Date(Date.now() - 13 * 3_600_000).toISOString(),
+    };
+    vi.spyOn(api, "fetchReviews").mockResolvedValue([oldCard]);
+    render(<ReviewQueueKanban />);
+    await waitFor(() =>
+      expect(screen.getByText("Old pending")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Waiting")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/review/ReviewQueueKanban.tsx
+++ b/web/src/components/review/ReviewQueueKanban.tsx
@@ -107,13 +107,27 @@ export default function ReviewQueueKanban() {
 
   return (
     <div className="notebook-surface" data-testid="review-queue-surface">
-      <a href="#nb-review-main" className="nb-skip-link">
+      {/* Skip link uses programmatic focus instead of href="#nb-review-main"
+       * because the app runs under hash-history routing — an anchor hash would
+       * clobber /#/reviews and navigate the user off the surface. */}
+      <button
+        type="button"
+        className="nb-skip-link"
+        onClick={() => {
+          const main = document.getElementById("nb-review-main");
+          if (main instanceof HTMLElement) {
+            main.focus();
+            main.scrollIntoView({ block: "start" });
+          }
+        }}
+      >
         Skip to review queue
-      </a>
+      </button>
       <main
         id="nb-review-main"
         className="nb-review-queue"
         aria-label="Review queue"
+        tabIndex={-1}
       >
         <header className="nb-review-queue-header">
           <h1 className="nb-review-queue-title">Reviews</h1>

--- a/web/src/components/review/ReviewQueueKanban.tsx
+++ b/web/src/components/review/ReviewQueueKanban.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useState } from "react";
+
+import {
+  fetchReviews,
+  type ReviewItem,
+  type ReviewState,
+  subscribeNotebookEvents,
+  updateReviewState,
+} from "../../api/notebook";
+import ReviewColumn from "./ReviewColumn";
+import ReviewDetail from "./ReviewDetail";
+import "../../styles/notebook.css";
+
+/** `/reviews` 5-column Kanban + detail drawer backed by the broker review log. */
+
+type ReviewColumnState = Extract<
+  ReviewState,
+  "pending" | "in-review" | "changes-requested" | "approved" | "archived"
+>;
+
+const STATE_ORDER: ReviewColumnState[] = [
+  "pending",
+  "in-review",
+  "changes-requested",
+  "approved",
+  "archived",
+];
+const STATE_TITLE: Record<ReviewColumnState, string> = {
+  pending: "Pending",
+  "in-review": "In review",
+  "changes-requested": "Changes requested",
+  approved: "Approved",
+  archived: "Archived",
+};
+
+function reviewColumnState(state: ReviewState): ReviewColumnState {
+  if (state === "rejected" || state === "expired") return "archived";
+  return state;
+}
+
+export default function ReviewQueueKanban() {
+  const [reviews, setReviews] = useState<ReviewItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [refreshTick, setRefreshTick] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetchReviews()
+      .then((r) => {
+        if (!cancelled) setReviews(r);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshTick]);
+
+  useEffect(() => {
+    const unsub = subscribeNotebookEvents((ev) => {
+      if (ev.type === "review:state_change") {
+        setRefreshTick((n) => n + 1);
+      }
+    });
+    return unsub;
+  }, []);
+
+  const grouped = useMemo(() => {
+    const out: Record<ReviewColumnState, ReviewItem[]> = {
+      pending: [],
+      "in-review": [],
+      "changes-requested": [],
+      approved: [],
+      archived: [],
+    };
+    for (const r of reviews) out[reviewColumnState(r.state)].push(r);
+    return out;
+  }, [reviews]);
+
+  const active = activeId
+    ? (reviews.find((r) => r.id === activeId) ?? null)
+    : null;
+
+  const handleStateChange = async (id: string, nextState: ReviewState) => {
+    // Optimistic update.
+    setReviews((prev) =>
+      prev.map((r) => (r.id === id ? { ...r, state: nextState } : r)),
+    );
+    try {
+      await updateReviewState(id, nextState);
+    } catch {
+      // Rollback on failure.
+      setRefreshTick((n) => n + 1);
+    }
+  };
+
+  const totalCounts = `${reviews.length} reviews · ${grouped.pending.length + grouped["in-review"].length + grouped["changes-requested"].length} open · ${grouped.approved.length} recently approved`;
+
+  return (
+    <div className="notebook-surface" data-testid="review-queue-surface">
+      <a href="#nb-review-main" className="nb-skip-link">
+        Skip to review queue
+      </a>
+      <main
+        id="nb-review-main"
+        className="nb-review-queue"
+        aria-label="Review queue"
+      >
+        <header className="nb-review-queue-header">
+          <h1 className="nb-review-queue-title">Reviews</h1>
+          <div className="nb-review-queue-meta">{totalCounts}</div>
+        </header>
+        {loading ? (
+          <div className="nb-loading" aria-busy="true">
+            Loading reviews…
+          </div>
+        ) : error ? (
+          <>
+            <p className="nb-error" role="alert">
+              Error: {error}
+            </p>
+            <button
+              type="button"
+              className="nb-retry-btn"
+              onClick={() => setRefreshTick((n) => n + 1)}
+            >
+              Retry
+            </button>
+          </>
+        ) : (
+          <ul className="nb-review-columns">
+            {STATE_ORDER.map((state) => (
+              <ReviewColumn
+                key={state}
+                title={STATE_TITLE[state]}
+                items={grouped[state]}
+                activeId={activeId}
+                onOpenCard={(id) => setActiveId(id)}
+              />
+            ))}
+          </ul>
+        )}
+      </main>
+      {active ? (
+        <ReviewDetail
+          review={active}
+          onClose={() => setActiveId(null)}
+          onApprove={(id) => {
+            void handleStateChange(id, "approved");
+            setActiveId(null);
+          }}
+          onRequestChanges={(id) => {
+            void handleStateChange(id, "changes-requested");
+            setActiveId(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -127,6 +127,9 @@ const DecisionPacketRoute = lazy(() =>
 );
 const CitedAnswer = lazy(() => import("../components/wiki/CitedAnswer"));
 const Wiki = lazy(() => import("../components/wiki/Wiki"));
+const ReviewQueueKanban = lazy(
+  () => import("../components/review/ReviewQueueKanban"),
+);
 // Phase 3 — Issues surface.
 const IssuesList = lazy(() =>
   import("../components/lifecycle/IssuesList").then((m) => ({
@@ -365,7 +368,7 @@ function WikiSurface({ current, route }: WikiSurfaceProps) {
             onNavigateWiki={(path) => navigateWikiArticle(path || null)}
           />
         )}
-        {current === "reviews" && <InboxRedirect />}
+        {current === "reviews" && <ReviewQueueKanban />}
       </div>
     </div>
   );
@@ -373,10 +376,10 @@ function WikiSurface({ current, route }: WikiSurfaceProps) {
 
 /**
  * InboxRedirect navigates the user from the deprecated /apps/requests
- * and /reviews surfaces to the unified Inbox. Phase 2 collapsed both
- * surfaces into one Decision Inbox; Phase 2b deletes the heavy
- * RequestsApp + ReviewQueueKanban components and routes the deep
- * links through this stub so existing bookmarks keep working.
+ * surface to the unified Inbox. Phase 2 collapsed Requests into the
+ * Decision Inbox; this stub keeps existing /apps/requests bookmarks
+ * working. (The Reviews tab inside Wiki is its own surface again —
+ * see ReviewQueueKanban.)
  */
 function InboxRedirect() {
   useEffect(() => {


### PR DESCRIPTION
## Summary

Phase 2b (#878) collapsed the standalone Reviews surface into the unified Decision Inbox and routed `/#/reviews` through an `InboxRedirect` stub. The Reviews tab *inside Wiki* kept its label and badge slot, but the panel underneath became that redirect — so the promotion-queue Kanban was effectively gone.

This brings the Kanban back as the panel under the Wiki → Reviews tab. The standalone `/apps/requests` surface is intentionally left as the InboxRedirect stub; the unified Inbox is still the canonical surface for action requests. It is the *promotion queue* that always belonged inside Wiki.

## Changes

- Restore `ReviewQueueKanban.tsx` + its vitest from the commit before the Phase 2b deletion.
- `WikiSurface` (`web/src/routes/RootRoute.tsx`) renders `<ReviewQueueKanban />` when `current === "reviews"` instead of `<InboxRedirect />`. InboxRedirect docstring narrowed to `/apps/requests`.
- `route-matrix.spec.ts`: `/#/reviews` asserts `review-queue-surface` again.
- `route-regressions.spec.ts`: `/#/reviews` re-added to the StatusBar / ChannelHeader parity loop.
- New screenshot spec at `web/e2e/screenshots/wiki-reviews-tab.mjs`.

Sidebar wiring (`AppList` badge count, `CollapsedSidebar` highlight, the Wiki tab chrome itself, route registry entry, breadcrumb label) was never removed in Phase 2b, so nothing else needs to change. The pending-reviews count now lights up the sidebar Wiki entry again, automatically.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bash scripts/test-web.sh` — 1620 pass
- [x] Live Playwright vs. running `wuphf` binary: `wiki, notebook, and review routes mount their first-class surfaces` and `StatusBar and ChannelHeader show identical titles on wiki / notebooks / reviews` both pass
- [ ] Manual: open Wiki → Reviews, confirm Kanban renders with a real review pending
- [ ] Manual: confirm sidebar Wiki badge updates as reviews are approved/archived



## Screenshots

![01-wiki-reviews-tab-active](https://github.com/nex-crm/wuphf/raw/screenshots/pr-925/01-wiki-reviews-tab-active.png)

![02-wiki-tabs-bar](https://github.com/nex-crm/wuphf/raw/screenshots/pr-925/02-wiki-tabs-bar.png)

![03-reviews-kanban-empty](https://github.com/nex-crm/wuphf/raw/screenshots/pr-925/03-reviews-kanban-empty.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reviews tab now opens a dedicated Reviews surface with a 5-column Kanban, detail drawer, approve/request actions, retry on failures, and "Waiting" aging badge.

* **Tests**
  * Added E2E screenshot coverage and updated route/regression tests to assert the Reviews surface mounts; added unit tests covering Kanban behavior and review state flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->