### PR TITLE
fix(seed): seed placeholder company/owner articles so README links never dangle (#946)

### DIFF
--- a/internal/operations/company_seed.go
+++ b/internal/operations/company_seed.go
@@ -43,10 +43,16 @@ type Completer interface {
 type CompanySeedInput struct {
 	WebsiteURL string
 	FilePaths  []string
-	OwnerName  string
-	OwnerRole  string
-	Completer  Completer
-	WikiRoot   string
+	// CompanyName is the user-supplied company name from onboarding
+	// (FormAnswers.CompanyName / config.CompanyName). Used to personalise
+	// the placeholder company.md so the seeded team/about/README links never
+	// dangle on day one even before the LLM extraction (which can fail or
+	// be skipped) has populated a real CompanyProfile. May be empty.
+	CompanyName string
+	OwnerName   string
+	OwnerRole   string
+	Completer   Completer
+	WikiRoot    string
 }
 
 // CompanySeedResult summarizes what SeedCompanyContext did.
@@ -129,6 +135,25 @@ func SeedCompanyContext(ctx context.Context, input CompanySeedInput) (*CompanySe
 	readmePath := filepath.Join(input.WikiRoot, "team", "about", "README.md")
 	if _, err := os.Stat(readmePath); os.IsNotExist(err) {
 		if err := atomicWrite(input.WikiRoot, "team/about/README.md", []byte(aboutReadmeContent)); err != nil {
+			return nil, err
+		}
+	}
+
+	// 4a. Seed placeholder company.md and owner.md so the links the README
+	// just promised always resolve. Both files are written skip-if-exists so
+	// a real article populated by a prior seed (or by steps 5 and 7 below in
+	// this run) is never overwritten. See issue #946.
+	companyPath := filepath.Join(input.WikiRoot, "team", "about", "company.md")
+	if _, err := os.Stat(companyPath); os.IsNotExist(err) {
+		if err := atomicWrite(input.WikiRoot, "team/about/company.md",
+			[]byte(buildCompanyPlaceholderMD(input.CompanyName))); err != nil {
+			return nil, err
+		}
+	}
+	ownerPath := filepath.Join(input.WikiRoot, "team", "about", "owner.md")
+	if _, err := os.Stat(ownerPath); os.IsNotExist(err) {
+		if err := atomicWrite(input.WikiRoot, "team/about/owner.md",
+			[]byte(buildOwnerPlaceholderMD(input.OwnerName, input.OwnerRole))); err != nil {
 			return nil, err
 		}
 	}
@@ -418,6 +443,44 @@ func buildCompanyMD(profile CompanyProfile) string {
 			}
 		}
 	}
+	return sb.String()
+}
+
+// buildCompanyPlaceholderMD renders the initial company.md body written when
+// the team/about/ section is first seeded, so the link from README.md always
+// resolves even before LLM extraction has populated a real CompanyProfile.
+// It is overwritten by buildCompanyMD as soon as a real profile is available.
+//
+// The TODO comment is intentional — it tells the next human or agent reader
+// that this file is a stub waiting to be filled in. See issue #946.
+func buildCompanyPlaceholderMD(name string) string {
+	displayName := strings.TrimSpace(name)
+	if displayName == "" {
+		displayName = "This company"
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# %s\n\n", displayName))
+	sb.WriteString("<!-- TODO: replace this placeholder with a short description of what the company does, who it serves, and what the current focus is. The CEO-onboarding scan or any agent with `wiki.write` permission can rewrite this file. -->\n\n")
+	sb.WriteString("This article will hold a short description of what the company does, who it serves, and what the current focus is. It is a placeholder so the link from `README.md` resolves on day one; the scan or any agent can rewrite it with the real profile.\n")
+	return sb.String()
+}
+
+// buildOwnerPlaceholderMD renders the initial owner.md body written when the
+// team/about/ section is first seeded. Mirrors buildCompanyPlaceholderMD: it
+// exists so the link from README.md never dangles, and is overwritten by
+// buildOwnerMD once a real name or role is collected.
+func buildOwnerPlaceholderMD(name, role string) string {
+	displayName := strings.TrimSpace(name)
+	if displayName == "" {
+		displayName = "Workspace owner"
+	}
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("# %s\n\n", displayName))
+	if r := strings.TrimSpace(role); r != "" {
+		sb.WriteString(fmt.Sprintf("**Role:** %s\n\n", r))
+	}
+	sb.WriteString("<!-- TODO: replace this placeholder with a short profile of the person running this workspace — name, role, and how agents should escalate to them. -->\n\n")
+	sb.WriteString("This article will hold a short profile of the person running this workspace and how agents should escalate to them. It is a placeholder so the link from `README.md` resolves on day one.\n")
 	return sb.String()
 }
 

