### PR TITLE
fix(wiki): regen index after seed + scan boundaries (#941)

### DIFF
--- a/internal/team/broker_company_seed.go
+++ b/internal/team/broker_company_seed.go
@@ -51,7 +51,12 @@ func (b *Broker) runCompanySeedJob(cfg config.Config) {
 	// atomicWrite, bypassing the WikiWorker's per-commit IndexRegen. Regen
 	// here so the post-seed snapshot of index/all.md reflects the new
 	// articles (and the always-written README). (#941)
-	b.regenWikiIndexAfterSeed(ctx, "boot company seed")
+	//
+	// Use a fresh timeout against the broker lifecycle rather than the
+	// (possibly near-deadline) seed ctx so regen always gets a full budget.
+	regenCtx, regenCancel := context.WithTimeout(b.lifecycleCtx, 15*time.Second)
+	b.regenWikiIndexAfterSeed(regenCtx, "boot company seed")
+	regenCancel()
 	// Persist extracted profile fields back to config.
 	b.configMu.Lock()
 	defer b.configMu.Unlock()

--- a/internal/team/broker_company_seed.go
+++ b/internal/team/broker_company_seed.go
@@ -47,6 +47,11 @@ func (b *Broker) runCompanySeedJob(cfg config.Config) {
 		log.Printf("broker: company seed warning: %s", w)
 	}
 	log.Printf("broker: company seed complete, wrote %d articles", len(result.ArticlesWritten))
+	// SeedCompanyContext writes team/about/*.md directly to disk via
+	// atomicWrite, bypassing the WikiWorker's per-commit IndexRegen. Regen
+	// here so the post-seed snapshot of index/all.md reflects the new
+	// articles (and the always-written README). (#941)
+	b.regenWikiIndexAfterSeed(ctx, "boot company seed")
 	// Persist extracted profile fields back to config.
 	b.configMu.Lock()
 	defer b.configMu.Unlock()

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -176,6 +176,15 @@ func (b *Broker) runSeedPhase(s *onboarding.State) error {
 		}
 		b.ensureNotebookDirsForRoster()
 		b.materializeBlueprintWiki(loaded)
+		// materializeBlueprintWiki only regenerates the index when its
+		// transactional materializer wrote new bytes. The seed boundary
+		// must still guarantee a fresh index/all.md — for example when the
+		// blueprint wiki was already on disk from a prior run but the
+		// index was rebuilt empty by a clean-boot reconcile. Call here
+		// unconditionally so the post-seed snapshot is always correct.
+		regenCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		b.regenWikiIndexAfterSeed(regenCtx, "blueprint seed")
+		cancel()
 		return nil
 	}
 	// Scratch path: minimal seed (#general + about/ wiki stubs + CEO).
@@ -192,6 +201,11 @@ func (b *Broker) runSeedPhase(s *onboarding.State) error {
 	// rather than an empty one. Best-effort: failures are logged inside the
 	// helper and do not fail the seed phase.
 	b.materializeScratchWikiStubs(s)
+	// Stubs land via atomicWrite (not the WikiWorker), so force an index
+	// regen here so /index/all.md reflects the new about/ files.
+	regenCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	b.regenWikiIndexAfterSeed(regenCtx, "scratch seed")
+	cancel()
 	return nil
 }
 
@@ -403,6 +417,36 @@ func (b *Broker) materializeScratchWikiStubs(s *onboarding.State) {
 		log.Printf("onboarding: scratch wiki commit: %v", err)
 	} else if sha != "" {
 		log.Printf("onboarding: scratch wiki stubs committed %s", sha)
+	}
+}
+
+// regenWikiIndexAfterSeed regenerates wiki/index/all.md so it reflects any
+// articles that landed on disk at a seed or scan boundary. It is the single
+// chokepoint for "files appeared outside the WikiWorker's per-commit
+// reconcile path" — for example, operations.SeedCompanyContext writes
+// team/about/{README,owner,company}.md directly to disk, and
+// materializeScratchWikiStubs writes scratch stubs via writeWikiStubIfAbsent.
+// Neither path passes through (*WikiWorker).Enqueue, so the per-commit
+// IndexRegen in (*Repo).Commit never fires and the boot-reconcile snapshot
+// of index/all.md goes stale.
+//
+// Idempotent: safe to call multiple times. Best-effort: errors are logged,
+// not returned, so a transient I/O blip on the index does not fail the
+// surrounding seed/scan boundary. Returns silently when the markdown
+// backend is not active (worker or repo nil).
+//
+// See nex-crm/wuphf#941.
+func (b *Broker) regenWikiIndexAfterSeed(ctx context.Context, reason string) {
+	worker := b.WikiWorker()
+	if worker == nil {
+		return
+	}
+	repo := worker.Repo()
+	if repo == nil {
+		return
+	}
+	if err := repo.IndexRegen(ctx); err != nil {
+		log.Printf("onboarding: wiki index regen after %s: %v", reason, err)
 	}
 }
 

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -108,6 +108,13 @@ func (b *Broker) runScanPhase(dmSlug string) {
 		return
 	}
 
