### PR TITLE
chore(broker): switch sqlite storage to node:sqlite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,13 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2.2.0
         with:
           bun-version: "1.3.13"
+      # Broker tests run under Vitest, which spawns workers on the system Node
+      # binary (not bun). The broker storage layer uses `node:sqlite` (stable
+      # in Node 22.13+, experimental from 22.5+), so we explicitly pin a Node
+      # that ships it — setup-bun's bundled Node is older and lacks the module.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
+        with:
+          node-version: "22.x"
       - name: Detect broker changes
         id: broker-changes
         env:
@@ -264,6 +271,11 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2.2.0
         with:
           bun-version: "1.3.13"
+      # llm-router imports broker types; transitively touches `node:sqlite`.
+      # See broker job for the runtime explanation.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
+        with:
+          node-version: "22.x"
       - name: Detect llm-router changes
         id: llm-router-changes
         env:
@@ -312,6 +324,11 @@ jobs:
           # threshold flag correctly (1.2.16 fails on moderate even when level=high).
           # Rest of repo can bump in a follow-up.
           bun-version: "1.3.13"
+      # Desktop tests import @wuphf/broker, which uses `node:sqlite`. Vitest
+      # spawns workers on system Node; pin a Node that ships the module.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6.4.0
+        with:
+          node-version: "22.x"
       - name: Detect desktop changes
         id: desktop-changes
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,9 +379,8 @@ jobs:
         #    which Node 22 strip-only TS would crash on at runtime
         #    (e.g. parameter properties on `SqliteReceiptStore`'s private
         #    constructor).
-        # 2. `better-sqlite3` getting inlined — its `bindings()` loader
-        #    needs the JS wrapper at its npm location to find the `.node`
-        #    sibling.
+        # 2. `node:sqlite` getting rewritten away from the Electron 42
+        #    stdlib builtin import.
         if: ${{ steps.desktop-changes.outputs.changed == 'true' }}
         working-directory: apps/desktop
         run: bun run check:build-externals

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -13,13 +13,8 @@ const rootDir = dirname(fileURLToPath(import.meta.url));
 // on startup.
 const WORKSPACE_BUNDLE = ["@wuphf/broker", "@wuphf/protocol"];
 