--- a/internal/operations/company_seed_test.go
+++ b/internal/operations/company_seed_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -36,11 +37,17 @@ func TestSeedCompanyContext(t *testing.T) {
 	validJSON := `{"company_name":"Acme","description":"B2B SaaS","industry":"SaaS","audience":"Ops teams","goals":"Launch Q3","key_facts":["Fact 1","Fact 2"]}`
 
 	tests := []struct {
-		name                string
-		setup               func(t *testing.T) // optional per-case setup (e.g. env scrubbing)
-		input               func(wikiRoot string) CompanySeedInput
-		wantCompanyMD       bool
-		wantOwnerMD         bool
+		name  string
+		setup func(t *testing.T) // optional per-case setup (e.g. env scrubbing)
+		input func(wikiRoot string) CompanySeedInput
+		// wantRealCompanyMD is true when company.md should hold a real
+		// LLM-derived profile (not the placeholder). The placeholder file
+		// is always written so the README link is never dead — see #946 —
+		// so we no longer assert on file existence directly.
+		wantRealCompanyMD bool
+		// wantRealOwnerMD is true when owner.md should hold a real
+		// owner profile (not the placeholder).
+		wantRealOwnerMD     bool
 		wantOwnerContent    []string // substrings that must appear in owner.md
 		wantReadme          bool
 		wantWarningContains string
@@ -56,9 +63,9 @@ func TestSeedCompanyContext(t *testing.T) {
 					FilePaths: []string{mustTempFile("wuphf-seed-*.txt", "Acme is a B2B SaaS company.")},
 				}
 			},
-			wantCompanyMD: true,
-			wantOwnerMD:   true,
-			wantReadme:    true,
+			wantRealCompanyMD: true,
+			wantRealOwnerMD:   true,
+			wantReadme:        true,
 		},
 		{
 			name: "JSON fence stripping",
@@ -70,8 +77,8 @@ func TestSeedCompanyContext(t *testing.T) {
 					FilePaths: []string{mustTempFile("wuphf-seed-*.txt", "Acme builds software.")},
 				}
 			},
-			wantCompanyMD: true,
-			wantReadme:    true,
+			wantRealCompanyMD: true,
+			wantReadme:        true,
 		},
 		{
 			name: "URL scheme rejected",
@@ -91,9 +98,8 @@ func TestSeedCompanyContext(t *testing.T) {
 					WikiRoot: wikiRoot,
 				}
 			},
-			wantReadme:    true,
-			wantCompanyMD: false,
-			wantOwnerMD:   false,
+			wantReadme: true,
+			// No real content for either file; both should hold the placeholder.
 		},
 		{
 			name: "owner name and role empty",
@@ -104,9 +110,9 @@ func TestSeedCompanyContext(t *testing.T) {
 					FilePaths: []string{mustTempFile("wuphf-seed-*.txt", "Some company content.")},
 				}
 			},
-			wantReadme:    true,
-			wantCompanyMD: true,
-			wantOwnerMD:   false,
+			wantReadme:        true,
+			wantRealCompanyMD: true,
+			// owner.md stays as placeholder (no name / role supplied).
 		},
 		{
 			name: "owner name provided",
@@ -118,7 +124,7 @@ func TestSeedCompanyContext(t *testing.T) {
 				}
 			},
 			wantReadme:       true,