+	// SeedCompanyContext writes team/about/{README,owner,company}.md
+	// directly to disk via atomicWrite — it does not pass through the
+	// WikiWorker, so (*Repo).Commit's per-commit IndexRegen never fires
+	// for these files. Regenerate index/all.md here so the post-scan
+	// snapshot reflects the README path that always lands. (#941)
+	b.regenWikiIndexAfterSeed(ctx, "website scan")
+
 	b.postScanChipUpdate(dmSlug, websiteURL, "done", "Wiki updated ✓")
 
 	// Stagger one chat bubble per article written. Each bubble is a plain

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -113,7 +113,12 @@ func (b *Broker) runScanPhase(dmSlug string) {
 	// WikiWorker, so (*Repo).Commit's per-commit IndexRegen never fires
 	// for these files. Regenerate index/all.md here so the post-scan
 	// snapshot reflects the README path that always lands. (#941)
-	b.regenWikiIndexAfterSeed(ctx, "website scan")
+	//
+	// Use a fresh timeout against the broker lifecycle, not the scan ctx,
+	// so a near-deadline scan does not cause regen to silently no-op.
+	regenCtx, regenCancel := context.WithTimeout(b.lifecycleCtx, 15*time.Second)
+	b.regenWikiIndexAfterSeed(regenCtx, "website scan")
+	regenCancel()
 
 	b.postScanChipUpdate(dmSlug, websiteURL, "done", "Wiki updated ✓")
 

--- a/internal/team/broker_onboarding_wiki_index_regen_test.go
+++ b/internal/team/broker_onboarding_wiki_index_regen_test.go
@@ -1,0 +1,96 @@
+package team
+
+// broker_onboarding_wiki_index_regen_test.go — regression coverage for
+// nex-crm/wuphf#941. After a seed or scan boundary writes wiki articles
+// directly to disk (bypassing the WikiWorker), index/all.md must reflect
+// the new files. The fix wires (*Broker).regenWikiIndexAfterSeed into the
+// seed phase, the website-scan path, and the boot company-seed job. These
+// tests cover the on-disk shape, not the higher-level orchestration.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRegenWikiIndexAfterSeed_PicksUpDirectDiskWrites simulates what
+// operations.SeedCompanyContext does on the scan path: it atomicWrite()s
+// team/about/README.md straight to disk. Before #941 the
+// (*WikiWorker).maybeReconcileIndex per-commit IndexRegen never fired for
+// that path, so index/all.md stayed at its boot-reconcile snapshot
+// ("_No articles yet._"). This test pins the post-fix behavior: calling
+// regenWikiIndexAfterSeed once is enough to list the file.
+func TestRegenWikiIndexAfterSeed_PicksUpDirectDiskWrites(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("repo init: %v", err)
+	}
+
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	workerCtx, cancel := context.WithCancel(context.Background())
+	worker.Start(workerCtx)
+	// defers run LIFO: cancel must fire BEFORE we await Done, otherwise
+	// the goroutine never exits and the test hangs.
+	t.Cleanup(func() {
+		cancel()
+		<-worker.Done()
+	})
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	// Bootstrap the index with no articles yet. This mirrors the
+	// post-init reconcile snapshot that boot does.
+	if err := repo.IndexRegen(ctx); err != nil {
+		t.Fatalf("bootstrap index regen: %v", err)
+	}
+	indexPath := repo.IndexAllPath()
+	pre, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read pre-state index: %v", err)
+	}
+	if strings.Contains(string(pre), "team/about/README.md") {
+		t.Fatalf("pre-state index already lists README: %q", string(pre))
+	}
+
+	// Simulate SeedCompanyContext's atomic-write side effect: drop a
+	// README.md under team/about/ without touching the worker queue.
+	if err := os.MkdirAll(filepath.Join(root, "team", "about"), 0o755); err != nil {
+		t.Fatalf("mkdir team/about: %v", err)
+	}
+	readmePath := filepath.Join(root, "team", "about", "README.md")
+	if err := os.WriteFile(readmePath, []byte("# About\n\nseeded\n"), 0o644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	// Fire the seed-boundary regen the production code now calls.
+	b.regenWikiIndexAfterSeed(ctx, "test")
+
+	got, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read post-state index: %v", err)
+	}
+	body := string(got)
+	if !strings.Contains(body, "team/about/README.md") {
+		t.Fatalf("expected index/all.md to list team/about/README.md after regen, got:\n%s", body)
+	}
+	if strings.Contains(body, "_No articles yet._") {
+		t.Fatalf("expected index/all.md to drop empty-state marker after regen, got:\n%s", body)
+	}
+}
+
+// TestRegenWikiIndexAfterSeed_NoWorkerIsNoop covers the non-markdown
+// backend branch. Helpers callers rely on must not panic when the broker
+// has no wiki worker attached (e.g. SQLite-only deployments). The fix's
+// guard is the only thing standing between this state and a nil-deref.
+func TestRegenWikiIndexAfterSeed_NoWorkerIsNoop(t *testing.T) {
+	b := newTestBroker(t)
+	// No worker installed — exercise the early return.
+	b.regenWikiIndexAfterSeed(context.Background(), "test no worker")
+}


