### PR TITLE
fix(onboarding): replace inconsistent step counter with phase labels (#939)

### DIFF
--- a/web/e2e/screenshots/wizard-step-counter.mjs
+++ b/web/e2e/screenshots/wizard-step-counter.mjs
@@ -1,0 +1,92 @@
+// Capture the OnboardingChat (full-screen wizard) header label per phase
+// for issue #939.
+//
+// Before this fix, the header read:
+//   STEP 1 OF 5 · OFFICE NAME
+//   STEP 2 OF 5 · WHO YOU ARE
+//   PHASE: WEBSITE        (no counter — fell through to fallback)
+//   PHASE: SCAN           (no counter — fell through to fallback)
+//   STEP 3 OF 5 · PICK A STARTING BLUEPRINT
+//   STEP 5 OF 5 · FIRST TASK   (step 4 silently skipped on scratch path)
+//
+// After: each phase shows a short human label, no step counter.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh wizard-step-counter <pr-number>
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+function stateFor(phase, extra = {}) {
+  return {
+    onboarded: false,
+    phase,
+    form_answers: { company_name: "Acme Billing" },
+    pending_suggestion: null,
+    ...extra,
+  };
+}
+
+async function installMocks(context, stateFixture) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      await ctx.route("**/api/onboarding/state", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(stateFixture),
+        }),
+      );
+      await ctx.route("**/api/onboarding/answer", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true }),
+        }),
+      );
+    },
+  });
+}
+
+async function bootWizard(page) {
+  await page.goto(DEFAULT_BASE, { waitUntil: "load" });
+  // Full-screen wizard mounts at top level via RootRoute when the boot
+  // phase is set and onboarded is false.
+  await page.waitForSelector('[data-testid="onboarding-chat"]', {
+    timeout: 15_000,
+  });
+  await page.waitForTimeout(300);
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 800 },
+});
+
+const FRAMES = [
+  ["greet", "01-greet-office-name"],
+  ["identity", "02-identity-what-you-do"],
+  ["website", "03-website"],
+  ["scan", "04-scan"],
+  ["blueprint", "05-blueprint-pick-a-starter"],
+  ["team", "06-team-confirm"],
+  ["bridge", "07-bridge-first-task"],
+];
+
+for (const [phase, label] of FRAMES) {
+  await installMocks(context, stateFor(phase));
+  await bootWizard(page);
+  await shotPage(page, OUT, label);
+}
+
+console.log(`captured ${FRAMES.length} screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/onboarding/OnboardingChat.test.tsx
+++ b/web/src/components/onboarding/OnboardingChat.test.tsx
@@ -4,8 +4,10 @@
  * The wizard renders outside the office Shell. Pins the structural
  * contract:
  *   - data-phase reflects the current onboarding phase
- *   - phase labels read like a wizard ("Step N of 5 · …") not raw enum
- *     names
+ *   - phase labels read as short human beats ("Office name", "What you
+ *     do", "Pick a starter"), never raw enum names. No step counter
+ *     ("Step N of M") — the scratch path skips phases, so a fixed
+ *     denominator would lie (#939).
  *   - InterviewBar mounts inside the footer so chip / form-field cards
  *     surface as the input zone
  *   - When there's no pending suggestion, a hint banner appears in place
@@ -73,10 +75,35 @@ describe("OnboardingChat", () => {
     expect(screen.getByTestId("interview-bar")).toBeDefined();
   });
 
-  it("translates phase enum into a wizard-style step label", async () => {
+  it("translates phase enum into a short human label, not the raw enum", async () => {
     getMock.mockResolvedValue({ phase: "blueprint", pending_suggestion: null });
     render(<OnboardingChat />, { wrapper });
-    await waitFor(() => expect(screen.getByText(/Step 3 of 5/)).toBeDefined());
+    await waitFor(() =>
+      expect(screen.getByText(/Pick a starter/i)).toBeDefined(),
+    );
+    // Guard against regressing to the inconsistent step counter format.
+    expect(screen.queryByText(/Step \d of \d/)).toBeNull();
+  });
+
+  it("labels the previously-uncovered website phase", async () => {
+    getMock.mockResolvedValue({ phase: "website", pending_suggestion: null });
+    render(<OnboardingChat />, { wrapper });
+    await waitFor(() => expect(screen.getByText(/^Website$/)).toBeDefined());
+  });
+
+  it("labels the previously-uncovered scan phase", async () => {
+    getMock.mockResolvedValue({ phase: "scan", pending_suggestion: null });
+    render(<OnboardingChat />, { wrapper });
+    await waitFor(() =>
+      expect(screen.getByText(/Scanning your site/i)).toBeDefined(),
+    );
+  });
+
+  it("labels the identity phase as 'What you do', not 'Who you are'", async () => {
+    getMock.mockResolvedValue({ phase: "identity", pending_suggestion: null });
+    render(<OnboardingChat />, { wrapper });
+    await waitFor(() => expect(screen.getByText(/What you do/i)).toBeDefined());
+    expect(screen.queryByText(/Who you are/i)).toBeNull();
   });
 
   it("shows a hint when no pending suggestion is present", async () => {

--- a/web/src/components/onboarding/OnboardingChat.tsx
+++ b/web/src/components/onboarding/OnboardingChat.tsx
@@ -38,17 +38,22 @@ const CEO_ONBOARDING_CHANNEL = directChannelSlug(CEO_AGENT_SLUG);
 
 /**
  * Phase → human-readable label for the wizard header. Order matches the
- * deterministic state machine in broker_onboarding_phase2.go. The labels
- * are intentionally short — they replace the dot-progress indicator the
- * old wizard used so the user can see where they are without leaving the
- * conversation.
+ * deterministic state machine in broker_onboarding_phase2.go.
+ *
+ * No `Step N of M · …` counter: the scratch path skips team-trim and the
+ * skip-website path skips scan, so any fixed denominator lies to the user
+ * (see #939). Each label just names what the CEO is doing in this beat —
+ * "feels like a colleague" beats "feels like a form".
  */
 const PHASE_LABELS: Record<string, string> = {
-  greet: "Step 1 of 5 · Office name",
-  identity: "Step 2 of 5 · Who you are",
-  blueprint: "Step 3 of 5 · Pick a starting blueprint",
-  team: "Step 4 of 5 · Confirm the team",
-  bridge: "Step 5 of 5 · First task",
+  greet: "Office name",
+  identity: "What you do",
+  website: "Website",
+  scan: "Scanning your site",
+  blueprint: "Pick a starter",
+  team: "Confirm the team",
+  seed: "Setting up your office",
+  bridge: "First task",
   draft: "Drafting your first issue",
   approve: "Review and approve",
   kickoff: "Starting your office",
@@ -57,7 +62,7 @@ const PHASE_LABELS: Record<string, string> = {
 
 function phaseLabel(phase: string | undefined): string {
   if (!phase) return "Loading…";
-  return PHASE_LABELS[phase] ?? `Phase: ${phase}`;
+  return PHASE_LABELS[phase] ?? phase;
 }
 
 function parsePendingSuggestion(raw: unknown): CeoSuggestion | null {


### PR DESCRIPTION
## Summary

The CEO onboarding wizard header used a \`Step N of 5 · …\` format that lied to the user in three places:

- The \`website\` and \`scan\` phases were never registered in \`PHASE_LABELS\`, so they rendered with the raw fallback \`Phase: website\` / \`Phase: scan\` — no counter at all.
- The scratch path (no blueprint) skips the team-trim phase, so the counter jumped from \`Step 3 of 5\` directly to \`Step 5 of 5\` — step 4 silently vanished.
- The \`identity\` phase was labelled \`Who you are\`, but the actual prompt is \`What does {company} do?\` — a company description, not a who-you-are question.

This PR drops the step counter entirely and replaces each phase header with a short human label naming what the CEO is doing in this beat:

| Phase | Before | After |
|---|---|---|
| greet | Step 1 of 5 · Office name | Office name |
| identity | Step 2 of 5 · Who you are | What you do |
| website | Phase: website | Website |
| scan | Phase: scan | Scanning your site |
| blueprint | Step 3 of 5 · Pick a starting blueprint | Pick a starter |
| team | Step 4 of 5 · Confirm the team | Confirm the team |
| seed | Phase: seed | Setting up your office |
| bridge | Step 5 of 5 · First task | First task |

This is the preferred path called out in the issue. Keeping the counter and fixing the accounting would have required recomputing N+M against the actual remaining phases (after skip-website and skip-team-trim) — feasible but brittle and at odds with the "feels like a colleague" product principle. Form-mode chrome belongs in forms, not in conversations.

Backend phase enum strings are unchanged; this is purely the frontend label translation in \`OnboardingChat.tsx\`.

## Files changed

- \`web/src/components/onboarding/OnboardingChat.tsx\` — new \`PHASE_LABELS\` map, no counter, full phase coverage.
- \`web/src/components/onboarding/OnboardingChat.test.tsx\` — replaced the \`Step 3 of 5\` assertion with a negative-assertion guard against \`Step \\d of \\d\`, plus coverage for the previously-uncovered \`website\` / \`scan\` phases and the \`What you do\` rename.
- \`web/e2e/screenshots/wizard-step-counter.mjs\` — screenshot harness walking the full phase set.

## Test plan

- [x] \`bash scripts/test-web.sh web/src/components/onboarding/OnboardingChat.test.tsx\` (8 passed)
- [x] \`bash scripts/test-web.sh\` (1619 passed, 2 skipped — no other tests asserted the old labels)
- [x] \`bunx tsc --noEmit\` (clean)
- [x] \`bunx biome check --write\` (clean for changed files; only pre-existing warning in unchanged code)
- [x] \`go build ./...\` (clean — no Go change, but verified the backend phase enum surface is untouched)
- [ ] Screenshots captured via \`bash web/e2e/screenshots/publish.sh wizard-step-counter <pr-number>\` (will append once PR number is known)
- [ ] Manual smoke: walk onboarding end-to-end on the scratch + skip-website path — verify no \`Step N of M\` text appears.

Closes #939


## Screenshots

![01-greet-office-name](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/01-greet-office-name.png)

![02-identity-what-you-do](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/02-identity-what-you-do.png)

![03-website](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/03-website.png)

![04-scan](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/04-scan.png)

![05-blueprint-pick-a-starter](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/05-blueprint-pick-a-starter.png)

![06-team-confirm](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/06-team-confirm.png)

![07-bridge-first-task](https://github.com/nex-crm/wuphf/raw/screenshots/pr-969/07-bridge-first-task.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **UI Updates**
  * Onboarding phase labels now display concise, descriptive text instead of step counter formatting for improved readability during the wizard experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->