### PR TITLE
fix(workspace): respect configured broker port in migration probe (#947)

### DIFF
--- a/internal/workspaces/migration.go
+++ b/internal/workspaces/migration.go
@@ -9,13 +9,19 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/brokeraddr"
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
 const (
-	migrationLockName   = ".wuphf-migration.lock"
-	mainBrokerProbePort = 7890
-	migrationProbeTO    = 2 * time.Second
+	migrationLockName = ".wuphf-migration.lock"
+	// legacyBrokerPort is the historical default the pre-symmetric layout ran
+	// on. The migration still probes it (in addition to the launching binary's
+	// configured port) because the legacy ~/.wuphf tree this migration mutates
+	// has historically been owned by a broker on 7890; renaming the tree out
+	// from under that broker would corrupt its state.
+	legacyBrokerPort = brokeraddr.DefaultPort
+	migrationProbeTO = 2 * time.Second
 )
 
 // brokerRunningFn is a var so tests can inject a controlled probe result
@@ -72,11 +78,21 @@ func MigrateToSymmetric() error {
 		return nil // already migrated
 	}
 
-	// Guard: refuse to migrate if the old broker is running.
-	if brokerRunningFn(mainBrokerProbePort) {
-		return fmt.Errorf("workspaces: migrate: broker is running on port %d; "+
-			"stop WUPHF before upgrading, then restart with `npx wuphf`",
-			mainBrokerProbePort)
+	// Guard: refuse to migrate if a broker is actually running on either the
+	// launching binary's configured port or the legacy default 7890. The
+	// migration rewrites ~/.wuphf, so any live broker pointing at that tree
+	// must be stopped first. Probe order matters only for the error message —
+	// we report whichever port we actually found.
+	configuredPort := brokeraddr.ResolvePort()
+	probePorts := []int{configuredPort}
+	if configuredPort != legacyBrokerPort {
+		probePorts = append(probePorts, legacyBrokerPort)
+	}
+	for _, port := range probePorts {
+		if brokerRunningFn(port) {
+			return fmt.Errorf("workspaces: migrate: broker is running on port %d; "+
+				"stop WUPHF before upgrading, then re-run this command", port)
+		}
 	}
 
 	oldPath := filepath.Join(home, ".wuphf")

--- a/internal/workspaces/migration_test.go
+++ b/internal/workspaces/migration_test.go
@@ -140,6 +140,68 @@ func TestMigrateToSymmetricAbortsWhenBrokerRunning(t *testing.T) {
 	}
 }
 
+// TestMigrateRespectsConfiguredBrokerPort guards against regressing nex-crm/wuphf#947
+// — when WUPHF_BROKER_PORT points at a non-default port and nothing is
+// listening on either that port or the legacy default, the probe must not
+// fire a false positive.
+func TestMigrateRespectsConfiguredBrokerPort(t *testing.T) {
+	home := withMigrationHome(t)
+	t.Setenv("WUPHF_BROKER_PORT", "7901")
+
+	// Track which ports the probe was asked about so we can assert it read
+	// from the configured-port source instead of a hard-coded 7890.
+	var probed []int
+	orig := brokerRunningFn
+	brokerRunningFn = func(port int) bool {
+		probed = append(probed, port)
+		return false
+	}
+	t.Cleanup(func() { brokerRunningFn = orig })
+
+	oldWuphf := filepath.Join(home, ".wuphf")
+	if err := os.MkdirAll(oldWuphf, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if err := MigrateToSymmetric(); err != nil {
+		t.Fatalf("MigrateToSymmetric with free configured port: %v", err)
+	}
+
+	if len(probed) == 0 {
+		t.Fatal("expected probe to be invoked at least once")
+	}
+	if probed[0] != 7901 {
+		t.Errorf("probe[0] = %d; want 7901 (configured port via WUPHF_BROKER_PORT)", probed[0])
+	}
+
+	// New path should exist — migration must have run, not aborted with the
+	// false-positive "broker is running" warning.
+	newPath := filepath.Join(home, ".wuphf-spaces", "main", ".wuphf")
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("new path %s missing after migration: %v", newPath, err)
+	}
+}
+
+// TestMigrateProbesLegacyPortAsSafetyNet ensures that when the launching
+// binary uses a non-default port but a legacy broker is still squatting on
+// 7890 against the same ~/.wuphf tree, the migration still aborts. Otherwise
+// the rename would corrupt the legacy broker's state.
+func TestMigrateProbesLegacyPortAsSafetyNet(t *testing.T) {
+	withMigrationHome(t)
+	t.Setenv("WUPHF_BROKER_PORT", "7901")
+
+	orig := brokerRunningFn
+	brokerRunningFn = func(port int) bool {
+		return port == legacyBrokerPort
+	}
+	t.Cleanup(func() { brokerRunningFn = orig })
+
+	err := MigrateToSymmetric()
+	if err == nil {
+		t.Fatal("expected error when legacy-port broker is running, even with non-default configured port")
+	}
+}
+
 func TestMigrateDoesNotRenameSymlink(t *testing.T) {
 	home := withMigrationHome(t)
 


### PR DESCRIPTION
## Summary

- The symmetric-layout migration probe hard-coded port 7890, so launching with `WUPHF_BROKER_PORT=7901 ./wuphf --broker-port 7901 ...` printed a false-positive warning at startup even when nothing was on 7890.
- Resolve the configured port via `brokeraddr.ResolvePort()` (the same source the launching binary uses) and only emit the warning when a broker is actually reachable. Still probe the legacy 7890 as a safety net when the configured port differs, because the migration mutates `~/.wuphf` and a legacy broker squatting on 7890 against the same tree would be corrupted by the rename.
- Drop the npm-specific `npx wuphf` recovery hint in favor of a runtime-neutral instruction, since source builds hit this path too.

## Test plan

- [x] `go build -o ./wuphf ./cmd/wuphf`
- [x] `go test -race ./internal/workspaces/...`
- [x] `go test -race ./internal/brokeraddr/...`
- [x] `gofmt -l` on changed files (clean)
- [x] `go vet ./internal/workspaces/...` (clean)
- [x] `golangci-lint run ./internal/workspaces/...` (0 issues)
- [x] New `TestMigrateRespectsConfiguredBrokerPort` asserts the probe reads `WUPHF_BROKER_PORT` and migration proceeds when 7890 is free.
- [x] New `TestMigrateProbesLegacyPortAsSafetyNet` asserts the legacy-port safety net still aborts the migration when a broker is squatting on 7890 even though the launching binary is on a non-default port.

Closes #947