-			wantOwnerMD:      true,
+			wantRealOwnerMD:  true,
 			wantOwnerContent: []string{"Alice", "CEO"},
 		},
 		{
@@ -170,8 +176,42 @@ func TestSeedCompanyContext(t *testing.T) {
 			}
 
 			checkExists(readmePath, tc.wantReadme, "README.md")
-			checkExists(companyPath, tc.wantCompanyMD, "company.md")
-			checkExists(ownerPath, tc.wantOwnerMD, "owner.md")
+
+			// company.md and owner.md are seeded with a placeholder on first
+			// run so the README links never dangle (#946). Whenever the
+			// README itself was written this run, both link targets must
+			// exist too — either as placeholders or as real articles.
+			if tc.wantReadme {
+				checkExists(companyPath, true, "company.md")
+				checkExists(ownerPath, true, "owner.md")
+			}
+
+			// When the LLM extraction succeeds the placeholder must have
+			// been overwritten with real content; the inverse is asserted
+			// implicitly by leaving the placeholder TODO marker in the file.
+			readBody := func(path string) string {
+				t.Helper()
+				data, readErr := os.ReadFile(path)
+				if readErr != nil {
+					t.Fatalf("read %s: %v", path, readErr)
+				}
+				return string(data)
+			}
+			const todoMarker = "<!-- TODO:"
+			if tc.wantReadme {
+				if tc.wantRealCompanyMD && strings.Contains(readBody(companyPath), todoMarker) {
+					t.Errorf("company.md still contains placeholder TODO marker but wantRealCompanyMD=true")
+				}
+				if !tc.wantRealCompanyMD && !strings.Contains(readBody(companyPath), todoMarker) {
+					t.Errorf("company.md missing placeholder TODO marker but wantRealCompanyMD=false")
+				}
+				if tc.wantRealOwnerMD && strings.Contains(readBody(ownerPath), todoMarker) {
+					t.Errorf("owner.md still contains placeholder TODO marker but wantRealOwnerMD=true")
+				}
+				if !tc.wantRealOwnerMD && !strings.Contains(readBody(ownerPath), todoMarker) {
+					t.Errorf("owner.md missing placeholder TODO marker but wantRealOwnerMD=false")
+				}
+			}
 
 			if tc.wantWarningContains != "" {
 				found := false
@@ -186,7 +226,7 @@ func TestSeedCompanyContext(t *testing.T) {
 				}
 			}
 
-			if len(tc.wantOwnerContent) > 0 && tc.wantOwnerMD {
+			if len(tc.wantOwnerContent) > 0 && tc.wantRealOwnerMD {
 				data, err := os.ReadFile(ownerPath)
 				if err != nil {
 					t.Fatalf("read owner.md: %v", err)
@@ -196,6 +236,86 @@ func TestSeedCompanyContext(t *testing.T) {
 					if !strings.Contains(got, want) {
 						t.Errorf("owner.md missing %q, got: %s", want, got)
 					}
+				}
+			}
+		})
+	}
+}
+
+// TestSeedCompanyContext_NoDeadLinksInSeededReadme is the regression guard
+// for issue #946. The seeded team/about/README.md links to company.md and
+// owner.md; both must resolve to files that exist after a first-run seed
+// even when the user has not supplied a website, files, or completer (the
+// minimal scratch path).
+func TestSeedCompanyContext_NoDeadLinksInSeededReadme(t *testing.T) {
+	tests := []struct {
+		name  string
+		input func(wikiRoot string) CompanySeedInput
+	}{
+		{
+			name: "minimal scratch seed — no website, no owner, no completer",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{WikiRoot: wikiRoot}
+			},
+		},
+		{
+			name: "scratch seed with company name only",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					WikiRoot:    wikiRoot,
+					CompanyName: "Acme",
+				}
+			},
+		},
+		{
+			name: "scratch seed with owner only",
+			input: func(wikiRoot string) CompanySeedInput {
+				return CompanySeedInput{
+					WikiRoot:  wikiRoot,
+					OwnerName: "Alice",
+					OwnerRole: "Founder",
+				}
+			},
+		},
+	}
+
+	// linkRE matches markdown link targets: [label](target).
+	linkRE := regexp.MustCompile(`\[[^\]]*\]\(([^)]+)\)`)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			wikiRoot := t.TempDir()
+			if _, err := SeedCompanyContext(context.Background(), tc.input(wikiRoot)); err != nil {
+				t.Fatalf("SeedCompanyContext: %v", err)
+			}
+
+			aboutDir := filepath.Join(wikiRoot, "team", "about")
+			readmePath := filepath.Join(aboutDir, "README.md")
+			body, err := os.ReadFile(readmePath)
+			if err != nil {
+				t.Fatalf("read README.md: %v", err)
+			}
+
+			matches := linkRE.FindAllStringSubmatch(string(body), -1)
+			if len(matches) == 0 {
+				t.Fatal("seeded README.md has no markdown links — refusing to silently pass")
+			}
+			for _, m := range matches {
+				target := m[1]
+				// Skip absolute URLs; only validate relative paths.
+				if strings.Contains(target, "://") || strings.HasPrefix(target, "/") {
+					continue
+				}
+				// Strip any trailing anchor.
+				if i := strings.Index(target, "#"); i != -1 {
+					target = target[:i]
+				}
+				if target == "" {
+					continue
+				}
+				resolved := filepath.Join(aboutDir, target)
+				if _, statErr := os.Stat(resolved); statErr != nil {
+					t.Errorf("seeded README links to %q which does not resolve: %v", target, statErr)
 				}
 			}
 		})