### PR DESCRIPTION
## Summary

Three call sites now invoke a new helper `regenWikiIndexAfterSeed`:
- `runSeedPhase` (blueprint + scratch paths) after stub materialization.
- `runScanPhase` (website scan path) after `SeedCompanyContext` returns.
- `runCompanySeedJob` (boot-time legacy entry point) after the seed completes.

`operations.SeedCompanyContext` and the scratch stub writer both `atomicWrite` to disk — they bypass `(*WikiWorker).Enqueue`, so the per-commit `IndexRegen` in `(*Repo).Commit` never fires for those paths. Before this fix the post-seed snapshot of `wiki/index/all.md` stayed at the boot-reconcile `_No articles yet._` placeholder even though `team/about/README.md` (and friends) were on disk.

Helper is best-effort: errors are logged, never returned. Idempotent when there are no new articles. Returns silently when the markdown backend is not active (worker or repo nil) so the SQLite-only deployment path is safe.

## Test plan

- [x] `go test -short -race -count=1 -run RegenWikiIndexAfterSeed ./internal/team/...` — both new tests pass (no-worker noop + direct-disk-write reconciliation).
- [x] `gofmt -l .`, `go vet ./...` clean.
- [x] Manual smoke: booted broker under isolated HOME, walked onboarding with `https://example.com`. With #941 alone the scan-fail path writes no `team/about/*.md`, so the regen has nothing to add — but the index regen call IS firing (no panic, no nil deref). Combined with #963 (which writes the README + company.md + owner.md on the scan-fail path) the index will list those files; the verify-wave-2 branch will exercise that path end-to-end.

Closes #941.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the wiki index is regenerated immediately after seeding and after scanning so articles written directly to disk are picked up; regeneration is best-effort, uses a short timeout, and won’t fail the overall flow.

* **Tests**
  * Added regression tests covering index regeneration picking up direct-disk writes and safe no-op behavior when the wiki worker is absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->