### PR TITLE
refactor(routing): sidebar TOOLS driven by APP_PANEL_IDS + alias first-class routes (#938)

### DIFF
--- a/web/src/components/layout/CollapsedSidebar.tsx
+++ b/web/src/components/layout/CollapsedSidebar.tsx
@@ -28,10 +28,12 @@ import {
 } from "iconoir-react";
 
 import { getUsage } from "../../api/platform";
-import { SIDEBAR_APPS } from "../../lib/constants";
 import { formatTokens, formatUSD } from "../../lib/format";
 import { navigateToSidebarApp } from "../../lib/sidebarNav";
-import { WIKI_SURFACE_APP_IDS } from "../../routes/routeRegistry";
+import {
+  SIDEBAR_TOOLS,
+  WIKI_SURFACE_APP_IDS,
+} from "../../routes/routeRegistry";
 import { useCurrentApp } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
 import { AgentList } from "../sidebar/AgentList";
@@ -162,28 +164,28 @@ export function CollapsedSidebar() {
       </div>
 
       <div className="sidebar-rail-apps">
-        {SIDEBAR_APPS.filter((a) => a.id !== "settings").map((app) => {
-          const Icon = APP_ICONS[app.id];
+        {SIDEBAR_TOOLS.filter((t) => t.id !== "settings").map((tool) => {
+          const Icon = APP_ICONS[tool.id];
           // Wiki entry lights up for the wiki, notebooks, and reviews surfaces
           // since those three share the Wiki app shell via tabs.
           const isActive =
-            app.id === "wiki"
+            tool.id === "wiki"
               ? WIKI_SURFACE_APPS.has(currentApp ?? "")
-              : currentApp === app.id;
+              : currentApp === tool.id;
           return (
             <button
-              key={app.id}
+              key={tool.id}
               type="button"
               className={`sidebar-icon-btn${isActive ? " active" : ""}`}
-              aria-label={app.name}
-              onClick={() => navigateToSidebarApp(app.id)}
-              onMouseEnter={(e) => showHint(e, app.name)}
+              aria-label={tool.label}
+              onClick={() => navigateToSidebarApp(tool.id)}
+              onMouseEnter={(e) => showHint(e, tool.label)}
               onMouseLeave={hideHint}
             >
               {Icon ? (
                 <Icon />
               ) : (
-                <span className="sidebar-item-emoji">{app.icon}</span>
+                <span className="sidebar-item-emoji">{tool.icon}</span>
               )}
             </button>
           );

--- a/web/src/components/sidebar/AppList.tsx
+++ b/web/src/components/sidebar/AppList.tsx
@@ -21,9 +21,11 @@ import {
 import { getRequests } from "../../api/client";
 import { fetchReviews } from "../../api/notebook";
 import { useOverflow } from "../../hooks/useOverflow";
-import { SIDEBAR_APPS } from "../../lib/constants";
 import { navigateToSidebarApp } from "../../lib/sidebarNav";
-import { WIKI_SURFACE_APP_IDS } from "../../routes/routeRegistry";
+import {
+  SIDEBAR_TOOLS,
+  WIKI_SURFACE_APP_IDS,
+} from "../../routes/routeRegistry";
 import {
   useCurrentApp,
   useFallbackChannelSlug,
@@ -77,28 +79,28 @@ export function AppList() {
   return (
     <div className="sidebar-scroll-wrap is-apps">
       <div className="sidebar-apps" ref={overflowRef}>
-        {SIDEBAR_APPS.filter((app) => app.id !== "settings").map((app) => {
+        {SIDEBAR_TOOLS.filter((tool) => tool.id !== "settings").map((tool) => {
           let badge: number | null = null;
-          if (app.id === "wiki" && pendingReviewsCount > 0)
+          if (tool.id === "wiki" && pendingReviewsCount > 0)
             badge = pendingReviewsCount;
-          const Icon = APP_ICONS[app.id];
+          const Icon = APP_ICONS[tool.id];
           const isActive =
-            app.id === "wiki"
+            tool.id === "wiki"
               ? WIKI_SURFACE_APPS.has(currentApp ?? "")
-              : currentApp === app.id;
+              : currentApp === tool.id;
           return (
             <SidebarItem
-              key={app.id}
+              key={tool.id}
               icon={
                 Icon ? (
                   <Icon className="sidebar-item-icon" />
                 ) : (
-                  <span className="sidebar-item-emoji">{app.icon}</span>
+                  <span className="sidebar-item-emoji">{tool.icon}</span>
                 )
               }
-              label={app.name}
+              label={tool.label}
               active={isActive}
-              onClick={() => navigateToSidebarApp(app.id)}
+              onClick={() => navigateToSidebarApp(tool.id)}
               badge={
                 badge !== null ? (
                   <span

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,30 +1,21 @@
-// Wiki unifies three surfaces behind one sidebar entry: the canonical
-// team wiki, per-agent notebooks (drafts), and the promotion review queue.
-// Each surface gets its own tab inside the Wiki app; notebooks/reviews
-// have no top-level sidebar entries of their own.
-// Inbox is hoisted out into a dedicated prominent button at the top of
-// the sidebar (see components/sidebar/InboxButton). It used to live in
-// this list as just another app; promoting it reflects that the inbox
-// is the primary attention surface, not a secondary tool.
-export const SIDEBAR_APPS = [
-  { id: "overview", icon: "\uD83C\uDFE0", name: "Overview" },
-  { id: "wiki", icon: "\uD83D\uDCD6", name: "Wiki" },
-  { id: "console", icon: ">", name: "Console" },
-  { id: "graph", icon: "\uD83D\uDD78", name: "Graph" },
-  { id: "policies", icon: "\uD83D\uDEE1", name: "Policies" },
-  { id: "calendar", icon: "\uD83D\uDCC5", name: "Calendar" },
-  { id: "skills", icon: "\u26A1", name: "Skills" },
-  { id: "activity", icon: "\uD83D\uDCE6", name: "Activity" },
-  { id: "receipts", icon: "\uD83E\uDDFE", name: "Receipts" },
-  { id: "health-check", icon: "\uD83D\uDCF6", name: "Access & Health" },
-  { id: "settings", icon: "\u2699", name: "Settings" },
-] as const;
+// Sidebar TOOLS entries (labels, ids, order) live in
+// `routes/routeRegistry.ts`. This file historically re-exported a
+// duplicate `SIDEBAR_APPS` list \u2014 that was deleted to keep the registry
+// the single source of truth. Resolve labels through `APP_LABELS` /
+// `SIDEBAR_TOOLS` and read the displayed order from `SIDEBAR_TOOLS`.
+import {
+  APP_LABELS,
+  type AppPanelId,
+  type FirstClassAppId,
+  isAppPanelId,
+  isFirstClassAppId,
+} from "../routes/routeRegistry";
 
 export function appTitle(app: string): string {
-  return (
-    SIDEBAR_APPS.find((item) => item.id === app)?.name ??
-    app.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
-  );
+  if (isAppPanelId(app) || isFirstClassAppId(app)) {
+    return APP_LABELS[app as AppPanelId | FirstClassAppId];
+  }
+  return app.replace(/-/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 export const ONBOARDING_COPY = {

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -36,7 +36,12 @@ import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
 import { rootRoute, router } from "../lib/router";
 import { getTheme } from "../lib/themes";
 import { useAppStore } from "../stores/app";
-import { type AppPanelId, isAppPanelId } from "./routeRegistry";
+import {
+  type AppPanelId,
+  type FirstClassAppId,
+  isAppPanelId,
+  isFirstClassAppId,
+} from "./routeRegistry";
 import {
   type CurrentRoute,
   useChannelSlug,
@@ -438,6 +443,44 @@ function IssueDetailRedirect({ issueId }: { issueId: string }) {
 }
 
 /**
+ * FirstClassAppRedirect navigates the user from a `/apps/$id` URL whose
+ * `$id` is a first-class app (wiki, inbox) to that app's canonical
+ * dedicated route. Users who type a sidebar-label-style URL by hand
+ * (e.g. `/#/apps/wiki`) used to hit "Page not found" because first-class
+ * apps live at `/wiki` and `/inbox`, not under `/apps`. Mirrors
+ * `InboxRedirect` and `IssuesRedirect` so the route ↔ sidebar mapping is
+ * forgiving without the route registry sprouting alias entries.
+ */
+function FirstClassAppRedirect({ appId }: { appId: FirstClassAppId }) {
+  useEffect(() => {
+    if (appId === "wiki") {
+      void router.navigate({ to: "/wiki", replace: true });
+    } else {
+      void router.navigate({ to: "/inbox", replace: true });
+    }
+  }, [appId]);
+  return (
+    <div
+      className="app-panel active"
+      data-testid={`legacy-redirect-first-class-${appId}`}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flex: 1,
+          color: "var(--text-tertiary)",
+          fontSize: 14,
+        }}
+      >
+        Redirecting…
+      </div>
+    </div>
+  );
+}
+
+/**
  * IssuesRedirect navigates the user from the deprecated /apps/tasks
  * surface to the unified Issues list. Tasks-as-a-sidebar-app was
  * replaced by the Issues group + dedicated /issues route; this stub
@@ -544,6 +587,14 @@ function MainContent() {
         <DMView agentSlug={route.agentSlug} channelSlug={route.channelSlug} />
       );
     case "app":
+      // `/apps/wiki` and `/apps/inbox` are not app-panel routes — the
+      // sidebar navigates to `/wiki` and `/inbox` directly — but users
+      // who type a sidebar-label-style URL by hand should not hit
+      // "Page not found". Forward them to the canonical first-class
+      // route instead.
+      if (isFirstClassAppId(route.appId)) {
+        return <FirstClassAppRedirect appId={route.appId} />;
+      }
       if (!isAppPanelId(route.appId)) {
         return <UnknownAppPanel appId={route.appId} />;
       }

--- a/web/src/routes/routeRegistry.test.ts
+++ b/web/src/routes/routeRegistry.test.ts
@@ -25,11 +25,15 @@ import {
   wikiLookupRoute,
 } from "../lib/router";
 import {
+  APP_LABELS,
   APP_PANEL_IDS,
+  FIRST_CLASS_APP_IDS,
   isAppPanelId,
+  isFirstClassAppId,
   ROUTE_CONTRACTS,
   ROUTE_PATHS,
   SIDEBAR_APP_IDS,
+  SIDEBAR_TOOLS,
   sidebarAppRouteKind,
 } from "./routeRegistry";
 
@@ -52,6 +56,31 @@ describe("route registry", () => {
     for (const id of SIDEBAR_APP_IDS) {
       expect(sidebarAppRouteKind(id), id).not.toBeNull();
     }
+  });
+
+  it("provides a human label for every routed sidebar id", () => {
+    for (const id of APP_PANEL_IDS) {
+      expect(APP_LABELS[id], id).toBeTruthy();
+    }
+    for (const id of FIRST_CLASS_APP_IDS) {
+      expect(APP_LABELS[id], id).toBeTruthy();
+    }
+  });
+
+  it("drives sidebar TOOLS labels from the route registry", () => {
+    // Every entry in the rendered TOOLS list is either an app-panel id
+    // (routed at /apps/$id) or a first-class app id (routed at /$id).
+    // Labels come from APP_LABELS, never an out-of-band constant.
+    for (const tool of SIDEBAR_TOOLS) {
+      expect(sidebarAppRouteKind(tool.id), tool.id).toBe(tool.kind);
+      expect(tool.label).toBe(APP_LABELS[tool.id]);
+    }
+  });
+
+  it("recognises first-class app ids that live outside /apps", () => {
+    expect(isFirstClassAppId("wiki")).toBe(true);
+    expect(isFirstClassAppId("inbox")).toBe(true);
+    expect(isFirstClassAppId("console")).toBe(false);
   });
 
   it("keeps the planned route contracts unique", () => {
@@ -131,6 +160,27 @@ describe("TanStack route tree", () => {
     // /apps/console URL is the single source of truth (and /apps/threads
     // is no longer a recognized app panel — see APP_PANEL_IDS).
     expect(leaf?.routeId).toBe(rootRoute.id);
+  });
+
+  it.each([
+    ["/apps/wiki", "wiki"],
+    ["/apps/inbox", "inbox"],
+  ])("routes %s through the generic app route so MainContent can redirect to the first-class surface", (path, expectedAppId) => {
+    // /apps/wiki and /apps/inbox match the generic /apps/$appId route
+    // because the router has no opinion on which app ids are
+    // first-class. MainContent narrows via isFirstClassAppId() and
+    // mounts FirstClassAppRedirect, which navigates to /wiki or
+    // /inbox respectively. Asserting both halves here keeps the
+    // aliasing contract pinned: a future drop of either side would
+    // silently bring the "Page not found" regression back.
+    const router = createAppRouter(
+      createMemoryHistory({ initialEntries: ["/"] }),
+    );
+    const leaf = router.matchRoutes(path).at(-1);
+
+    expect(leaf?.routeId).toBe(appRoute.id);
+    expect((leaf?.params as { appId?: string })?.appId).toBe(expectedAppId);
+    expect(isFirstClassAppId(expectedAppId)).toBe(true);
   });
 
   it("treats /apps/threads as an unknown app panel", () => {

--- a/web/src/routes/routeRegistry.ts
+++ b/web/src/routes/routeRegistry.ts
@@ -1,5 +1,3 @@
-import { SIDEBAR_APPS } from "../lib/constants";
-
 export const APP_PANEL_IDS = [
   "activity",
   "calendar",
@@ -29,6 +27,10 @@ export function isAppPanelId(value: string): value is AppPanelId {
   return APP_PANEL_ID_SET.has(value);
 }
 
+export function isFirstClassAppId(value: string): value is FirstClassAppId {
+  return FIRST_CLASS_APP_ID_SET.has(value);
+}
+
 export function sidebarAppRouteKind(
   id: string,
 ): "app-panel" | "first-class" | null {
@@ -36,6 +38,92 @@ export function sidebarAppRouteKind(
   if (FIRST_CLASS_APP_ID_SET.has(id)) return "first-class";
   return null;
 }
+
+/**
+ * Human-readable labels for every routed sidebar surface. Keyed by every
+ * `AppPanelId` and every `FirstClassAppId`, so the sidebar TOOLS list and
+ * any other route-driven UI can resolve a label from a single source of
+ * truth instead of duplicating the string in a sidebar constant.
+ */
+export const APP_LABELS: Record<AppPanelId | FirstClassAppId, string> = {
+  // First-class surfaces (live at `/wiki` and `/inbox`, not `/apps/$id`).
+  wiki: "Wiki",
+  inbox: "Inbox",
+  // Routed app panels under `/apps/$appId`.
+  activity: "Activity",
+  calendar: "Calendar",
+  console: "Console",
+  graph: "Graph",
+  "health-check": "Access & Health",
+  overview: "Overview",
+  policies: "Policies",
+  receipts: "Receipts",
+  requests: "Requests",
+  settings: "Settings",
+  skills: "Skills",
+  tasks: "Tasks",
+};
+
+/**
+ * Emoji fallback icons rendered when a `SidebarTool` has no iconoir-react
+ * mapping in the rendering component. Lookups for unknown ids fall back
+ * to a generic glyph at the call site.
+ */
+const SIDEBAR_TOOL_EMOJIS: Partial<
+  Record<AppPanelId | FirstClassAppId, string>
+> = {
+  overview: "🏠",
+  wiki: "📖",
+  console: ">",
+  graph: "🕸",
+  policies: "🛡",
+  calendar: "📅",
+  skills: "⚡",
+  activity: "📦",
+  receipts: "🧾",
+  "health-check": "📶",
+  settings: "⚙",
+};
+
+export interface SidebarTool {
+  /** Either an `AppPanelId` or a `FirstClassAppId`. */
+  id: AppPanelId | FirstClassAppId;
+  /** Display label resolved from `APP_LABELS`. */
+  label: string;
+  /** Whether this entry routes to `/apps/$id` or to a dedicated path. */
+  kind: "app-panel" | "first-class";
+  /** Optional emoji glyph for callers without an icon mapping. */
+  icon?: string;
+}
+
+/**
+ * Ordered list of sidebar TOOLS entries. The renderer (`AppList`,
+ * `CollapsedSidebar`) maps over this array directly — labels and order
+ * are owned here, not duplicated in `lib/constants.ts`.
+ *
+ * `settings` lives at the bottom because `AppList`/`CollapsedSidebar`
+ * render it separately (it's filtered out of the TOOLS section and
+ * mounted in a fixed slot). It is kept in the array so the route
+ * registry stays the single source of truth for which ids are valid
+ * sidebar destinations.
+ */
+export const SIDEBAR_TOOLS: readonly SidebarTool[] = [
+  { id: "overview", kind: "app-panel" },
+  { id: "wiki", kind: "first-class" },
+  { id: "console", kind: "app-panel" },
+  { id: "graph", kind: "app-panel" },
+  { id: "policies", kind: "app-panel" },
+  { id: "calendar", kind: "app-panel" },
+  { id: "skills", kind: "app-panel" },
+  { id: "activity", kind: "app-panel" },
+  { id: "receipts", kind: "app-panel" },
+  { id: "health-check", kind: "app-panel" },
+  { id: "settings", kind: "app-panel" },
+].map((entry) => ({
+  ...entry,
+  label: APP_LABELS[entry.id as AppPanelId | FirstClassAppId],
+  icon: SIDEBAR_TOOL_EMOJIS[entry.id as AppPanelId | FirstClassAppId],
+})) as readonly SidebarTool[];
 
 export const ROUTE_PATHS = {
   index: "/",
@@ -179,4 +267,6 @@ export const ROUTE_CONTRACTS: readonly RouteContract[] = [
   { key: "issueNew", path: ROUTE_PATHS.issueNew, params: [], search: [] },
 ] as const;
 
-export const SIDEBAR_APP_IDS = SIDEBAR_APPS.map((app) => app.id);
+export const SIDEBAR_APP_IDS: readonly string[] = SIDEBAR_TOOLS.map(
+  (tool) => tool.id,
+);


### PR DESCRIPTION
## Summary

Two changes, one PR, closing the sidebar / app-route registry drift (B-11 + I-10):

- **Single source of truth for sidebar TOOLS.** `APP_LABELS` and `SIDEBAR_TOOLS` now live alongside `APP_PANEL_IDS` / `FIRST_CLASS_APP_IDS` in `routes/routeRegistry.ts`. `AppList` and `CollapsedSidebar` map over `SIDEBAR_TOOLS` directly. The old duplicated `SIDEBAR_APPS` constant in `lib/constants.ts` is gone, and `appTitle()` now resolves through `APP_LABELS`. Visual order and labels are unchanged.
- **Alias first-class routes.** `/#/apps/wiki` and `/#/apps/inbox` (the URLs a user types after seeing "Wiki" or "Inbox" in the sidebar) used to fall through to "Page not found" because both surfaces are first-class and live at `/wiki` and `/inbox`. `MainContent` now dispatches those `appId`s through a new `FirstClassAppRedirect` (mirroring the existing `InboxRedirect` / `IssuesRedirect`) so a hand-typed sidebar-label URL navigates to the canonical first-class path.

Closes #938.

## Visual delta

No visible UI delta — same labels in the same order. Per the screenshot rule, screenshots are skipped because the change is a pure refactor with no UI change.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean on all touched files (two pre-existing warnings in `AppList.tsx` for an unused `getRequests` import and `currentChannel` local are unrelated to this PR)
- [x] `bash scripts/test-web.sh web/src/routes/ web/src/components/sidebar/` — 102 passed (was 97; 5 new tests added)
- [x] `bash scripts/test-web.sh` — full suite: 1619 passed, 2 skipped
- Manual: `/#/apps/wiki` redirects to `/#/wiki`, `/#/apps/inbox` redirects to `/#/inbox`, sidebar TOOLS list renders identically.

### New tests

- `provides a human label for every routed sidebar id` — every `AppPanelId` and `FirstClassAppId` has an entry in `APP_LABELS`.
- `drives sidebar TOOLS labels from the route registry` — every `SIDEBAR_TOOLS` entry matches `sidebarAppRouteKind(id)` and pulls its label from `APP_LABELS`. (Asserts the "every TOOLS label has a matching route" invariant.)
- `recognises first-class app ids that live outside /apps` — pins the new `isFirstClassAppId` helper.
- `routes /apps/wiki through the generic app route so MainContent can redirect to the first-class surface` — parametrized over `/apps/wiki` and `/apps/inbox`; pins both halves of the redirect contract (URL still matches `appRoute` + `appId` is first-class, so `MainContent` mounts `FirstClassAppRedirect`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated sidebar app configuration and labels into a centralized registry for improved consistency across the navigation system.

* **Bug Fixes**
  * Enhanced app navigation routing with proper redirect handling for first-class applications.

* **Tests**
  * Added comprehensive test coverage for app routing, centralized label resolution, and navigation redirect behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->