### PR TITLE
fix(onboarding): swap scan chip for next pending suggestion on terminal status (#936)

### DIFF
--- a/web/e2e/screenshots/scan-chip-desync-fix.mjs
+++ b/web/e2e/screenshots/scan-chip-desync-fix.mjs
@@ -1,0 +1,192 @@
+// Capture the scan-chip → blueprint chip-row swap that fixes #936.
+//
+// Two frames:
+//   01-stranded — what users saw BEFORE the fix: scanning chip pinned in the
+//                 composer slot with no buttons. Reproduced by stubbing
+//                 /onboarding/state to return the scan chip as the pending
+//                 suggestion even though the broker has moved on.
+//   02-recovered — what users see AFTER the fix lands: the blueprint chip-row
+//                  swaps into the slot automatically (no hard reload),
+//                  surfacing the Bookkeeping / Niche CRM / scratch options.
+//
+// The two frames use the same mock backend layer; only the
+// /onboarding/state response differs between mounts, which is exactly what
+// the SSE-driven onboarding-state invalidate (useBrokerEvents.ts) causes
+// in production.
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const baseAnswers = {
+  company_name: "Acme Billing",
+  description: "Subscription billing for indie SaaS",
+  website_url: "https://example.com",
+};
+
+// Frame 1 — the broken state: scan chip pinned with no buttons.
+const STATE_STRANDED = {
+  onboarded: false,
+  phase: "scan",
+  form_answers: baseAnswers,
+  pending_suggestion: {
+    id: "scan-progress-example-com",
+    phase: "scan",
+    kind: "ceo_scan_chip",
+    payload: {
+      url: "https://example.com",
+      status: "scanning",
+      scanning_label: "Scanning example.com…",
+    },
+  },
+};
+
+// Frame 2 — the recovered state: blueprint chip-row swaps in automatically.
+const STATE_RECOVERED = {
+  onboarded: false,
+  phase: "blueprint",
+  form_answers: { ...baseAnswers, scan_complete: false },
+  pending_suggestion: {
+    id: "blueprint-pick",
+    phase: "blueprint",
+    kind: "ceo_chip_row",
+    payload: {
+      field: "blueprint_id",
+      label: "Pick a starter template, or start from scratch:",
+      options: [
+        { id: "bookkeeping-invoicing-service", label: "Bookkeeping" },
+        { id: "niche-crm", label: "Niche CRM" },
+        { id: "youtube-factory", label: "YouTube Factory" },
+        { id: "", label: "Start from scratch" },
+      ],
+    },
+  },
+};
+
+// Chat history shared between frames: the user submitted example.com, the
+// broker emitted the scanning chip, then the scan failed.
+const dmSlug = "dm:ceo:onboarding";
+const FAILED_SCAN_MESSAGES = [
+  {
+    id: "msg-1",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "text",
+    content: "Got a website I can scan for context?",
+    timestamp: "2026-05-20T12:43:10Z",
+  },
+  {
+    id: "msg-2",
+    from: "human",
+    channel: dmSlug,
+    kind: "text",
+    content: "https://example.com",
+    timestamp: "2026-05-20T12:43:14Z",
+  },
+  {
+    id: "msg-3",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "ceo_scan_chip",
+    content: "Scanning example.com…",
+    payload: { url: "https://example.com", status: "scanning" },
+    timestamp: "2026-05-20T12:43:15Z",
+  },
+  {
+    id: "msg-4",
+    from: "ceo",
+    channel: dmSlug,
+    kind: "ceo_scan_chip",
+    content: "Couldn't read that URL",
+    payload: {
+      url: "https://example.com",
+      status: "failed",
+      failed_label: "Couldn't read that URL",
+    },
+    timestamp: "2026-05-20T12:43:18Z",
+  },
+];
+
+async function installFrameMocks(context, stateFixture, messages) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      await ctx.route("**/api/onboarding/state", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(stateFixture),
+        }),
+      );
+      await ctx.route("**/api/onboarding/answer", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true }),
+        }),
+      );
+      await ctx.route("**/api/onboarding/transition", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ ok: true, phase: stateFixture.phase }),
+        }),
+      );
+      await ctx.route(
+        `**/api/messages?channel=${encodeURIComponent(dmSlug)}**`,
+        (r) =>
+          r.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ messages }),
+          }),
+      );
+      await ctx.route("**/api/messages**", (r) =>
+        r.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ messages }),
+        }),
+      );
+    },
+  });
+}
+
+async function bootFrame(page) {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("wuphf:onboarding-v2", "1");
+      window.localStorage.setItem("wuphf:in-ceo-onboarding", "1");
+    } catch {
+      // private-mode tabs; the query param fallback handles it.
+    }
+  });
+  await page.goto(`${DEFAULT_BASE}/?onboardingV2=1`, { waitUntil: "load" });
+  await page.waitForSelector('[data-testid="onboarding-dm-route"]', {
+    timeout: 15_000,
+  });
+  await page.waitForTimeout(400);
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 800 },
+});
+
+try {
+  await installFrameMocks(context, STATE_STRANDED, FAILED_SCAN_MESSAGES);
+  await bootFrame(page);
+  await shotPage(page, OUT, "01-stranded-before-fix");
+
+  await installFrameMocks(context, STATE_RECOVERED, FAILED_SCAN_MESSAGES);
+  await bootFrame(page);
+  await shotPage(page, OUT, "02-recovered-after-fix");
+
+  console.log(`captured 2 screenshots to ${OUT}`);
+} finally {
+  await browser.close();
+}

