### PR TITLE
fix(onboarding): disable browser autofill on wizard inputs (#943)

### DIFF
--- a/web/src/components/messages/cards/CeoFormField.tsx
+++ b/web/src/components/messages/cards/CeoFormField.tsx
@@ -98,6 +98,15 @@ export function CeoFormField({
           }
         }}
         aria-label={payload.label}
+        // Suppress browser password-manager / autofill popups. The CEO card is
+        // a single-field conversational prompt, not a login or profile form;
+        // 1Password and Chrome were offering credential fills on company
+        // name / website / description (issue #943). The `data-*-ignore`
+        // attributes are vendor escape hatches for 1Password and LastPass,
+        // which sometimes ignore plain `autoComplete="off"`.
+        autoComplete="off"
+        data-1p-ignore="true"
+        data-lpignore="true"
       />
       <div className="ceo-card-actions">
         <button


### PR DESCRIPTION
## Summary

The CEO card form field (`web/src/components/messages/cards/CeoFormField.tsx`) is what the onboarding wizard actually renders for company name, company description, website URL, owner name, and owner role. It had no `autoComplete` hint, so 1Password and Chrome were popping credential / address autofill suggestions over the wizard during onboarding.

This PR sets, on the single shared CEO form input:
- `autoComplete="off"` — standard browser opt-out.
- `data-1p-ignore="true"` — 1Password vendor escape hatch.
- `data-lpignore="true"` — LastPass vendor escape hatch.

The `data-*-ignore` attributes are needed because 1Password and LastPass routinely ignore plain `autoComplete="off"` on text inputs.

Attribute-only change. No visible UI delta — the only behavior change is that password-manager popups stop firing on the wizard's company-name / description / website-URL prompts.

Closes #943.

## Scope

- Touched: `web/src/components/messages/cards/CeoFormField.tsx` (one input)
- Did NOT touch: `Composer.tsx`, `ThreadPanel.tsx`, the `#general` chat composer, or any non-onboarding input. Those are different surfaces where password-manager opt-out is not the desired default.
- Did NOT change the input's `type` (left as `text`). The task notes "keep `type='url'` if it already has it" — it did not, and adding a per-field type switch is out of scope for this attribute-only fix.

## Verification

- `bunx tsc --noEmit` — clean.
- `bunx biome check --write web/src/components/messages/cards/CeoFormField.tsx` — clean, no changes.
- `bash scripts/test-web.sh web/src/components/messages/cards/StructuredMessageCard.test.tsx` — 13/13 passed.

## Screenshots

Skipped per the screenshot rule's refactor exception: this is an attribute-only change with no visible UI delta. The only observable behavior is that the 1Password / Chrome autofill popup no longer fires over the wizard.

## Test plan

- [ ] Open onboarding flow with 1Password (or Chrome built-in password manager) installed.
- [ ] Reach the company-name CEO card. Verify no autofill popup appears.
- [ ] Repeat for the website-URL and description cards.
- [ ] Confirm the input itself still accepts typing, Enter still submits, and the existing focus behavior is unchanged.