--- a/internal/team/broker_company_seed.go
+++ b/internal/team/broker_company_seed.go
@@ -20,12 +20,13 @@ func (c brokerCompleter) Complete(ctx context.Context, prompt string) (string, e
 func (b *Broker) runCompanySeedJob(cfg config.Config) {
 	wikiRoot := filepath.Join(config.RuntimeHomeDir(), ".wuphf", "wiki")
 	input := operations.CompanySeedInput{
-		WebsiteURL: cfg.CompanyWebsite,
-		FilePaths:  cfg.CompanyFilePaths,
-		OwnerName:  cfg.OwnerName,
-		OwnerRole:  cfg.OwnerRole,
-		Completer:  brokerCompleter{},
-		WikiRoot:   wikiRoot,
+		WebsiteURL:  cfg.CompanyWebsite,
+		FilePaths:   cfg.CompanyFilePaths,
+		CompanyName: cfg.CompanyName,
+		OwnerName:   cfg.OwnerName,
+		OwnerRole:   cfg.OwnerRole,
+		Completer:   brokerCompleter{},
+		WikiRoot:    wikiRoot,
 	}
 	ctx, cancel := context.WithTimeout(b.lifecycleCtx, 120*time.Second)
 	defer cancel()

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -77,11 +77,12 @@ func (b *Broker) runScanPhase(dmSlug string) {
 	}
 
 	input := operations.CompanySeedInput{
-		WebsiteURL: websiteURL,
-		OwnerName:  s.FormAnswers.OwnerName,
-		OwnerRole:  s.FormAnswers.OwnerRole,
-		Completer:  brokerCompleter{},
-		WikiRoot:   wikiRoot,
+		WebsiteURL:  websiteURL,
+		CompanyName: s.FormAnswers.CompanyName,
+		OwnerName:   s.FormAnswers.OwnerName,
+		OwnerRole:   s.FormAnswers.OwnerRole,
+		Completer:   brokerCompleter{},
+		WikiRoot:    wikiRoot,
 	}
 
 	ctx, cancel := context.WithTimeout(b.lifecycleCtx, scanTimeout)


### PR DESCRIPTION
## Summary

- Adds `CompanyName` field to `CompanySeedInput` (wired through from both `broker_company_seed.go` and `broker_onboarding_scan.go`)
- Seeds skip-if-exists placeholder `team/about/company.md` and `team/about/owner.md` **before** the LLM extraction step, so every link the seeded `README.md` emits resolves on day one — even when the scan times out, is skipped, or context is empty
- Real content from `buildCompanyMD` / `buildOwnerMD` still overwrites the stubs on a successful extraction run
- Adds `TestSeedCompanyContext_NoDeadLinksInSeededReadme` — three sub-cases verifying no dangling links regardless of whether company name, owner, or scan context is supplied

## Test plan
- [ ] `go test ./internal/operations/... -run TestSeedCompanyContext` — all 10 pass (verified locally)
- [ ] `go build ./internal/...` — clean (verified locally)
- [ ] Fresh onboarding flow with no website / no company data — `team/about/company.md` and `team/about/owner.md` exist and README links resolve
- [ ] Onboarding flow with full scan — real articles overwrite placeholders, README links still resolve

Fixes #946.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Placeholder markdown files are now automatically created during seeding to prevent broken README links until real content is populated.

* **Bug Fixes**
  * README markdown links now resolve correctly from the start with placeholder content in place.

* **Tests**
  * Added regression test to validate all markdown links in seeded README resolve to existing files, catching dead links early.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->