### PR TITLE
fix(bootstrap): build web bundle before Go embed (#931)

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -47,6 +47,13 @@ bun install
 info "bun install (web/)"
 (cd web && bun install)
 
+# ---- bun run build in web/ (so cmd/wuphf can embed web/dist) ----
+# Without this, a fresh clone + `go build ./cmd/wuphf` + `./wuphf` lands on
+# the "WUPHF web UI assets are missing" fallback page. Fail loudly on build
+# error rather than silently producing a broken binary.
+info "bun run build (web/)"
+(cd web && bun run build) || fail "web build failed — run 'cd web && bun run build' to see the error"
+
 # ---- lefthook: install git hooks into .git/hooks ----
 info "lefthook install"
 lefthook install


### PR DESCRIPTION
## Summary

- `scripts/bootstrap.sh` now runs `bun run build` in `web/` after `bun install` so `cmd/wuphf` can embed `web/dist` via `go:embed` on a fresh clone.
- Without this, `./scripts/bootstrap.sh` + `go build ./cmd/wuphf` + `./wuphf` lands on the "WUPHF web UI assets are missing" fallback page.
- Build failures (e.g., low-memory CI) cause bootstrap to fail loudly via the existing `fail` helper rather than silently producing a broken binary.

Out of scope: the `cmd/wuphf` fallback-page logic itself is unchanged.

## Test plan

- [x] `bash scripts/bootstrap.sh` runs through the new `bun run build (web/)` step.
- [x] `web/dist/index.html` exists after bootstrap.
- [ ] Reviewer: fresh clone + `./scripts/bootstrap.sh` + `go build -o wuphf ./cmd/wuphf` + `./wuphf` opens the real web UI (not the assets-missing fallback).
- [ ] Reviewer: simulate a web build failure (e.g., add a syntax error in `web/src`) and confirm bootstrap exits non-zero.

Closes #931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability with enhanced validation and error handling to ensure all necessary components compile correctly.
  * Added clearer error messages when build steps fail, enabling faster troubleshooting and issue resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->