-// Packages that MUST stay external in the main bundle even after
-// inlining the workspace deps. `better-sqlite3` is a transitive of
-// `@wuphf/broker` and pulls native bindings via `bindings()` — the
-// resolver looks for its sibling `.node` file in `node_modules/
-// better-sqlite3/`, so the JS wrapper must remain a runtime require
-// rather than getting flattened into our chunk.
-const NATIVE_EXTERNAL = ["better-sqlite3"];
+// `@wuphf/broker` now uses Node's stdlib `node:sqlite`; no native npm
+// SQLite binding needs to remain as a runtime external.
 
 export default defineConfig({
   main: {
@@ -27,7 +22,6 @@ export default defineConfig({
     build: {
       outDir: "out/main",
       rollupOptions: {
-        external: NATIVE_EXTERNAL,
         input: {
           index: resolve(rootDir, "src/main/index.ts"),
           "broker-entry": resolve(rootDir, "src/main/broker-entry.ts"),

--- a/apps/desktop/scripts/check-build-externals.sh
+++ b/apps/desktop/scripts/check-build-externals.sh
@@ -21,12 +21,9 @@
 #   - any `out/{main,preload}/**.js` imports a `@wuphf/*` workspace
 #     package by name (means the workspace dep wasn't bundled), OR
 #   - any output file imports a raw `*.ts` path (means an external's
-#     `exports` field still points to source).
-#
-# It also asserts that `better-sqlite3` IS still an external — its
-# native-binding loader (`bindings()`) walks up the filesystem to find
-# its `.node` sibling, which requires the JS wrapper to live at its
-# npm location rather than getting flattened into our bundle.
+#     `exports` field still points to source), OR
+#   - `node:sqlite` is rewritten to a relative runtime import instead
+#     of remaining a Node builtin import.
 
 set -euo pipefail
 
@@ -89,12 +86,13 @@ if [ -n "${raw_ts_hits}" ]; then
   echo "${raw_ts_hits}" >&2
 fi
 
-# --- Required: better-sqlite3 stays external ---
-# Its `bindings()` loader resolves `.node` via the npm filesystem layout.
-# If the JS wrapper got bundled, the native binding fails to load at
-# runtime even though the build succeeds.
-if ! grep -rqE 'from "better-sqlite3"' "${out_dir}/main"; then
-  report "better-sqlite3 import missing from out/main/ — the wrapper got inlined, and bindings() will fail to locate the .node sibling at runtime."
+# --- Required: node:sqlite stays a builtin import ---
+# `from "node:sqlite"` is correct. A relative import for that builtin means
+# a bundler shim/chunk replaced the Electron 42 stdlib module.
+node_sqlite_relative_hits="$(grep -nE '(from[[:space:]]+"|import\(")\.\.?/[^"]*node:?sqlite' "${output_files[@]}" 2>/dev/null || true)"
+if [ -n "${node_sqlite_relative_hits}" ]; then
+  report "node:sqlite was rewritten to a relative runtime import:"
+  echo "${node_sqlite_relative_hits}" >&2
 fi
 
 if [ "${fail}" -ne 0 ]; then

--- a/bun.lock
+++ b/bun.lock
@@ -68,13 +68,11 @@
         "@wuphf/agent-runners": "workspace:*",
         "@wuphf/credentials": "workspace:*",
         "@wuphf/protocol": "workspace:*",
-        "better-sqlite3": "12.9.0",
         "ws": "8.20.0",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.15",
-        "@types/better-sqlite3": "7.6.13",
-        "@types/node": "^22.10.0",
+        "@types/node": "25.6.2",
         "@types/ws": "8.18.1",
         "@vitest/coverage-v8": "2.1.9",
         "tsx": "^4.19.0",
@@ -274,57 +272,57 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
 
@@ -702,7 +700,7 @@
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "chromium-pickle-js": ["chromium-pickle-js@0.2.0", "", {}, "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw=="],
 
@@ -852,7 +850,7 @@
 
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
-    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -1560,6 +1558,8 @@
 
     "@vitest/mocker/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
+    "@wuphf/broker/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+
     "@wuphf/desktop/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "@wuphf/desktop/@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.5", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.5", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.5", "vitest": "4.1.5" }, "optionalPeers": ["@vitest/browser"] }, "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A=="],
@@ -1619,6 +1619,8 @@
     "electron-builder-squirrel-windows/app-builder-lib": ["app-builder-lib@25.1.8", "", { "dependencies": { "@develar/schema-utils": "~2.6.5", "@electron/notarize": "2.5.0", "@electron/osx-sign": "1.3.1", "@electron/rebuild": "3.6.1", "@electron/universal": "2.0.1", "@malept/flatpak-bundler": "^0.4.0", "@types/fs-extra": "9.0.13", "async-exit-hook": "^2.0.1", "bluebird-lst": "^1.0.9", "builder-util": "25.1.7", "builder-util-runtime": "9.2.10", "chromium-pickle-js": "^0.2.0", "config-file-ts": "0.2.8-rc1", "debug": "^4.3.4", "dotenv": "^16.4.5", "dotenv-expand": "^11.0.6", "ejs": "^3.1.8", "electron-publish": "25.1.7", "form-data": "^4.0.0", "fs-extra": "^10.1.0", "hosted-git-info": "^4.1.0", "is-ci": "^3.0.0", "isbinaryfile": "^5.0.0", "js-yaml": "^4.1.0", "json5": "^2.2.3", "lazy-val": "^1.0.5", "minimatch": "^10.0.0", "resedit": "^1.7.0", "sanitize-filename": "^1.6.3", "semver": "^7.3.8", "tar": "^6.1.12", "temp-file": "^3.4.0" }, "peerDependencies": { "dmg-builder": "25.1.8", "electron-builder-squirrel-windows": "25.1.8" } }, "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg=="],
 
     "electron-builder-squirrel-windows/builder-util": ["builder-util@25.1.7", "", { "dependencies": { "7zip-bin": "~5.2.0", "@types/debug": "^4.1.6", "app-builder-bin": "5.0.0-alpha.10", "bluebird-lst": "^1.0.9", "builder-util-runtime": "9.2.10", "chalk": "^4.1.2", "cross-spawn": "^7.0.3", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "is-ci": "^3.0.0", "js-yaml": "^4.1.0", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0" } }, "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww=="],
+
+    "electron-vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 
@@ -1706,13 +1708,11 @@
 
     "table/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "test-exclude/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "tiny-async-pool/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
-
-    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
@@ -1763,6 +1763,8 @@
     "@types/ws/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@vitest/mocker/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "@wuphf/broker/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@wuphf/desktop/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -1862,6 +1864,58 @@
 
     "electron-builder/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "electron-vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "electron-vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "electron-vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "electron-vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "electron-vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "electron-vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "electron-vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "electron-vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "electron-vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "electron-vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "electron-vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "electron-vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "electron-vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "electron-vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "electron-vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "electron-vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "electron-vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "electron-vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "electron-vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "electron-vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "electron-vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "electron-vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "electron-vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "electron-vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "electron-vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "electron-vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
     "electron/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
@@ -1917,58 +1971,6 @@
     "test-exclude/glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "test-exclude/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
-
-    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
-
-    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
-
-    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
-
-    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
-
-    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
-
-    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
-
-    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
-
-    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
-
-    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
-
-    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
-
-    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
-
-    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
-
-    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
-
-    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
-
-    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
-
-    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
-
-    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
-
-    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
-
-    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
-
-    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
-
-    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
-
-    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
-
-    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
-
-    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
-
-    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -2037,8 +2039,6 @@
     "@wuphf/desktop/@vitest/coverage-v8/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
 
     "@wuphf/desktop/vitest/@vitest/expect/chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "app-builder-lib/@electron/asar/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
@@ -2189,58 +2189,6 @@
     "zip-stream/archiver-utils/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@electron/universal/@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
-
-    "@wuphf/desktop/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "app-builder-lib/@electron/asar/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -18,9 +18,9 @@ implementations:
 - `InMemoryReceiptStore` (default) — process-local; lost across restarts.
   Useful for tests and headless smoke runs.
 - `SqliteReceiptStore` from `@wuphf/broker/sqlite` — durable, SQLite
-  event-log-backed. Loads the native `better-sqlite3` binding only when
-  imported, so consumers that only need the in-memory path don't pay the
-  cost. Hosts (e.g. the Electron utility process) wire this in by
+  event-log-backed. Uses Node's built-in `node:sqlite` module, so the
+  storage layer does not carry a native binding. Hosts (e.g. the Electron
+  utility process) wire this in by
   passing `receiptStore: SqliteReceiptStore.open({ path })`, or by using
   `SqliteReceiptStore.fromDatabase(db, eventLog)` with
   `createThreadSubsystem(db, eventLog, receiptStore)` when thread routes are

--- a/packages/broker/README.md
+++ b/packages/broker/README.md
@@ -26,6 +26,10 @@ implementations:
   `createThreadSubsystem(db, eventLog, receiptStore)` when thread routes are
   mounted.
 
+SQLite BLOB reads exposed by approval projection/replay helpers are `Uint8Array`
+values. Treat them as generic bytes and decode with `TextDecoder` when text is
+needed; do not rely on Node `Buffer`-specific methods at those boundaries.
+
 ## API
 
 ```ts

--- a/packages/broker/docs/event-log-projections-design.md
+++ b/packages/broker/docs/event-log-projections-design.md
@@ -14,7 +14,7 @@ Replace the in-memory `ReceiptStore` with a durable, event-log-backed implementa
 
 ```text
 packages/broker/
-├── package.json                              # better-sqlite3 dep
+├── package.json                              # broker package metadata
 ├── src/
 │   ├── event-log/                            # internal — append, replay, migrations
 │   │   ├── index.ts                          # internal re-exports
@@ -93,12 +93,10 @@ The broker package exposes two import paths:
 
 - `@wuphf/broker` (the root) — `createBroker`, `ReceiptStore`,
   `InMemoryReceiptStore`, `ListFilter`/`ListPage` types, cursor + limit
-  helpers and error classes, and the broker config types. No native
-  binding is loaded by importing the root.
+  helpers and error classes, and the broker config types.
 - `@wuphf/broker/sqlite` — `SqliteReceiptStore` and
-  `SqliteReceiptStoreConfig`. Importing this subpath evaluates
-  `better-sqlite3`'s native binding, so hosts that don't need the
-  durable store skip the cost by not importing it.
+  `SqliteReceiptStoreConfig`. This subpath uses Node's built-in
+  `node:sqlite` module for the durable store.
 
 `SqliteReceiptStore`'s constructor is `private`; the only supported
 construction path is `SqliteReceiptStore.open(config)` so
@@ -125,7 +123,7 @@ to mirror the TypeScript class structure.
 ### `event-log/event-log.ts`
 
 ```ts
-import type Database from "better-sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 
 export type EventType = "receipt.put";   // branch-6 only event; expand later
 
@@ -143,8 +141,8 @@ export interface AppendArgs {
 
 export interface EventLog {
   /**
-   * Append-only. Returns the assigned LSN. Synchronous — better-sqlite3
-   * does not expose an async API and the broker is the sole writer.
+   * Append-only. Returns the assigned LSN. Synchronous — node:sqlite
+   * exposes a sync API and the broker is the sole writer.
    *
    * MUST be invoked inside a containing transaction when the caller is
    * also writing to a projection table (see SqliteReceiptStore.put).
@@ -168,21 +166,21 @@ export interface OpenDatabaseArgs {
   readonly path: string;
 }
 
-export function openDatabase(args: OpenDatabaseArgs): Database.Database;
-export function createEventLog(db: Database.Database): EventLog;
+export function openDatabase(args: OpenDatabaseArgs): DatabaseSync;
+export function createEventLog(db: DatabaseSync): EventLog;
 ```
 
 ### `event-log/migrations.ts`
 
 ```ts
-import type Database from "better-sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 
 /**
  * Apply all forward-only migrations whose number > current `PRAGMA user_version`.
  * Runs each migration in its own transaction; sets `user_version` on success.
  * Throws on first failure — caller MUST treat the DB as uninitialized.
  */
-export function runMigrations(db: Database.Database): void;
+export function runMigrations(db: DatabaseSync): void;
 
 export const CURRENT_SCHEMA_VERSION: number;  // = 1
 ```
@@ -190,7 +188,7 @@ export const CURRENT_SCHEMA_VERSION: number;  // = 1
 ### `sqlite-receipt-store.ts`
 
 ```ts
-import type Database from "better-sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 import type { ReceiptSnapshot } from "@wuphf/protocol";
 import type { ReceiptStore } from "./receipt-store.ts";
 

--- a/packages/broker/package.json
+++ b/packages/broker/package.json
@@ -34,13 +34,11 @@
     "@wuphf/agent-runners": "workspace:*",
     "@wuphf/credentials": "workspace:*",
     "@wuphf/protocol": "workspace:*",
-    "better-sqlite3": "12.9.0",
     "ws": "8.20.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
-    "@types/better-sqlite3": "7.6.13",
-    "@types/node": "^22.10.0",
+    "@types/node": "25.6.2",
     "@types/ws": "8.18.1",
     "@vitest/coverage-v8": "2.1.9",
     "tsx": "^4.19.0",

--- a/packages/broker/scripts/branch-10-demo.ts
+++ b/packages/broker/scripts/branch-10-demo.ts
@@ -30,11 +30,10 @@ import {
   asTimestampMs,
   threadSpecContentHash,
 } from "@wuphf/protocol";
-import BetterSqlite3 from "better-sqlite3";
 
 import { createAgentProviderRoutingStore } from "../src/agent-provider-routing/index.ts";
 import { createApprovalAppender, createApprovalProjection } from "../src/approvals/index.ts";
-import { createEventLog, runMigrations } from "../src/event-log/index.ts";
+import { createEventLog, openDatabase, runMigrations } from "../src/event-log/index.ts";
 import { createBroker } from "../src/index.ts";
 import { SqliteReceiptStore } from "../src/sqlite-receipt-store.ts";
 import { createThreadSubsystem, SYSTEM_INBOX_THREAD_ID } from "../src/threads/index.ts";
@@ -43,7 +42,7 @@ const tmp = mkdtempSync(join(tmpdir(), "wuphf-branch-10-"));
 const dbPath = join(tmp, "broker.db");
 
 console.log(`[demo] SQLite DB: ${dbPath}`);
-const db = new BetterSqlite3(dbPath);
+const db = openDatabase({ path: dbPath });
 runMigrations(db);
 const eventLog = createEventLog(db);
 const approvalProjection = createApprovalProjection(db);

--- a/packages/broker/scripts/thread-stress-profile.ts
+++ b/packages/broker/scripts/thread-stress-profile.ts
@@ -92,9 +92,7 @@ async function main(): Promise<void> {
     const eventLog = createEventLog(db);
     receiptStore = SqliteReceiptStore.fromDatabase(db, eventLog);
     const threads = createThreadSubsystem(db, eventLog, receiptStore);
-    const threadExistsStmt = db.prepare<[string], { readonly present: 1 }>(
-      "SELECT 1 AS present FROM threads WHERE thread_id = ?",
-    );
+    const threadExistsStmt = db.prepare("SELECT 1 AS present FROM threads WHERE thread_id = ?");
     const approvals = createApprovalSubsystem(db, eventLog, {
       threadRefValidator: (threadId) => threadExistsStmt.get(threadId) !== undefined,
     });
@@ -651,11 +649,11 @@ function assertReplayCheckOk(db: ReturnType<typeof openDatabase>, label: string)
 
 function countEvents(db: ReturnType<typeof openDatabase>, type: string): number {
   return (
-    db
-      .prepare<[string], { readonly count: number }>(
-        "SELECT COUNT(*) AS count FROM event_log WHERE type = ?",
-      )
-      .get(type)?.count ?? 0
+    (
+      db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE type = ?").get(type) as
+        | { readonly count: number }
+        | undefined
+    )?.count ?? 0
   );
 }
 

--- a/packages/broker/src/agent-provider-routing/store.ts
+++ b/packages/broker/src/agent-provider-routing/store.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync, StatementSync } from "node:sqlite";
 import {
   type AgentId,
   type AgentProviderRouting,
@@ -12,9 +13,9 @@ import {
   RUNNER_KIND_VALUES,
   type RunnerKind,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import { type OpenDatabaseArgs, openDatabase, runMigrations } from "../event-log/index.ts";
+import { createTransaction, type TransactionFn } from "../internal/sqlite-transaction.ts";
 import type { AgentProviderRoutingStore } from "./types.ts";
 
 export interface SqliteAgentProviderRoutingStoreConfig extends OpenDatabaseArgs {}
@@ -29,19 +30,17 @@ interface RoutingEntryDbRow {
   readonly providerKind: string;
 }
 
-type InsertRouteParams = [AgentId, RunnerKind, CredentialScope, ProviderKind];
-
 const KIND_ORDER: ReadonlyMap<RunnerKind, number> = new Map(
   RUNNER_KIND_VALUES.map((kind, index) => [kind, index] as const),
 );
 
 export class SqliteAgentProviderRoutingStore implements AgentProviderRoutingStore {
   private readonly closeDatabase: boolean;
-  private readonly listRoutesStmt: Database.Statement<[AgentId], RoutingEntryDbRow>;
-  private readonly getEntryStmt: Database.Statement<[AgentId, RunnerKind], RoutingEntryDbRow>;
-  private readonly deleteAgentStmt: Database.Statement<[AgentId]>;
-  private readonly insertRouteStmt: Database.Statement<InsertRouteParams>;
-  private readonly putTransaction: Database.Transaction<(config: AgentProviderRouting) => void>;
+  private readonly listRoutesStmt: StatementSync;
+  private readonly getEntryStmt: StatementSync;
+  private readonly deleteAgentStmt: StatementSync;
+  private readonly insertRouteStmt: StatementSync;
+  private readonly putTransaction: TransactionFn<[AgentProviderRouting], void>;
   private closed = false;
 
   static open(config: SqliteAgentProviderRoutingStoreConfig): SqliteAgentProviderRoutingStore {
@@ -56,33 +55,31 @@ export class SqliteAgentProviderRoutingStore implements AgentProviderRoutingStor
   }
 
   constructor(
-    private readonly db: Database.Database,
+    private readonly db: DatabaseSync,
     options: SqliteAgentProviderRoutingStoreOptions = {},
   ) {
     this.closeDatabase = options.closeDatabase ?? false;
-    this.listRoutesStmt = db.prepare<[AgentId], RoutingEntryDbRow>(
+    this.listRoutesStmt = db.prepare(
       `SELECT runner_kind AS kind,
               credential_scope AS credentialScope,
               provider_kind AS providerKind
        FROM agent_provider_routing
        WHERE agent_id = ?`,
     );
-    this.getEntryStmt = db.prepare<[AgentId, RunnerKind], RoutingEntryDbRow>(
+    this.getEntryStmt = db.prepare(
       `SELECT runner_kind AS kind,
               credential_scope AS credentialScope,
               provider_kind AS providerKind
        FROM agent_provider_routing
        WHERE agent_id = ? AND runner_kind = ?`,
     );
-    this.deleteAgentStmt = db.prepare<[AgentId]>(
-      "DELETE FROM agent_provider_routing WHERE agent_id = ?",
-    );
-    this.insertRouteStmt = db.prepare<InsertRouteParams>(
+    this.deleteAgentStmt = db.prepare("DELETE FROM agent_provider_routing WHERE agent_id = ?");
+    this.insertRouteStmt = db.prepare(
       `INSERT INTO agent_provider_routing
          (agent_id, runner_kind, credential_scope, provider_kind)
        VALUES (?, ?, ?, ?)`,
     );
-    this.putTransaction = db.transaction((config: AgentProviderRouting) => {
+    this.putTransaction = createTransaction(db, (config: AgentProviderRouting) => {
       this.deleteAgentStmt.run(config.agentId);
       for (const route of config.routes) {
         this.insertRouteStmt.run(
@@ -98,7 +95,9 @@ export class SqliteAgentProviderRoutingStore implements AgentProviderRoutingStor
   async get(agentId: AgentId): Promise<AgentProviderRouting> {
     this.assertOpen();
     const validAgentId = validateAgentId(agentId, "agentProviderRoutingStore.get.agentId");
-    const routes = this.listRoutesStmt.all(validAgentId).map(rowToEntry).sort(compareEntriesByKind);
+    const routes = (this.listRoutesStmt.all(validAgentId) as unknown as RoutingEntryDbRow[])
+      .map(rowToEntry)
+      .sort(compareEntriesByKind);
     return { agentId: validAgentId, routes };
   }
 
@@ -112,7 +111,7 @@ export class SqliteAgentProviderRoutingStore implements AgentProviderRoutingStor
     this.assertOpen();
     const validAgentId = validateAgentId(agentId, "agentProviderRoutingStore.getEntry.agentId");
     const validKind = validateRunnerKind(kind, "agentProviderRoutingStore.getEntry.kind");
-    const row = this.getEntryStmt.get(validAgentId, validKind);
+    const row = this.getEntryStmt.get(validAgentId, validKind) as RoutingEntryDbRow | undefined;
     if (row === undefined) {
       return null;
     }
@@ -145,7 +144,7 @@ export class SqliteAgentProviderRoutingStore implements AgentProviderRoutingStor
   }
 }
 
-export function createAgentProviderRoutingStore(db: Database.Database): AgentProviderRoutingStore {
+export function createAgentProviderRoutingStore(db: DatabaseSync): AgentProviderRoutingStore {
   return new SqliteAgentProviderRoutingStore(db);
 }
 

--- a/packages/broker/src/approvals/appender.ts
+++ b/packages/broker/src/approvals/appender.ts
@@ -23,6 +23,7 @@ import {
 
 import type { EventLog } from "../event-log/index.ts";
 import { createTransaction } from "../internal/sqlite-transaction.ts";
+import { typed } from "../internal/typed-statement.ts";
 import type { ParsedApprovalIdempotencyKey } from "./idempotency.ts";
 import {
   type ApprovalProjection,
@@ -161,16 +162,23 @@ export function createApprovalAppender(
      FROM command_idempotency
      WHERE idempotency_key = ? AND command = ?`,
   );
-  const idempotencyInsertStmt = db.prepare(
-    `INSERT INTO command_idempotency
+  const idempotencyInsertStmt = typed<
+    [string, string, number, Buffer, number | null, number, string],
+    never
+  >(
+    db.prepare(
+      `INSERT INTO command_idempotency
        (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms,
         request_fingerprint)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ),
   );
-  const pruneIdempotencyStmt = db.prepare(
-    `DELETE FROM command_idempotency
+  const pruneIdempotencyStmt = typed<[number], never>(
+    db.prepare(
+      `DELETE FROM command_idempotency
      WHERE created_at_ms < ?
        AND command IN ('approval.requested', 'approval.decided')`,
+    ),
   );
   const threadRefValidator = options.threadRefValidator ?? null;
 

--- a/packages/broker/src/approvals/appender.ts
+++ b/packages/broker/src/approvals/appender.ts
@@ -5,6 +5,7 @@
 // updates the projection, and stores the idempotency replay row in one
 // BEGIN IMMEDIATE transaction.
 
+import type { DatabaseSync } from "node:sqlite";
 import {
   type ApprovalDecidedAuditPayload,
   type ApprovalRequest,
@@ -19,9 +20,9 @@ import {
   parseLsn,
   type ThreadId,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 import type { ParsedApprovalIdempotencyKey } from "./idempotency.ts";
 import {
   type ApprovalProjection,
@@ -65,7 +66,7 @@ export interface IdempotentApprovalDecisionArgs {
 }
 
 export interface ApprovalAppender {
-  sharesProvenance(db: Database.Database, eventLog: EventLog): boolean;
+  sharesProvenance(db: DatabaseSync, eventLog: EventLog): boolean;
   requestApproval(payload: ApprovalRequestedAuditPayload): ApprovalAppendResult;
   decideApproval(payload: ApprovalDecidedAuditPayload): ApprovalAppendResult;
   requestApprovalIdempotent(args: IdempotentApprovalRequestArgs): IdempotentApprovalAppendResult;
@@ -133,7 +134,7 @@ export class ApprovalIdempotencyConflictError extends Error {
 
 interface IdempotencyRow {
   readonly statusCode: number;
-  readonly responsePayload: Buffer;
+  readonly responsePayload: Uint8Array;
   readonly createdAtLsn: number | null;
   readonly requestFingerprint: string | null;
 }
@@ -143,32 +144,30 @@ interface TokenUsageRow {
 }
 
 export function createApprovalAppender(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog: EventLog,
   projection: ApprovalProjection,
   options: ApprovalAppenderOptions = {},
 ): ApprovalAppender {
-  const tokenUsageStmt = db.prepare<[string, string], TokenUsageRow>(
+  const tokenUsageStmt = db.prepare(
     `SELECT approval_id AS approvalId
      FROM pending_approvals
      WHERE token_id = ? AND approval_id != ?
      LIMIT 1`,
   );
-  const idempotencyLookupStmt = db.prepare<[string, string], IdempotencyRow>(
+  const idempotencyLookupStmt = db.prepare(
     `SELECT status_code AS statusCode, response_payload AS responsePayload,
             created_at_lsn AS createdAtLsn, request_fingerprint AS requestFingerprint
      FROM command_idempotency
      WHERE idempotency_key = ? AND command = ?`,
   );
-  const idempotencyInsertStmt = db.prepare<
-    [string, string, number, Buffer, number | null, number, string]
-  >(
+  const idempotencyInsertStmt = db.prepare(
     `INSERT INTO command_idempotency
        (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms,
         request_fingerprint)
      VALUES (?, ?, ?, ?, ?, ?, ?)`,
   );
-  const pruneIdempotencyStmt = db.prepare<[number]>(
+  const pruneIdempotencyStmt = db.prepare(
     `DELETE FROM command_idempotency
      WHERE created_at_ms < ?
        AND command IN ('approval.requested', 'approval.decided')`,
@@ -178,7 +177,9 @@ export function createApprovalAppender(
   const assertApprovalTokenUnused = (payload: ApprovalDecidedAuditPayload): void => {
     const suppliedApprovalToken = payload.decision === "approve" ? payload.token : undefined;
     if (suppliedApprovalToken === undefined) return;
-    const existing = tokenUsageStmt.get(suppliedApprovalToken.tokenId, payload.requestId);
+    const existing = tokenUsageStmt.get(suppliedApprovalToken.tokenId, payload.requestId) as
+      | TokenUsageRow
+      | undefined;
     if (existing !== undefined) {
       throw new ApprovalTokenAlreadyUsedError(suppliedApprovalToken.tokenId);
     }
@@ -268,13 +269,16 @@ export function createApprovalAppender(
     return { lsn: lsnFromV1Number(lsn), approval: applied.approval };
   };
 
-  const requestApprovalTransaction = db.transaction(requestApprovalInner);
-  const decideApprovalTransaction = db.transaction(decideApprovalInner);
+  const requestApprovalTransaction = createTransaction(db, requestApprovalInner);
+  const decideApprovalTransaction = createTransaction(db, decideApprovalInner);
 
-  const requestApprovalIdempotentTransaction = db.transaction(
+  const requestApprovalIdempotentTransaction = createTransaction(
+    db,
     (args: IdempotentApprovalRequestArgs): IdempotentApprovalAppendResult => {
       assertRequestFingerprint(args.requestFingerprint);
-      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+        | IdempotencyRow
+        | undefined;
       if (cached !== undefined) {
         assertIdempotencyFingerprint(cached, args.requestFingerprint);
         return idempotentReplay(cached);
@@ -300,10 +304,13 @@ export function createApprovalAppender(
     },
   );
 
-  const decideApprovalIdempotentTransaction = db.transaction(
+  const decideApprovalIdempotentTransaction = createTransaction(
+    db,
     (args: IdempotentApprovalDecisionArgs): IdempotentApprovalAppendResult => {
       assertRequestFingerprint(args.requestFingerprint);
-      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+        | IdempotencyRow
+        | undefined;
       if (cached !== undefined) {
         assertIdempotencyFingerprint(cached, args.requestFingerprint);
         return idempotentReplay(cached);
@@ -330,7 +337,7 @@ export function createApprovalAppender(
   );
 
   return {
-    sharesProvenance(candidateDb: Database.Database, candidateEventLog: EventLog): boolean {
+    sharesProvenance(candidateDb: DatabaseSync, candidateEventLog: EventLog): boolean {
       return candidateDb === db && candidateEventLog === eventLog;
     },
     requestApproval(payload: ApprovalRequestedAuditPayload): ApprovalAppendResult {
@@ -349,7 +356,7 @@ export function createApprovalAppender(
       if (!Number.isSafeInteger(cutoffMs)) {
         throw new Error("pruneIdempotencyOlderThan: cutoffMs must be a safe integer");
       }
-      return pruneIdempotencyStmt.run(cutoffMs).changes;
+      return Number(pruneIdempotencyStmt.run(cutoffMs).changes);
     },
   };
 }

--- a/packages/broker/src/approvals/index.ts
+++ b/packages/broker/src/approvals/index.ts
@@ -1,6 +1,6 @@
 // Public surface of `@wuphf/broker/approvals`.
 
-import type Database from "better-sqlite3";
+import type { DatabaseSync } from "node:sqlite";
 
 import type { EventLog as ApprovalEventLog } from "../event-log/index.ts";
 import {
@@ -37,7 +37,7 @@ export interface ApprovalSubsystemOptions {
 }
 
 export function createApprovalSubsystem(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog: ApprovalEventLog,
   options: ApprovalSubsystemOptions = {},
 ): ApprovalSubsystem {

--- a/packages/broker/src/approvals/projections.ts
+++ b/packages/broker/src/approvals/projections.ts
@@ -4,6 +4,7 @@
 // source of truth; writes apply one event incrementally in the append
 // transaction, and replay can rebuild the table from LSN 0.
 
+import type { DatabaseSync } from "node:sqlite";
 import {
   APPROVAL_REQUEST_SCHEMA_VERSION,
   type ApprovalAuditPayload,
@@ -24,9 +25,9 @@ import {
   type TaskId,
   type ThreadId,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog, EventLogRecord, EventType } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 
 const APPROVAL_EVENT_BATCH_SIZE = 1_000;
 
@@ -59,7 +60,7 @@ export interface ApprovalPendingByThreadSnapshot {
 export interface ApprovalProjectionEvent {
   readonly lsn: number;
   readonly type: EventType | string;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 export interface ApprovalProjectionRebuildResult {
@@ -68,7 +69,7 @@ export interface ApprovalProjectionRebuildResult {
 }
 
 export interface ApprovalProjection {
-  sharesProvenance(db: Database.Database, eventLog: EventLog): boolean;
+  sharesProvenance(db: DatabaseSync, eventLog: EventLog): boolean;
   applyEvent(event: ApprovalProjectionEvent): FoldedApprovalRow | null;
   rebuildFromLog(eventLog: EventLog): ApprovalProjectionRebuildResult;
   getById(id: ApprovalRequestId): FoldedApprovalRow | null;
@@ -141,7 +142,7 @@ interface ApprovalDbRow {
 interface ApprovalEventDbRow {
   readonly lsn: number;
   readonly type: string;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface CountRow {
@@ -187,60 +188,31 @@ interface ApprovalRequestWireForRow {
   decision?: ApprovalDecisionWireForRow;
 }
 
-type RequestUpsertParams = [
-  string,
-  string,
-  number,
-  string,
-  string,
-  string,
-  string | null,
-  string | null,
-  string | null,
-  string,
-  number,
-];
-
-type DecisionUpdateParams = [
-  ApprovalRequestStatus,
-  number,
-  string,
-  number,
-  ApprovalDecision,
-  string | null,
-  string | null,
-  string,
-];
-
-export function createApprovalProjection(db: Database.Database): ApprovalProjection {
-  const selectByIdStmt = db.prepare<[string], ApprovalDbRow>(
-    approvalSelectSql("WHERE approval_id = ?"),
-  );
-  const insertRequestedStmt = db.prepare<RequestUpsertParams>(
+export function createApprovalProjection(db: DatabaseSync): ApprovalProjection {
+  const selectByIdStmt = db.prepare(approvalSelectSql("WHERE approval_id = ?"));
+  const insertRequestedStmt = db.prepare(
     `INSERT INTO pending_approvals
        (approval_id, status, head_lsn, claim, scope, risk_class, thread_id, task_id, receipt_id,
         requested_by, requested_at_ms, decided_by, decided_at_ms, decision, token, token_id)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL)`,
   );
-  const updateDecidedStmt = db.prepare<DecisionUpdateParams>(
+  const updateDecidedStmt = db.prepare(
     `UPDATE pending_approvals
      SET status = ?, head_lsn = ?, decided_by = ?, decided_at_ms = ?, decision = ?, token = ?,
          token_id = ?
      WHERE approval_id = ? AND status = 'pending'`,
   );
-  const clearStmt = db.prepare<[]>("DELETE FROM pending_approvals");
-  const countPendingByThreadStmt = db.prepare<[string], CountRow>(
+  const clearStmt = db.prepare("DELETE FROM pending_approvals");
+  const countPendingByThreadStmt = db.prepare(
     "SELECT COUNT(*) AS count FROM pending_approvals WHERE thread_id = ? AND status = 'pending'",
   );
-  const latestHeadLsnByThreadStmt = db.prepare<[string], MaxLsnRow>(
+  const latestHeadLsnByThreadStmt = db.prepare(
     "SELECT MAX(head_lsn) AS headLsn FROM pending_approvals WHERE thread_id = ?",
   );
-  const threadExistsStmt = db.prepare<[string], ExistsRow>(
-    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
-  );
+  const threadExistsStmt = db.prepare("SELECT 1 AS present FROM threads WHERE thread_id = ?");
 
   const pendingCountByThread = (threadId: ThreadId): number => {
-    const row = countPendingByThreadStmt.get(threadId);
+    const row = countPendingByThreadStmt.get(threadId) as CountRow | undefined;
     if (row === undefined) {
       throw new Error(`pending approval count query returned no row for ${threadId}`);
     }
@@ -253,7 +225,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
   ): void => {
     const threadId = payload.threadId;
     if (threadId === undefined) return;
-    if (threadExistsStmt.get(threadId) === undefined) {
+    if ((threadExistsStmt.get(threadId) as ExistsRow | undefined) === undefined) {
       throw new ApprovalReplayThreadNotFoundError(threadId, lsn);
     }
     if (pendingCountByThread(threadId) >= MAX_ROUTE_APPROVAL_LIST_ITEMS) {
@@ -284,7 +256,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       approval.requestedBy,
       dateToMs(approval.requestedAt, "approval.requestedAt"),
     );
-    const row = selectByIdStmt.get(approval.id);
+    const row = selectByIdStmt.get(approval.id) as ApprovalDbRow | undefined;
     if (row === undefined) {
       throw new Error("pending_approvals insert produced no row");
     }
@@ -307,7 +279,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
     if (result.changes !== 1) {
       throw new Error(`approval.decided has no pending request: ${payload.requestId}`);
     }
-    const row = selectByIdStmt.get(payload.requestId);
+    const row = selectByIdStmt.get(payload.requestId) as ApprovalDbRow | undefined;
     if (row === undefined) {
       throw new Error(`approval.decided update produced no row: ${payload.requestId}`);
     }
@@ -332,7 +304,8 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
     return applyDecided(decoded.payload, event.lsn);
   };
 
-  const rebuildTransaction = db.transaction(
+  const rebuildTransaction = createTransaction(
+    db,
     (eventLog: EventLog): ApprovalProjectionRebuildResult => {
       clearStmt.run();
       let cursor = 0;
@@ -355,7 +328,8 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       return { eventsApplied, highestLsn: lsnFromV1Number(highestLsn) };
     },
   );
-  const pendingByThreadSnapshotTransaction = db.transaction(
+  const pendingByThreadSnapshotTransaction = createTransaction(
+    db,
     (threadId: ThreadId): ApprovalPendingByThreadSnapshot => {
       const rows = listRows(
         db,
@@ -368,7 +342,8 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
         const count = pendingCountByThread(threadId);
         throw new ApprovalPendingSnapshotOverflowError(threadId, count);
       }
-      const headLsn = latestHeadLsnByThreadStmt.get(threadId)?.headLsn ?? null;
+      const headLsn =
+        (latestHeadLsnByThreadStmt.get(threadId) as MaxLsnRow | undefined)?.headLsn ?? null;
       return {
         rows: rows.map(rowToFolded),
         headLsn: headLsn === null ? null : lsnFromV1Number(headLsn),
@@ -377,7 +352,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
   );
 
   return {
-    sharesProvenance(candidateDb: Database.Database, _eventLog: EventLog): boolean {
+    sharesProvenance(candidateDb: DatabaseSync, _eventLog: EventLog): boolean {
       return candidateDb === db;
     },
     applyEvent,
@@ -385,7 +360,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       return rebuildTransaction.immediate(eventLog);
     },
     getById(id: ApprovalRequestId): FoldedApprovalRow | null {
-      const row = selectByIdStmt.get(id);
+      const row = selectByIdStmt.get(id) as ApprovalDbRow | undefined;
       return row === undefined ? null : rowToFolded(row);
     },
     list(filter?: ApprovalListFilter): readonly FoldedApprovalRow[] {
@@ -414,7 +389,7 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
       return pendingCountByThread(threadId);
     },
     latestHeadLsnByThread(threadId: ThreadId): EventLsn | null {
-      const row = latestHeadLsnByThreadStmt.get(threadId);
+      const row = latestHeadLsnByThreadStmt.get(threadId) as MaxLsnRow | undefined;
       if (row === undefined || row.headLsn === null) return null;
       return lsnFromV1Number(row.headLsn);
     },
@@ -425,16 +400,16 @@ export function createApprovalProjection(db: Database.Database): ApprovalProject
 }
 
 export function foldApprovalFromLog(
-  db: Database.Database,
+  db: DatabaseSync,
   requestId: ApprovalRequestId,
 ): FoldedApprovalRow | null {
   const rows = db
-    .prepare<[], ApprovalEventDbRow>(
+    .prepare(
       `SELECT lsn, type, payload FROM event_log
        WHERE type IN ('approval.requested', 'approval.decided')
        ORDER BY lsn ASC`,
     )
-    .all();
+    .all() as unknown as ApprovalEventDbRow[];
   let folded: FoldedApprovalRow | null = null;
   for (const row of rows) {
     const decoded = parseApprovalEvent(row);
@@ -502,7 +477,7 @@ export function statusForDecision(
 }
 
 function listRows(
-  db: Database.Database,
+  db: DatabaseSync,
   filter: ApprovalListFilter | undefined,
   page?: ApprovalListPageOptions,
 ): ApprovalDbRow[] {
@@ -528,10 +503,8 @@ function listRows(
   const limit = page === undefined ? "" : " LIMIT ?";
   if (page !== undefined) params.push(page.limit);
   return db
-    .prepare<(number | string)[], ApprovalDbRow>(
-      `${approvalSelectSql(where)} ORDER BY head_lsn ASC${limit}`,
-    )
-    .all(...params);
+    .prepare(`${approvalSelectSql(where)} ORDER BY head_lsn ASC${limit}`)
+    .all(...params) as unknown as ApprovalDbRow[];
 }
 
 function approvalSelectSql(where: string): string {
@@ -555,7 +528,7 @@ function parseApprovalEvent(
       kind: "approval_requested",
       payload: approvalAuditPayloadFromJsonValue(
         "approval_requested",
-        JSON.parse(event.payload.toString("utf8")) as unknown,
+        JSON.parse(new TextDecoder().decode(event.payload)) as unknown,
       ) as ApprovalRequestedAuditPayload,
     };
   }
@@ -564,7 +537,7 @@ function parseApprovalEvent(
       kind: "approval_decided",
       payload: approvalAuditPayloadFromJsonValue(
         "approval_decided",
-        JSON.parse(event.payload.toString("utf8")) as unknown,
+        JSON.parse(new TextDecoder().decode(event.payload)) as unknown,
       ) as ApprovalDecidedAuditPayload,
     };
   }

--- a/packages/broker/src/approvals/rebuild/index.ts
+++ b/packages/broker/src/approvals/rebuild/index.ts
@@ -108,7 +108,7 @@ export function replayApprovalsProjectionSnapshot(
     );
     const insertEvents = createTransaction(replayDb, () => {
       for (const row of rows) {
-        insertEventStmt.run(row.lsn, row.tsMs, row.type, Buffer.from(row.payload));
+        insertEventStmt.run(row.lsn, row.tsMs, row.type, row.payload);
       }
     });
     insertEvents.immediate();

--- a/packages/broker/src/approvals/rebuild/index.ts
+++ b/packages/broker/src/approvals/rebuild/index.ts
@@ -1,3 +1,4 @@
+import { DatabaseSync } from "node:sqlite";
 import {
   type EventLsn,
   lsnFromV1Number,
@@ -6,10 +7,9 @@ import {
   type ThreadId,
   threadAuditPayloadFromJsonValue,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
-import BetterSqlite3 from "better-sqlite3";
 
 import { createEventLog, type EventLog, runMigrations } from "../../event-log/index.ts";
+import { createTransaction } from "../../internal/sqlite-transaction.ts";
 import {
   createThreadStateStore,
   type ThreadStateStore,
@@ -42,7 +42,7 @@ export interface ApprovalReplayEventRow {
   readonly lsn: number;
   readonly tsMs: number;
   readonly type: string;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 const THREAD_PROJECTION_CHECK_BATCH_SIZE = 500;
@@ -73,7 +73,7 @@ export class ApprovalRebuildThreadProjectionNotReadyError extends Error {
 }
 
 export function rebuildApprovalsProjectionFromLog(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog: EventLog,
   threadStateStore: ThreadStateStore,
 ): ApprovalProjectionRebuildResult {
@@ -82,10 +82,10 @@ export function rebuildApprovalsProjectionFromLog(
 }
 
 export function snapshotApprovalsProjection(
-  db: Database.Database,
+  db: DatabaseSync,
 ): readonly ApprovalProjectionSnapshotRow[] {
   return db
-    .prepare<[], ApprovalProjectionSnapshotRow>(
+    .prepare(
       `SELECT approval_id AS approvalId, status, head_lsn AS headLsn, claim, scope,
               risk_class AS riskClass, thread_id AS threadId, task_id AS taskId,
               receipt_id AS receiptId, requested_by AS requestedBy,
@@ -94,19 +94,19 @@ export function snapshotApprovalsProjection(
        FROM pending_approvals
        ORDER BY approval_id ASC`,
     )
-    .all();
+    .all() as unknown as ApprovalProjectionSnapshotRow[];
 }
 
 export function replayApprovalsProjectionSnapshot(
   rows: readonly ApprovalReplayEventRow[],
 ): readonly ApprovalProjectionSnapshotRow[] {
-  const replayDb = new BetterSqlite3(":memory:");
+  const replayDb = new DatabaseSync(":memory:");
   try {
     runMigrations(replayDb);
-    const insertEventStmt = replayDb.prepare<[number, number, string, Buffer]>(
+    const insertEventStmt = replayDb.prepare(
       "INSERT INTO event_log (lsn, ts_ms, type, payload) VALUES (?, ?, ?, ?)",
     );
-    const insertEvents = replayDb.transaction(() => {
+    const insertEvents = createTransaction(replayDb, () => {
       for (const row of rows) {
         insertEventStmt.run(row.lsn, row.tsMs, row.type, Buffer.from(row.payload));
       }
@@ -151,7 +151,7 @@ function expectedThreadProjectionState(eventLog: EventLog): {
       if (kind === null) continue;
       headLsn = record.lsn;
       if (kind === "thread_created") {
-        const parsed = JSON.parse(record.payload.toString("utf8")) as unknown;
+        const parsed = JSON.parse(new TextDecoder().decode(record.payload)) as unknown;
         const payload = threadAuditPayloadFromJsonValue(kind, parsed) as ThreadCreatedAuditPayload;
         threadIds.add(payload.threadId);
       }

--- a/packages/broker/src/approvals/routes.ts
+++ b/packages/broker/src/approvals/routes.ts
@@ -42,9 +42,13 @@ import {
   type ThreadId,
   validateApprovalStreamEvent,
 } from "@wuphf/protocol";
-import BetterSqlite3 from "better-sqlite3";
 
 import { agentIdForBearer } from "../auth.ts";
+import {
+  isSqliteBusyError,
+  isSqliteFullError,
+  isSqliteUnavailableError,
+} from "../internal/sqlite-errors.ts";
 import type { BrokerLogger } from "../types.ts";
 import {
   type ApprovalAppender,
@@ -650,7 +654,6 @@ function writeSqliteErrorResponse(
   logger: BrokerLogger,
   rejectedEvent: string,
 ): boolean {
-  if (!isSqliteError(err)) return false;
   if (isSqliteBusyError(err)) {
     logger.warn(rejectedEvent, { reason: "store_busy" });
     writeRouteError(res, 503, { error: "store_busy", retryAfterMs: 1000 }, { "Retry-After": "1" });
@@ -667,39 +670,6 @@ function writeSqliteErrorResponse(
     return true;
   }
   return false;
-}
-
-interface SqliteErrorWithCode extends Error {
-  readonly code: string;
-}
-
-function isSqliteError(err: unknown): err is SqliteErrorWithCode {
-  return err instanceof BetterSqlite3.SqliteError;
-}
-
-function isSqliteFullError(err: SqliteErrorWithCode): boolean {
-  return err.code === "SQLITE_FULL";
-}
-
-function isSqliteBusyError(err: SqliteErrorWithCode): boolean {
-  return (
-    err.code === "SQLITE_BUSY" ||
-    err.code === "SQLITE_LOCKED" ||
-    err.code.startsWith("SQLITE_BUSY_") ||
-    err.code.startsWith("SQLITE_LOCKED_")
-  );
-}
-
-function isSqliteUnavailableError(err: SqliteErrorWithCode): boolean {
-  return (
-    err.code === "SQLITE_READONLY" ||
-    err.code === "SQLITE_CANTOPEN" ||
-    err.code === "SQLITE_CORRUPT" ||
-    err.code.startsWith("SQLITE_READONLY_") ||
-    err.code.startsWith("SQLITE_IOERR") ||
-    err.code.startsWith("SQLITE_CANTOPEN_") ||
-    err.code.startsWith("SQLITE_CORRUPT_")
-  );
 }
 
 function writeJson(

--- a/packages/broker/src/cost-ledger/projections.ts
+++ b/packages/broker/src/cost-ledger/projections.ts
@@ -21,6 +21,7 @@
 // Integer math throughout (amounts, projections) keeps both invariants
 // decidable across a long-lived ledger.
 
+import type { DatabaseSync } from "node:sqlite";
 import {
   asMicroUsd,
   type BudgetId,
@@ -35,9 +36,9 @@ import {
   type MicroUsd,
   parseLsn,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 import type { ParsedIdempotencyKey } from "./idempotency.ts";
 import { type NewCrossing, processCostEventForCrossings } from "./reactor.ts";
 
@@ -175,31 +176,36 @@ interface ThresholdCrossingDbRow {
   readonly limitMicroUsd: number;
 }
 
-export function createCostLedger(db: Database.Database, eventLog: EventLog): CostLedger {
-  const upsertAgentSpend = db.prepare<[string, string, number, number]>(
+interface IdempotencyDbRow {
+  readonly statusCode: number;
+  readonly responsePayload: Uint8Array;
+}
+
+export function createCostLedger(db: DatabaseSync, eventLog: EventLog): CostLedger {
+  const upsertAgentSpend = db.prepare(
     `INSERT INTO cost_by_agent (agent_slug, day_utc, total_micro_usd, last_lsn)
      VALUES (?, ?, ?, ?)
      ON CONFLICT (agent_slug, day_utc) DO UPDATE SET
        total_micro_usd = total_micro_usd + excluded.total_micro_usd,
        last_lsn = excluded.last_lsn`,
   );
-  const selectAgentSpend = db.prepare<[string, string], AgentSpendDbRow>(
+  const selectAgentSpend = db.prepare(
     `SELECT agent_slug AS agentSlug, day_utc AS dayUtc,
             total_micro_usd AS totalMicroUsd, last_lsn AS lastLsn
      FROM cost_by_agent WHERE agent_slug = ? AND day_utc = ?`,
   );
-  const upsertTaskSpend = db.prepare<[string, number, number]>(
+  const upsertTaskSpend = db.prepare(
     `INSERT INTO cost_by_task (task_id, total_micro_usd, last_lsn)
      VALUES (?, ?, ?)
      ON CONFLICT (task_id) DO UPDATE SET
        total_micro_usd = total_micro_usd + excluded.total_micro_usd,
        last_lsn = excluded.last_lsn`,
   );
-  const selectTaskSpend = db.prepare<[string], TaskSpendDbRow>(
+  const selectTaskSpend = db.prepare(
     `SELECT task_id AS taskId, total_micro_usd AS totalMicroUsd, last_lsn AS lastLsn
      FROM cost_by_task WHERE task_id = ?`,
   );
-  const upsertBudget = db.prepare<[string, string, string | null, number, string, number, number]>(
+  const upsertBudget = db.prepare(
     `INSERT INTO cost_budgets (budget_id, scope, subject_id, limit_micro_usd, thresholds_bps, set_at_lsn, tombstoned)
      VALUES (?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT (budget_id) DO UPDATE SET
@@ -210,42 +216,42 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
        set_at_lsn = excluded.set_at_lsn,
        tombstoned = excluded.tombstoned`,
   );
-  const selectBudget = db.prepare<[string], BudgetDbRow>(
+  const selectBudget = db.prepare(
     `SELECT budget_id AS budgetId, scope, subject_id AS subjectId,
             limit_micro_usd AS limitMicroUsd, thresholds_bps AS thresholdsBps,
             set_at_lsn AS setAtLsn, tombstoned
      FROM cost_budgets WHERE budget_id = ?`,
   );
-  const listBudgetsStmt = db.prepare<[], BudgetDbRow>(
+  const listBudgetsStmt = db.prepare(
     `SELECT budget_id AS budgetId, scope, subject_id AS subjectId,
             limit_micro_usd AS limitMicroUsd, thresholds_bps AS thresholdsBps,
             set_at_lsn AS setAtLsn, tombstoned
      FROM cost_budgets ORDER BY budget_id ASC`,
   );
-  const listAgentSpendAllStmt = db.prepare<[], AgentSpendDbRow>(
+  const listAgentSpendAllStmt = db.prepare(
     `SELECT agent_slug AS agentSlug, day_utc AS dayUtc,
             total_micro_usd AS totalMicroUsd, last_lsn AS lastLsn
      FROM cost_by_agent ORDER BY day_utc DESC, agent_slug ASC`,
   );
-  const listAgentSpendDayStmt = db.prepare<[string], AgentSpendDbRow>(
+  const listAgentSpendDayStmt = db.prepare(
     `SELECT agent_slug AS agentSlug, day_utc AS dayUtc,
             total_micro_usd AS totalMicroUsd, last_lsn AS lastLsn
      FROM cost_by_agent WHERE day_utc = ? ORDER BY agent_slug ASC`,
   );
-  const insertCrossingStmt = db.prepare<[string, number, number, number, number, number]>(
+  const insertCrossingStmt = db.prepare(
     `INSERT INTO cost_threshold_crossings
        (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
      VALUES (?, ?, ?, ?, ?, ?)
      ON CONFLICT (budget_id, budget_set_lsn, threshold_bps) DO NOTHING`,
   );
-  const listCrossingsAllStmt = db.prepare<[], ThresholdCrossingDbRow>(
+  const listCrossingsAllStmt = db.prepare(
     `SELECT budget_id AS budgetId, budget_set_lsn AS budgetSetLsn,
             threshold_bps AS thresholdBps, crossed_at_lsn AS crossedAtLsn,
             observed_micro_usd AS observedMicroUsd, limit_micro_usd AS limitMicroUsd
      FROM cost_threshold_crossings
      ORDER BY budget_id ASC, budget_set_lsn ASC, threshold_bps ASC`,
   );
-  const listCrossingsForBudgetStmt = db.prepare<[string], ThresholdCrossingDbRow>(
+  const listCrossingsForBudgetStmt = db.prepare(
     `SELECT budget_id AS budgetId, budget_set_lsn AS budgetSetLsn,
             threshold_bps AS thresholdBps, crossed_at_lsn AS crossedAtLsn,
             observed_micro_usd AS observedMicroUsd, limit_micro_usd AS limitMicroUsd
@@ -256,23 +262,17 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
   // Idempotency-row statements (B1 fix). Lookup + insert run inside the
   // SAME transaction as the append so a crash between the two is
   // impossible — a retry sees either both committed or both rolled back.
-  const idempotencyLookupStmt = db.prepare<
-    [string, string],
-    {
-      readonly statusCode: number;
-      readonly responsePayload: Buffer;
-    }
-  >(
+  const idempotencyLookupStmt = db.prepare(
     `SELECT status_code AS statusCode, response_payload AS responsePayload
      FROM command_idempotency
      WHERE idempotency_key = ? AND command = ?`,
   );
-  const idempotencyInsertStmt = db.prepare<[string, string, number, Buffer, number | null, number]>(
+  const idempotencyInsertStmt = db.prepare(
     `INSERT INTO command_idempotency
        (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms)
      VALUES (?, ?, ?, ?, ?, ?)`,
   );
-  const pruneIdempotencyStmt = db.prepare<[number]>(
+  const pruneIdempotencyStmt = db.prepare(
     `DELETE FROM command_idempotency
      WHERE created_at_ms < ?
        AND command IN ('cost.event', 'cost.budget.set', 'cost.budget.tombstone')`,
@@ -287,14 +287,14 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
     const lsn = eventLog.append({ type: "cost.event", payload: Buffer.from(bytes) });
     const dayUtc = isoDateUtc(payload.occurredAt);
     upsertAgentSpend.run(payload.agentSlug, dayUtc, payload.amountMicroUsd as number, lsn);
-    const agentRow = selectAgentSpend.get(payload.agentSlug, dayUtc);
+    const agentRow = selectAgentSpend.get(payload.agentSlug, dayUtc) as AgentSpendDbRow | undefined;
     if (agentRow === undefined) {
       throw new Error("cost_by_agent upsert produced no row (concurrent delete?)");
     }
     let taskTotal: MicroUsd | null = null;
     if (payload.taskId !== undefined) {
       upsertTaskSpend.run(payload.taskId, payload.amountMicroUsd as number, lsn);
-      const taskRow = selectTaskSpend.get(payload.taskId);
+      const taskRow = selectTaskSpend.get(payload.taskId) as TaskSpendDbRow | undefined;
       if (taskRow === undefined) {
         throw new Error("cost_by_task upsert produced no row (concurrent delete?)");
       }
@@ -333,12 +333,15 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
     return { lsn: lsnFromV1Number(lsn), tombstoned };
   };
 
-  const appendCostEventTransaction = db.transaction(appendCostEventInner);
-  const appendBudgetSetTransaction = db.transaction(appendBudgetSetInner);
+  const appendCostEventTransaction = createTransaction(db, appendCostEventInner);
+  const appendBudgetSetTransaction = createTransaction(db, appendBudgetSetInner);
 
-  const appendCostEventIdempotentTransaction = db.transaction(
+  const appendCostEventIdempotentTransaction = createTransaction(
+    db,
     (args: IdempotentCostEventArgs): IdempotentAppendResult => {
-      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+        | IdempotencyDbRow
+        | undefined;
       if (cached !== undefined) {
         return {
           replayed: true,
@@ -365,9 +368,12 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
     },
   );
 
-  const appendBudgetSetIdempotentTransaction = db.transaction(
+  const appendBudgetSetIdempotentTransaction = createTransaction(
+    db,
     (args: IdempotentBudgetSetArgs): IdempotentAppendResult => {
-      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+      const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+        | IdempotencyDbRow
+        | undefined;
       if (cached !== undefined) {
         return {
           replayed: true,
@@ -393,7 +399,8 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
     },
   );
 
-  const appendThresholdCrossedTransaction = db.transaction(
+  const appendThresholdCrossedTransaction = createTransaction(
+    db,
     (payload: BudgetThresholdCrossedAuditPayload): ThresholdCrossedAppendResult => {
       const bytes = costAuditPayloadToBytes("budget_threshold_crossed", payload);
       const lsn = eventLog.append({
@@ -430,7 +437,7 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
       if (!Number.isSafeInteger(cutoffMs)) {
         throw new Error("pruneIdempotencyOlderThan: cutoffMs must be a safe integer");
       }
-      return pruneIdempotencyStmt.run(cutoffMs).changes;
+      return Number(pruneIdempotencyStmt.run(cutoffMs).changes);
     },
     appendCostEventIdempotent(args: IdempotentCostEventArgs): IdempotentAppendResult {
       return appendCostEventIdempotentTransaction.immediate(args);
@@ -439,32 +446,32 @@ export function createCostLedger(db: Database.Database, eventLog: EventLog): Cos
       return appendBudgetSetIdempotentTransaction.immediate(args);
     },
     getAgentSpend(agentSlug: string, dayUtc: string): AgentSpendRow | null {
-      const row = selectAgentSpend.get(agentSlug, dayUtc);
+      const row = selectAgentSpend.get(agentSlug, dayUtc) as AgentSpendDbRow | undefined;
       return row === undefined ? null : toAgentSpendRow(row);
     },
     listAgentSpend(filter?: { dayUtc?: string }): readonly AgentSpendRow[] {
       const rows =
         filter?.dayUtc !== undefined
-          ? listAgentSpendDayStmt.all(filter.dayUtc)
-          : listAgentSpendAllStmt.all();
+          ? (listAgentSpendDayStmt.all(filter.dayUtc) as unknown as AgentSpendDbRow[])
+          : (listAgentSpendAllStmt.all() as unknown as AgentSpendDbRow[]);
       return rows.map(toAgentSpendRow);
     },
     getTaskSpend(taskId: string): TaskSpendRow | null {
-      const row = selectTaskSpend.get(taskId);
+      const row = selectTaskSpend.get(taskId) as TaskSpendDbRow | undefined;
       return row === undefined ? null : toTaskSpendRow(row);
     },
     getBudget(budgetId: BudgetId): BudgetRow | null {
-      const row = selectBudget.get(budgetId);
+      const row = selectBudget.get(budgetId) as BudgetDbRow | undefined;
       return row === undefined ? null : toBudgetRow(row);
     },
     listBudgets(): readonly BudgetRow[] {
-      return listBudgetsStmt.all().map(toBudgetRow);
+      return (listBudgetsStmt.all() as unknown as BudgetDbRow[]).map(toBudgetRow);
     },
     listThresholdCrossings(budgetId?: BudgetId): readonly ThresholdCrossingRow[] {
       const rows =
         budgetId === undefined
-          ? listCrossingsAllStmt.all()
-          : listCrossingsForBudgetStmt.all(budgetId);
+          ? (listCrossingsAllStmt.all() as unknown as ThresholdCrossingDbRow[])
+          : (listCrossingsForBudgetStmt.all(budgetId) as unknown as ThresholdCrossingDbRow[]);
       return rows.map(toThresholdCrossingRow);
     },
   };

--- a/packages/broker/src/cost-ledger/reactor.ts
+++ b/packages/broker/src/cost-ledger/reactor.ts
@@ -35,6 +35,7 @@
 // use integer math throughout (multiplication may exceed 2^53 — see the note
 // inside `crossesThreshold` for the bound check).
 
+import type { DatabaseSync, StatementSync } from "node:sqlite";
 import {
   asAgentSlug,
   asBudgetId,
@@ -46,7 +47,6 @@ import {
   lsnFromV1Number,
   type MicroUsd,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog } from "../event-log/index.ts";
 
@@ -107,11 +107,11 @@ export const BUDGET_THRESHOLD_REACTOR_NAME = "budget_threshold";
  * threshold_bps asc) so the caller can log/emit them.
  */
 export function processCostEventForCrossings(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog: EventLog,
   input: ReactorInput,
 ): readonly NewCrossing[] {
-  const selectAffectedBudgets = db.prepare<[string, string | null], BudgetRow>(
+  const selectAffectedBudgets = db.prepare(
     `SELECT budget_id AS budgetId, scope, subject_id AS subjectId,
             limit_micro_usd AS limitMicroUsd, thresholds_bps AS thresholdsBps,
             set_at_lsn AS setAtLsn, tombstoned
@@ -124,27 +124,27 @@ export function processCostEventForCrossings(
        )
      ORDER BY budget_id ASC`,
   );
-  const agentLifetimeStmt = db.prepare<[string], AggregateRow>(
+  const agentLifetimeStmt = db.prepare(
     "SELECT COALESCE(SUM(total_micro_usd), 0) AS total FROM cost_by_agent WHERE agent_slug = ?",
   );
-  const globalLifetimeStmt = db.prepare<[], AggregateRow>(
+  const globalLifetimeStmt = db.prepare(
     "SELECT COALESCE(SUM(total_micro_usd), 0) AS total FROM cost_by_agent",
   );
-  const taskLifetimeStmt = db.prepare<[string], AggregateRow>(
+  const taskLifetimeStmt = db.prepare(
     "SELECT COALESCE(total_micro_usd, 0) AS total FROM cost_by_task WHERE task_id = ?",
   );
-  const existingThresholdsStmt = db.prepare<[string, number], ExistingThresholdRow>(
+  const existingThresholdsStmt = db.prepare(
     `SELECT threshold_bps AS thresholdBps
      FROM cost_threshold_crossings
      WHERE budget_id = ? AND budget_set_lsn = ?`,
   );
-  const insertCrossingStmt = db.prepare<[string, number, number, number, number, number]>(
+  const insertCrossingStmt = db.prepare(
     `INSERT INTO cost_threshold_crossings
        (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
      VALUES (?, ?, ?, ?, ?, ?)
      ON CONFLICT DO NOTHING`,
   );
-  const upsertCursorStmt = db.prepare<[string, number, number]>(
+  const upsertCursorStmt = db.prepare(
     `INSERT INTO reactor_cursors (reactor_name, last_processed_lsn, updated_at_ms)
      VALUES (?, ?, ?)
      ON CONFLICT (reactor_name) DO UPDATE SET
@@ -153,7 +153,7 @@ export function processCostEventForCrossings(
   );
 
   const taskKey = input.taskId ?? null;
-  const candidates = selectAffectedBudgets.all(input.agentSlug, taskKey);
+  const candidates = selectAffectedBudgets.all(input.agentSlug, taskKey) as unknown as BudgetRow[];
   const results: NewCrossing[] = [];
 
   for (const budget of candidates) {
@@ -167,7 +167,12 @@ export function processCostEventForCrossings(
     );
     if (observed === 0 && budget.limitMicroUsd === 0) continue;
     const existing = new Set<number>(
-      existingThresholdsStmt.all(budget.budgetId, budget.setAtLsn).map((row) => row.thresholdBps),
+      (
+        existingThresholdsStmt.all(
+          budget.budgetId,
+          budget.setAtLsn,
+        ) as unknown as ExistingThresholdRow[]
+      ).map((row) => row.thresholdBps),
     );
     const thresholds = parseThresholds(budget);
     for (const thresholdBps of thresholds) {
@@ -229,12 +234,12 @@ interface ReactorCursorDbRow {
  * `/replay-check` route to confirm the reactor has caught up to the latest
  * cost_event in event_log.
  */
-export function readReactorCursor(db: Database.Database): ReactorState | null {
-  const stmt = db.prepare<[string], ReactorCursorDbRow>(
+export function readReactorCursor(db: DatabaseSync): ReactorState | null {
+  const stmt = db.prepare(
     `SELECT last_processed_lsn AS lastProcessedLsn, updated_at_ms AS updatedAtMs
      FROM reactor_cursors WHERE reactor_name = ?`,
   );
-  const row = stmt.get(BUDGET_THRESHOLD_REACTOR_NAME);
+  const row = stmt.get(BUDGET_THRESHOLD_REACTOR_NAME) as ReactorCursorDbRow | undefined;
   if (row === undefined) return null;
   return {
     lastProcessedLsn: lsnFromV1Number(row.lastProcessedLsn),
@@ -260,19 +265,19 @@ function isApplicable(budget: BudgetRow, input: ReactorInput): boolean {
 function lifetimeFor(
   budget: BudgetRow,
   input: ReactorInput,
-  agentStmt: Database.Statement<[string], AggregateRow>,
-  globalStmt: Database.Statement<[], AggregateRow>,
-  taskStmt: Database.Statement<[string], AggregateRow>,
+  agentStmt: StatementSync,
+  globalStmt: StatementSync,
+  taskStmt: StatementSync,
 ): number {
   if (budget.scope === "global") {
-    return globalStmt.get()?.total ?? 0;
+    return (globalStmt.get() as AggregateRow | undefined)?.total ?? 0;
   }
   if (budget.scope === "agent") {
-    return agentStmt.get(input.agentSlug)?.total ?? 0;
+    return (agentStmt.get(input.agentSlug) as AggregateRow | undefined)?.total ?? 0;
   }
   // task
   if (input.taskId === undefined) return 0;
-  return taskStmt.get(input.taskId)?.total ?? 0;
+  return (taskStmt.get(input.taskId) as AggregateRow | undefined)?.total ?? 0;
 }
 
 function parseThresholds(row: BudgetRow): readonly number[] {

--- a/packages/broker/src/cost-ledger/reactor.ts
+++ b/packages/broker/src/cost-ledger/reactor.ts
@@ -45,6 +45,7 @@ import {
   costAuditPayloadToBytes,
   type EventLsn,
   lsnFromV1Number,
+  MAX_BUDGET_LIMIT_MICRO_USD,
   type MicroUsd,
 } from "@wuphf/protocol";
 
@@ -77,7 +78,7 @@ interface BudgetRow {
 }
 
 interface AggregateRow {
-  readonly total: number;
+  readonly total: bigint;
 }
 
 interface ExistingThresholdRow {
@@ -127,12 +128,15 @@ export function processCostEventForCrossings(
   const agentLifetimeStmt = db.prepare(
     "SELECT COALESCE(SUM(total_micro_usd), 0) AS total FROM cost_by_agent WHERE agent_slug = ?",
   );
+  agentLifetimeStmt.setReadBigInts(true);
   const globalLifetimeStmt = db.prepare(
     "SELECT COALESCE(SUM(total_micro_usd), 0) AS total FROM cost_by_agent",
   );
+  globalLifetimeStmt.setReadBigInts(true);
   const taskLifetimeStmt = db.prepare(
     "SELECT COALESCE(total_micro_usd, 0) AS total FROM cost_by_task WHERE task_id = ?",
   );
+  taskLifetimeStmt.setReadBigInts(true);
   const existingThresholdsStmt = db.prepare(
     `SELECT threshold_bps AS thresholdBps
      FROM cost_threshold_crossings
@@ -165,7 +169,7 @@ export function processCostEventForCrossings(
       globalLifetimeStmt,
       taskLifetimeStmt,
     );
-    if (observed === 0 && budget.limitMicroUsd === 0) continue;
+    if (observed === 0n && budget.limitMicroUsd === 0) continue;
     const existing = new Set<number>(
       (
         existingThresholdsStmt.all(
@@ -178,11 +182,12 @@ export function processCostEventForCrossings(
     for (const thresholdBps of thresholds) {
       if (existing.has(thresholdBps)) continue;
       if (!crossesThreshold(observed, budget.limitMicroUsd, thresholdBps)) continue;
+      const observedMicroUsd = observedForEmit(observed);
       const crossingPayload: BudgetThresholdCrossedAuditPayload = {
         budgetId: asBudgetId(budget.budgetId),
         budgetSetLsn: lsnFromV1Number(budget.setAtLsn),
         thresholdBps,
-        observedMicroUsd: asMicroUsd(observed),
+        observedMicroUsd,
         limitMicroUsd: asMicroUsd(budget.limitMicroUsd),
         crossedAtLsn: lsnFromV1Number(input.costEventLsn),
         crossedAt: input.occurredAt,
@@ -197,14 +202,14 @@ export function processCostEventForCrossings(
         budget.setAtLsn,
         thresholdBps,
         input.costEventLsn,
-        observed,
+        observedMicroUsd,
         budget.limitMicroUsd,
       );
       results.push({
         budgetId: budget.budgetId,
         budgetSetLsn: budget.setAtLsn,
         thresholdBps,
-        observedMicroUsd: asMicroUsd(observed),
+        observedMicroUsd,
         limitMicroUsd: asMicroUsd(budget.limitMicroUsd),
         crossingEventLsn: crossingLsn,
       });
@@ -268,16 +273,16 @@ function lifetimeFor(
   agentStmt: StatementSync,
   globalStmt: StatementSync,
   taskStmt: StatementSync,
-): number {
+): bigint {
   if (budget.scope === "global") {
-    return (globalStmt.get() as AggregateRow | undefined)?.total ?? 0;
+    return (globalStmt.get() as AggregateRow | undefined)?.total ?? 0n;
   }
   if (budget.scope === "agent") {
-    return (agentStmt.get(input.agentSlug) as AggregateRow | undefined)?.total ?? 0;
+    return (agentStmt.get(input.agentSlug) as AggregateRow | undefined)?.total ?? 0n;
   }
   // task
-  if (input.taskId === undefined) return 0;
-  return (taskStmt.get(input.taskId) as AggregateRow | undefined)?.total ?? 0;
+  if (input.taskId === undefined) return 0n;
+  return (taskStmt.get(input.taskId) as AggregateRow | undefined)?.total ?? 0n;
 }
 
 function parseThresholds(row: BudgetRow): readonly number[] {
@@ -315,7 +320,17 @@ function parseThresholds(row: BudgetRow): readonly number[] {
  * the full documented range — the cost over plain Number is one
  * coercion per threshold per cost event, negligible.
  */
-function crossesThreshold(observed: number, limit: number, thresholdBps: number): boolean {
+function crossesThreshold(observed: bigint, limit: number, thresholdBps: number): boolean {
   if (limit === 0) return false;
-  return BigInt(observed) * 10_000n >= BigInt(limit) * BigInt(thresholdBps);
+  return observed * 10_000n >= BigInt(limit) * BigInt(thresholdBps);
+}
+
+// Threshold semantics only need to report "at or above every valid budget";
+// the public protocol field is bounded to MAX_BUDGET_LIMIT_MICRO_USD.
+function observedForEmit(observed: bigint): MicroUsd {
+  const maxPublicObserved = BigInt(MAX_BUDGET_LIMIT_MICRO_USD);
+  if (observed >= maxPublicObserved) {
+    return asMicroUsd(MAX_BUDGET_LIMIT_MICRO_USD);
+  }
+  return asMicroUsd(Number(observed));
 }

--- a/packages/broker/src/cost-ledger/replay-check/index.ts
+++ b/packages/broker/src/cost-ledger/replay-check/index.ts
@@ -68,6 +68,7 @@ export type { ReplayCheckReport, ReplayDiscrepancy } from "./discrepancy.ts";
 // agent-day key encoder are only used during the scan loop.
 
 const BATCH_SIZE = 1_000;
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 interface CostEventBatchRow {
   readonly lsn: number;
@@ -228,7 +229,7 @@ export function runReplayCheck(db: DatabaseSync): ReplayCheckReport {
           if (kind === "cost_event") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
-              JSON.parse(new TextDecoder().decode(row.payload)),
+              JSON.parse(utf8Decoder.decode(row.payload)),
             ) as CostEventAuditPayload;
             const occurredAtMs = parsed.occurredAt.getTime();
             costEventOccurredAtMs.set(row.lsn, occurredAtMs);
@@ -298,7 +299,7 @@ export function runReplayCheck(db: DatabaseSync): ReplayCheckReport {
           } else if (kind === "budget_set") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
-              JSON.parse(new TextDecoder().decode(row.payload)),
+              JSON.parse(utf8Decoder.decode(row.payload)),
             ) as BudgetSetAuditPayload;
             const previous = replayedBudgets.get(parsed.budgetId);
             const replayedBudget: ReplayedBudget = {
@@ -315,7 +316,7 @@ export function runReplayCheck(db: DatabaseSync): ReplayCheckReport {
           } else if (kind === "budget_threshold_crossed") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
-              JSON.parse(new TextDecoder().decode(row.payload)),
+              JSON.parse(utf8Decoder.decode(row.payload)),
             ) as BudgetThresholdCrossedAuditPayload;
             const budgetSetLsnInt = parseLsn(parsed.budgetSetLsn).localLsn;
             const crossedAtLsnInt = parseLsn(parsed.crossedAtLsn).localLsn;

--- a/packages/broker/src/cost-ledger/replay-check/index.ts
+++ b/packages/broker/src/cost-ledger/replay-check/index.ts
@@ -18,10 +18,11 @@
 // Read-only: this function never writes. It is safe to call on a live
 // broker; the entire check runs inside a single `BEGIN DEFERRED`
 // transaction so concurrent writers can commit but won't be observed
-// mid-check. better-sqlite3's WAL does NOT give per-statement
+// mid-check. SQLite WAL does NOT give per-statement
 // snapshots on its own — the explicit transaction is what produces
 // the consistent read view.
 
+import type { DatabaseSync } from "node:sqlite";
 import {
   type AuditEventKind,
   type BudgetSetAuditPayload,
@@ -31,7 +32,7 @@ import {
   lsnFromV1Number,
   parseLsn,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
+import { createTransaction } from "../../internal/sqlite-transaction.ts";
 import { compareAgentDays, compareTasks } from "./aggregate-comparators.ts";
 import { createBudgetCandidateIndexes, replaceBudgetInIndex } from "./budget-candidate-index.ts";
 import { compareBudgets } from "./budget-comparator.ts";
@@ -71,13 +72,13 @@ const BATCH_SIZE = 1_000;
 interface CostEventBatchRow {
   readonly lsn: number;
   readonly type: string;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface AgentDayDbRow {
   readonly agentSlug: string;
   readonly dayUtc: string;
-  // Aggregate totals are read with `.safeIntegers(true)` so a hostile
+  // Aggregate totals are read with `.setReadBigInts(true)` so a hostile
   // INTEGER value in the projection (past `Number.MAX_SAFE_INTEGER`)
   // doesn't silently round in the diagnostic — the "diagnostic of last
   // resort" preserves exact bytes from the row.
@@ -108,34 +109,30 @@ function eventTypeToKind(type: string): AuditEventKind | "other" {
   return "other";
 }
 
-export function runReplayCheck(db: Database.Database): ReplayCheckReport {
-  const readBatchStmt = db.prepare<[number, number], CostEventBatchRow>(
+export function runReplayCheck(db: DatabaseSync): ReplayCheckReport {
+  const readBatchStmt = db.prepare(
     `SELECT lsn, type, payload FROM event_log
      WHERE lsn > ? AND type IN ('cost.event', 'cost.budget.set', 'cost.budget.threshold.crossed')
      ORDER BY lsn ASC
      LIMIT ?`,
   );
-  const highestLsnStmt = db.prepare<[], HighestLsnRow>(
-    "SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log",
-  );
-  // `safeIntegers(true)` makes better-sqlite3 return INTEGER columns
+  const highestLsnStmt = db.prepare("SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log");
+  // `setReadBigInts(true)` makes node:sqlite return INTEGER columns
   // as bigint instead of JS number. Required for the aggregate-totals
   // path: cumulative spend past `Number.MAX_SAFE_INTEGER` (or a hostile
   // projection row past that boundary) would silently round and the
   // diagnostic would report the rounded value instead of the bytes
   // actually in the row.
-  const listAgentDaysStmt = db
-    .prepare<[], AgentDayDbRow>(
-      `SELECT agent_slug AS agentSlug, day_utc AS dayUtc, total_micro_usd AS totalMicroUsd
+  const listAgentDaysStmt = db.prepare(
+    `SELECT agent_slug AS agentSlug, day_utc AS dayUtc, total_micro_usd AS totalMicroUsd
      FROM cost_by_agent`,
-    )
-    .safeIntegers(true);
-  const listTasksStmt = db
-    .prepare<[], TaskDbRow>(
-      `SELECT task_id AS taskId, total_micro_usd AS totalMicroUsd FROM cost_by_task`,
-    )
-    .safeIntegers(true);
-  const listBudgetsStmt = db.prepare<[], BudgetDbRow>(
+  );
+  listAgentDaysStmt.setReadBigInts(true);
+  const listTasksStmt = db.prepare(
+    `SELECT task_id AS taskId, total_micro_usd AS totalMicroUsd FROM cost_by_task`,
+  );
+  listTasksStmt.setReadBigInts(true);
+  const listBudgetsStmt = db.prepare(
     `SELECT budget_id AS budgetId, scope, subject_id AS subjectId,
             limit_micro_usd AS limitMicroUsd, thresholds_bps AS thresholdsBps,
             set_at_lsn AS setAtLsn, tombstoned
@@ -146,7 +143,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
   // bytes instead of silently rounding through JS `number`. The other
   // INTEGER columns are bounded (LSNs, thresholdBps, limitMicroUsd ≤
   // MicroUsd brand) and stay as `number` for ergonomic compares.
-  const listCrossingsStmt = db.prepare<[], ThresholdCrossingDbRow>(
+  const listCrossingsStmt = db.prepare(
     `SELECT budget_id AS budgetId, budget_set_lsn AS budgetSetLsn,
             threshold_bps AS thresholdBps, crossed_at_lsn AS crossedAtLsn,
             CAST(observed_micro_usd AS TEXT) AS observedMicroUsd,
@@ -155,14 +152,14 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
   );
 
   // Run all reads inside a single SQLite snapshot so concurrent
-  // writers can't shift state mid-check. better-sqlite3's WAL does
+  // writers can't shift state mid-check. SQLite WAL does
   // not give per-statement snapshots; only an explicit transaction
   // does. `.deferred()` acquires a SHARED lock on first read and
   // holds it through the rest of the function; concurrent writers
   // can still
   // commit but this function won't observe them, so replay-vs-stored
   // can't mix snapshots.
-  const txn = db.transaction((): ReplayCheckReport => {
+  const txn = createTransaction(db, (): ReplayCheckReport => {
     // Aggregate accumulators run in bigint to mirror the lifetime-oracle
     // fix. `total_micro_usd` is cumulative; past `Number.MAX_SAFE_INTEGER`
     // a `number` accumulator silently rounds, and the diagnostic (which
@@ -223,7 +220,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     let cursor = 0;
     let scanned = 0;
     for (;;) {
-      const rows = readBatchStmt.all(cursor, BATCH_SIZE);
+      const rows = readBatchStmt.all(cursor, BATCH_SIZE) as unknown as CostEventBatchRow[];
       if (rows.length === 0) break;
       for (const row of rows) {
         const kind = eventTypeToKind(row.type);
@@ -231,7 +228,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
           if (kind === "cost_event") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
-              JSON.parse(row.payload.toString("utf8")),
+              JSON.parse(new TextDecoder().decode(row.payload)),
             ) as CostEventAuditPayload;
             const occurredAtMs = parsed.occurredAt.getTime();
             costEventOccurredAtMs.set(row.lsn, occurredAtMs);
@@ -301,7 +298,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
           } else if (kind === "budget_set") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
-              JSON.parse(row.payload.toString("utf8")),
+              JSON.parse(new TextDecoder().decode(row.payload)),
             ) as BudgetSetAuditPayload;
             const previous = replayedBudgets.get(parsed.budgetId);
             const replayedBudget: ReplayedBudget = {
@@ -318,7 +315,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
           } else if (kind === "budget_threshold_crossed") {
             const parsed = costAuditPayloadFromJsonValue(
               kind,
-              JSON.parse(row.payload.toString("utf8")),
+              JSON.parse(new TextDecoder().decode(row.payload)),
             ) as BudgetThresholdCrossedAuditPayload;
             const budgetSetLsnInt = parseLsn(parsed.budgetSetLsn).localLsn;
             const crossedAtLsnInt = parseLsn(parsed.crossedAtLsn).localLsn;
@@ -361,25 +358,25 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     const discrepancies: ReplayDiscrepancy[] = [...inlineDiscrepancies];
 
     const storedAgentDays = new Map<string, bigint>();
-    for (const row of listAgentDaysStmt.all()) {
+    for (const row of listAgentDaysStmt.all() as unknown as AgentDayDbRow[]) {
       storedAgentDays.set(agentDayKey(row.agentSlug, row.dayUtc), row.totalMicroUsd);
     }
     compareAgentDays(replayedAgentDays, storedAgentDays, discrepancies);
 
     const storedTasks = new Map<string, bigint>();
-    for (const row of listTasksStmt.all()) {
+    for (const row of listTasksStmt.all() as unknown as TaskDbRow[]) {
       storedTasks.set(row.taskId, row.totalMicroUsd);
     }
     compareTasks(replayedTasks, storedTasks, discrepancies);
 
     const storedBudgets = new Map<string, BudgetDbRow>();
-    for (const row of listBudgetsStmt.all()) {
+    for (const row of listBudgetsStmt.all() as unknown as BudgetDbRow[]) {
       storedBudgets.set(row.budgetId, row);
     }
     compareBudgets(replayedBudgets, storedBudgets, discrepancies);
 
     const storedCrossings = new Map<string, ThresholdCrossingDbRow>();
-    for (const row of listCrossingsStmt.all()) {
+    for (const row of listCrossingsStmt.all() as unknown as ThresholdCrossingDbRow[]) {
       storedCrossings.set(crossingKey(row.budgetId, row.budgetSetLsn, row.thresholdBps), row);
     }
     compareCrossings(replayedCrossings, storedCrossings, discrepancies);
@@ -403,7 +400,7 @@ export function runReplayCheck(db: Database.Database): ReplayCheckReport {
     detectDelayedEmissions(replayedCrossings, expectedCrossings, discrepancies);
     compareExpectedAndLoggedCrossings(expectedCrossings, replayedCrossings, discrepancies);
 
-    const highest = highestLsnStmt.get()?.lsn ?? 0;
+    const highest = (highestLsnStmt.get() as HighestLsnRow | undefined)?.lsn ?? 0;
     return {
       ok: discrepancies.length === 0,
       highestLsn: lsnFromV1Number(highest),

--- a/packages/broker/src/cost-ledger/routes.ts
+++ b/packages/broker/src/cost-ledger/routes.ts
@@ -22,6 +22,7 @@
 // the acting operator.
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { DatabaseSync } from "node:sqlite";
 
 import {
   type ApiToken,
@@ -58,7 +59,7 @@ const DECIMAL_INTEGER_RE = /^(0|[1-9]\d*)$/;
 export interface CostRouteDeps {
   readonly ledger: CostLedger;
   readonly logger: BrokerLogger;
-  readonly db: import("better-sqlite3").Database;
+  readonly db: DatabaseSync;
   readonly operatorToken: ApiToken | null;
   readonly nowMs: () => number;
 }

--- a/packages/broker/src/event-log/event-log.ts
+++ b/packages/broker/src/event-log/event-log.ts
@@ -1,5 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 
+import { typed } from "../internal/typed-statement.ts";
+
 export type EventType =
   | "receipt.put"
   | "cost.event"
@@ -77,8 +79,8 @@ export function openDatabase(args: OpenDatabaseArgs): DatabaseSync {
 }
 
 export function createEventLog(db: DatabaseSync): EventLog {
-  const appendStmt = db.prepare(
-    "INSERT INTO event_log (ts_ms, type, payload) VALUES (?, ?, ?) RETURNING lsn",
+  const appendStmt = typed<[number, EventType, Buffer], InsertedLsnRow>(
+    db.prepare("INSERT INTO event_log (ts_ms, type, payload) VALUES (?, ?, ?) RETURNING lsn"),
   );
   const readFromLsnStmt = db.prepare(
     "SELECT lsn, ts_ms AS tsMs, type, payload FROM event_log WHERE lsn > ? ORDER BY lsn ASC LIMIT ?",
@@ -121,6 +123,7 @@ function rowToEventLogRecord(row: EventLogRow): EventLogRecord {
     lsn: row.lsn,
     tsMs: row.tsMs,
     type: toEventType(row.type),
+    // Public EventLogRecord still promises Buffer, so normalize sqlite BLOBs here.
     payload: Buffer.from(row.payload),
   };
 }

--- a/packages/broker/src/event-log/event-log.ts
+++ b/packages/broker/src/event-log/event-log.ts
@@ -1,5 +1,4 @@
-import type Database from "better-sqlite3";
-import BetterSqlite3 from "better-sqlite3";
+import { DatabaseSync } from "node:sqlite";
 
 export type EventType =
   | "receipt.put"
@@ -54,16 +53,16 @@ interface EventLogRow {
   readonly lsn: number;
   readonly tsMs: number;
   readonly type: string;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface HighestLsnRow {
   readonly lsn: number;
 }
 
-export function openDatabase(args: OpenDatabaseArgs): Database.Database {
-  const db = new BetterSqlite3(args.path);
-  db.pragma("journal_mode = WAL");
+export function openDatabase(args: OpenDatabaseArgs): DatabaseSync {
+  const db = new DatabaseSync(args.path);
+  db.exec("PRAGMA journal_mode = WAL");
   // `synchronous = FULL` because the broker returns HTTP 201 on
   // POST /api/receipts AFTER `store.put` resolves; the client races
   // the 201 against follow-up reads. `synchronous = NORMAL` would
@@ -71,26 +70,24 @@ export function openDatabase(args: OpenDatabaseArgs): Database.Database {
   // though the client believed the write was durable. FULL pays one
   // fsync per commit — on the receipt-write hot path that's one
   // fsync per agent run, well below the dominant LLM latency.
-  db.pragma("synchronous = FULL");
-  db.pragma("foreign_keys = ON");
-  db.pragma("busy_timeout = 5000");
+  db.exec("PRAGMA synchronous = FULL");
+  db.exec("PRAGMA foreign_keys = ON");
+  db.exec("PRAGMA busy_timeout = 5000");
   return db;
 }
 
-export function createEventLog(db: Database.Database): EventLog {
-  const appendStmt = db.prepare<[number, EventType, Buffer], InsertedLsnRow>(
+export function createEventLog(db: DatabaseSync): EventLog {
+  const appendStmt = db.prepare(
     "INSERT INTO event_log (ts_ms, type, payload) VALUES (?, ?, ?) RETURNING lsn",
   );
-  const readFromLsnStmt = db.prepare<[number, number], EventLogRow>(
+  const readFromLsnStmt = db.prepare(
     "SELECT lsn, ts_ms AS tsMs, type, payload FROM event_log WHERE lsn > ? ORDER BY lsn ASC LIMIT ?",
   );
-  const highestLsnStmt = db.prepare<[], HighestLsnRow>(
-    "SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log",
-  );
+  const highestLsnStmt = db.prepare("SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log");
 
   return {
     append(args: AppendArgs): number {
-      const row = appendStmt.get(Date.now(), args.type, args.payload);
+      const row = appendStmt.get(Date.now(), args.type, args.payload) as InsertedLsnRow | undefined;
       if (row === undefined) {
         throw new Error("event_log append returned no LSN");
       }
@@ -104,11 +101,13 @@ export function createEventLog(db: Database.Database): EventLog {
       if (!Number.isInteger(limit) || limit < 0) {
         throw new Error(`limit must be a non-negative integer, got ${limit}`);
       }
-      return readFromLsnStmt.all(fromLsn, limit).map(rowToEventLogRecord);
+      return (readFromLsnStmt.all(fromLsn, limit) as unknown as EventLogRow[]).map(
+        rowToEventLogRecord,
+      );
     },
 
     highestLsn(): number {
-      const row = highestLsnStmt.get();
+      const row = highestLsnStmt.get() as HighestLsnRow | undefined;
       if (row === undefined) {
         throw new Error("event_log highestLsn query returned no row");
       }

--- a/packages/broker/src/event-log/migrations.ts
+++ b/packages/broker/src/event-log/migrations.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
 
-import type Database from "better-sqlite3";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 
 export const CURRENT_SCHEMA_VERSION = 9;
 
@@ -51,8 +52,8 @@ const MIGRATIONS: readonly Migration[] = [
   },
 ];
 
-export function runMigrations(db: Database.Database): void {
-  db.pragma("foreign_keys = ON");
+export function runMigrations(db: DatabaseSync): void {
+  db.exec("PRAGMA foreign_keys = ON");
 
   // Read `user_version` AFTER acquiring an EXCLUSIVE write lock and
   // apply pending migrations inside the same transaction. Otherwise
@@ -61,7 +62,7 @@ export function runMigrations(db: Database.Database): void {
   // and one or both fail mid-startup with "table already exists" or
   // lock errors. EXCLUSIVE blocks readers and writers; cheap because
   // migrations only run on schema upgrades.
-  const applyPending = db.transaction(() => {
+  const applyPending = createTransaction(db, () => {
     const currentVersion = readUserVersion(db);
     if (currentVersion > CURRENT_SCHEMA_VERSION) {
       throw new Error(
@@ -71,14 +72,19 @@ export function runMigrations(db: Database.Database): void {
     for (const migration of MIGRATIONS) {
       if (migration.version <= currentVersion) continue;
       db.exec(migration.sql);
-      db.pragma(`user_version = ${migration.version}`);
+      db.exec(`PRAGMA user_version = ${migration.version}`);
     }
   });
   applyPending.exclusive();
 }
 
-function readUserVersion(db: Database.Database): number {
-  const value = db.pragma("user_version", { simple: true });
+interface UserVersionRow {
+  readonly user_version: number;
+}
+
+function readUserVersion(db: DatabaseSync): number {
+  const row = db.prepare("PRAGMA user_version").get() as UserVersionRow | undefined;
+  const value = row?.user_version;
   if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
     throw new Error(`Invalid SQLite user_version: ${String(value)}`);
   }

--- a/packages/broker/src/internal/sqlite-errors.ts
+++ b/packages/broker/src/internal/sqlite-errors.ts
@@ -1,0 +1,67 @@
+interface SqliteErrorLike extends Error {
+  readonly errcode: number;
+}
+
+const SQLITE_BASE_MASK = 0xff;
+const SQLITE_PERM = 3;
+const SQLITE_BUSY = 5;
+const SQLITE_LOCKED = 6;
+const SQLITE_READONLY = 8;
+const SQLITE_IOERR = 10;
+const SQLITE_CORRUPT = 11;
+const SQLITE_FULL = 13;
+const SQLITE_CANTOPEN = 14;
+const SQLITE_CONSTRAINT = 19;
+const SQLITE_NOTADB = 26;
+
+export function isSqliteError(err: unknown): err is SqliteErrorLike {
+  if (!(err instanceof Error)) return false;
+  const candidate = err as { readonly errcode?: unknown };
+  return typeof candidate.errcode === "number" && Number.isInteger(candidate.errcode);
+}
+
+export function isSqliteConstraintError(err: unknown): boolean {
+  return sqliteBaseCode(err) === SQLITE_CONSTRAINT;
+}
+
+export function isSqliteFullError(err: unknown): boolean {
+  return sqliteBaseCode(err) === SQLITE_FULL;
+}
+
+export function isSqliteBusyError(err: unknown): boolean {
+  const code = sqliteBaseCode(err);
+  return code === SQLITE_BUSY || code === SQLITE_LOCKED;
+}
+
+export function isSqliteUnavailableError(err: unknown): boolean {
+  const code = sqliteBaseCode(err);
+  return (
+    code === SQLITE_READONLY ||
+    code === SQLITE_CANTOPEN ||
+    code === SQLITE_CORRUPT ||
+    code === SQLITE_NOTADB ||
+    code === SQLITE_PERM ||
+    code === SQLITE_IOERR
+  );
+}
+
+export function sqliteErrorLabel(err: unknown): string {
+  const code = sqliteBaseCode(err);
+  if (code === null) return "unknown";
+  if (code === SQLITE_PERM) return "SQLITE_PERM";
+  if (code === SQLITE_BUSY) return "SQLITE_BUSY";
+  if (code === SQLITE_LOCKED) return "SQLITE_LOCKED";
+  if (code === SQLITE_READONLY) return "SQLITE_READONLY";
+  if (code === SQLITE_IOERR) return "SQLITE_IOERR";
+  if (code === SQLITE_CORRUPT) return "SQLITE_CORRUPT";
+  if (code === SQLITE_FULL) return "SQLITE_FULL";
+  if (code === SQLITE_CANTOPEN) return "SQLITE_CANTOPEN";
+  if (code === SQLITE_CONSTRAINT) return "SQLITE_CONSTRAINT";
+  if (code === SQLITE_NOTADB) return "SQLITE_NOTADB";
+  return `SQLITE_${code}`;
+}
+
+function sqliteBaseCode(err: unknown): number | null {
+  if (!isSqliteError(err)) return null;
+  return err.errcode & SQLITE_BASE_MASK;
+}

--- a/packages/broker/src/internal/sqlite-receipt-store-testing.ts
+++ b/packages/broker/src/internal/sqlite-receipt-store-testing.ts
@@ -10,8 +10,8 @@
 // supported construction path is `SqliteReceiptStore.open(config)` so
 // migrations always run before any read or write.
 
+import type { DatabaseSync } from "node:sqlite";
 import type { ThreadId } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import type { EventLog } from "../event-log/index.ts";
 import { SqliteReceiptStore } from "../sqlite-receipt-store.ts";
 
@@ -20,14 +20,14 @@ import { SqliteReceiptStore } from "../sqlite-receipt-store.ts";
 // on `SqliteReceiptStore`'s constructor is a TypeScript-level fence;
 // the call below bypasses it deliberately for test-only construction.
 type SqliteReceiptStoreCtor = new (
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog?: EventLog,
   maxReceipts?: number,
   defaultThreadId?: ThreadId | null,
 ) => SqliteReceiptStore;
 
 export function constructSqliteReceiptStoreForTesting(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog?: EventLog,
   maxReceipts?: number,
   defaultThreadId?: ThreadId | null,

--- a/packages/broker/src/internal/sqlite-transaction.ts
+++ b/packages/broker/src/internal/sqlite-transaction.ts
@@ -13,9 +13,34 @@ export function createTransaction<TArgs extends readonly unknown[], TResult>(
   db: DatabaseSync,
   fn: (...args: TArgs) => TResult,
 ): TransactionFn<TArgs, TResult> {
+  let savepointCounter = 0;
   const run =
     (variant: TransactionVariant) =>
     (...args: TArgs): TResult => {
+      if (db.isTransaction) {
+        const savepoint = `wuphf_tx_${savepointCounter}`;
+        savepointCounter += 1;
+        // Nested transaction variants are moot: SQLite savepoints are deferred.
+        db.exec(`SAVEPOINT ${savepoint}`);
+        try {
+          const result = fn(...args);
+          db.exec(`RELEASE SAVEPOINT ${savepoint}`);
+          return result;
+        } catch (err) {
+          try {
+            db.exec(`ROLLBACK TO SAVEPOINT ${savepoint}`);
+          } catch {
+            // Preserve the original callback/release error.
+          }
+          try {
+            db.exec(`RELEASE SAVEPOINT ${savepoint}`);
+          } catch {
+            // Preserve the original callback/release error.
+          }
+          throw err;
+        }
+      }
+
       const beginSql = variant === "deferred" ? "BEGIN" : `BEGIN ${variant.toUpperCase()}`;
       db.exec(beginSql);
       let committed = false;

--- a/packages/broker/src/internal/sqlite-transaction.ts
+++ b/packages/broker/src/internal/sqlite-transaction.ts
@@ -1,0 +1,45 @@
+import type { DatabaseSync } from "node:sqlite";
+
+type TransactionVariant = "deferred" | "immediate" | "exclusive";
+
+export interface TransactionFn<TArgs extends readonly unknown[], TResult> {
+  (...args: TArgs): TResult;
+  readonly deferred: (...args: TArgs) => TResult;
+  readonly immediate: (...args: TArgs) => TResult;
+  readonly exclusive: (...args: TArgs) => TResult;
+}
+
+export function createTransaction<TArgs extends readonly unknown[], TResult>(
+  db: DatabaseSync,
+  fn: (...args: TArgs) => TResult,
+): TransactionFn<TArgs, TResult> {
+  const run =
+    (variant: TransactionVariant) =>
+    (...args: TArgs): TResult => {
+      const beginSql = variant === "deferred" ? "BEGIN" : `BEGIN ${variant.toUpperCase()}`;
+      db.exec(beginSql);
+      let committed = false;
+      try {
+        const result = fn(...args);
+        db.exec("COMMIT");
+        committed = true;
+        return result;
+      } finally {
+        if (!committed) {
+          try {
+            db.exec("ROLLBACK");
+          } catch {
+            // db may already be in autocommit if BEGIN itself threw,
+            // or the connection may be unusable. Swallow so the
+            // original error reaches the caller.
+          }
+        }
+      }
+    };
+  const deferred = run("deferred");
+  const callable = ((...args: TArgs) => deferred(...args)) as TransactionFn<TArgs, TResult>;
+  Object.defineProperty(callable, "deferred", { value: deferred });
+  Object.defineProperty(callable, "immediate", { value: run("immediate") });
+  Object.defineProperty(callable, "exclusive", { value: run("exclusive") });
+  return callable;
+}

--- a/packages/broker/src/internal/typed-statement.ts
+++ b/packages/broker/src/internal/typed-statement.ts
@@ -1,0 +1,32 @@
+import type { StatementSync } from "node:sqlite";
+
+type RunArgs = Parameters<StatementSync["run"]>;
+type GetArgs = Parameters<StatementSync["get"]>;
+type AllArgs = Parameters<StatementSync["all"]>;
+type IterateArgs = Parameters<StatementSync["iterate"]>;
+
+export interface TypedStatement<TParams extends readonly unknown[], TRow> {
+  readonly inner: StatementSync;
+  run(...args: TParams): { changes: number; lastInsertRowid: number | bigint };
+  get(...args: TParams): TRow | undefined;
+  all(...args: TParams): readonly TRow[];
+  iterate(...args: TParams): IterableIterator<TRow>;
+}
+
+export function typed<TParams extends readonly unknown[], TRow>(
+  stmt: StatementSync,
+): TypedStatement<TParams, TRow> {
+  return {
+    inner: stmt,
+    run: (...args: TParams) =>
+      stmt.run(...(args as unknown as RunArgs)) as {
+        changes: number;
+        lastInsertRowid: number | bigint;
+      },
+    get: (...args: TParams) => stmt.get(...(args as unknown as GetArgs)) as TRow | undefined,
+    all: (...args: TParams) =>
+      stmt.all(...(args as unknown as AllArgs)) as unknown as readonly TRow[],
+    iterate: (...args: TParams) =>
+      stmt.iterate(...(args as unknown as IterateArgs)) as IterableIterator<TRow>,
+  };
+}

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -5,6 +5,7 @@ import {
   type ReceiptSnapshot,
   receiptFromJson,
   receiptToJson,
+  type TaskId,
   type ThreadId,
 } from "@wuphf/protocol";
 
@@ -17,6 +18,7 @@ import {
   sqliteErrorLabel,
 } from "./internal/sqlite-errors.ts";
 import { createTransaction, type TransactionFn } from "./internal/sqlite-transaction.ts";
+import { type TypedStatement, typed } from "./internal/typed-statement.ts";
 import {
   decodeListCursor,
   encodeListCursor,
@@ -37,6 +39,7 @@ import {
 // client's disk-fill DoS. Hosts can raise or lower via
 // `SqliteReceiptStore.open({ path, maxReceipts })`.
 const DEFAULT_SQLITE_MAX_RECEIPTS = 100_000;
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 export interface SqliteReceiptStoreConfig {
   readonly path: string;
@@ -76,8 +79,14 @@ export class SqliteReceiptStore implements ReceiptStore {
   private readonly maxReceipts: number;
   private readonly receiptExistsStmt: StatementSync;
   private readonly threadExistsStmt: StatementSync;
-  private readonly insertProjectionStmt: StatementSync;
-  private readonly insertThreadReceiptStmt: StatementSync;
+  private readonly insertProjectionStmt: TypedStatement<
+    [ReceiptId, ThreadId | null, number, number, Uint8Array],
+    never
+  >;
+  private readonly insertThreadReceiptStmt: TypedStatement<
+    [ThreadId, ReceiptId, TaskId | undefined, number],
+    never
+  >;
   private readonly getPayloadStmt: StatementSync;
   private readonly listAllStmt: StatementSync;
   private readonly listThreadStmt: StatementSync;
@@ -129,12 +138,19 @@ export class SqliteReceiptStore implements ReceiptStore {
       "SELECT 1 AS present FROM receipts_projection WHERE receipt_id = ?",
     );
     this.threadExistsStmt = db.prepare("SELECT 1 AS present FROM threads WHERE thread_id = ?");
-    this.insertProjectionStmt = db.prepare(
-      "INSERT INTO receipts_projection (receipt_id, thread_id, schema_version, lsn, payload) VALUES (?, ?, ?, ?, ?)",
+    this.insertProjectionStmt = typed<
+      [ReceiptId, ThreadId | null, number, number, Uint8Array],
+      never
+    >(
+      db.prepare(
+        "INSERT INTO receipts_projection (receipt_id, thread_id, schema_version, lsn, payload) VALUES (?, ?, ?, ?, ?)",
+      ),
     );
-    this.insertThreadReceiptStmt = db.prepare(
-      `INSERT INTO thread_receipts (thread_id, receipt_id, task_id, lsn)
-       VALUES (?, ?, ?, ?)`,
+    this.insertThreadReceiptStmt = typed<[ThreadId, ReceiptId, TaskId | undefined, number], never>(
+      db.prepare(
+        `INSERT INTO thread_receipts (thread_id, receipt_id, task_id, lsn)
+         VALUES (?, ?, ?, ?)`,
+      ),
     );
     this.getPayloadStmt = db.prepare(
       "SELECT lsn, payload FROM receipts_projection WHERE receipt_id = ?",
@@ -226,7 +242,7 @@ export class SqliteReceiptStore implements ReceiptStore {
     if (row === undefined) {
       return null;
     }
-    return receiptFromJson(new TextDecoder().decode(row.payload));
+    return receiptFromJson(utf8Decoder.decode(row.payload));
   }
 
   async list(filter?: ListFilter): Promise<ListPage> {
@@ -246,7 +262,7 @@ export class SqliteReceiptStore implements ReceiptStore {
       throw classifySqliteReadError(err);
     }
     const visibleRows = rows.slice(0, limit);
-    const items = visibleRows.map((row) => receiptFromJson(new TextDecoder().decode(row.payload)));
+    const items = visibleRows.map((row) => receiptFromJson(utf8Decoder.decode(row.payload)));
     const lastRow = visibleRows.at(-1);
 
     return {

--- a/packages/broker/src/sqlite-receipt-store.ts
+++ b/packages/broker/src/sqlite-receipt-store.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync, StatementSync } from "node:sqlite";
 import {
   lsnFromV1Number,
   type ReceiptId,
@@ -6,10 +7,16 @@ import {
   receiptToJson,
   type ThreadId,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
-import BetterSqlite3 from "better-sqlite3";
 
 import { createEventLog, type EventLog, openDatabase, runMigrations } from "./event-log/index.ts";
+import {
+  isSqliteBusyError,
+  isSqliteConstraintError,
+  isSqliteFullError,
+  isSqliteUnavailableError,
+  sqliteErrorLabel,
+} from "./internal/sqlite-errors.ts";
+import { createTransaction, type TransactionFn } from "./internal/sqlite-transaction.ts";
 import {
   decodeListCursor,
   encodeListCursor,
@@ -53,7 +60,7 @@ interface ReceiptExistsRow {
 
 interface ProjectionPayloadRow {
   readonly lsn: number;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface CountRow {
@@ -64,26 +71,18 @@ interface ExistsRow {
   readonly present: 1;
 }
 
-type ProjectionInsertParams = [ReceiptId, ThreadId | null, number, number, Buffer];
-type ThreadReceiptInsertParams = [ThreadId, ReceiptId, string, number];
-
 export class SqliteReceiptStore implements ReceiptStore {
   private readonly eventLog: EventLog;
   private readonly maxReceipts: number;
-  private readonly receiptExistsStmt: Database.Statement<[ReceiptId], ReceiptExistsRow>;
-  private readonly threadExistsStmt: Database.Statement<[ThreadId], ExistsRow>;
-  private readonly insertProjectionStmt: Database.Statement<ProjectionInsertParams>;
-  private readonly insertThreadReceiptStmt: Database.Statement<ThreadReceiptInsertParams>;
-  private readonly getPayloadStmt: Database.Statement<[ReceiptId], ProjectionPayloadRow>;
-  private readonly listAllStmt: Database.Statement<[number, number], ProjectionPayloadRow>;
-  private readonly listThreadStmt: Database.Statement<
-    [ThreadId, number, number],
-    ProjectionPayloadRow
-  >;
-  private readonly countStmt: Database.Statement<[], CountRow>;
-  private readonly putTransaction: Database.Transaction<
-    (receipt: ReceiptSnapshot) => ReceiptPutResult
-  >;
+  private readonly receiptExistsStmt: StatementSync;
+  private readonly threadExistsStmt: StatementSync;
+  private readonly insertProjectionStmt: StatementSync;
+  private readonly insertThreadReceiptStmt: StatementSync;
+  private readonly getPayloadStmt: StatementSync;
+  private readonly listAllStmt: StatementSync;
+  private readonly listThreadStmt: StatementSync;
+  private readonly countStmt: StatementSync;
+  private readonly putTransaction: TransactionFn<[ReceiptSnapshot], ReceiptPutResult>;
   private defaultThreadId: ThreadId | null;
   private closed = false;
 
@@ -104,7 +103,7 @@ export class SqliteReceiptStore implements ReceiptStore {
   }
 
   static fromDatabase(
-    db: Database.Database,
+    db: DatabaseSync,
     eventLog: EventLog,
     config: SqliteReceiptStoreFromDatabaseConfig = {},
   ): SqliteReceiptStore {
@@ -112,7 +111,7 @@ export class SqliteReceiptStore implements ReceiptStore {
   }
 
   private constructor(
-    private readonly db: Database.Database,
+    private readonly db: DatabaseSync,
     eventLog: EventLog = createEventLog(db),
     maxReceipts: number | undefined = undefined,
     defaultThreadId: ThreadId | null = null,
@@ -126,31 +125,29 @@ export class SqliteReceiptStore implements ReceiptStore {
       );
     }
     this.maxReceipts = requestedMax;
-    this.receiptExistsStmt = db.prepare<[ReceiptId], ReceiptExistsRow>(
+    this.receiptExistsStmt = db.prepare(
       "SELECT 1 AS present FROM receipts_projection WHERE receipt_id = ?",
     );
-    this.threadExistsStmt = db.prepare<[ThreadId], ExistsRow>(
-      "SELECT 1 AS present FROM threads WHERE thread_id = ?",
-    );
-    this.insertProjectionStmt = db.prepare<ProjectionInsertParams>(
+    this.threadExistsStmt = db.prepare("SELECT 1 AS present FROM threads WHERE thread_id = ?");
+    this.insertProjectionStmt = db.prepare(
       "INSERT INTO receipts_projection (receipt_id, thread_id, schema_version, lsn, payload) VALUES (?, ?, ?, ?, ?)",
     );
-    this.insertThreadReceiptStmt = db.prepare<ThreadReceiptInsertParams>(
+    this.insertThreadReceiptStmt = db.prepare(
       `INSERT INTO thread_receipts (thread_id, receipt_id, task_id, lsn)
        VALUES (?, ?, ?, ?)`,
     );
-    this.getPayloadStmt = db.prepare<[ReceiptId], ProjectionPayloadRow>(
+    this.getPayloadStmt = db.prepare(
       "SELECT lsn, payload FROM receipts_projection WHERE receipt_id = ?",
     );
-    this.listAllStmt = db.prepare<[number, number], ProjectionPayloadRow>(
+    this.listAllStmt = db.prepare(
       "SELECT lsn, payload FROM receipts_projection WHERE lsn > ? ORDER BY lsn ASC LIMIT ?",
     );
-    this.listThreadStmt = db.prepare<[ThreadId, number, number], ProjectionPayloadRow>(
+    this.listThreadStmt = db.prepare(
       "SELECT lsn, payload FROM receipts_projection WHERE thread_id = ? AND lsn > ? ORDER BY lsn ASC LIMIT ?",
     );
-    this.countStmt = db.prepare<[], CountRow>("SELECT COUNT(*) AS count FROM receipts_projection");
-    this.putTransaction = db.transaction((receipt: ReceiptSnapshot) => {
-      if (this.receiptExistsStmt.get(receipt.id) !== undefined) {
+    this.countStmt = db.prepare("SELECT COUNT(*) AS count FROM receipts_projection");
+    this.putTransaction = createTransaction(db, (receipt: ReceiptSnapshot) => {
+      if ((this.receiptExistsStmt.get(receipt.id) as ReceiptExistsRow | undefined) !== undefined) {
         return { existed: true, lsn: null };
       }
       // Cap check runs AFTER the existence check (mirrors the in-memory
@@ -158,13 +155,16 @@ export class SqliteReceiptStore implements ReceiptStore {
       // returns 409, not 507. The count query inside the
       // `BEGIN IMMEDIATE` transaction is serialized against concurrent
       // writers, so the check + insert are atomic.
-      const countRow = this.countStmt.get();
+      const countRow = this.countStmt.get() as CountRow | undefined;
       if (countRow !== undefined && countRow.count >= this.maxReceipts) {
         throw new ReceiptStoreFullError(`SqliteReceiptStore at capacity (${this.maxReceipts})`);
       }
 
       const threadId = projectionThreadId(receipt, this.defaultThreadId);
-      if (threadId !== null && this.threadExistsStmt.get(threadId) === undefined) {
+      if (
+        threadId !== null &&
+        (this.threadExistsStmt.get(threadId) as ExistsRow | undefined) === undefined
+      ) {
         throw new ReceiptThreadNotFoundError(`thread ${threadId} not found`);
       }
 
@@ -178,7 +178,7 @@ export class SqliteReceiptStore implements ReceiptStore {
     });
   }
 
-  sharesProvenance(db: Database.Database, eventLog: EventLog): boolean {
+  sharesProvenance(db: DatabaseSync, eventLog: EventLog): boolean {
     return this.db === db && this.eventLog === eventLog;
   }
 
@@ -209,9 +209,7 @@ export class SqliteReceiptStore implements ReceiptStore {
       }
       if (isSqliteUnavailableError(err)) {
         throw new ReceiptStoreUnavailableError(
-          `SqliteReceiptStore: storage error (${
-            err instanceof BetterSqlite3.SqliteError ? err.code : "unknown"
-          })`,
+          `SqliteReceiptStore: storage error (${sqliteErrorLabel(err)})`,
         );
       }
       throw err;
@@ -221,14 +219,14 @@ export class SqliteReceiptStore implements ReceiptStore {
   async get(id: ReceiptId): Promise<ReceiptSnapshot | null> {
     let row: ProjectionPayloadRow | undefined;
     try {
-      row = this.getPayloadStmt.get(id);
+      row = this.getPayloadStmt.get(id) as ProjectionPayloadRow | undefined;
     } catch (err) {
       throw classifySqliteReadError(err);
     }
     if (row === undefined) {
       return null;
     }
-    return receiptFromJson(row.payload.toString("utf8"));
+    return receiptFromJson(new TextDecoder().decode(row.payload));
   }
 
   async list(filter?: ListFilter): Promise<ListPage> {
@@ -238,13 +236,17 @@ export class SqliteReceiptStore implements ReceiptStore {
     try {
       rows =
         filter?.threadId === undefined
-          ? this.listAllStmt.all(afterLsn, limit + 1)
-          : this.listThreadStmt.all(filter.threadId, afterLsn, limit + 1);
+          ? (this.listAllStmt.all(afterLsn, limit + 1) as unknown as ProjectionPayloadRow[])
+          : (this.listThreadStmt.all(
+              filter.threadId,
+              afterLsn,
+              limit + 1,
+            ) as unknown as ProjectionPayloadRow[]);
     } catch (err) {
       throw classifySqliteReadError(err);
     }
     const visibleRows = rows.slice(0, limit);
-    const items = visibleRows.map((row) => receiptFromJson(row.payload.toString("utf8")));
+    const items = visibleRows.map((row) => receiptFromJson(new TextDecoder().decode(row.payload)));
     const lastRow = visibleRows.at(-1);
 
     return {
@@ -257,7 +259,7 @@ export class SqliteReceiptStore implements ReceiptStore {
   size(): number {
     let row: CountRow | undefined;
     try {
-      row = this.countStmt.get();
+      row = this.countStmt.get() as CountRow | undefined;
     } catch (err) {
       throw classifySqliteReadError(err);
     }
@@ -288,9 +290,7 @@ function classifySqliteReadError(err: unknown): Error {
   }
   if (isSqliteUnavailableError(err)) {
     return new ReceiptStoreUnavailableError(
-      `SqliteReceiptStore: storage error (${
-        err instanceof BetterSqlite3.SqliteError ? err.code : "unknown"
-      })`,
+      `SqliteReceiptStore: storage error (${sqliteErrorLabel(err)})`,
     );
   }
   return err instanceof Error ? err : new Error(String(err));
@@ -306,41 +306,8 @@ function projectionThreadId(
 
 function isReceiptIdConstraintError(err: unknown): boolean {
   return (
-    err instanceof BetterSqlite3.SqliteError &&
-    (err.code === "SQLITE_CONSTRAINT_PRIMARYKEY" || err.code === "SQLITE_CONSTRAINT_UNIQUE") &&
+    isSqliteConstraintError(err) &&
+    err instanceof Error &&
     err.message.includes("receipts_projection.receipt_id")
-  );
-}
-
-function isSqliteFullError(err: unknown): boolean {
-  return err instanceof BetterSqlite3.SqliteError && err.code === "SQLITE_FULL";
-}
-
-function isSqliteBusyError(err: unknown): boolean {
-  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
-  // SQLITE_BUSY / SQLITE_LOCKED + extended-code variants. The base
-  // codes also surface as extended codes like `SQLITE_BUSY_SNAPSHOT`.
-  return (
-    err.code === "SQLITE_BUSY" ||
-    err.code === "SQLITE_LOCKED" ||
-    err.code.startsWith("SQLITE_BUSY_") ||
-    err.code.startsWith("SQLITE_LOCKED_")
-  );
-}
-
-function isSqliteUnavailableError(err: unknown): boolean {
-  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
-  // Persistent / operator-intervention failure modes: read-only DB,
-  // I/O errors at any layer, corruption, can't-open. SQLITE_FULL is
-  // handled separately because it maps to 507 (out of space, distinct
-  // from "store is broken").
-  return (
-    err.code === "SQLITE_READONLY" ||
-    err.code === "SQLITE_CANTOPEN" ||
-    err.code === "SQLITE_CORRUPT" ||
-    err.code.startsWith("SQLITE_READONLY_") ||
-    err.code.startsWith("SQLITE_IOERR") ||
-    err.code.startsWith("SQLITE_CANTOPEN_") ||
-    err.code.startsWith("SQLITE_CORRUPT_")
   );
 }

--- a/packages/broker/src/threads/appender.ts
+++ b/packages/broker/src/threads/appender.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   asThreadSpecRevisionId,
   type EventLsn,
@@ -21,9 +22,9 @@ import {
   validateThreadStatusChangedAuditPayload,
   validateThreadStatusFold,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog, EventLogRecord } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 import type { ParsedIdempotencyKey } from "./idempotency.ts";
 import type { ThreadStateStore } from "./projections.ts";
 
@@ -113,24 +114,22 @@ export class ThreadIdempotencyConflictError extends Error {
 
 interface IdempotencyRow {
   readonly statusCode: number;
-  readonly responsePayload: Buffer;
+  readonly responsePayload: Uint8Array;
   readonly requestFingerprint: string | null;
 }
 
 export function createThreadAppender(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog: EventLog,
   threadState: ThreadStateStore,
 ): ThreadAppender {
-  const idempotencyLookupStmt = db.prepare<[string, string], IdempotencyRow>(
+  const idempotencyLookupStmt = db.prepare(
     `SELECT status_code AS statusCode, response_payload AS responsePayload,
             request_fingerprint AS requestFingerprint
      FROM command_idempotency
      WHERE idempotency_key = ? AND command = ?`,
   );
-  const idempotencyInsertStmt = db.prepare<
-    [string, string, number, Buffer, number | null, number, string]
-  >(
+  const idempotencyInsertStmt = db.prepare(
     `INSERT INTO command_idempotency
        (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms,
         request_fingerprint)
@@ -139,7 +138,9 @@ export function createThreadAppender(
 
   const appendCreateInner = (args: ThreadCreateIdempotentArgs): IdempotentThreadAppendResult => {
     assertRequestFingerprint(args.requestFingerprint);
-    const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+    const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+      | IdempotencyRow
+      | undefined;
     if (cached !== undefined) {
       assertIdempotencyFingerprint(cached, args.requestFingerprint);
       return idempotentReplay(cached);
@@ -209,7 +210,9 @@ export function createThreadAppender(
     args: ThreadSpecEditIdempotentArgs,
   ): IdempotentThreadAppendResult => {
     assertRequestFingerprint(args.requestFingerprint);
-    const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+    const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+      | IdempotencyRow
+      | undefined;
     if (cached !== undefined) {
       assertIdempotencyFingerprint(cached, args.requestFingerprint);
       return idempotentReplay(cached);
@@ -279,7 +282,9 @@ export function createThreadAppender(
     args: ThreadStatusChangeIdempotentArgs,
   ): IdempotentThreadAppendResult => {
     assertRequestFingerprint(args.requestFingerprint);
-    const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command);
+    const cached = idempotencyLookupStmt.get(args.idempotency.raw, args.idempotency.command) as
+      | IdempotencyRow
+      | undefined;
     if (cached !== undefined) {
       assertIdempotencyFingerprint(cached, args.requestFingerprint);
       return idempotentReplay(cached);
@@ -328,9 +333,9 @@ export function createThreadAppender(
     return { replayed: false, statusCode: rendered.statusCode, payload: rendered.payload, applied };
   };
 
-  const appendCreateTransaction = db.transaction(appendCreateInner);
-  const appendSpecEditTransaction = db.transaction(appendSpecEditInner);
-  const appendStatusChangeTransaction = db.transaction(appendStatusChangeInner);
+  const appendCreateTransaction = createTransaction(db, appendCreateInner);
+  const appendSpecEditTransaction = createTransaction(db, appendSpecEditInner);
+  const appendStatusChangeTransaction = createTransaction(db, appendStatusChangeInner);
 
   const appendThreadEvent = (
     type: "thread.created" | "thread.spec_edited" | "thread.status_changed",

--- a/packages/broker/src/threads/projections.ts
+++ b/packages/broker/src/threads/projections.ts
@@ -27,6 +27,7 @@ import {
 
 import type { EventLog, EventLogRecord, EventType } from "../event-log/index.ts";
 import { createTransaction } from "../internal/sqlite-transaction.ts";
+import { typed } from "../internal/typed-statement.ts";
 
 const THREAD_EVENT_BATCH_SIZE = 500;
 const THREAD_STATUS_SET: ReadonlySet<string> = new Set<string>(THREAD_STATUS_VALUES);
@@ -90,13 +91,22 @@ type DecodedThreadEvent =
     };
 
 export function createThreadStateStore(db: DatabaseSync): ThreadStateStore {
-  const insertCreatedStmt = db.prepare(
-    `INSERT INTO threads
+  const insertCreatedStmt = typed<
+    [ThreadId, string, "open", number, SignerIdentity, number, number, string],
+    never
+  >(
+    db.prepare(
+      `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms, external_refs)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ),
   );
-  const updateSpecStmt = db.prepare(
-    `UPDATE threads SET
+  const updateSpecStmt = typed<
+    [number, number, string, string | null, string, Sha256Hex, SignerIdentity, number, ThreadId],
+    never
+  >(
+    db.prepare(
+      `UPDATE threads SET
        head_lsn = ?,
        updated_at_ms = ?,
        spec_revision_id = ?,
@@ -106,18 +116,23 @@ export function createThreadStateStore(db: DatabaseSync): ThreadStateStore {
        spec_authored_by = ?,
        spec_authored_at_ms = ?
      WHERE thread_id = ?`,
+    ),
   );
-  const updateStatusStmt = db.prepare(
-    `UPDATE threads SET
+  const updateStatusStmt = typed<[ThreadStatus, number, number, number | null, ThreadId], never>(
+    db.prepare(
+      `UPDATE threads SET
        status = ?,
        head_lsn = ?,
        updated_at_ms = ?,
        closed_at_ms = ?
      WHERE thread_id = ?`,
+    ),
   );
-  const insertSpecRevisionStmt = db.prepare(
-    `INSERT INTO thread_spec_revisions (revision_id, thread_id, lsn)
+  const insertSpecRevisionStmt = typed<[string, ThreadId, number], never>(
+    db.prepare(
+      `INSERT INTO thread_spec_revisions (revision_id, thread_id, lsn)
      VALUES (?, ?, ?)`,
+    ),
   );
   const hasSpecRevisionStmt = db.prepare(
     "SELECT 1 AS present FROM thread_spec_revisions WHERE revision_id = ?",

--- a/packages/broker/src/threads/projections.ts
+++ b/packages/broker/src/threads/projections.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   asSha256Hex,
   asSignerIdentity,
@@ -23,9 +24,9 @@ import {
   threadExternalRefsFromJsonValue,
   threadExternalRefsToJsonValue,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog, EventLogRecord, EventType } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 
 const THREAD_EVENT_BATCH_SIZE = 500;
 const THREAD_STATUS_SET: ReadonlySet<string> = new Set<string>(THREAD_STATUS_VALUES);
@@ -88,17 +89,13 @@ type DecodedThreadEvent =
       readonly payload: ThreadStatusChangedAuditPayload;
     };
 
-export function createThreadStateStore(db: Database.Database): ThreadStateStore {
-  const insertCreatedStmt = db.prepare<
-    [string, string, string, number, string, number, number, string]
-  >(
+export function createThreadStateStore(db: DatabaseSync): ThreadStateStore {
+  const insertCreatedStmt = db.prepare(
     `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms, external_refs)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   );
-  const updateSpecStmt = db.prepare<
-    [number, number, string, string | null, string, string, string, number, string]
-  >(
+  const updateSpecStmt = db.prepare(
     `UPDATE threads SET
        head_lsn = ?,
        updated_at_ms = ?,
@@ -110,7 +107,7 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
        spec_authored_at_ms = ?
      WHERE thread_id = ?`,
   );
-  const updateStatusStmt = db.prepare<[string, number, number, number | null, string]>(
+  const updateStatusStmt = db.prepare(
     `UPDATE threads SET
        status = ?,
        head_lsn = ?,
@@ -118,14 +115,14 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
        closed_at_ms = ?
      WHERE thread_id = ?`,
   );
-  const insertSpecRevisionStmt = db.prepare<[string, string, number]>(
+  const insertSpecRevisionStmt = db.prepare(
     `INSERT INTO thread_spec_revisions (revision_id, thread_id, lsn)
      VALUES (?, ?, ?)`,
   );
-  const hasSpecRevisionStmt = db.prepare<[string], ExistsRow>(
+  const hasSpecRevisionStmt = db.prepare(
     "SELECT 1 AS present FROM thread_spec_revisions WHERE revision_id = ?",
   );
-  const getByIdStmt = db.prepare<[string], ThreadDbRow>(
+  const getByIdStmt = db.prepare(
     `SELECT thread_id AS threadId,
             title,
             status,
@@ -143,7 +140,7 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
             external_refs AS externalRefs
      FROM threads WHERE thread_id = ?`,
   );
-  const listAllStmt = db.prepare<[], ThreadDbRow>(
+  const listAllStmt = db.prepare(
     `SELECT thread_id AS threadId,
             title,
             status,
@@ -161,7 +158,7 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
             external_refs AS externalRefs
      FROM threads ORDER BY head_lsn ASC`,
   );
-  const listByStatusStmt = db.prepare<[string], ThreadDbRow>(
+  const listByStatusStmt = db.prepare(
     `SELECT thread_id AS threadId,
             title,
             status,
@@ -179,8 +176,8 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
             external_refs AS externalRefs
      FROM threads WHERE status = ? ORDER BY head_lsn ASC`,
   );
-  const clearSpecRevisionsStmt = db.prepare<[]>("DELETE FROM thread_spec_revisions");
-  const clearThreadsStmt = db.prepare<[]>("DELETE FROM threads");
+  const clearSpecRevisionsStmt = db.prepare("DELETE FROM thread_spec_revisions");
+  const clearThreadsStmt = db.prepare("DELETE FROM threads");
 
   const applyEventInner = (record: EventLogRecord): void => {
     const decoded = decodeThreadEvent(record);
@@ -232,7 +229,7 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
     }
   };
 
-  const rebuildTransaction = db.transaction((eventLog: EventLog, fromLsn: number): void => {
+  const rebuildTransaction = createTransaction(db, (eventLog: EventLog, fromLsn: number): void => {
     if (!Number.isSafeInteger(fromLsn) || fromLsn < 0) {
       throw new Error(
         `rebuildFromLog: fromLsn must be a non-negative safe integer, got ${fromLsn}`,
@@ -268,15 +265,17 @@ export function createThreadStateStore(db: Database.Database): ThreadStateStore 
       rebuildTransaction.immediate(eventLog, fromLsn);
     },
     getById(threadId: ThreadId): ThreadStateRow | null {
-      const row = getByIdStmt.get(threadId);
+      const row = getByIdStmt.get(threadId) as ThreadDbRow | undefined;
       return row === undefined ? null : toThreadStateRow(row);
     },
     hasSpecRevision(revisionId: string): boolean {
-      return hasSpecRevisionStmt.get(revisionId) !== undefined;
+      return (hasSpecRevisionStmt.get(revisionId) as ExistsRow | undefined) !== undefined;
     },
     list(filter?: { readonly status?: ThreadStatus }): readonly ThreadStateRow[] {
       const rows =
-        filter?.status === undefined ? listAllStmt.all() : listByStatusStmt.all(filter.status);
+        filter?.status === undefined
+          ? (listAllStmt.all() as unknown as ThreadDbRow[])
+          : (listByStatusStmt.all(filter.status) as unknown as ThreadDbRow[]);
       return rows.map(toThreadStateRow);
     },
   };
@@ -307,7 +306,7 @@ export function threadStateRowToThread(row: ThreadStateRow, taskIds: Thread["tas
 function decodeThreadEvent(record: EventLogRecord): DecodedThreadEvent | null {
   const kind = threadAuditKindForEventType(record.type);
   if (kind === null) return null;
-  const parsed = JSON.parse(record.payload.toString("utf8")) as unknown;
+  const parsed = JSON.parse(new TextDecoder().decode(record.payload)) as unknown;
   const payload = threadAuditPayloadFromJsonValue(kind, parsed);
   if (kind === "thread_created") {
     return { kind, payload: payload as ThreadCreatedAuditPayload };

--- a/packages/broker/src/threads/receipt-index.ts
+++ b/packages/broker/src/threads/receipt-index.ts
@@ -20,6 +20,7 @@ import {
 } from "../receipt-store.ts";
 
 const RECEIPT_EVENT_BATCH_SIZE = 500;
+const utf8Decoder = new TextDecoder("utf-8", { fatal: true });
 
 export interface ThreadReceiptIndexEntry {
   readonly receiptId: ReceiptId;
@@ -141,7 +142,7 @@ export function createThreadReceiptIndexStore(db: DatabaseSync): ThreadReceiptIn
 
   const applyEventInner = (record: EventLogRecord): void => {
     if (record.type !== "receipt.put") return;
-    const receipt = receiptFromJson(new TextDecoder().decode(record.payload));
+    const receipt = receiptFromJson(utf8Decoder.decode(record.payload));
     applyReplayReceipt(receipt, record.lsn);
   };
 
@@ -191,7 +192,7 @@ export function createThreadReceiptIndexStore(db: DatabaseSync): ThreadReceiptIn
     latestForThread(threadId: ThreadId): ThreadLatestReceipt | null {
       const row = latestStmt.get(threadId) as ThreadLatestReceiptRow | undefined;
       if (row === undefined) return null;
-      const receipt = receiptFromJson(new TextDecoder().decode(row.payload));
+      const receipt = receiptFromJson(utf8Decoder.decode(row.payload));
       return {
         receiptId: row.receiptId as ReceiptId,
         taskId: row.taskId as TaskId,

--- a/packages/broker/src/threads/receipt-index.ts
+++ b/packages/broker/src/threads/receipt-index.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   MAX_THREAD_TASK_IDS,
   type ReceiptId,
@@ -7,9 +8,9 @@ import {
   type TaskId,
   type ThreadId,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { EventLog, EventLogRecord } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 import {
   decodeListCursor,
   encodeListCursor,
@@ -59,26 +60,26 @@ interface ThreadReceiptIndexRow {
 }
 
 interface ThreadLatestReceiptRow extends ThreadReceiptIndexRow {
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface ThreadTaskIndexRow {
   readonly taskId: string;
 }
 
-export function createThreadReceiptIndexStore(db: Database.Database): ThreadReceiptIndexStore {
-  const insertStmt = db.prepare<[string, string, string, number]>(
+export function createThreadReceiptIndexStore(db: DatabaseSync): ThreadReceiptIndexStore {
+  const insertStmt = db.prepare(
     `INSERT INTO thread_receipts (thread_id, receipt_id, task_id, lsn)
      VALUES (?, ?, ?, ?)`,
   );
-  const listStmt = db.prepare<[string, number, number], ThreadReceiptIndexRow>(
+  const listStmt = db.prepare(
     `SELECT receipt_id AS receiptId, task_id AS taskId, lsn
      FROM thread_receipts
      WHERE thread_id = ? AND lsn > ?
      ORDER BY lsn ASC
      LIMIT ?`,
   );
-  const taskRefsStmt = db.prepare<[string, number], ThreadTaskIndexRow>(
+  const taskRefsStmt = db.prepare(
     `SELECT task_id AS taskId
      FROM (
        SELECT task_id, MIN(lsn) AS first_lsn
@@ -90,14 +91,14 @@ export function createThreadReceiptIndexStore(db: Database.Database): ThreadRece
      )
      ORDER BY first_lsn ASC`,
   );
-  const receiptRefsStmt = db.prepare<[string, number], ThreadReceiptIndexRow>(
+  const receiptRefsStmt = db.prepare(
     `SELECT receipt_id AS receiptId, task_id AS taskId, lsn
      FROM thread_receipts
      WHERE thread_id = ?
      ORDER BY lsn ASC
      LIMIT ?`,
   );
-  const latestStmt = db.prepare<[string], ThreadLatestReceiptRow>(
+  const latestStmt = db.prepare(
     `SELECT tr.receipt_id AS receiptId, tr.task_id AS taskId, tr.lsn, rp.payload
      FROM thread_receipts AS tr
      INNER JOIN receipts_projection AS rp ON rp.receipt_id = tr.receipt_id
@@ -105,7 +106,7 @@ export function createThreadReceiptIndexStore(db: Database.Database): ThreadRece
      ORDER BY tr.lsn DESC
      LIMIT 1`,
   );
-  const clearStmt = db.prepare<[]>("DELETE FROM thread_receipts");
+  const clearStmt = db.prepare("DELETE FROM thread_receipts");
 
   // Replay-only writer. The live receipt.put transaction owns thread_receipts
   // insertion so route writes cannot accidentally double-apply this index.
@@ -115,7 +116,7 @@ export function createThreadReceiptIndexStore(db: Database.Database): ThreadRece
     insertStmt.run(receipt.threadId, receipt.id, receipt.taskId, lsn);
   };
 
-  const rebuildTransaction = db.transaction((eventLog: EventLog, fromLsn: number): void => {
+  const rebuildTransaction = createTransaction(db, (eventLog: EventLog, fromLsn: number): void => {
     if (!Number.isSafeInteger(fromLsn) || fromLsn < 0) {
       throw new Error(
         `rebuildFromLog: fromLsn must be a non-negative safe integer, got ${fromLsn}`,
@@ -140,7 +141,7 @@ export function createThreadReceiptIndexStore(db: Database.Database): ThreadRece
 
   const applyEventInner = (record: EventLogRecord): void => {
     if (record.type !== "receipt.put") return;
-    const receipt = receiptFromJson(record.payload.toString("utf8"));
+    const receipt = receiptFromJson(new TextDecoder().decode(record.payload));
     applyReplayReceipt(receipt, record.lsn);
   };
 
@@ -160,7 +161,11 @@ export function createThreadReceiptIndexStore(db: Database.Database): ThreadRece
     ): ThreadReceiptIndexPage {
       const limit = resolveListLimit(filter?.limit);
       const afterLsn = filter?.cursor === undefined ? 0 : decodeListCursor(filter.cursor);
-      const rows = listStmt.all(threadId, afterLsn, limit + 1);
+      const rows = listStmt.all(
+        threadId,
+        afterLsn,
+        limit + 1,
+      ) as unknown as ThreadReceiptIndexRow[];
       const visibleRows = rows.slice(0, limit);
       const lastRow = visibleRows.at(-1);
       return {
@@ -170,17 +175,23 @@ export function createThreadReceiptIndexStore(db: Database.Database): ThreadRece
       };
     },
     refsForThread(threadId: ThreadId): ThreadReceiptIndexRefs {
-      const receiptRows = receiptRefsStmt.all(threadId, MAX_THREAD_TASK_IDS);
-      const taskRows = taskRefsStmt.all(threadId, MAX_THREAD_TASK_IDS);
+      const receiptRows = receiptRefsStmt.all(
+        threadId,
+        MAX_THREAD_TASK_IDS,
+      ) as unknown as ThreadReceiptIndexRow[];
+      const taskRows = taskRefsStmt.all(
+        threadId,
+        MAX_THREAD_TASK_IDS,
+      ) as unknown as ThreadTaskIndexRow[];
       return {
         receiptIds: receiptRows.map((row) => row.receiptId as ReceiptId),
         taskIds: taskRows.map((row) => row.taskId as TaskId),
       };
     },
     latestForThread(threadId: ThreadId): ThreadLatestReceipt | null {
-      const row = latestStmt.get(threadId);
+      const row = latestStmt.get(threadId) as ThreadLatestReceiptRow | undefined;
       if (row === undefined) return null;
-      const receipt = receiptFromJson(row.payload.toString("utf8"));
+      const receipt = receiptFromJson(new TextDecoder().decode(row.payload));
       return {
         receiptId: row.receiptId as ReceiptId,
         taskId: row.taskId as TaskId,

--- a/packages/broker/src/threads/replay-check/index.ts
+++ b/packages/broker/src/threads/replay-check/index.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   asThreadId,
   canonicalJSON,
@@ -16,7 +17,6 @@ import {
   threadAuditPayloadFromJsonValue,
   threadExternalRefsToJsonValue,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import {
   type ApprovalProjectionSnapshotRow,
@@ -24,6 +24,7 @@ import {
   replayApprovalsProjectionSnapshot,
   snapshotApprovalsProjection,
 } from "../../approvals/index.ts";
+import { createTransaction } from "../../internal/sqlite-transaction.ts";
 import { deriveThreadEffectiveStatus } from "../effective-status.ts";
 import { SYSTEM_INBOX_THREAD_ID } from "../subsystem.ts";
 
@@ -61,7 +62,7 @@ interface ReplayEventRow {
   readonly lsn: number;
   readonly tsMs: number;
   readonly type: string;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface HighestLsnRow {
@@ -73,7 +74,7 @@ interface ThreadReceiptProjectionRow {
   readonly receiptId: string;
   readonly taskId: string;
   readonly lsn: number;
-  readonly payload: Buffer;
+  readonly payload: Uint8Array;
 }
 
 interface ReplayedThreadState {
@@ -116,11 +117,9 @@ interface EffectiveStatusProjection {
   readonly pendingApprovalCount: number;
 }
 
-export function snapshotThreadProjection(
-  db: Database.Database,
-): readonly ThreadProjectionSnapshotRow[] {
+export function snapshotThreadProjection(db: DatabaseSync): readonly ThreadProjectionSnapshotRow[] {
   return db
-    .prepare<[], ThreadProjectionSnapshotRow>(
+    .prepare(
       `SELECT thread_id AS threadId,
               title,
               status,
@@ -139,21 +138,19 @@ export function snapshotThreadProjection(
        FROM threads
        ORDER BY thread_id ASC`,
     )
-    .all();
+    .all() as unknown as ThreadProjectionSnapshotRow[];
 }
 
-export function runThreadReplayCheck(db: Database.Database): ThreadReplayCheckReport {
-  const readBatchStmt = db.prepare<[number, number], ReplayEventRow>(
+export function runThreadReplayCheck(db: DatabaseSync): ThreadReplayCheckReport {
+  const readBatchStmt = db.prepare(
     `SELECT lsn, ts_ms AS tsMs, type, payload
      FROM event_log
      WHERE lsn > ? AND type IN (${THREAD_EVENT_TYPE_SQL})
      ORDER BY lsn ASC
      LIMIT ?`,
   );
-  const highestLsnStmt = db.prepare<[], HighestLsnRow>(
-    "SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log",
-  );
-  const listThreadReceiptsStmt = db.prepare<[], ThreadReceiptProjectionRow>(
+  const highestLsnStmt = db.prepare("SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log");
+  const listThreadReceiptsStmt = db.prepare(
     `SELECT tr.thread_id AS threadId, tr.receipt_id AS receiptId, tr.task_id AS taskId,
             tr.lsn, rp.payload
      FROM thread_receipts AS tr
@@ -161,7 +158,7 @@ export function runThreadReplayCheck(db: Database.Database): ThreadReplayCheckRe
      ORDER BY tr.thread_id ASC, tr.lsn ASC`,
   );
 
-  const txn = db.transaction((): ThreadReplayCheckReport => {
+  const txn = createTransaction(db, (): ThreadReplayCheckReport => {
     const replayedThreads = new Map<string, ReplayedThreadState>();
     const acceptedRevisionIds = new Map<string, number>();
     const taskThreadIds = new Map<string, string>();
@@ -171,7 +168,7 @@ export function runThreadReplayCheck(db: Database.Database): ThreadReplayCheckRe
     let scanned = 0;
 
     for (;;) {
-      const rows = readBatchStmt.all(cursor, BATCH_SIZE);
+      const rows = readBatchStmt.all(cursor, BATCH_SIZE) as unknown as ReplayEventRow[];
       if (rows.length === 0) break;
       for (const row of rows) {
         scanned += 1;
@@ -207,7 +204,9 @@ export function runThreadReplayCheck(db: Database.Database): ThreadReplayCheckRe
     }
     compareThreadRows(replayedThreadRows, liveThreads, discrepancies);
 
-    const liveReceiptRefs = liveThreadReceiptRefs(listThreadReceiptsStmt.all());
+    const liveReceiptRefs = liveThreadReceiptRefs(
+      listThreadReceiptsStmt.all() as unknown as ThreadReceiptProjectionRow[],
+    );
     const replayedReceiptRefs = new Map<string, ThreadReceiptRefs>();
     for (const row of replayedThreads.values()) {
       replayedReceiptRefs.set(row.threadId, {
@@ -232,7 +231,7 @@ export function runThreadReplayCheck(db: Database.Database): ThreadReplayCheckRe
 
     return {
       ok: discrepancies.length === 0,
-      highestLsn: lsnFromV1Number(highestLsnStmt.get()?.lsn ?? 0),
+      highestLsn: lsnFromV1Number((highestLsnStmt.get() as HighestLsnRow | undefined)?.lsn ?? 0),
       eventsScanned: scanned,
       discrepancies,
     };
@@ -251,7 +250,7 @@ function applyReplayEvent(
     if (row.type === "thread.created") {
       const payload = threadAuditPayloadFromJsonValue(
         "thread_created",
-        JSON.parse(row.payload.toString("utf8")) as unknown,
+        JSON.parse(new TextDecoder().decode(row.payload)) as unknown,
       ) as ThreadCreatedAuditPayload;
       threads.set(payload.threadId, {
         threadId: payload.threadId,
@@ -278,7 +277,7 @@ function applyReplayEvent(
     if (row.type === "thread.spec_edited") {
       const payload = threadAuditPayloadFromJsonValue(
         "thread_spec_edited",
-        JSON.parse(row.payload.toString("utf8")) as unknown,
+        JSON.parse(new TextDecoder().decode(row.payload)) as unknown,
       ) as ThreadSpecEditedAuditPayload;
       applySpecEdit(row, payload, threads, acceptedRevisionIds, discrepancies);
       return;
@@ -286,7 +285,7 @@ function applyReplayEvent(
     if (row.type === "thread.status_changed") {
       const payload = threadAuditPayloadFromJsonValue(
         "thread_status_changed",
-        JSON.parse(row.payload.toString("utf8")) as unknown,
+        JSON.parse(new TextDecoder().decode(row.payload)) as unknown,
       ) as ThreadStatusChangedAuditPayload;
       applyStatusChange(row, payload, threads, discrepancies);
       return;
@@ -379,7 +378,7 @@ function applyReceipt(
   taskThreadIds: Map<string, string>,
   discrepancies: ThreadReplayCheckDiscrepancy[],
 ): void {
-  const receipt = receiptFromJson(row.payload.toString("utf8"));
+  const receipt = receiptFromJson(new TextDecoder().decode(row.payload));
   if (receipt.schemaVersion !== 2) return;
   const threadId = receipt.threadId ?? SYSTEM_INBOX_THREAD_ID;
   const thread = threads.get(threadId);
@@ -471,7 +470,7 @@ function liveThreadReceiptRefs(
     if (!entry.taskIds.includes(row.taskId)) {
       entry.taskIds.push(row.taskId);
     }
-    entry.latestReceiptStatus = receiptFromJson(row.payload.toString("utf8")).status;
+    entry.latestReceiptStatus = receiptFromJson(new TextDecoder().decode(row.payload)).status;
   }
   return out;
 }

--- a/packages/broker/src/threads/routes.ts
+++ b/packages/broker/src/threads/routes.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { DatabaseSync } from "node:sqlite";
 
 import {
   asIdempotencyKey,
@@ -33,9 +34,14 @@ import {
   threadStatusChangeRequestFromJson,
   threadStatusChangeRequestToJsonValue,
 } from "@wuphf/protocol";
-import BetterSqlite3 from "better-sqlite3";
 import { ApprovalPendingSnapshotOverflowError } from "../approvals/index.ts";
 import { approvalViewFromApproval } from "../approvals/view.ts";
+import {
+  isSqliteBusyError,
+  isSqliteConstraintError,
+  isSqliteFullError,
+  isSqliteUnavailableError,
+} from "../internal/sqlite-errors.ts";
 import {
   InvalidListCursorError,
   InvalidListLimitError,
@@ -80,7 +86,7 @@ const EMPTY_EXTERNAL_REFS: ThreadExternalRefs = Object.freeze({
 });
 
 export interface ThreadRouteDeps {
-  readonly db: BetterSqlite3.Database;
+  readonly db: DatabaseSync;
   readonly appender: ThreadAppender;
   readonly state: ThreadStateStore;
   readonly receiptIndex: ThreadReceiptIndexStore;
@@ -719,36 +725,9 @@ function writeSqliteErrorResponse(
 
 function isCommandIdempotencyConstraintError(err: unknown): boolean {
   return (
-    err instanceof BetterSqlite3.SqliteError &&
-    (err.code === "SQLITE_CONSTRAINT_PRIMARYKEY" || err.code === "SQLITE_CONSTRAINT_UNIQUE") &&
+    isSqliteConstraintError(err) &&
+    err instanceof Error &&
     err.message.includes("command_idempotency.idempotency_key")
-  );
-}
-
-function isSqliteFullError(err: unknown): boolean {
-  return err instanceof BetterSqlite3.SqliteError && err.code === "SQLITE_FULL";
-}
-
-function isSqliteBusyError(err: unknown): boolean {
-  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
-  return (
-    err.code === "SQLITE_BUSY" ||
-    err.code === "SQLITE_LOCKED" ||
-    err.code.startsWith("SQLITE_BUSY_") ||
-    err.code.startsWith("SQLITE_LOCKED_")
-  );
-}
-
-function isSqliteUnavailableError(err: unknown): boolean {
-  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
-  return (
-    err.code === "SQLITE_READONLY" ||
-    err.code === "SQLITE_CANTOPEN" ||
-    err.code === "SQLITE_CORRUPT" ||
-    err.code.startsWith("SQLITE_READONLY_") ||
-    err.code.startsWith("SQLITE_IOERR") ||
-    err.code.startsWith("SQLITE_CANTOPEN_") ||
-    err.code.startsWith("SQLITE_CORRUPT_")
   );
 }
 

--- a/packages/broker/src/threads/subsystem.ts
+++ b/packages/broker/src/threads/subsystem.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   asIdempotencyKey,
   asSignerIdentity,
@@ -7,10 +8,10 @@ import {
   type ThreadId,
   threadMutationResponseToJsonValue,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
 import type { ApprovalAppender, ApprovalProjection } from "../approvals/index.ts";
 import type { EventLog } from "../event-log/index.ts";
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 import type { SqliteReceiptStore } from "../sqlite-receipt-store.ts";
 import { createThreadAppender, type ThreadAppender } from "./appender.ts";
 import type { ParsedIdempotencyKey } from "./idempotency.ts";
@@ -33,7 +34,7 @@ const SYSTEM_INBOX_EXTERNAL_REFS: ThreadExternalRefs = Object.freeze({
 const THREAD_REBUILD_BATCH_SIZE = 500;
 
 export interface ThreadSubsystem {
-  readonly db: Database.Database;
+  readonly db: DatabaseSync;
   readonly appender: ThreadAppender;
   readonly state: ThreadStateStore;
   readonly receiptIndex: ThreadReceiptIndexStore;
@@ -45,7 +46,7 @@ export interface ThreadSubsystem {
 }
 
 export function createThreadSubsystem(
-  db: Database.Database,
+  db: DatabaseSync,
   eventLog: EventLog,
   receiptStore: SqliteReceiptStore,
 ): ThreadSubsystem {
@@ -58,7 +59,7 @@ export function createThreadSubsystem(
   const appender = createThreadAppender(db, eventLog, state);
   ensureSystemInboxThread(appender, state);
   receiptStore.setDefaultThreadIdForThreadlessReceipts(SYSTEM_INBOX_THREAD_ID);
-  const rebuildTransaction = db.transaction((fromLsn: number): void => {
+  const rebuildTransaction = createTransaction(db, (fromLsn: number): void => {
     if (!Number.isSafeInteger(fromLsn) || fromLsn < 0) {
       throw new Error(
         `rebuildFromLog: fromLsn must be a non-negative safe integer, got ${fromLsn}`,

--- a/packages/broker/src/threads/views.ts
+++ b/packages/broker/src/threads/views.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   type ApprovalRequest,
   type EventLsn,
@@ -12,8 +13,8 @@ import {
   type ThreadView,
   validateThread,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 
+import { createTransaction } from "../internal/sqlite-transaction.ts";
 import { deriveThreadEffectiveStatus } from "./effective-status.ts";
 import {
   type ThreadStateRow,
@@ -76,11 +77,11 @@ interface ThreadViewDeps {
 }
 
 export function createThreadViewStore(
-  db: Database.Database,
+  db: DatabaseSync,
   state: ThreadStateStore,
   receiptIndex: ThreadReceiptIndexStore,
 ): ThreadViewStore {
-  const listThreadViewsTransaction = db.transaction((args: ThreadListViewArgs) =>
+  const listThreadViewsTransaction = createTransaction(db, (args: ThreadListViewArgs) =>
     listThreadViewPage(state, receiptIndex, args),
   );
 

--- a/packages/broker/src/types.ts
+++ b/packages/broker/src/types.ts
@@ -1,7 +1,7 @@
 // Public broker types. No I/O here — implementations live in sibling modules.
 
+import type { DatabaseSync } from "node:sqlite";
 import type { AgentId, ApiToken, BrokerPort } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import type { ApprovalAppender, ApprovalProjection } from "./approvals/index.ts";
 import type { CostLedger } from "./cost-ledger/index.ts";
 import type { ReceiptStore } from "./receipt-store.ts";
@@ -113,7 +113,7 @@ export interface BrokerConfig {
    */
   readonly cost?: {
     readonly ledger: CostLedger;
-    readonly db: Database.Database;
+    readonly db: DatabaseSync;
     /**
      * Additional bearer-like capability required for cost-ledger mutation
      * routes. Read routes continue to use the broker bearer only.

--- a/packages/broker/src/webauthn/store.ts
+++ b/packages/broker/src/webauthn/store.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync, StatementSync } from "node:sqlite";
 import {
   type AgentId,
   type ApprovalRole,
@@ -12,12 +13,16 @@ import {
   isApprovalRole,
   type JsonValue,
   type Sha256Hex,
-  type TimestampMs,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
-import BetterSqlite3 from "better-sqlite3";
 
 import { type OpenDatabaseArgs, openDatabase, runMigrations } from "../event-log/index.ts";
+import {
+  isSqliteBusyError,
+  isSqliteFullError,
+  isSqliteUnavailableError,
+  sqliteErrorLabel,
+} from "../internal/sqlite-errors.ts";
+import { createTransaction, type TransactionFn } from "../internal/sqlite-transaction.ts";
 import {
   type ConsumeCosignChallengeArgs,
   type ConsumedWebAuthnTokenRecord,
@@ -86,73 +91,35 @@ interface RoleRow {
   readonly role: string;
 }
 
-type InsertRegistrationChallengeParams = [string, string, ApprovalRole, AgentId, number, number];
-type InsertCosignChallengeParams = [
-  string,
-  string,
-  ApprovalTokenId,
-  ApprovalRole,
-  AgentId,
-  string,
-  string,
-  Sha256Hex,
-  Sha256Hex,
-  TimestampMs,
-  TimestampMs,
-  number,
-];
-type InsertCredentialParams = [string, string, number, ApprovalRole, AgentId, number];
-type MarkChallengeConsumedParams = [number, string];
-type UpdateCredentialCounterParams = [number, string, number];
-type InsertConsumedTokenParams = [
-  ApprovalTokenId,
-  string,
-  WebAuthnTokenOutcome,
-  string,
-  ApprovalRole,
-  Sha256Hex,
-  AgentId,
-  number,
-  number,
-];
-type UpdateConsumedTokenParams = [WebAuthnTokenOutcome, string, ApprovalTokenId];
-type PruneExpiredParams = [number, number];
-
 const TOKEN_OUTCOME_SET: ReadonlySet<string> = new Set(["approval_pending", "approved"]);
 const DEFAULT_PRUNE_EXPIRED_BATCH_ROWS = 100;
 const MAX_PRUNE_EXPIRED_BATCH_ROWS = 1_000;
 
 export class SqliteWebAuthnStore implements WebAuthnStore {
   private readonly closeDatabase: boolean;
-  private readonly insertRegistrationChallengeStmt: Database.Statement<InsertRegistrationChallengeParams>;
-  private readonly insertCosignChallengeStmt: Database.Statement<InsertCosignChallengeParams>;
-  private readonly getChallengeStmt: Database.Statement<[string], ChallengeRow>;
-  private readonly listCredentialsForAgentStmt: Database.Statement<[AgentId], CredentialRow>;
-  private readonly listCredentialsForAgentRoleStmt: Database.Statement<
-    [AgentId, ApprovalRole],
-    CredentialRow
+  private readonly insertRegistrationChallengeStmt: StatementSync;
+  private readonly insertCosignChallengeStmt: StatementSync;
+  private readonly getChallengeStmt: StatementSync;
+  private readonly listCredentialsForAgentStmt: StatementSync;
+  private readonly listCredentialsForAgentRoleStmt: StatementSync;
+  private readonly getCredentialStmt: StatementSync;
+  private readonly insertCredentialStmt: StatementSync;
+  private readonly markChallengeConsumedStmt: StatementSync;
+  private readonly getConsumedTokenStmt: StatementSync;
+  private readonly listSatisfiedRolesStmt: StatementSync;
+  private readonly updateCredentialCounterStmt: StatementSync;
+  private readonly insertConsumedTokenStmt: StatementSync;
+  private readonly updateConsumedTokenStmt: StatementSync;
+  private readonly pruneExpiredConsumedTokensStmt: StatementSync;
+  private readonly pruneExpiredOrphanChallengesStmt: StatementSync;
+  private readonly saveCredentialTransaction: TransactionFn<[SaveCredentialArgs], void>;
+  private readonly consumeCosignTransaction: TransactionFn<
+    [ConsumeCosignChallengeArgs],
+    ConsumedWebAuthnTokenRecord
   >;
-  private readonly getCredentialStmt: Database.Statement<[string], CredentialRow>;
-  private readonly insertCredentialStmt: Database.Statement<InsertCredentialParams>;
-  private readonly markChallengeConsumedStmt: Database.Statement<MarkChallengeConsumedParams>;
-  private readonly getConsumedTokenStmt: Database.Statement<[ApprovalTokenId], ConsumedTokenRow>;
-  private readonly listSatisfiedRolesStmt: Database.Statement<
-    [Sha256Hex, AgentId, number],
-    RoleRow
-  >;
-  private readonly updateCredentialCounterStmt: Database.Statement<UpdateCredentialCounterParams>;
-  private readonly insertConsumedTokenStmt: Database.Statement<InsertConsumedTokenParams>;
-  private readonly updateConsumedTokenStmt: Database.Statement<UpdateConsumedTokenParams>;
-  private readonly pruneExpiredConsumedTokensStmt: Database.Statement<PruneExpiredParams>;
-  private readonly pruneExpiredOrphanChallengesStmt: Database.Statement<PruneExpiredParams>;
-  private readonly saveCredentialTransaction: Database.Transaction<
-    (args: SaveCredentialArgs) => void
-  >;
-  private readonly consumeCosignTransaction: Database.Transaction<
-    (args: ConsumeCosignChallengeArgs) => ConsumedWebAuthnTokenRecord
-  >;
-  private readonly pruneExpiredTransaction: Database.Transaction<
-    (args: Required<PruneExpiredWebAuthnStateArgs>) => PruneExpiredWebAuthnStateResult
+  private readonly pruneExpiredTransaction: TransactionFn<
+    [Required<PruneExpiredWebAuthnStateArgs>],
+    PruneExpiredWebAuthnStateResult
   >;
   private closed = false;
 
@@ -168,23 +135,23 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   }
 
   constructor(
-    private readonly db: Database.Database,
+    private readonly db: DatabaseSync,
     options: SqliteWebAuthnStoreOptions = {},
   ) {
     this.closeDatabase = options.closeDatabase ?? false;
-    this.insertRegistrationChallengeStmt = db.prepare<InsertRegistrationChallengeParams>(
+    this.insertRegistrationChallengeStmt = db.prepare(
       `INSERT INTO webauthn_challenges
         (challenge_id, challenge_type, challenge_b64url, role, agent_id, expires_at_ms, created_at_ms)
        VALUES (?, 'registration', ?, ?, ?, ?, ?)`,
     );
-    this.insertCosignChallengeStmt = db.prepare<InsertCosignChallengeParams>(
+    this.insertCosignChallengeStmt = db.prepare(
       `INSERT INTO webauthn_challenges
         (challenge_id, challenge_type, challenge_b64url, token_id, role, agent_id,
          claim_json, scope_json, claim_scope_hash, approval_group_hash,
          not_before_ms, expires_at_ms, created_at_ms)
        VALUES (?, 'cosign', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
-    this.getChallengeStmt = db.prepare<[string], ChallengeRow>(
+    this.getChallengeStmt = db.prepare(
       `SELECT challenge_id AS challengeId,
               challenge_type AS challengeType,
               challenge_b64url AS challenge,
@@ -201,7 +168,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
        FROM webauthn_challenges
        WHERE challenge_id = ?`,
     );
-    this.listCredentialsForAgentStmt = db.prepare<[AgentId], CredentialRow>(
+    this.listCredentialsForAgentStmt = db.prepare(
       `SELECT credential_id AS credentialId,
               public_key_b64url AS publicKeyB64url,
               sign_count AS signCount,
@@ -212,7 +179,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
        WHERE agent_id = ?
        ORDER BY role ASC, credential_id ASC`,
     );
-    this.listCredentialsForAgentRoleStmt = db.prepare<[AgentId, ApprovalRole], CredentialRow>(
+    this.listCredentialsForAgentRoleStmt = db.prepare(
       `SELECT credential_id AS credentialId,
               public_key_b64url AS publicKeyB64url,
               sign_count AS signCount,
@@ -223,7 +190,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
        WHERE agent_id = ? AND role = ?
        ORDER BY credential_id ASC`,
     );
-    this.getCredentialStmt = db.prepare<[string], CredentialRow>(
+    this.getCredentialStmt = db.prepare(
       `SELECT credential_id AS credentialId,
               public_key_b64url AS publicKeyB64url,
               sign_count AS signCount,
@@ -233,15 +200,15 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
        FROM webauthn_registered_credentials
        WHERE credential_id = ?`,
     );
-    this.insertCredentialStmt = db.prepare<InsertCredentialParams>(
+    this.insertCredentialStmt = db.prepare(
       `INSERT INTO webauthn_registered_credentials
         (credential_id, public_key_b64url, sign_count, role, agent_id, created_at_ms)
        VALUES (?, ?, ?, ?, ?, ?)`,
     );
-    this.markChallengeConsumedStmt = db.prepare<MarkChallengeConsumedParams>(
+    this.markChallengeConsumedStmt = db.prepare(
       "UPDATE webauthn_challenges SET consumed_at_ms = ? WHERE challenge_id = ? AND consumed_at_ms IS NULL",
     );
-    this.getConsumedTokenStmt = db.prepare<[ApprovalTokenId], ConsumedTokenRow>(
+    this.getConsumedTokenStmt = db.prepare(
       `SELECT t.token_id AS tokenId,
               t.challenge_id AS challengeId,
               t.outcome,
@@ -257,7 +224,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
          ON c.challenge_id = t.challenge_id
        WHERE t.token_id = ?`,
     );
-    this.listSatisfiedRolesStmt = db.prepare<[Sha256Hex, AgentId, number], RoleRow>(
+    this.listSatisfiedRolesStmt = db.prepare(
       `SELECT DISTINCT role
        FROM webauthn_consumed_tokens
        WHERE approval_group_hash = ?
@@ -266,24 +233,24 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
          AND outcome IN ('approval_pending', 'approved')
        ORDER BY role ASC`,
     );
-    this.updateCredentialCounterStmt = db.prepare<UpdateCredentialCounterParams>(
+    this.updateCredentialCounterStmt = db.prepare(
       `UPDATE webauthn_registered_credentials
        SET sign_count = ?
        WHERE credential_id = ?
          AND (sign_count = 0 OR sign_count < ?)`,
     );
-    this.insertConsumedTokenStmt = db.prepare<InsertConsumedTokenParams>(
+    this.insertConsumedTokenStmt = db.prepare(
       `INSERT INTO webauthn_consumed_tokens
         (token_id, challenge_id, outcome, response_json, role, approval_group_hash,
          agent_id, expires_at_ms, consumed_at_ms)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
-    this.updateConsumedTokenStmt = db.prepare<UpdateConsumedTokenParams>(
+    this.updateConsumedTokenStmt = db.prepare(
       `UPDATE webauthn_consumed_tokens
        SET outcome = ?, response_json = ?
        WHERE token_id = ?`,
     );
-    this.pruneExpiredConsumedTokensStmt = db.prepare<PruneExpiredParams>(
+    this.pruneExpiredConsumedTokensStmt = db.prepare(
       `DELETE FROM webauthn_consumed_tokens
        WHERE token_id IN (
          SELECT token_id
@@ -293,7 +260,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
          LIMIT ?
        )`,
     );
-    this.pruneExpiredOrphanChallengesStmt = db.prepare<PruneExpiredParams>(
+    this.pruneExpiredOrphanChallengesStmt = db.prepare(
       `DELETE FROM webauthn_challenges
        WHERE challenge_id IN (
          SELECT c.challenge_id
@@ -308,7 +275,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
          LIMIT ?
        )`,
     );
-    this.saveCredentialTransaction = db.transaction((args: SaveCredentialArgs) => {
+    this.saveCredentialTransaction = createTransaction(db, (args: SaveCredentialArgs) => {
       this.insertCredentialStmt.run(
         args.credential.credentialId,
         Buffer.from(args.credential.publicKey).toString("base64url"),
@@ -322,8 +289,8 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
         throw new Error("webauthn registration challenge was already consumed");
       }
     });
-    this.consumeCosignTransaction = db.transaction((args: ConsumeCosignChallengeArgs) => {
-      const challenge = this.getChallengeStmt.get(args.challengeId);
+    this.consumeCosignTransaction = createTransaction(db, (args: ConsumeCosignChallengeArgs) => {
+      const challenge = this.getChallengeStmt.get(args.challengeId) as ChallengeRow | undefined;
       if (
         challenge === undefined ||
         challenge.tokenId === null ||
@@ -339,7 +306,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
       const approvalGroupHash = asSha256Hex(challenge.approvalGroupHash);
       const issuedToAgentId = asAgentId(challenge.agentId);
       const expiresAtMs = challenge.expiresAtMs;
-      const existing = this.getConsumedTokenStmt.get(tokenId);
+      const existing = this.getConsumedTokenStmt.get(tokenId) as ConsumedTokenRow | undefined;
       if (existing !== undefined) return consumedTokenFromRow(existing);
       const result = this.markChallengeConsumedStmt.run(args.consumedAtMs, challenge.challengeId);
       if (result.changes !== 1) {
@@ -369,9 +336,13 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
         args.consumedAtMs,
       );
       const satisfiedRoles = sortedUniqueRoles(
-        this.listSatisfiedRolesStmt
-          .all(approvalGroupHash, issuedToAgentId, args.consumedAtMs)
-          .map((row) => roleFromString(row.role, "webauthn_consumed_tokens.role")),
+        (
+          this.listSatisfiedRolesStmt.all(
+            approvalGroupHash,
+            issuedToAgentId,
+            args.consumedAtMs,
+          ) as unknown as RoleRow[]
+        ).map((row) => roleFromString(row.role, "webauthn_consumed_tokens.role")),
       );
       const thresholdMet = satisfiedRoles.length >= args.requiredThreshold;
       const outcome = thresholdMet ? "approved" : "approval_pending";
@@ -396,16 +367,15 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
         consumedAtMs: args.consumedAtMs,
       };
     });
-    this.pruneExpiredTransaction = db.transaction(
+    this.pruneExpiredTransaction = createTransaction(
+      db,
       (args: Required<PruneExpiredWebAuthnStateArgs>) => {
-        const consumedTokens = this.pruneExpiredConsumedTokensStmt.run(
-          args.nowMs,
-          args.maxRows,
-        ).changes;
-        const orphanChallenges = this.pruneExpiredOrphanChallengesStmt.run(
-          args.nowMs,
-          args.maxRows,
-        ).changes;
+        const consumedTokens = Number(
+          this.pruneExpiredConsumedTokensStmt.run(args.nowMs, args.maxRows).changes,
+        );
+        const orphanChallenges = Number(
+          this.pruneExpiredOrphanChallengesStmt.run(args.nowMs, args.maxRows).changes,
+        );
         return { consumedTokens, orphanChallenges };
       },
     );
@@ -466,7 +436,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   async getChallenge(challengeId: string): Promise<WebAuthnChallengeRecord | null> {
     try {
       this.assertOpen();
-      const row = this.getChallengeStmt.get(challengeId);
+      const row = this.getChallengeStmt.get(challengeId) as ChallengeRow | undefined;
       return row === undefined ? null : challengeFromRow(row);
     } catch (err) {
       throw classifySqliteReadError(err, "SqliteWebAuthnStore.getChallenge");
@@ -478,7 +448,9 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   ): Promise<readonly RegisteredWebAuthnCredential[]> {
     try {
       this.assertOpen();
-      return this.listCredentialsForAgentStmt.all(agentId).map(credentialFromRow);
+      return (this.listCredentialsForAgentStmt.all(agentId) as unknown as CredentialRow[]).map(
+        credentialFromRow,
+      );
     } catch (err) {
       throw classifySqliteReadError(err, "SqliteWebAuthnStore.listCredentialsForAgent");
     }
@@ -490,9 +462,12 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   }): Promise<readonly RegisteredWebAuthnCredential[]> {
     try {
       this.assertOpen();
-      return this.listCredentialsForAgentRoleStmt
-        .all(args.agentId, args.role)
-        .map(credentialFromRow);
+      return (
+        this.listCredentialsForAgentRoleStmt.all(
+          args.agentId,
+          args.role,
+        ) as unknown as CredentialRow[]
+      ).map(credentialFromRow);
     } catch (err) {
       throw classifySqliteReadError(err, "SqliteWebAuthnStore.listCredentialsForAgentRole");
     }
@@ -501,7 +476,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   async getCredential(credentialId: string): Promise<RegisteredWebAuthnCredential | null> {
     try {
       this.assertOpen();
-      const row = this.getCredentialStmt.get(credentialId);
+      const row = this.getCredentialStmt.get(credentialId) as CredentialRow | undefined;
       return row === undefined ? null : credentialFromRow(row);
     } catch (err) {
       throw classifySqliteReadError(err, "SqliteWebAuthnStore.getCredential");
@@ -520,7 +495,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   async getConsumedToken(tokenId: ApprovalTokenId): Promise<ConsumedWebAuthnTokenRecord | null> {
     try {
       this.assertOpen();
-      const row = this.getConsumedTokenStmt.get(tokenId);
+      const row = this.getConsumedTokenStmt.get(tokenId) as ConsumedTokenRow | undefined;
       return row === undefined ? null : consumedTokenFromRow(row);
     } catch (err) {
       throw classifySqliteReadError(err, "SqliteWebAuthnStore.getConsumedToken");
@@ -534,9 +509,13 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   }): Promise<readonly ApprovalRole[]> {
     try {
       this.assertOpen();
-      return this.listSatisfiedRolesStmt
-        .all(args.approvalGroupHash, args.issuedToAgentId, args.nowMs)
-        .map((row) => roleFromString(row.role, "webauthn_consumed_tokens.role"));
+      return (
+        this.listSatisfiedRolesStmt.all(
+          args.approvalGroupHash,
+          args.issuedToAgentId,
+          args.nowMs,
+        ) as unknown as RoleRow[]
+      ).map((row) => roleFromString(row.role, "webauthn_consumed_tokens.role"));
     } catch (err) {
       throw classifySqliteReadError(err, "SqliteWebAuthnStore.listSatisfiedRoles");
     }
@@ -571,7 +550,7 @@ export class SqliteWebAuthnStore implements WebAuthnStore {
   }
 }
 
-export function createWebAuthnStore(db: Database.Database): WebAuthnStore {
+export function createWebAuthnStore(db: DatabaseSync): WebAuthnStore {
   return new SqliteWebAuthnStore(db);
 }
 
@@ -706,9 +685,7 @@ function classifySqliteWriteError(err: unknown, operation: string): Error {
   }
   if (isSqliteUnavailableError(err)) {
     return new WebAuthnStoreUnavailableError(
-      `${operation}: storage error (${
-        err instanceof BetterSqlite3.SqliteError ? err.code : "unknown"
-      })`,
+      `${operation}: storage error (${sqliteErrorLabel(err)})`,
     );
   }
   return err instanceof Error ? err : new Error(String(err));
@@ -730,35 +707,6 @@ function classifySqliteReadError(err: unknown, operation: string): Error {
   }
   return new WebAuthnStoreUnavailableError(
     `${operation}: storage error (${err instanceof Error ? err.message : String(err)})`,
-  );
-}
-
-function isSqliteFullError(err: unknown): boolean {
-  return err instanceof BetterSqlite3.SqliteError && err.code === "SQLITE_FULL";
-}
-
-function isSqliteBusyError(err: unknown): boolean {
-  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
-  return (
-    err.code === "SQLITE_BUSY" ||
-    err.code === "SQLITE_LOCKED" ||
-    err.code.startsWith("SQLITE_BUSY_") ||
-    err.code.startsWith("SQLITE_LOCKED_")
-  );
-}
-
-function isSqliteUnavailableError(err: unknown): boolean {
-  if (!(err instanceof BetterSqlite3.SqliteError)) return false;
-  return (
-    err.code === "SQLITE_READONLY" ||
-    err.code === "SQLITE_CANTOPEN" ||
-    err.code === "SQLITE_CORRUPT" ||
-    err.code === "SQLITE_NOTADB" ||
-    err.code === "SQLITE_PERM" ||
-    err.code.startsWith("SQLITE_READONLY_") ||
-    err.code.startsWith("SQLITE_IOERR") ||
-    err.code.startsWith("SQLITE_CANTOPEN_") ||
-    err.code.startsWith("SQLITE_CORRUPT_")
   );
 }
 

--- a/packages/broker/tests/agent-provider-routing/store.spec.ts
+++ b/packages/broker/tests/agent-provider-routing/store.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import type { DatabaseSync } from "node:sqlite";
 import {
   type AgentProviderRouting,
   type AgentProviderRoutingEntry,
@@ -9,7 +9,6 @@ import {
   asCredentialScope,
   asProviderKind,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
@@ -86,8 +85,8 @@ function route(
   };
 }
 
-function insertRawRoute(db: Database.Database, rawRoute: RawRoute): void {
-  db.prepare<RawRoute>(
+function insertRawRoute(db: DatabaseSync, rawRoute: RawRoute): void {
+  db.prepare(
     `INSERT INTO agent_provider_routing
        (agent_id, runner_kind, credential_scope, provider_kind)
      VALUES (?, ?, ?, ?)`,
@@ -102,6 +101,11 @@ function expectRawRouteCheckFailure(rawRoute: RawRoute, constraint: string): voi
   } finally {
     db.close();
   }
+}
+
+function userVersion(db: DatabaseSync): number {
+  return (db.prepare("PRAGMA user_version").get() as { readonly user_version: number })
+    .user_version;
 }
 
 describe("SqliteAgentProviderRoutingStore", () => {
@@ -251,14 +255,13 @@ describe("SqliteAgentProviderRoutingStore", () => {
     try {
       runMigrations(db);
 
-      expect(db.pragma("user_version", { simple: true })).toBe(CURRENT_SCHEMA_VERSION);
-      expect(
-        db
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'agent_provider_routing'",
-          )
-          .get()?.name,
-      ).toBe("agent_provider_routing");
+      expect(userVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+      const row = db
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'agent_provider_routing'",
+        )
+        .get() as { readonly name: string } | undefined;
+      expect(row?.name).toBe("agent_provider_routing");
     } finally {
       db.close();
     }
@@ -276,7 +279,7 @@ describe("SqliteAgentProviderRoutingStore", () => {
     try {
       runMigrations(first);
       first
-        .prepare<[string, string, string, string]>(
+        .prepare(
           `INSERT INTO agent_provider_routing
              (agent_id, runner_kind, credential_scope, provider_kind)
            VALUES (?, ?, ?, ?)`,
@@ -289,13 +292,10 @@ describe("SqliteAgentProviderRoutingStore", () => {
     const second = openDatabase({ path });
     try {
       runMigrations(second);
-      expect(
-        second
-          .prepare<[], { readonly count: number }>(
-            "SELECT COUNT(*) AS count FROM agent_provider_routing",
-          )
-          .get()?.count,
-      ).toBe(1);
+      const row = second.prepare("SELECT COUNT(*) AS count FROM agent_provider_routing").get() as
+        | { readonly count: number }
+        | undefined;
+      expect(row?.count).toBe(1);
     } finally {
       second.close();
     }

--- a/packages/broker/tests/approvals/projections.spec.ts
+++ b/packages/broker/tests/approvals/projections.spec.ts
@@ -64,9 +64,7 @@ function setupWithThreadValidator(
   for (const threadId of threadIds) {
     insertThreadProjectionRow(db, eventLog, threadId);
   }
-  const threadExistsStmt = db.prepare<[string], { readonly present: 1 }>(
-    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
-  );
+  const threadExistsStmt = db.prepare("SELECT 1 AS present FROM threads WHERE thread_id = ?");
   const projection = createApprovalProjection(db);
   const appender = createApprovalAppender(db, eventLog, projection, {
     threadRefValidator: (threadId) => threadExistsStmt.get(threadId) !== undefined,
@@ -163,11 +161,11 @@ function signedApprovalTokenFixture(
 
 function eventCount(db: ReturnType<typeof openDatabase>, type: string): number {
   return (
-    db
-      .prepare<[string], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = ?",
-      )
-      .get(type)?.n ?? 0
+    (
+      db.prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = ?").get(type) as
+        | { readonly n: number }
+        | undefined
+    )?.n ?? 0
   );
 }
 
@@ -187,7 +185,7 @@ function insertThreadProjectionRow(
   threadId = THREAD_ID,
 ): void {
   const lsn = appendThreadCreatedEvent(eventLog, threadId);
-  db.prepare<[string, number, string, string], void>(
+  db.prepare(
     `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms,
         external_refs)
@@ -211,27 +209,7 @@ function appendThreadCreatedEvent(
 
 function projectionSnapshot(db: ReturnType<typeof openDatabase>): string {
   const rows = db
-    .prepare<
-      [],
-      {
-        readonly approvalId: string;
-        readonly status: string;
-        readonly headLsn: number;
-        readonly claim: string;
-        readonly scope: string;
-        readonly riskClass: string;
-        readonly threadId: string | null;
-        readonly taskId: string | null;
-        readonly receiptId: string | null;
-        readonly requestedBy: string;
-        readonly requestedAtMs: number;
-        readonly decidedBy: string | null;
-        readonly decidedAtMs: number | null;
-        readonly decision: string | null;
-        readonly token: string | null;
-        readonly tokenId: string | null;
-      }
-    >(
+    .prepare(
       `SELECT approval_id AS approvalId, status, head_lsn AS headLsn, claim, scope,
               risk_class AS riskClass, thread_id AS threadId, task_id AS taskId,
               receipt_id AS receiptId, requested_by AS requestedBy,
@@ -239,8 +217,27 @@ function projectionSnapshot(db: ReturnType<typeof openDatabase>): string {
               decided_at_ms AS decidedAtMs, decision, token, token_id AS tokenId
        FROM pending_approvals ORDER BY approval_id ASC`,
     )
-    .all();
+    .all() as unknown as readonly ApprovalProjectionSnapshotTestRow[];
   return canonicalJSON(rows);
+}
+
+interface ApprovalProjectionSnapshotTestRow {
+  readonly approvalId: string;
+  readonly status: string;
+  readonly headLsn: number;
+  readonly claim: string;
+  readonly scope: string;
+  readonly riskClass: string;
+  readonly threadId: string | null;
+  readonly taskId: string | null;
+  readonly receiptId: string | null;
+  readonly requestedBy: string;
+  readonly requestedAtMs: number;
+  readonly decidedBy: string | null;
+  readonly decidedAtMs: number | null;
+  readonly decision: string | null;
+  readonly token: string | null;
+  readonly tokenId: string | null;
 }
 
 function requestFingerprint(
@@ -442,8 +439,11 @@ describe("approval projection and appender", () => {
       expect(eventCount(db, "approval.requested")).toBe(1);
       expect(eventCount(db, "approval.decided")).toBe(1);
       expect(
-        db.prepare<[], { readonly n: number }>("SELECT COUNT(*) AS n FROM pending_approvals").get()
-          ?.n,
+        (
+          db.prepare("SELECT COUNT(*) AS n FROM pending_approvals").get() as
+            | { readonly n: number }
+            | undefined
+        )?.n,
       ).toBe(1);
     } finally {
       db.close();
@@ -489,13 +489,13 @@ describe("approval projection and appender", () => {
   it("prunes only approval command idempotency rows", () => {
     const { db, appender } = setup();
     try {
-      db.prepare<[string, string, number], void>(
+      db.prepare(
         `INSERT INTO command_idempotency
            (idempotency_key, command, status_code, response_payload, created_at_lsn,
             created_at_ms, request_fingerprint)
          VALUES (?, ?, 201, x'7B7D', NULL, ?, NULL)`,
       ).run("old-approval", "approval.requested", 1_700_000_000_000);
-      db.prepare<[string, string, number], void>(
+      db.prepare(
         `INSERT INTO command_idempotency
            (idempotency_key, command, status_code, response_payload, created_at_lsn,
             created_at_ms, request_fingerprint)
@@ -504,11 +504,9 @@ describe("approval projection and appender", () => {
 
       expect(appender.pruneIdempotencyOlderThan(1_700_000_000_001)).toBe(1);
       expect(
-        db
-          .prepare<[], { readonly command: string }>(
-            "SELECT command FROM command_idempotency ORDER BY command ASC",
-          )
-          .all(),
+        db.prepare("SELECT command FROM command_idempotency ORDER BY command ASC").all() as {
+          readonly command: string;
+        }[],
       ).toEqual([{ command: "cost.event" }]);
     } finally {
       db.close();
@@ -537,10 +535,10 @@ describe("approval projection and appender", () => {
       expect(projection.countPendingByThread(otherThreadId)).toBe(1);
 
       const indexes = db
-        .prepare<[], { readonly name: string }>(
+        .prepare(
           "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'pending_approvals_thread_status'",
         )
-        .all();
+        .all() as { readonly name: string }[];
       expect(indexes.map((row) => row.name)).toEqual(["pending_approvals_thread_status"]);
     } finally {
       db.close();

--- a/packages/broker/tests/approvals/routes.spec.ts
+++ b/packages/broker/tests/approvals/routes.spec.ts
@@ -34,7 +34,6 @@ import {
   signedApprovalTokenToJsonValue,
   validateApprovalStreamEvent,
 } from "@wuphf/protocol";
-import BetterSqlite3 from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { ApprovalAppender, ApprovalProjection } from "../../src/approvals/index.ts";
@@ -156,9 +155,7 @@ async function buildFixture(overrides?: FixtureOverrides): Promise<Fixture> {
   for (const threadId of threadIds) {
     insertThreadProjectionRow(db, eventLog, threadId);
   }
-  const threadExistsStmt = db.prepare<[string], { readonly present: 1 }>(
-    "SELECT 1 AS present FROM threads WHERE thread_id = ?",
-  );
+  const threadExistsStmt = db.prepare("SELECT 1 AS present FROM threads WHERE thread_id = ?");
   const { appender: baseAppender, projection: baseProjection } = createApprovalSubsystem(
     db,
     eventLog,
@@ -187,7 +184,7 @@ function insertThreadProjectionRow(
   threadId: ReturnType<typeof asThreadId>,
 ): void {
   const lsn = eventLog.append({ type: "thread.created", payload: Buffer.from("{}") });
-  db.prepare<[string, number, string, string], void>(
+  db.prepare(
     `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms,
         external_refs)
@@ -258,16 +255,41 @@ async function postApproval(fix: Fixture, idempotencyKey = REQUEST_KEY) {
 
 function eventCount(db: ReturnType<typeof openDatabase>, type: string): number {
   return (
-    db
-      .prepare<[string], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = ?",
-      )
-      .get(type)?.n ?? 0
+    (
+      db.prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = ?").get(type) as
+        | { readonly n: number }
+        | undefined
+    )?.n ?? 0
   );
 }
 
 function sqliteError(code: string): Error {
-  return new BetterSqlite3.SqliteError("test sqlite error", code);
+  return Object.assign(new Error("test sqlite error"), {
+    code: "ERR_SQLITE_ERROR",
+    errcode: sqliteErrcode(code),
+    errstr: code,
+  });
+}
+
+function sqliteErrcode(code: string): number {
+  switch (code) {
+    case "SQLITE_BUSY":
+      return 5;
+    case "SQLITE_LOCKED":
+      return 6;
+    case "SQLITE_FULL":
+      return 13;
+    case "SQLITE_READONLY":
+      return 8;
+    case "SQLITE_CANTOPEN":
+      return 14;
+    case "SQLITE_CORRUPT":
+      return 11;
+    case "SQLITE_IOERR_READ":
+      return 266;
+    default:
+      throw new Error(`unknown sqlite test code: ${code}`);
+  }
 }
 
 function rawRequest(args: {

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -11,6 +11,7 @@ import {
   type CostEventAuditPayload,
   costAuditPayloadToBytes,
   lsnFromV1Number,
+  MAX_BUDGET_LIMIT_MICRO_USD,
   parseLsn,
 } from "@wuphf/protocol";
 import { describe, expect, it } from "vitest";
@@ -20,6 +21,7 @@ import {
   type ReplayDiscrepancy,
   runReplayCheck,
 } from "../src/cost-ledger/index.ts";
+import { processCostEventForCrossings } from "../src/cost-ledger/reactor.ts";
 import {
   __createBudgetCandidateIndexesForTesting,
   __replayCheckTesting,
@@ -206,6 +208,25 @@ describe("BudgetThresholdReactor", () => {
     // Fourth event: same threshold doesn't re-fire under same budget_set LSN.
     const fourth = ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 100_000 }));
     expect(fourth.newCrossings).toEqual([]);
+  });
+
+  it("reads lifetime aggregates past Number.MAX_SAFE_INTEGER without RangeError", () => {
+    const { db, eventLog, ledger } = setup();
+    ledger.appendBudgetSet(buildBudgetSet({ limitMicroUsd: 1_000_000, thresholdsBps: [5_000] }));
+    db.prepare(
+      `INSERT INTO cost_by_agent (agent_slug, day_utc, total_micro_usd, last_lsn)
+       VALUES (?, ?, ?, ?)`,
+    ).run("primary", "2026-05-08", 2n ** 60n, 1);
+
+    const crossings = processCostEventForCrossings(db, eventLog, {
+      costEventLsn: 1,
+      agentSlug: "primary",
+      taskId: undefined,
+      occurredAt: new Date("2026-05-08T10:00:00.000Z"),
+    });
+
+    expect(crossings).toHaveLength(1);
+    expect(crossings[0]?.observedMicroUsd as number).toBe(MAX_BUDGET_LIMIT_MICRO_USD);
   });
 
   it("raising a budget re-arms thresholds (new budget_set LSN, new crossing rows)", () => {

--- a/packages/broker/tests/cost-ledger.spec.ts
+++ b/packages/broker/tests/cost-ledger.spec.ts
@@ -86,10 +86,8 @@ describe("cost ledger projections", () => {
     expect(result.newCrossings).toEqual([]);
 
     const eventCount = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly n: number } | undefined;
     expect(eventCount?.n).toBe(1);
 
     const agentRow = ledger.getAgentSpend("primary", "2026-05-08");
@@ -126,20 +124,18 @@ describe("cost ledger projections", () => {
       ledger.appendCostEvent(buildCostEvent(opts));
     }
     const eventSum = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly n: number } | undefined;
     expect(eventSum?.n).toBe(20);
     const agentSum = ledger
       .listAgentSpend()
       .reduce((acc, row) => acc + (row.totalMicroUsd as number), 0);
     const taskSum =
-      db
-        .prepare<[], { readonly s: number }>(
-          "SELECT COALESCE(SUM(total_micro_usd), 0) AS s FROM cost_by_task",
-        )
-        .get()?.s ?? 0;
+      (
+        db.prepare("SELECT COALESCE(SUM(total_micro_usd), 0) AS s FROM cost_by_task").get() as
+          | { readonly s: number }
+          | undefined
+      )?.s ?? 0;
     // Expected: sum of all 20 amounts = 20*100_000 + (0+1+...+19) = 2_000_190
     const expected = 20 * 100_000 + (19 * 20) / 2;
     expect(agentSum).toBe(expected);
@@ -169,10 +165,8 @@ describe("cost ledger budget projection", () => {
     expect(row?.tombstoned).toBe(true);
     expect(row?.limitMicroUsd as number).toBe(0);
     const eventCount = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.budget.set'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.budget.set'")
+      .get() as { readonly n: number } | undefined;
     expect(eventCount?.n).toBe(2);
   });
 
@@ -322,18 +316,18 @@ describe("idempotency", () => {
 
     // Only one event_log row.
     const count = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly n: number } | undefined;
     expect(count?.n).toBe(1);
 
     // Idempotency row exists with the response bytes.
     const idemRow = db
-      .prepare<[string], { readonly statusCode: number; readonly responsePayload: Buffer }>(
+      .prepare(
         "SELECT status_code AS statusCode, response_payload AS responsePayload FROM command_idempotency WHERE idempotency_key = ?",
       )
-      .get(parsed.key.raw);
+      .get(parsed.key.raw) as
+      | { readonly statusCode: number; readonly responsePayload: Uint8Array }
+      | undefined;
     expect(idemRow?.statusCode).toBe(201);
     expect(Buffer.from(idemRow?.responsePayload ?? Buffer.alloc(0)).toString()).toBe(
       r1.payload.toString(),
@@ -366,12 +360,12 @@ describe("idempotency", () => {
         payload: Buffer.from(JSON.stringify({ lsn: applied.lsn }), "utf8"),
       }),
     });
-    db.prepare<[string, string, number], void>(
+    db.prepare(
       `INSERT INTO command_idempotency
          (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms)
        VALUES (?, ?, 201, x'7B7D', NULL, ?)`,
     ).run("old-approval", "approval.requested", 1_000);
-    db.prepare<[string, string, number], void>(
+    db.prepare(
       `INSERT INTO command_idempotency
          (idempotency_key, command, status_code, response_payload, created_at_lsn, created_at_ms)
        VALUES (?, ?, 201, x'7B7D', NULL, ?)`,
@@ -380,7 +374,7 @@ describe("idempotency", () => {
     expect(ledger.pruneIdempotencyOlderThan(3_000)).toBe(1);
 
     const idempotencyRows = db
-      .prepare<[], { readonly idempotencyKey: string }>(
+      .prepare(
         "SELECT idempotency_key AS idempotencyKey FROM command_idempotency ORDER BY idempotency_key ASC",
       )
       .all();
@@ -391,10 +385,8 @@ describe("idempotency", () => {
     ]);
 
     const eventCountAfterPrune = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly n: number } | undefined;
     expect(eventCountAfterPrune?.n).toBe(2);
     expect(ledger.getAgentSpend("primary", "2026-05-08")?.totalMicroUsd as number).toBe(3_000_000);
 
@@ -409,10 +401,8 @@ describe("idempotency", () => {
     });
     expect(reapplied.replayed).toBe(false);
     const eventCountAfterReapply = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly n: number } | undefined;
     expect(eventCountAfterReapply?.n).toBe(3);
   });
 });
@@ -472,7 +462,7 @@ describe("replay-check", () => {
     // Inject a stray crossing row that points to the existing budget_set
     // event LSN (so the FK is satisfied), but with a threshold the
     // event_log has no matching `cost.budget.threshold.crossed` for.
-    db.prepare<[string, number, number, number, number, number]>(
+    db.prepare(
       `INSERT INTO cost_threshold_crossings
          (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -570,12 +560,10 @@ describe("replay-check", () => {
     // Overwrite the second cost.event payload with garbage JSON so the
     // codec rejects it. (We pick the highest cost.event LSN.)
     const tamperedLsn = db
-      .prepare<[], { readonly lsn: number }>(
-        "SELECT MAX(lsn) AS lsn FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT MAX(lsn) AS lsn FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly lsn: number } | undefined;
     if (tamperedLsn === undefined) throw new Error("no cost.event row to tamper");
-    db.prepare<[Buffer, number]>("UPDATE event_log SET payload = ? WHERE lsn = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE lsn = ?").run(
       Buffer.from('{"not":"a valid cost event"}', "utf8"),
       tamperedLsn.lsn,
     );
@@ -648,7 +636,7 @@ describe("replay-check oracle (#836)", () => {
       type: "cost.budget.threshold.crossed",
       payload: Buffer.from(bytes),
     });
-    db.prepare<[string, number, number, number, number, number]>(
+    db.prepare(
       `INSERT INTO cost_threshold_crossings
          (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -691,7 +679,7 @@ describe("replay-check oracle (#836)", () => {
       crossedAt: new Date("2026-05-08T10:00:00.000Z"),
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -729,7 +717,7 @@ describe("replay-check oracle (#836)", () => {
       crossedAt: new Date("2026-05-08T10:00:00.000Z"),
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -823,16 +811,14 @@ describe("replay-check oracle (#836)", () => {
     // event. A future regression that skipped the second epoch would
     // still pass `ok === true` if no spurious entry fires.
     const crossingCount = db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.budget.threshold.crossed'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.budget.threshold.crossed'")
+      .get() as { readonly n: number } | undefined;
     expect(crossingCount?.n).toBe(2);
     const projectionRows = db
-      .prepare<[], { readonly budgetSetLsn: number }>(
+      .prepare(
         "SELECT budget_set_lsn AS budgetSetLsn FROM cost_threshold_crossings ORDER BY budget_set_lsn ASC",
       )
-      .all();
+      .all() as unknown as { readonly budgetSetLsn: number }[];
     expect(projectionRows.length).toBe(2);
     expect(projectionRows[0]?.budgetSetLsn).not.toBe(projectionRows[1]?.budgetSetLsn);
   });
@@ -1031,7 +1017,7 @@ describe("replay-check oracle round-2 fixes (#841)", () => {
       crossedAt: new Date("2026-05-08T10:00:00.000Z"),
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -1066,7 +1052,7 @@ describe("replay-check oracle round-2 fixes (#841)", () => {
       crossedAt: new Date("2099-12-31T23:59:59.000Z"), // future timestamp
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -1109,7 +1095,7 @@ describe("replay-check oracle round-2 fixes (#841)", () => {
       type: "cost.budget.threshold.crossed",
       payload: Buffer.from(strayBytes),
     });
-    db.prepare<[string, number, number, number, number, number]>(
+    db.prepare(
       `INSERT INTO cost_threshold_crossings
          (budget_id, budget_set_lsn, threshold_bps, crossed_at_lsn, observed_micro_usd, limit_micro_usd)
        VALUES (?, ?, ?, ?, ?, ?)`,
@@ -1145,7 +1131,7 @@ describe("replay-check oracle round-2 fixes (PR #841 r2)", () => {
       crossedAt: new Date("2026-05-08T10:00:00.000Z"),
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -1301,7 +1287,7 @@ describe("replay-check oracle round-3 fixes (PR #841 r3)", () => {
       crossedAt: new Date("2026-05-08T10:00:00.000Z"),
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -1350,7 +1336,7 @@ describe("replay-check oracle round-3 fixes (PR #841 r3)", () => {
       crossedAt: new Date("2026-05-08T10:00:00.000Z"),
     };
     const tamperedBytes = costAuditPayloadToBytes("budget_threshold_crossed", tamperedPayload);
-    db.prepare<[Buffer, string]>("UPDATE event_log SET payload = ? WHERE type = ?").run(
+    db.prepare("UPDATE event_log SET payload = ? WHERE type = ?").run(
       Buffer.from(tamperedBytes),
       "cost.budget.threshold.crossed",
     );
@@ -1521,7 +1507,7 @@ describe("replay-check aggregate paths round-4 (PR #845 r4 triangulation)", () =
   // `MAX_BUDGET_LIMIT_MICRO_USD` it forges the brand; past
   // `Number.MAX_SAFE_INTEGER` (or a hostile projection row at that
   // boundary) it silently rounds. The accumulators are now bigint, the
-  // SQLite reads use `.safeIntegers(true)`, and the discrepancies emit
+  // SQLite reads use `.setReadBigInts(true)`, and the discrepancies emit
   // decimal strings.
   //
   // End-to-end coverage past 2^53 is blocked by the protocol per-event
@@ -1644,7 +1630,7 @@ describe("replay-check aggregate paths round-4 (PR #845 r4 triangulation)", () =
     // The security lens's specific concern: stored projection rows are
     // hostile input. A row past 2^53 used to round through JS number
     // and the diagnostic would carry the rounded value. With
-    // `.safeIntegers(true)` the bigint flows straight to the string
+    // `.setReadBigInts(true)` the bigint flows straight to the string
     // emission. Use 2^53 + 17 — outside JS-number exact range.
     const { db, ledger } = setup();
     ledger.appendCostEvent(buildCostEvent({ amountMicroUsd: 1_000_000 }));

--- a/packages/broker/tests/cost-routes.spec.ts
+++ b/packages/broker/tests/cost-routes.spec.ts
@@ -392,9 +392,7 @@ describe("/api/v1/cost routes", () => {
     });
     expect(append.status).toBe(201);
     fix.db
-      .prepare<[number, string]>(
-        "UPDATE command_idempotency SET created_at_ms = ? WHERE idempotency_key = ?",
-      )
+      .prepare("UPDATE command_idempotency SET created_at_ms = ? WHERE idempotency_key = ?")
       .run(1, key);
 
     const res = await fetch(`${fix.broker.url}/api/v1/cost/idempotency/prune`, {
@@ -412,14 +410,12 @@ describe("/api/v1/cost routes", () => {
     expect(Number.isSafeInteger(body.cutoffMs)).toBe(true);
 
     const idempotencyCount = fix.db
-      .prepare<[], { readonly n: number }>("SELECT COUNT(*) AS n FROM command_idempotency")
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM command_idempotency")
+      .get() as { readonly n: number } | undefined;
     expect(idempotencyCount?.n).toBe(0);
     const eventCount = fix.db
-      .prepare<[], { readonly n: number }>(
-        "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+      .get() as { readonly n: number } | undefined;
     expect(eventCount?.n).toBe(1);
   });
 
@@ -589,14 +585,14 @@ describe("/api/v1/cost routes", () => {
     expect(res.status).toBe(201);
 
     const row = fix.db
-      .prepare<[], { readonly payload: Buffer }>(
+      .prepare(
         "SELECT payload FROM event_log WHERE type = 'cost.budget.set' ORDER BY lsn DESC LIMIT 1",
       )
-      .get();
+      .get() as { readonly payload: Uint8Array } | undefined;
     if (row === undefined) throw new Error("missing budget_set event");
     const payload = costAuditPayloadFromJsonValue(
       "budget_set",
-      JSON.parse(row.payload.toString("utf8")) as unknown,
+      JSON.parse(new TextDecoder().decode(row.payload)) as unknown,
     ) as BudgetSetAuditPayload;
     expect(payload.setBy).toBe(OPERATOR_IDENTITY);
     expect(payload.setAt.toISOString()).not.toBe(forgedBody.setAt);
@@ -634,15 +630,13 @@ describe("cost idempotency startup prune", () => {
       cost: { ledger, db, operatorToken: OPERATOR_TOKEN },
     });
     try {
-      const idempotencyCount = db
-        .prepare<[], { readonly n: number }>("SELECT COUNT(*) AS n FROM command_idempotency")
-        .get();
+      const idempotencyCount = db.prepare("SELECT COUNT(*) AS n FROM command_idempotency").get() as
+        | { readonly n: number }
+        | undefined;
       expect(idempotencyCount?.n).toBe(0);
       const eventCount = db
-        .prepare<[], { readonly n: number }>(
-          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-        )
-        .get();
+        .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+        .get() as { readonly n: number } | undefined;
       expect(eventCount?.n).toBe(1);
     } finally {
       await broker.stop();

--- a/packages/broker/tests/event-log.spec.ts
+++ b/packages/broker/tests/event-log.spec.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -12,6 +13,19 @@ import {
 } from "../src/event-log/index.ts";
 
 const tempDirs: string[] = [];
+
+function userVersion(db: DatabaseSync): number {
+  return (db.prepare("PRAGMA user_version").get() as { readonly user_version: number })
+    .user_version;
+}
+
+function sqliteMasterName(db: DatabaseSync, type: string, name: string): string | undefined {
+  return (
+    db.prepare("SELECT name FROM sqlite_master WHERE type = ? AND name = ?").get(type, name) as
+      | { readonly name: string }
+      | undefined
+  )?.name;
+}
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
@@ -84,14 +98,8 @@ describe("event log", () => {
     const first = openDatabase({ path });
     try {
       runMigrations(first);
-      expect(first.pragma("user_version", { simple: true })).toBe(CURRENT_SCHEMA_VERSION);
-      expect(
-        first
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'event_log'",
-          )
-          .get()?.name,
-      ).toBe("event_log");
+      expect(userVersion(first)).toBe(CURRENT_SCHEMA_VERSION);
+      expect(sqliteMasterName(first, "table", "event_log")).toBe("event_log");
     } finally {
       first.close();
     }
@@ -99,55 +107,28 @@ describe("event log", () => {
     const second = openDatabase({ path });
     try {
       runMigrations(second);
-      expect(second.pragma("user_version", { simple: true })).toBe(CURRENT_SCHEMA_VERSION);
+      expect(userVersion(second)).toBe(CURRENT_SCHEMA_VERSION);
+      expect(sqliteMasterName(second, "table", "receipts_projection")).toBe("receipts_projection");
+      expect(sqliteMasterName(second, "table", "webauthn_registered_credentials")).toBe(
+        "webauthn_registered_credentials",
+      );
+      expect(sqliteMasterName(second, "table", "webauthn_challenges")).toBe("webauthn_challenges");
+      expect(sqliteMasterName(second, "table", "webauthn_consumed_tokens")).toBe(
+        "webauthn_consumed_tokens",
+      );
+      expect(sqliteMasterName(second, "index", "webauthn_challenges_expires_at_ms_idx")).toBe(
+        "webauthn_challenges_expires_at_ms_idx",
+      );
+      expect(sqliteMasterName(second, "index", "webauthn_consumed_tokens_expires_at_ms_idx")).toBe(
+        "webauthn_consumed_tokens_expires_at_ms_idx",
+      );
       expect(
         second
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'receipts_projection'",
-          )
-          .get()?.name,
-      ).toBe("receipts_projection");
-      expect(
-        second
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'webauthn_registered_credentials'",
-          )
-          .get()?.name,
-      ).toBe("webauthn_registered_credentials");
-      expect(
-        second
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'webauthn_challenges'",
-          )
-          .get()?.name,
-      ).toBe("webauthn_challenges");
-      expect(
-        second
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'webauthn_consumed_tokens'",
-          )
-          .get()?.name,
-      ).toBe("webauthn_consumed_tokens");
-      expect(
-        second
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'webauthn_challenges_expires_at_ms_idx'",
-          )
-          .get()?.name,
-      ).toBe("webauthn_challenges_expires_at_ms_idx");
-      expect(
-        second
-          .prepare<[], { readonly name: string }>(
-            "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'webauthn_consumed_tokens_expires_at_ms_idx'",
-          )
-          .get()?.name,
-      ).toBe("webauthn_consumed_tokens_expires_at_ms_idx");
-      expect(
-        second
-          .prepare<[], { readonly table: string; readonly from: string; readonly to: string }>(
-            "PRAGMA foreign_key_list('pending_approvals')",
-          )
+          .prepare("PRAGMA foreign_key_list('pending_approvals')")
           .all()
+          .map(
+            (row) => row as { readonly table: string; readonly from: string; readonly to: string },
+          )
           .map((row) => ({ table: row.table, from: row.from, to: row.to })),
       ).toContainEqual({ table: "threads", from: "thread_id", to: "thread_id" });
     } finally {

--- a/packages/broker/tests/internal/sqlite-transaction.spec.ts
+++ b/packages/broker/tests/internal/sqlite-transaction.spec.ts
@@ -1,0 +1,226 @@
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+import { createTransaction } from "../../src/internal/sqlite-transaction.ts";
+
+interface CountRow {
+  readonly count: number;
+}
+
+interface NameRow {
+  readonly name: string;
+}
+
+interface RecordingDb {
+  isTransaction: boolean;
+  readonly execSql: string[];
+  exec(sql: string): void;
+}
+
+function createRecordingDb(isTransaction = false): RecordingDb {
+  return {
+    isTransaction,
+    execSql: [],
+    exec(sql: string): void {
+      this.execSql.push(sql);
+      if (sql.startsWith("BEGIN") || sql.startsWith("SAVEPOINT ")) {
+        this.isTransaction = true;
+      }
+      if (sql === "COMMIT" || sql === "ROLLBACK" || sql.startsWith("RELEASE SAVEPOINT ")) {
+        this.isTransaction = false;
+      }
+    },
+  };
+}
+
+function asDatabase(db: RecordingDb): DatabaseSync {
+  return db as unknown as DatabaseSync;
+}
+
+function openItemsDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE items (name TEXT PRIMARY KEY)");
+  return db;
+}
+
+function countItems(db: DatabaseSync): number {
+  return (
+    (db.prepare("SELECT COUNT(*) AS count FROM items").get() as CountRow | undefined)?.count ?? 0
+  );
+}
+
+function itemNames(db: DatabaseSync): readonly string[] {
+  return (db.prepare("SELECT name FROM items ORDER BY name ASC").all() as unknown as NameRow[]).map(
+    (row) => row.name,
+  );
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+describe("createTransaction", () => {
+  it("default callable commits on success and passes args through", () => {
+    const recording = createRecordingDb();
+    const tx = createTransaction(asDatabase(recording), (left: number, right: number) => {
+      recording.execSql.push("body");
+      return left + right;
+    });
+
+    expect(tx(2, 3)).toBe(5);
+    expect(recording.execSql).toEqual(["BEGIN", "body", "COMMIT"]);
+  });
+
+  it("deferred, immediate, and exclusive variants emit the expected BEGIN", () => {
+    const cases = [
+      { name: "deferred", begin: "BEGIN" },
+      { name: "immediate", begin: "BEGIN IMMEDIATE" },
+      { name: "exclusive", begin: "BEGIN EXCLUSIVE" },
+    ] as const;
+
+    for (const testCase of cases) {
+      const recording = createRecordingDb();
+      const tx = createTransaction(asDatabase(recording), () => {
+        recording.execSql.push("body");
+      });
+
+      tx[testCase.name]();
+
+      expect(recording.execSql).toEqual([testCase.begin, "body", "COMMIT"]);
+    }
+  });
+
+  it("rolls back on synchronous throw", () => {
+    const db = openItemsDb();
+    try {
+      const insert = db.prepare("INSERT INTO items (name) VALUES (?)");
+      const tx = createTransaction(db, () => {
+        insert.run("rolled-back");
+        throw new Error("boom");
+      });
+
+      expect(() => tx.immediate()).toThrow("boom");
+      expect(countItems(db)).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("documents the sync-only contract for promise-returning callbacks", async () => {
+    const db = openItemsDb();
+    try {
+      const insert = db.prepare("INSERT INTO items (name) VALUES (?)");
+      const tx = createTransaction(db, async () => {
+        insert.run("committed-before-rejection");
+        await Promise.resolve();
+        throw new Error("late failure");
+      });
+
+      await expect(tx.immediate()).rejects.toThrow("late failure");
+      expect(itemNames(db)).toEqual(["committed-before-rejection"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("surfaces the original closed-database BEGIN failure", () => {
+    const db = new DatabaseSync(":memory:");
+    db.close();
+    let directMessage = "";
+    try {
+      db.exec("BEGIN");
+    } catch (err) {
+      directMessage = errorMessage(err);
+    }
+
+    const tx = createTransaction(db, () => undefined);
+    let transactionMessage = "";
+    try {
+      tx.immediate();
+    } catch (err) {
+      transactionMessage = errorMessage(err);
+    }
+
+    expect(transactionMessage).toBe(directMessage);
+  });
+
+  it("commits nested savepoints when outer and inner both succeed", () => {
+    const db = openItemsDb();
+    try {
+      const insert = db.prepare("INSERT INTO items (name) VALUES (?)");
+      const inner = createTransaction(db, (name: string) => {
+        insert.run(name);
+      });
+      const outer = createTransaction(db, () => {
+        insert.run("outer");
+        inner.deferred("inner");
+      });
+
+      outer.immediate();
+
+      expect(itemNames(db)).toEqual(["inner", "outer"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("rolls back an inner savepoint while allowing the outer transaction to continue", () => {
+    const db = openItemsDb();
+    try {
+      const insert = db.prepare("INSERT INTO items (name) VALUES (?)");
+      const inner = createTransaction(db, () => {
+        insert.run("inner");
+        throw new Error("inner failed");
+      });
+      const outer = createTransaction(db, () => {
+        try {
+          inner.deferred();
+        } catch (err) {
+          expect(errorMessage(err)).toBe("inner failed");
+        }
+        insert.run("outer");
+      });
+
+      outer.immediate();
+
+      expect(itemNames(db)).toEqual(["outer"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("outer rollback still rolls back changes from a released inner savepoint", () => {
+    const db = openItemsDb();
+    try {
+      const insert = db.prepare("INSERT INTO items (name) VALUES (?)");
+      const inner = createTransaction(db, () => {
+        insert.run("inner");
+      });
+      const outer = createTransaction(db, () => {
+        inner.deferred();
+        throw new Error("outer failed");
+      });
+
+      expect(() => outer.immediate()).toThrow("outer failed");
+      expect(countItems(db)).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("uses SAVEPOINT for nested variants", () => {
+    const recording = createRecordingDb(true);
+    const tx = createTransaction(asDatabase(recording), () => {
+      recording.execSql.push("body");
+    });
+
+    tx.exclusive();
+
+    expect(recording.execSql).toEqual([
+      "SAVEPOINT wuphf_tx_0",
+      "body",
+      "RELEASE SAVEPOINT wuphf_tx_0",
+    ]);
+  });
+});

--- a/packages/broker/tests/receipt-store-parity.spec.ts
+++ b/packages/broker/tests/receipt-store-parity.spec.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   asAgentSlug,
   asProviderKind,
@@ -8,7 +9,6 @@ import {
   SanitizedString,
   sha256Hex,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 import { openDatabase, runMigrations } from "../src/event-log/index.ts";
 import { constructSqliteReceiptStoreForTesting } from "../src/internal/sqlite-receipt-store-testing.ts";
@@ -245,17 +245,19 @@ function sqliteReceiptStoreFactory(options: StoreFactoryOptions = {}): ReceiptSt
   return constructSqliteReceiptStoreForTesting(db);
 }
 
-function seedThreadRows(db: Database.Database, ...threadIds: readonly string[]): void {
-  const appendEvent = db.prepare<[Buffer], { readonly lsn: number }>(
+function seedThreadRows(db: DatabaseSync, ...threadIds: readonly string[]): void {
+  const appendEvent = db.prepare(
     "INSERT INTO event_log (ts_ms, type, payload) VALUES (0, 'thread.created', ?) RETURNING lsn",
   );
-  const insertThread = db.prepare<[string, number, string]>(
+  const insertThread = db.prepare(
     `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms, external_refs)
      VALUES (?, 'receipt store parity thread', 'open', ?, 'broker', 0, 0, ?)`,
   );
   for (const threadId of threadIds) {
-    const row = appendEvent.get(Buffer.from(`{"threadId":"${threadId}"}`, "utf8"));
+    const row = appendEvent.get(Buffer.from(`{"threadId":"${threadId}"}`, "utf8")) as
+      | { readonly lsn: number }
+      | undefined;
     if (row === undefined) throw new Error("seed thread event insert returned no row");
     insertThread.run(threadId, row.lsn, '{"source_urls":[],"entity_ids":[]}');
   }

--- a/packages/broker/tests/sqlite-receipt-store.spec.ts
+++ b/packages/broker/tests/sqlite-receipt-store.spec.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
+import type { DatabaseSync } from "node:sqlite";
 import {
   asAgentSlug,
   asProviderKind,
@@ -12,7 +12,6 @@ import {
   SanitizedString,
   sha256Hex,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createEventLog, openDatabase, runMigrations } from "../src/event-log/index.ts";
@@ -76,14 +75,14 @@ function minimalReceiptV2(id: string, threadIdStr: string): ReceiptSnapshot {
   return { ...minimalReceiptV1(id), threadId: asThreadId(threadIdStr), schemaVersion: 2 };
 }
 
-function openStore(): { readonly db: Database.Database; readonly store: SqliteReceiptStore } {
+function openStore(): { readonly db: DatabaseSync; readonly store: SqliteReceiptStore } {
   const db = openDatabase({ path: ":memory:" });
   runMigrations(db);
   return { db, store: constructSqliteReceiptStoreForTesting(db) };
 }
 
 function openStoreWithThreads(): {
-  readonly db: Database.Database;
+  readonly db: DatabaseSync;
   readonly store: SqliteReceiptStore;
 } {
   const db = openDatabase({ path: ":memory:" });
@@ -108,38 +107,40 @@ const COUNT_ROWS_TABLES = {
   receipts_projection: "receipts_projection",
 } as const;
 
-function countRows(db: Database.Database, tableName: keyof typeof COUNT_ROWS_TABLES): number {
+function countRows(db: DatabaseSync, tableName: keyof typeof COUNT_ROWS_TABLES): number {
   const safeTable = COUNT_ROWS_TABLES[tableName];
-  const row = db
-    .prepare<[], { readonly count: number }>(`SELECT COUNT(*) AS count FROM ${safeTable}`)
-    .get();
+  const row = db.prepare(`SELECT COUNT(*) AS count FROM ${safeTable}`).get() as
+    | { readonly count: number }
+    | undefined;
   if (row === undefined) {
     throw new Error(`count query returned no row for ${safeTable}`);
   }
   return row.count;
 }
 
-function maxEventLogLsn(db: Database.Database): number {
-  const row = db
-    .prepare<[], { readonly lsn: number }>("SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log")
-    .get();
+function maxEventLogLsn(db: DatabaseSync): number {
+  const row = db.prepare("SELECT COALESCE(MAX(lsn), 0) AS lsn FROM event_log").get() as
+    | { readonly lsn: number }
+    | undefined;
   if (row === undefined) {
     throw new Error("max lsn query returned no row");
   }
   return row.lsn;
 }
 
-function seedThreadRows(db: Database.Database, ...threadIds: readonly string[]): void {
-  const appendEvent = db.prepare<[Buffer], { readonly lsn: number }>(
+function seedThreadRows(db: DatabaseSync, ...threadIds: readonly string[]): void {
+  const appendEvent = db.prepare(
     "INSERT INTO event_log (ts_ms, type, payload) VALUES (0, 'thread.created', ?) RETURNING lsn",
   );
-  const insertThread = db.prepare<[string, number, string]>(
+  const insertThread = db.prepare(
     `INSERT INTO threads
        (thread_id, title, status, head_lsn, created_by, created_at_ms, updated_at_ms, external_refs)
      VALUES (?, 'receipt store test thread', 'open', ?, 'broker', 0, 0, ?)`,
   );
   for (const threadId of threadIds) {
-    const row = appendEvent.get(Buffer.from(`{"threadId":"${threadId}"}`, "utf8"));
+    const row = appendEvent.get(Buffer.from(`{"threadId":"${threadId}"}`, "utf8")) as
+      | { readonly lsn: number }
+      | undefined;
     if (row === undefined) {
       throw new Error("seed thread event insert returned no row");
     }

--- a/packages/broker/tests/threads/thread-routes-unit.spec.ts
+++ b/packages/broker/tests/threads/thread-routes-unit.spec.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { DatabaseSync } from "node:sqlite";
 import { Readable } from "node:stream";
 
 import {
@@ -11,7 +12,6 @@ import {
   type ThreadExternalRefs,
   threadSpecContentHash,
 } from "@wuphf/protocol";
-import type BetterSqlite3 from "better-sqlite3";
 import { describe, expect, it } from "vitest";
 
 import { openDatabase, runMigrations } from "../../src/event-log/index.ts";
@@ -251,7 +251,7 @@ describe("handleThreadRoute unit error paths", () => {
         prepare: () => {
           throw new ReceiptStoreFullError("full");
         },
-      } as unknown as BetterSqlite3.Database,
+      } as unknown as DatabaseSync,
     };
     try {
       await expectRoute("/api/v1/threads/replay-check", "GET", replayFull, 507, false, undefined, {

--- a/packages/broker/tests/threads/thread-routes.spec.ts
+++ b/packages/broker/tests/threads/thread-routes.spec.ts
@@ -926,10 +926,8 @@ describe("/api/v1/threads routes", () => {
     expect(statuses.filter((status) => status === 200)).toHaveLength(1);
     expect(statuses.filter((status) => status === 409)).toHaveLength(9);
     const count = fixture.db
-      .prepare<[], { readonly count: number }>(
-        "SELECT COUNT(*) AS count FROM event_log WHERE type = 'thread.spec_edited'",
-      )
-      .get();
+      .prepare("SELECT COUNT(*) AS count FROM event_log WHERE type = 'thread.spec_edited'")
+      .get() as { readonly count: number } | undefined;
     expect(count?.count).toBe(3);
   });
 
@@ -953,10 +951,10 @@ describe("/api/v1/threads routes", () => {
     expect(await second.text()).toBe(firstText);
 
     const count = fixture.db
-      .prepare<[], { readonly count: number }>(
+      .prepare(
         "SELECT COUNT(*) AS count FROM event_log WHERE type IN ('thread.created', 'thread.spec_edited')",
       )
-      .get();
+      .get() as { readonly count: number } | undefined;
     expect(count?.count).toBe(4);
   });
 
@@ -983,10 +981,10 @@ describe("/api/v1/threads routes", () => {
     expect(await second.text()).toBe(firstText);
 
     const count = fixture.db
-      .prepare<[], { readonly count: number }>(
+      .prepare(
         "SELECT COUNT(*) AS count FROM event_log WHERE type IN ('thread.created', 'thread.spec_edited')",
       )
-      .get();
+      .get() as { readonly count: number } | undefined;
     expect(count?.count).toBe(4);
   });
 
@@ -1008,10 +1006,10 @@ describe("/api/v1/threads routes", () => {
     expect((await second.json()) as unknown).toEqual({ error: "idempotency_key_conflict" });
 
     const count = fixture.db
-      .prepare<[], { readonly count: number }>(
+      .prepare(
         "SELECT COUNT(*) AS count FROM event_log WHERE type IN ('thread.created', 'thread.spec_edited')",
       )
-      .get();
+      .get() as { readonly count: number } | undefined;
     expect(count?.count).toBe(4);
   });
 

--- a/packages/broker/tests/threads/thread-state.spec.ts
+++ b/packages/broker/tests/threads/thread-state.spec.ts
@@ -204,21 +204,20 @@ function appendStatus(fix: Fixture, command: ThreadStatusChangeCommand, key: str
 
 function countEvents(fix: Fixture, type: string): number {
   return (
-    fix.db
-      .prepare<[string], { readonly count: number }>(
-        "SELECT COUNT(*) AS count FROM event_log WHERE type = ?",
-      )
-      .get(type)?.count ?? 0
+    (
+      fix.db.prepare("SELECT COUNT(*) AS count FROM event_log WHERE type = ?").get(type) as
+        | { readonly count: number }
+        | undefined
+    )?.count ?? 0
   );
 }
 
 function eventPayloadBytes(fix: Fixture, type: string): readonly Buffer[] {
-  return fix.db
-    .prepare<[string], { readonly payload: Buffer }>(
-      "SELECT payload FROM event_log WHERE type = ? ORDER BY lsn ASC",
-    )
-    .all(type)
-    .map((row) => row.payload);
+  return (
+    fix.db
+      .prepare("SELECT payload FROM event_log WHERE type = ? ORDER BY lsn ASC")
+      .all(type) as unknown as { readonly payload: Uint8Array }[]
+  ).map((row) => Buffer.from(row.payload));
 }
 
 function expectThreadPayloadBytes(
@@ -336,7 +335,7 @@ describe("thread appender and projection", () => {
     const fix = setup();
     const observed: { readonly name: string; readonly inTransaction: boolean }[] = [];
     const record = (name: string): void => {
-      observed.push({ name, inTransaction: fix.db.inTransaction });
+      observed.push({ name, inTransaction: fix.db.isTransaction });
     };
     const state: ThreadStateStore = {
       applyEvent(recordEvent) {
@@ -430,15 +429,15 @@ describe("thread appender and projection", () => {
     expect(row?.spec.content).toEqual(nextContent);
 
     const latestSpec = fix.db
-      .prepare<[], { readonly payload: Buffer }>(
+      .prepare(
         "SELECT payload FROM event_log WHERE type = 'thread.spec_edited' ORDER BY lsn DESC LIMIT 1",
       )
-      .get();
+      .get() as { readonly payload: Uint8Array } | undefined;
     expect(latestSpec).toBeDefined();
     if (latestSpec === undefined) return;
     const payload = threadAuditPayloadFromJsonValue(
       "thread_spec_edited",
-      JSON.parse(latestSpec.payload.toString("utf8")) as unknown,
+      JSON.parse(new TextDecoder().decode(latestSpec.payload)) as unknown,
     ) as ThreadSpecEditedAuditPayload;
     expect(canonicalJSON(row?.spec.content)).toBe(canonicalJSON(payload.content));
   });
@@ -476,14 +475,12 @@ describe("thread appender and projection", () => {
     expect(countEvents(fix, "thread.spec_edited")).toBe(3);
 
     const specRows = fix.db
-      .prepare<[], { readonly payload: Buffer }>(
-        "SELECT payload FROM event_log WHERE type = 'thread.spec_edited' ORDER BY lsn ASC",
-      )
-      .all();
+      .prepare("SELECT payload FROM event_log WHERE type = 'thread.spec_edited' ORDER BY lsn ASC")
+      .all() as unknown as { readonly payload: Uint8Array }[];
     const baseRevisionIds = specRows.map((row) => {
       const payload = threadAuditPayloadFromJsonValue(
         "thread_spec_edited",
-        JSON.parse(row.payload.toString("utf8")) as unknown,
+        JSON.parse(new TextDecoder().decode(row.payload)) as unknown,
       ) as ThreadSpecEditedAuditPayload;
       return payload.baseRevisionId ?? null;
     });
@@ -991,10 +988,10 @@ describe("thread appender and projection", () => {
             WHERE thread_id = ?`,
       )
       .run(OTHER_THREAD_ID, THREAD_ID);
-    fix.db.pragma("foreign_keys = OFF");
+    fix.db.exec("PRAGMA foreign_keys = OFF");
     fix.db.prepare("DELETE FROM thread_spec_revisions WHERE thread_id = ?").run(THREAD_ID);
     fix.db.prepare("DELETE FROM threads WHERE thread_id = ?").run(THREAD_ID);
-    fix.db.pragma("foreign_keys = ON");
+    fix.db.exec("PRAGMA foreign_keys = ON");
 
     const report = runThreadReplayCheck(fix.db);
     expect(report.ok).toBe(false);
@@ -1009,11 +1006,11 @@ describe("thread appender and projection", () => {
   it("replay-check detects invalid live status effective projection drift", () => {
     const fix = setup();
     appendCreate(fix);
-    fix.db.pragma("ignore_check_constraints = ON");
+    fix.db.exec("PRAGMA ignore_check_constraints = ON");
     fix.db
       .prepare("UPDATE threads SET status = ? WHERE thread_id = ?")
       .run("bad_status", THREAD_ID);
-    fix.db.pragma("ignore_check_constraints = OFF");
+    fix.db.exec("PRAGMA ignore_check_constraints = OFF");
 
     const report = runThreadReplayCheck(fix.db);
     expect(report.ok).toBe(false);
@@ -1142,9 +1139,11 @@ describe("thread appender and projection", () => {
       minimalReceiptV2("01PRZ3NDEKTSV4RRFFQ69G5FP0", "01MRZ3NDEKTSV4RRFFQ69G5FM0"),
     );
     const live = snapshotThreadProjection(fix.db);
-    const liveReceiptRows = fix.db
-      .prepare<[], { readonly count: number }>("SELECT COUNT(*) AS count FROM thread_receipts")
-      .get()?.count;
+    const liveReceiptRows = (
+      fix.db.prepare("SELECT COUNT(*) AS count FROM thread_receipts").get() as
+        | { readonly count: number }
+        | undefined
+    )?.count;
 
     fix.eventLog.append({
       type: "thread.status_changed",
@@ -1164,9 +1163,11 @@ describe("thread appender and projection", () => {
     );
     expect(snapshotThreadProjection(fix.db)).toEqual(live);
     expect(
-      fix.db
-        .prepare<[], { readonly count: number }>("SELECT COUNT(*) AS count FROM thread_receipts")
-        .get()?.count,
+      (
+        fix.db.prepare("SELECT COUNT(*) AS count FROM thread_receipts").get() as
+          | { readonly count: number }
+          | undefined
+      )?.count,
     ).toBe(liveReceiptRows);
   });
 });

--- a/packages/broker/tests/threads/thread-triangulation.spec.ts
+++ b/packages/broker/tests/threads/thread-triangulation.spec.ts
@@ -244,10 +244,8 @@ async function postReceipt(fix: Fixture, receipt: ReceiptSnapshot): Promise<Resp
 
 function latestReceiptPutLsn(fix: Fixture): EventLsn {
   const row = fix.db
-    .prepare<[], { readonly lsn: number }>(
-      "SELECT lsn FROM event_log WHERE type = 'receipt.put' ORDER BY lsn DESC LIMIT 1",
-    )
-    .get();
+    .prepare("SELECT lsn FROM event_log WHERE type = 'receipt.put' ORDER BY lsn DESC LIMIT 1")
+    .get() as { readonly lsn: number } | undefined;
   if (row === undefined) throw new Error("missing receipt.put event");
   return `v1:${row.lsn}` as EventLsn;
 }

--- a/packages/broker/tests/threads/triangulation-regression.spec.ts
+++ b/packages/broker/tests/threads/triangulation-regression.spec.ts
@@ -3,6 +3,7 @@
 // on the cherry-picked #916 fix round, and asserts the post-fix invariant.
 // Reverting any of GROUPs 2/3/4 will turn one of these red on `bun run test`.
 
+import type { DatabaseSync } from "node:sqlite";
 import {
   type ApprovalRequestedAuditPayload,
   approvalAuditPayloadToBytes,
@@ -21,7 +22,6 @@ import {
   threadListResponseFromJson,
   threadMutationResponseFromJson,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { type ApprovalProjection, createApprovalSubsystem } from "../../src/approvals/index.ts";
@@ -44,7 +44,7 @@ const APPROVAL_REQUEST_ID = "01MRZ3NDEKTSV4RRFFQ69G5FM0";
 
 interface Fixture {
   readonly broker: BrokerHandle;
-  readonly db: Database.Database;
+  readonly db: DatabaseSync;
   readonly eventLog: EventLog;
   readonly approvals: ApprovalProjection;
   readonly receiptStore: SqliteReceiptStore;

--- a/packages/broker/tests/webauthn/route.spec.ts
+++ b/packages/broker/tests/webauthn/route.spec.ts
@@ -1,5 +1,6 @@
 import { type IncomingHttpHeaders, type OutgoingHttpHeaders, request } from "node:http";
 import { isIP } from "node:net";
+import type { DatabaseSync } from "node:sqlite";
 
 import type {
   AuthenticationResponseJSON,
@@ -41,7 +42,6 @@ import {
   sha256Hex,
   signedApprovalTokenFromJson,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { openDatabase, runMigrations } from "../../src/event-log/index.ts";
@@ -66,7 +66,7 @@ const agentId = asAgentId("agent_alpha");
 const otherAgentId = asAgentId("agent_beta");
 
 let broker: BrokerHandle | null = null;
-let db: Database.Database | null = null;
+let db: DatabaseSync | null = null;
 
 const agentScopedClaimFixtureCases: readonly [
   string,
@@ -1071,7 +1071,7 @@ function createTestWebAuthnStore(): WebAuthnStore {
   return createWebAuthnStore(db);
 }
 
-function requiredDb(): Database.Database {
+function requiredDb(): DatabaseSync {
   if (db === null) {
     throw new Error("test database is not open");
   }

--- a/packages/broker/tests/webauthn/store.spec.ts
+++ b/packages/broker/tests/webauthn/store.spec.ts
@@ -1,3 +1,4 @@
+import type { DatabaseSync } from "node:sqlite";
 import {
   type ApprovalClaim,
   type ApprovalRole,
@@ -13,8 +14,6 @@ import {
   type ReceiptCoSignScope,
   sha256Hex,
 } from "@wuphf/protocol";
-import type Database from "better-sqlite3";
-import BetterSqlite3 from "better-sqlite3";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { openDatabase, runMigrations } from "../../src/event-log/index.ts";
@@ -32,7 +31,7 @@ import {
 
 const agentId = asAgentId("agent_alpha");
 
-let db: Database.Database | null = null;
+let db: DatabaseSync | null = null;
 
 afterEach(() => {
   if (db !== null) {
@@ -274,7 +273,7 @@ function createTestStore(): WebAuthnStore {
   return createWebAuthnStore(db);
 }
 
-function requiredDb(): Database.Database {
+function requiredDb(): DatabaseSync {
   if (db === null) {
     throw new Error("test database is not open");
   }
@@ -442,5 +441,38 @@ function hashClaimScopeForTest(
 }
 
 function sqliteError(code: string): Error {
-  return new BetterSqlite3.SqliteError("test sqlite error", code);
+  return Object.assign(new Error("test sqlite error"), {
+    code: "ERR_SQLITE_ERROR",
+    errcode: sqliteErrcode(code),
+    errstr: code,
+  });
+}
+
+function sqliteErrcode(code: string): number {
+  switch (code) {
+    case "SQLITE_BUSY":
+      return 5;
+    case "SQLITE_LOCKED":
+      return 6;
+    case "SQLITE_BUSY_SNAPSHOT":
+      return 517;
+    case "SQLITE_LOCKED_SHAREDCACHE":
+      return 262;
+    case "SQLITE_FULL":
+      return 13;
+    case "SQLITE_READONLY":
+      return 8;
+    case "SQLITE_CANTOPEN":
+      return 14;
+    case "SQLITE_CORRUPT":
+      return 11;
+    case "SQLITE_IOERR_READ":
+      return 266;
+    case "SQLITE_NOTADB":
+      return 26;
+    case "SQLITE_PERM":
+      return 3;
+    default:
+      throw new Error(`unknown sqlite test code: ${code}`);
+  }
 }

--- a/packages/broker/vitest.config.ts
+++ b/packages/broker/vitest.config.ts
@@ -8,7 +8,7 @@ function nodeSqliteVitestPlugin() {
     name: "broker-node-sqlite",
     enforce: "pre" as const,
     resolveId(id: string) {
-      if (id === "node:sqlite" || id === "sqlite") {
+      if (id === "node:sqlite") {
         return virtualId;
       }
       return undefined;

--- a/packages/broker/vitest.config.ts
+++ b/packages/broker/vitest.config.ts
@@ -1,9 +1,40 @@
 import { defineConfig } from "vitest/config";
 
+// Vitest 2 on local Node 22 strips `node:` from experimental builtins that
+// are absent from `module.builtinModules`; keep production imports direct.
+function nodeSqliteVitestPlugin() {
+  const virtualId = "\0broker-node-sqlite";
+  return {
+    name: "broker-node-sqlite",
+    enforce: "pre" as const,
+    resolveId(id: string) {
+      if (id === "node:sqlite" || id === "sqlite") {
+        return virtualId;
+      }
+      return undefined;
+    },
+    load(id: string) {
+      if (id !== virtualId) {
+        return undefined;
+      }
+
+      return [
+        'const sqlite = require("node:sqlite");',
+        "export const DatabaseSync = sqlite.DatabaseSync;",
+        "export const StatementSync = sqlite.StatementSync;",
+        "export const backup = sqlite.backup;",
+        "export const constants = sqlite.constants;",
+        "export default sqlite;",
+      ].join("\n");
+    },
+  };
+}
+
 // One-way ratchet: each PR must hold or improve every metric. Lower a number
 // only by adding a docs commit that explains why; never to make a red PR
 // green. Aspirational floor 98/98/98/98.
 export default defineConfig({
+  plugins: [nodeSqliteVitestPlugin()],
   test: {
     include: ["tests/**/*.spec.ts"],
     environment: "node",

--- a/packages/llm-router/tests/gateway.spec.ts
+++ b/packages/llm-router/tests/gateway.spec.ts
@@ -83,10 +83,8 @@ describe("gateway happy path", () => {
     // The §15.A invariant: event_log holds exactly one cost.event row at
     // the LSN we returned.
     const row = fix.db
-      .prepare<[number], { readonly lsn: number; readonly type: string }>(
-        "SELECT lsn, type FROM event_log WHERE lsn = ?",
-      )
-      .get(1);
+      .prepare("SELECT lsn, type FROM event_log WHERE lsn = ?")
+      .get(1) as { readonly lsn: number; readonly type: string } | undefined;
     expect(row?.type).toBe("cost.event");
     expect(row?.lsn).toBe(1);
   });
@@ -115,10 +113,8 @@ describe("dedupe", () => {
       expect(r2.costMicroUsd).toBe(r1.costMicroUsd);
 
       const eventCount = fix.db
-        .prepare<[], { readonly n: number }>(
-          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-        )
-        .get();
+        .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+        .get() as { readonly n: number } | undefined;
       expect(eventCount?.n).toBe(1);
     } finally {
       fix.db.close();
@@ -471,12 +467,10 @@ describe("audit row records served model id (#827)", () => {
         { model: "alias-model", prompt: "p", maxOutputTokens: 8 },
       );
       const row = db
-        .prepare<[], { readonly payload: Buffer }>(
-          "SELECT payload FROM event_log WHERE type = 'cost.event' LIMIT 1",
-        )
-        .get();
+        .prepare("SELECT payload FROM event_log WHERE type = 'cost.event' LIMIT 1")
+        .get() as { readonly payload: Uint8Array } | undefined;
       if (row === undefined) throw new Error("no cost.event row");
-      const parsed = JSON.parse(row.payload.toString("utf8")) as { model: string };
+      const parsed = JSON.parse(new TextDecoder().decode(row.payload)) as { model: string };
       expect(parsed.model).toBe("alias-model-2025-04-12-snapshot");
     } finally {
       db.close();
@@ -496,12 +490,10 @@ describe("audit row records served model id (#827)", () => {
     try {
       await gateway.complete(CTX, REQ);
       const row = db
-        .prepare<[], { readonly payload: Buffer }>(
-          "SELECT payload FROM event_log WHERE type = 'cost.event' LIMIT 1",
-        )
-        .get();
+        .prepare("SELECT payload FROM event_log WHERE type = 'cost.event' LIMIT 1")
+        .get() as { readonly payload: Uint8Array } | undefined;
       if (row === undefined) throw new Error("no cost.event row");
-      const parsed = JSON.parse(row.payload.toString("utf8")) as { model: string };
+      const parsed = JSON.parse(new TextDecoder().decode(row.payload)) as { model: string };
       expect(parsed.model).toBe(STUB_MODEL_FIXED_COST);
     } finally {
       db.close();
@@ -549,10 +541,8 @@ describe("gateway rejects runaway cost estimate before ledger append (#824)", ()
       ).rejects.toThrow(/exceeds per-event cap/);
       // No cost_event written for the over-cap call.
       const count = db
-        .prepare<[], { readonly n: number }>(
-          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-        )
-        .get();
+        .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+        .get() as { readonly n: number } | undefined;
       expect(count?.n).toBe(0);
     } finally {
       db.close();
@@ -608,10 +598,8 @@ describe("concurrent-call coalescing + reservation atomicity (PR #834 round-1 BL
       expect(r1.dedupeReplay).toBe(false);
       // Exactly one cost_event row was written.
       const count = db
-        .prepare<[], { readonly n: number }>(
-          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-        )
-        .get();
+        .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+        .get() as { readonly n: number } | undefined;
       expect(count?.n).toBe(1);
     } finally {
       db.close();
@@ -647,10 +635,8 @@ describe("concurrent-call coalescing + reservation atomicity (PR #834 round-1 BL
       await expect(p1).rejects.toThrow();
       await expect(p2).rejects.toThrow();
       const count = db
-        .prepare<[], { readonly n: number }>(
-          "SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'",
-        )
-        .get();
+        .prepare("SELECT COUNT(*) AS n FROM event_log WHERE type = 'cost.event'")
+        .get() as { readonly n: number } | undefined;
       expect(count?.n).toBe(0);
     } finally {
       db.close();

--- a/packages/llm-router/tests/gateway.spec.ts
+++ b/packages/llm-router/tests/gateway.spec.ts
@@ -82,9 +82,9 @@ describe("gateway happy path", () => {
 
     // The §15.A invariant: event_log holds exactly one cost.event row at
     // the LSN we returned.
-    const row = fix.db
-      .prepare("SELECT lsn, type FROM event_log WHERE lsn = ?")
-      .get(1) as { readonly lsn: number; readonly type: string } | undefined;
+    const row = fix.db.prepare("SELECT lsn, type FROM event_log WHERE lsn = ?").get(1) as
+      | { readonly lsn: number; readonly type: string }
+      | undefined;
     expect(row?.type).toBe("cost.event");
     expect(row?.lsn).toBe(1);
   });

--- a/packages/llm-router/tests/threshold-integration.spec.ts
+++ b/packages/llm-router/tests/threshold-integration.spec.ts
@@ -109,10 +109,8 @@ describe("gateway → ledger → threshold reactor integration", () => {
     // The event_log must contain: 1 budget_set + 6 cost_event + 2
     // threshold-crossed = 9 cost.* events.
     const counts = db
-      .prepare<[], { readonly type: string; readonly n: number }>(
-        "SELECT type, COUNT(*) AS n FROM event_log GROUP BY type ORDER BY type",
-      )
-      .all();
+      .prepare("SELECT type, COUNT(*) AS n FROM event_log GROUP BY type ORDER BY type")
+      .all() as unknown as ReadonlyArray<{ readonly type: string; readonly n: number }>;
     const byType = new Map(counts.map((row) => [row.type, row.n]));
     expect(byType.get("cost.event")).toBe(6);
     expect(byType.get("cost.budget.set")).toBe(1);

--- a/packages/llm-router/vitest.config.ts
+++ b/packages/llm-router/vitest.config.ts
@@ -1,11 +1,45 @@
 import { defineConfig } from "vitest/config";
 
+// Vitest 2 on Node 22 strips the `node:` prefix from experimental builtins
+// (absent from `module.builtinModules`) when transitively loading sources
+// from a workspace dependency. llm-router imports `@wuphf/broker`, which
+// uses `node:sqlite`; once vite-node strips the prefix, the bare `sqlite`
+// resolves to nothing. Shim both forms so transitive broker loads work.
+function nodeSqliteVitestPlugin() {
+  const virtualId = "\0llm-router-node-sqlite";
+  return {
+    name: "llm-router-node-sqlite",
+    enforce: "pre" as const,
+    resolveId(id: string) {
+      if (id === "node:sqlite" || id === "sqlite") {
+        return virtualId;
+      }
+      return undefined;
+    },
+    load(id: string) {
+      if (id !== virtualId) {
+        return undefined;
+      }
+
+      return [
+        'const sqlite = require("node:sqlite");',
+        "export const DatabaseSync = sqlite.DatabaseSync;",
+        "export const StatementSync = sqlite.StatementSync;",
+        "export const backup = sqlite.backup;",
+        "export const constants = sqlite.constants;",
+        "export default sqlite;",
+      ].join("\n");
+    },
+  };
+}
+
 // One-way ratchet (matches broker convention): each PR must hold or improve
 // every metric. Lower a number only by adding a commit that explains why;
 // never to make a red PR green. Aspirational floor 95/95/95/95 once the
 // SDK-loader convenience constructors (createXxxProviderWithKey) and ollama
 // transport-failure paths grow integration tests against real fakes.
 export default defineConfig({
+  plugins: [nodeSqliteVitestPlugin()],
   test: {
     include: ["tests/**/*.spec.ts"],
     environment: "node",


### PR DESCRIPTION
## Why

`better-sqlite3` is a native binding compiled against a specific Node.js ABI. Every Electron major bumps that ABI, and the project tracks it via prebuilds. Right now that lottery has bitten us:

- Electron 42 ships Node 24 (ABI 146).
- `better-sqlite3` 12.10.0 (latest) has no v146 prebuild and its source can't compile against Electron 42's V8 because the C++ `v8::External::New` call now requires a third \`ExternalPointerTypeTag\` argument (memory-tagging extension) — see [WiseLibs/better-sqlite3#1335](https://github.com/WiseLibs/better-sqlite3/issues/1335) / [#1356](https://github.com/WiseLibs/better-sqlite3/issues/1356).
- So `@electron/rebuild` fails, no prebuild exists, the desktop broker subprocess crashes on `import` whenever a SQLite-backed store is wired.

The choices were: vendor a patched fork, downgrade Electron, ship without persistence, or swap to `node:sqlite`. This PR takes the last option. `node:sqlite` is part of Node's standard library (stable in Node 24, available behind `--experimental-sqlite` in Node 22.5+, no flag in Node 23.10+), ships with Electron 42 automatically, has no separate compile/prebuild step, and removes the entire native-binding-vs-Electron-ABI class of problem from the codebase.

## What

| Concern | better-sqlite3 | node:sqlite |
|---|---|---|
| Import | `import Database from "better-sqlite3"` | `import { DatabaseSync, StatementSync } from "node:sqlite"` |
| Constructor | `new Database(path)` | `new DatabaseSync(path)` |
| Pragma set | `db.pragma("foreign_keys = ON")` | `db.exec("PRAGMA foreign_keys = ON")` |
| Pragma read | `db.pragma("user_version", { simple: true })` | `(db.prepare("PRAGMA user_version").get() as { user_version: number }).user_version` |
| Transactions | `db.transaction(fn).exclusive()` | `createTransaction(db, fn).exclusive()` (new helper) |
| BigInt mode | `stmt.safeIntegers(true)` | `stmt.setReadBigInts(true)` |
| BLOB reads | `Buffer` | `Uint8Array` (decode with `TextDecoder` for UTF-8) |
| Closed check | `db.open` | `db.isOpen` |
| Statement generics | `Database.Statement<P, R>` | `StatementSync` returns `unknown`; cast at the call site |

19 files touched (`packages/broker/src/**` + tests). New file: `packages/broker/src/internal/sqlite-transaction.ts` — preserves better-sqlite3's `db.transaction(fn).{deferred,immediate,exclusive}` semantics on top of explicit `BEGIN`/`COMMIT`/`ROLLBACK`.

`packages/broker/vitest.config.ts` carries a small test-only vite plugin that re-exports the real `node:sqlite` module via `createRequire`. vite-node 2.1's builtin allowlist predates `node:sqlite`; without the shim the test runner would try to externalize it as a missing dep.

## Invariants preserved

- `runMigrations` still holds an **EXCLUSIVE** transaction so two broker processes opening a fresh db never race `CREATE TABLE`.
- Receipt-store inserts still run in **IMMEDIATE** so FK validation runs against committed state.
- No `any`, no `// @ts-ignore`, no `// biome-ignore`. Row types are asserted at every `stmt.get()` / `.all()` / `.iterate()` call site.
- BigInt-mode reads stay BigInt — no narrowing to `number` unless the call site already did so.
- Wire format unchanged. No schema-version bump. No `verifier-reference.go` update (no wire-shape change).

## Verification

```
bun --cwd packages/broker run typecheck            ✓
bun --cwd packages/broker run check                ✓ biome clean
bun --cwd packages/broker run test                 ✓ 305/305
bun --cwd packages/broker run check:invariants     ✓
cd packages/protocol/testdata && go run verifier-reference.go  ✓ 60 vectors
```

## Downstream

- `apps/desktop` no longer needs `better-sqlite3` as a direct dep (it was added in #923 to satisfy Node resolution from `out/main/broker-entry.js`). Once this lands and `apps/desktop` rebases, that dep + the Electron 39 downgrade workaround on `feat/work-board` both go away.
- `packages/broker/src/sqlite.ts` (the `@wuphf/broker/sqlite` subpath) still exports `SqliteReceiptStore` with the same surface. Consumers don't need to change.

## Out of scope

- electron-builder `asarUnpack` config (no longer needed — there's no `.node` file to unpack)
- bumping `apps/desktop` Electron back to 42 (will land in a follow-up rebase of `feat/work-board`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Infrastructure**
  * Updated CI workflow to pin Node 22.x for jobs requiring SQLite support in Vitest worker processes.
  * Updated desktop application build configuration and externals validation for database compatibility.

* **Documentation**
  * Updated broker documentation to describe database storage implementation and binary data handling guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->