--- a/web/src/components/messages/InterviewBar.scanChipSwap.test.tsx
+++ b/web/src/components/messages/InterviewBar.scanChipSwap.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Regression test for nex-crm/wuphf#936 — frontend desync after scan failure.
+ *
+ * The CEO wizard renders the current PendingSuggestion in a single composer
+ * slot. When the broker swaps the suggestion from `ceo_scan_chip`
+ * (phase=scan) to `ceo_chip_row` (phase=blueprint) — which is exactly what
+ * happens when a website scan fails and `advanceAfterScan` transitions to
+ * PhaseBlueprint — the slot must re-render with the new card immediately.
+ *
+ * Before the fix the slot kept showing the scan chip until a hard reload
+ * because `useOnboardingState` only polled every 3s and the read-only scan
+ * chip never had buttons. This test pins the swap behaviour at the
+ * CeoCardSection layer: switch the pendingSuggestion in the
+ * OnboardingDMContext and assert the scan chip is gone and the new
+ * chip-row buttons render.
+ */
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingDMContextProvider } from "../onboarding/OnboardingDMRoute";
+import type { CeoSuggestion } from "../onboarding/types";
+import { CeoCardSection } from "./InterviewBar";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return { ...actual, get: vi.fn(), post: vi.fn() };
+});
+
+vi.mock("../../hooks/useRequests", () => ({
+  useRequests: () => ({ pending: [] }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const scanChipSuggestion: CeoSuggestion = {
+  id: "scan-progress-example-com",
+  phase: "scan",
+  kind: "ceo_scan_chip",
+  payload: {
+    field: "website_url",
+    url: "https://example.com",
+    status: "scanning",
+  },
+};
+
+const blueprintChipRowSuggestion: CeoSuggestion = {
+  id: "blueprint-pick",
+  phase: "blueprint",
+  kind: "ceo_chip_row",
+  payload: {
+    field: "blueprint_id",
+    label: "Pick a starter template, or start from scratch:",
+    options: [
+      { id: "bookkeeping-invoicing-service", label: "Bookkeeping" },
+      { id: "niche-crm", label: "Niche CRM" },
+      { id: "", label: "Start from scratch" },
+    ],
+  },
+};
+
+interface HarnessProps {
+  initial: CeoSuggestion;
+  next: CeoSuggestion;
+}
+
+/**
+ * Test harness that exposes a button to swap the OnboardingDMContext's
+ * pendingSuggestion from `initial` to `next`. Mirrors how the SSE-driven
+ * invalidation of `["onboarding-state"]` in useBrokerEvents.ts causes the
+ * `useOnboardingState` query to refetch with the new suggestion — but
+ * compressed to a single synchronous click so we don't depend on real
+ * SSE or polling.
+ */
+function SwapHarness({ initial, next }: HarnessProps) {
+  const [suggestion, setSuggestion] = useState<CeoSuggestion>(initial);
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={qc}>
+      <OnboardingDMContextProvider
+        value={{ phase: suggestion.phase, pendingSuggestion: suggestion }}
+      >
+        <button type="button" onClick={() => setSuggestion(next)}>
+          swap
+        </button>
+        <CeoCardSection />
+      </OnboardingDMContextProvider>
+    </QueryClientProvider>
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CeoCardSection — scan-chip → blueprint-pick swap (regression #936)", () => {
+  it("renders the scan chip initially, then swaps to the blueprint chip-row when the suggestion id changes", () => {
+    render(
+      <SwapHarness
+        initial={scanChipSuggestion}
+        next={blueprintChipRowSuggestion}
+      />,
+    );
+
+    // Initial render: read-only scan chip, no buttons in the slot.
+    const section = screen.getByTestId("ceo-card-section");
+    expect(section.getAttribute("data-kind")).toBe("ceo_scan_chip");
+    expect(section.getAttribute("data-suggestion-id")).toBe(
+      "scan-progress-example-com",
+    );
+    expect(screen.getByTestId("ceo-scan-chip")).toBeInTheDocument();
+    // ceo-chip-row is the testid CeoChipRow renders.
+    expect(screen.queryByTestId("ceo-chip-row")).toBeNull();
+
+    // Swap the pending suggestion (simulating the SSE-driven onboarding-state
+    // invalidate landing the new blueprint-pick into the context).
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "swap" }));
+    });
+
+    // Post-swap: scan chip is gone, chip-row is mounted, and the section's
+    // data attributes reflect the new suggestion identity.
+    const swapped = screen.getByTestId("ceo-card-section");
+    expect(swapped.getAttribute("data-kind")).toBe("ceo_chip_row");
+    expect(swapped.getAttribute("data-suggestion-id")).toBe("blueprint-pick");
+    expect(screen.queryByTestId("ceo-scan-chip")).toBeNull();
+    expect(screen.getByTestId("ceo-chip-row")).toBeInTheDocument();
+    // The blueprint options must render as interactive chips (role=option
+    // inside the listbox) — this is what the user was missing while
+    // stranded with the scan chip pinned.
+    expect(
+      screen.getByRole("option", { name: "Bookkeeping" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Start from scratch" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -730,12 +730,20 @@ export function CeoCardSection() {
     await submitAnswer(field, "");
   };
 
+  // Key the inner card on the suggestion id so React forcibly unmounts the
+  // previous card when the broker swaps it. The useEffect above resets the
+  // local stage when the id changes, but keying is defense in depth: it
+  // guarantees no stale child state (focus, in-flight submit handler closure,
+  // sub-component refs) leaks from one suggestion into the next. The
+  // failure-mode this guards against is the scan-chip → blueprint-pick swap
+  // after a scan failure (see useBrokerEvents.ts onboarding-state invalidate).
   return (
     <section
       className="ceo-card-section"
       aria-label="CEO question"
       data-testid="ceo-card-section"
       data-kind={pendingSuggestion.kind}
+      data-suggestion-id={pendingSuggestion.id}
     >
       {renderCeoCard(
         pendingSuggestion,
@@ -845,8 +853,15 @@ function renderCeoCard(
   onSkip: (field: string) => Promise<void>,
   onStageChange?: (next: CardStage) => void,
 ): ReactNode {
+  // Key on the suggestion id so React unmounts and remounts the card when the
+  // broker swaps the pending suggestion (e.g. ceo_scan_chip → ceo_chip_row
+  // after a scan failure). Without the key React would reconcile the same
+  // StructuredMessageCard instance across kinds and any child-level state
+  // (focus, controlled inputs, sub-component refs) could leak from one
+  // suggestion into the next.
   return (
     <StructuredMessageCard
+      key={suggestion.id}
       suggestion={suggestion}
       stage={stage}
       committedValue={committedValue}

--- a/web/src/hooks/useBrokerEvents.ts
+++ b/web/src/hooks/useBrokerEvents.ts
@@ -131,6 +131,17 @@ export function useBrokerEvents(enabled: boolean) {
       void queryClient.invalidateQueries({ queryKey: ["thread-messages"] });
       void queryClient.invalidateQueries({ queryKey: ["office-members"] });
       void queryClient.invalidateQueries({ queryKey: ["channel-members"] });
+      // Refresh onboarding state on every message: the deterministic CEO
+      // wizard (broker_onboarding_phase2.advancePhase + advanceAfterScan)
+      // mutates s.PendingSuggestion in lockstep with the CEO DM message it
+      // appends, but those mutations have no dedicated SSE event yet. Without
+      // this nudge the chat surface can sit on a stale pending suggestion for
+      // up to the 3s poll interval — most visibly after a scan failure, where
+      // the read-only scan chip would otherwise stay pinned in the composer
+      // slot while the broker has already moved on to PhaseBlueprint. The
+      // query has no observers outside onboarding, so the invalidate is a
+      // no-op on the regular shell surfaces. Closes nex-crm/wuphf#936.
+      void queryClient.invalidateQueries({ queryKey: ["onboarding-state"] });
     });
     source.addEventListener("activity", (event) => {
       // CRITICAL REGRESSION: cache invalidation MUST keep firing — other


### PR DESCRIPTION
## Summary

After a website scan fails during onboarding, the broker correctly transitions to `PhaseBlueprint` and writes a new `PendingSuggestion` (`blueprint-pick`), but the frontend kept showing the read-only "Scanning..." chip until a hard reload. The user was stranded with no buttons.

Two surgical changes on the frontend (Go broker is left alone — it correctly writes the new `PendingSuggestion` and broadcasts the new card message):

1. **`useBrokerEvents` now invalidates `["onboarding-state"]`** alongside `["messages"]` on every SSE `message` event. The broker emits the new blueprint chip-row as a CEO DM message in the same critical section that updates `PendingSuggestion`, so any message arrival is a reliable signal that the onboarding state may have moved. The query has no observers outside onboarding, so the invalidate is a no-op on the regular shell.
2. **`CeoCardSection` keys its inner `StructuredMessageCard` on the suggestion id** and exposes `data-suggestion-id` on the section element. Keying is defense in depth on top of the existing `useEffect`-based stage reset: a forced unmount guarantees no stale child state (focus, controlled inputs, sub-component refs) leaks across the `scan-chip → blueprint-pick` swap.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check` clean (only pre-existing warnings on unrelated lines in InterviewBar.tsx)
- [x] `bash scripts/test-web.sh web/src/components/messages/InterviewBar.scanChipSwap.test.tsx` — new regression test passes
- [x] `bash scripts/test-web.sh` — full web suite (170 files, 1617 tests) passes
- [x] `go build -o /tmp/wuphf-scan-chip-fix ./cmd/wuphf` clean
- [x] Screenshot harness `web/e2e/screenshots/scan-chip-desync-fix.mjs` captures the before/after states with stubbed `/onboarding/state` swaps (mirrors the SSE-driven invalidate)

## Regression test

`web/src/components/messages/InterviewBar.scanChipSwap.test.tsx` mounts `CeoCardSection` with the scan chip as the initial pending suggestion, swaps to the blueprint chip-row via the `OnboardingDMContext`, and asserts the scan chip is gone and the Bookkeeping / Start-from-scratch options render.

## Why frontend-only

The Go broker side of this loop is correct: `runScanPhase` → `advanceAfterScan` → `advancePhase(PhaseBlueprint)` writes the new `PendingSuggestion`, appends the blueprint card as a CEO DM message, and the message append fires the existing SSE `message` event. The bug was purely that the frontend cache for `/onboarding/state` did not listen for that event.

Closes #936


## Screenshots

Before the fix — composer slot stuck on the scanning chip with no buttons (`data-phase="scan"`):

![01-stranded-before-fix](https://github.com/nex-crm/wuphf/raw/screenshots/pr-970/01-stranded-before-fix.png)

After the fix — slot swaps to the blueprint chip-row (`data-phase="blueprint"`), Bookkeeping / Niche CRM / YouTube Factory / Start from scratch options render:

![02-recovered-after-fix](https://github.com/nex-crm/wuphf/raw/screenshots/pr-970/02-recovered-after-fix.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where onboarding card elements would not properly reset when transitioning between different scanning phases.

* **Tests**
  * Added regression test and E2E screenshot tests to verify onboarding UI correctly re-renders during phase transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->