### PR TITLE
fix(wiki): replace indefinite 'Loading article…' with timeout + error state + notebooks list (#935)

### DIFF
--- a/web/e2e/screenshots/wiki-loader-stuck.mjs
+++ b/web/e2e/screenshots/wiki-loader-stuck.mjs
@@ -1,0 +1,188 @@
+// Capture the wiki article loader's three observable states for issue #935:
+//   1. healthy fetch — article renders within ~1s
+//   2. stalled fetch — loader transitions to a retry-able error after 5s
+//   3. `#/wiki/notebooks` — the legacy splat now redirects to /notebooks
+//      and lands on the bookshelf empty state instead of hanging on
+//      "Loading article…"
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh wiki-loader-stuck <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const STUB_ARTICLE = {
+  path: "team/about/README.md",
+  title: "About",
+  content:
+    "# About\n\nThis team works on local-first AI agents. The home page is the wiki, and the wiki writes itself as agents do work.",
+  last_edited_by: "ceo",
+  last_edited_ts: "2026-05-19T12:00:00Z",
+  revisions: 4,
+  contributors: ["ceo", "pm"],
+  backlinks: [],
+  word_count: 42,
+  categories: ["About"],
+};
+
+const EMPTY_CATALOG = { entries: [] };
+const EMPTY_SECTIONS = { sections: [] };
+const EMPTY_HISTORY = { commits: [] };
+const EMPTY_NOTEBOOK_CATALOG = {
+  agents: [],
+  total_agents: 0,
+  total_entries: 0,
+  pending_promotion: 0,
+};
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1480, height: 980 },
+});
+
+// ─── 1. Healthy article load ──
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/wiki/catalog*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_CATALOG),
+      }),
+    );
+    await ctx.route("**/api/wiki/sections*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_SECTIONS),
+      }),
+    );
+    await ctx.route("**/api/wiki/article*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(STUB_ARTICLE),
+      }),
+    );
+    await ctx.route("**/api/wiki/history*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_HISTORY),
+      }),
+    );
+    await ctx.route("**/api/wiki/visual-artifact*", (r) =>
+      r.fulfill({ status: 404, body: "" }),
+    );
+    await ctx.route("**/api/humans*", (r) =>
+      r.fulfill({ contentType: "application/json", body: JSON.stringify([]) }),
+    );
+  },
+});
+await bootShell(page);
+await page.evaluate(() => {
+  window.location.hash = "#/wiki/team/about/README.md";
+});
+await page.waitForSelector('[data-testid="wk-article-body"]', {
+  timeout: 5_000,
+});
+await shotPage(page, OUT, "01-wiki-article-loaded");
+
+// ─── 2. Stalled fetch → retry-able error ──
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/wiki/catalog*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_CATALOG),
+      }),
+    );
+    await ctx.route("**/api/wiki/sections*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_SECTIONS),
+      }),
+    );
+    // Hold the article fetch open so the loader transitions to the
+    // 5s-timeout error state. This is exactly the B-08 hang the issue
+    // describes — without the fix the placeholder would never resolve.
+    await ctx.route("**/api/wiki/article*", () => new Promise(() => {}));
+    await ctx.route("**/api/wiki/history*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_HISTORY),
+      }),
+    );
+    await ctx.route("**/api/wiki/visual-artifact*", (r) =>
+      r.fulfill({ status: 404, body: "" }),
+    );
+    await ctx.route("**/api/humans*", (r) =>
+      r.fulfill({ contentType: "application/json", body: JSON.stringify([]) }),
+    );
+  },
+});
+await bootShell(page);
+await page.evaluate(() => {
+  window.location.hash = "#/wiki/team/about/README.md";
+});
+// Wait past the 5s timeout, then capture the error+retry state.
+await page.waitForSelector(".wk-retry-btn", { timeout: 10_000 });
+await shotPage(page, OUT, "02-wiki-article-timeout-retry");
+
+// ─── 3. `#/wiki/notebooks` redirects to /notebooks (B-17 fix) ──
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/wiki/catalog*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_CATALOG),
+      }),
+    );
+    await ctx.route("**/api/wiki/sections*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_SECTIONS),
+      }),
+    );
+    await ctx.route("**/api/notebook/catalog*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(EMPTY_NOTEBOOK_CATALOG),
+      }),
+    );
+    await ctx.route("**/api/review/list*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ reviews: [] }),
+      }),
+    );
+  },
+});
+await bootShell(page);
+await page.evaluate(() => {
+  window.location.hash = "#/wiki/notebooks";
+});
+await page.waitForSelector('[data-testid="notebook-surface"]', {
+  timeout: 10_000,
+});
+// Confirm the hash landed on /notebooks, not #/wiki/notebooks.
+await page.waitForFunction(
+  () => window.location.hash === "#/notebooks",
+  null,
+  { timeout: 5_000 },
+);
+await shotPage(page, OUT, "03-wiki-notebooks-redirect");
+
+console.log(`captured 3 screenshots to ${OUT}`);
+if (errors.length > 0) {
+  console.error("page errors during capture:", errors);
+}
+await browser.close();

--- a/web/src/components/wiki/WikiArticle.test.tsx
+++ b/web/src/components/wiki/WikiArticle.test.tsx
@@ -200,6 +200,85 @@ describe("<WikiArticle content>", () => {
     await waitFor(() =>
       expect(screen.getByText(/network down/)).toBeInTheDocument(),
     );
+    // The error state must expose a retry affordance so the user is not
+    // stuck on a dead end if the broker recovers.
+    expect(
+      screen.getByRole("button", { name: /retry loading article/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("<WikiArticle loader timeout and retry>", () => {
+  it("transitions Loading article… to an error+retry state on timeout and retries on click", async () => {
+    // Arrange — first call hangs forever to simulate a stalled broker.
+    type Resolve = (v: api.WikiArticle) => void;
+    let firstResolve: Resolve | null = null;
+    const fetchSpy = vi.spyOn(api, "fetchArticle");
+    fetchSpy.mockImplementationOnce(
+      () =>
+        new Promise<api.WikiArticle>((r) => {
+          firstResolve = r as Resolve;
+        }),
+    );
+    // Second call (after Retry) resolves successfully.
+    fetchSpy.mockResolvedValueOnce({
+      path: "team/about/README.md",
+      title: "About",
+      content: "Body after retry.",
+      last_edited_by: "pm",
+      last_edited_ts: new Date().toISOString(),
+      revisions: 1,
+      contributors: ["pm"],
+      backlinks: [],
+      word_count: 3,
+      categories: [],
+    });
+
+    vi.useFakeTimers();
+    try {
+      render(
+        <WikiArticle
+          path="team/about/README.md"
+          catalog={[]}
+          onNavigate={() => {}}
+        />,
+      );
+      expect(screen.getByText(/Loading article/i)).toBeInTheDocument();
+
+      // Advance past the 5s timeout — loader should flip to the error state.
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(
+        screen.getByText(/Still waiting on the broker/i),
+      ).toBeInTheDocument();
+      const retry = screen.getByRole("button", {
+        name: /retry loading article/i,
+      });
+      expect(retry).toBeInTheDocument();
+
+      // Click Retry — the second fetch resolves and the article renders.
+      retry.click();
+      // Release the dangling first promise so it cannot stomp later state.
+      const releaseFirst = firstResolve as Resolve | null;
+      releaseFirst?.({
+        path: "team/about/README.md",
+        title: "About",
+        content: "stale",
+        last_edited_by: "pm",
+        last_edited_ts: new Date().toISOString(),
+        revisions: 1,
+        contributors: ["pm"],
+        backlinks: [],
+        word_count: 1,
+        categories: [],
+      });
+      await vi.runAllTimersAsync();
+    } finally {
+      vi.useRealTimers();
+    }
+    await waitFor(() =>
+      expect(screen.getByText(/Body after retry/)).toBeInTheDocument(),
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
   it("shows a loading state before the fetch resolves", async () => {

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -56,6 +56,15 @@ import WikiMaintenanceAssistant from "./WikiMaintenanceAssistant";
 const STALENESS_STALE_DAYS = 30;
 const STALENESS_AGING_DAYS = 7;
 
+/**
+ * If the article fetch has not resolved within this window we treat the
+ * loader as stalled and surface a retry-able error state. Picked to be
+ * comfortably longer than a healthy local broker response (~tens of ms)
+ * while still short enough that a hung request stops looking like a
+ * permanent "Loading article…" placeholder.
+ */
+export const WIKI_ARTICLE_FETCH_TIMEOUT_MS = 5_000;
+
 // StalenessIndicator shows a small badge when an article has not been accessed
 // by anyone (human or agent) in a while. "Agents only" signals an article
 // actively used for context but never opened by a human.
@@ -193,23 +202,97 @@ type MarkdownComponents = ReturnType<typeof buildMarkdownComponents>;
 type DetectedEntity = { kind: EntityKind; slug: string };
 type DetectedPlaybook = NonNullable<ReturnType<typeof detectPlaybook>>;
 
+interface ArticleFetchState {
+  article: WikiArticleT | null;
+  loading: boolean;
+  error: string | null;
+  /**
+   * True once the fetch has been outstanding longer than
+   * WIKI_ARTICLE_FETCH_TIMEOUT_MS. The fetch itself is not aborted — if
+   * the broker eventually answers we still take the response — but the
+   * UI swaps the loading placeholder for a retry-able error state so
+   * the user is never stuck on an indefinite "Loading article…" hang.
+   */
+  timedOut: boolean;
+  retry: () => void;
+}
+
+/**
+ * Drives the article-fetch lifecycle for the wiki right pane. Owns the
+ * timeout that flips the placeholder into an error state and the
+ * retry-nonce that re-runs the fetch when the user clicks Retry.
+ */
+function useArticleFetch(
+  path: string,
+  externalRefreshNonce: number,
+  refreshNonce: number,
+): ArticleFetchState {
+  const [article, setArticle] = useState<WikiArticleT | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
+  useEffect(() => {
+    let cancelled = false;
+    void externalRefreshNonce;
+    void refreshNonce;
+    void retryNonce;
+    setLoading(true);
+    setError(null);
+    setTimedOut(false);
+    const timeoutId = globalThis.setTimeout(() => {
+      if (cancelled) return;
+      setTimedOut(true);
+    }, WIKI_ARTICLE_FETCH_TIMEOUT_MS);
+    fetchArticle(path)
+      .then((a) => {
+        if (cancelled) return;
+        setArticle(a);
+        setTimedOut(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : "Failed to load article");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+        globalThis.clearTimeout(timeoutId);
+      });
+    return () => {
+      cancelled = true;
+      globalThis.clearTimeout(timeoutId);
+    };
+  }, [path, externalRefreshNonce, refreshNonce, retryNonce]);
+  return {
+    article,
+    loading,
+    error,
+    timedOut,
+    retry: () => setRetryNonce((n) => n + 1),
+  };
+}
+
 export default function WikiArticle({
   path,
   catalog,
   onNavigate,
   externalRefreshNonce = 0,
 }: WikiArticleProps) {
-  const [article, setArticle] = useState<WikiArticleT | null>(null);
   const [tab, setTab] = useState<HatBarTab>("article");
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [refreshNonce, setRefreshNonce] = useState(0);
+  const {
+    article,
+    loading,
+    error,
+    timedOut,
+    retry: handleRetry,
+  } = useArticleFetch(path, externalRefreshNonce, refreshNonce);
   const [historyCommits, setHistoryCommits] = useState<
     WikiHistoryCommit[] | null
   >(null);
   const [historyLoading, setHistoryLoading] = useState(true);
   const [historyError, setHistoryError] = useState(false);
   const [liveAgent, setLiveAgent] = useState<string | null>(null);
-  const [refreshNonce, setRefreshNonce] = useState(0);
   const [humans, setHumans] = useState<HumanIdentity[]>([]);
   const [visualArtifact, setVisualArtifact] =
     useState<RichArtifactDetail | null>(null);
@@ -233,31 +316,6 @@ export default function WikiArticle({
       cancelled = true;
     };
   }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    // These nonce values are explicit refetch triggers. The effect body only
-    // needs their change notification, not their numeric value.
-    void externalRefreshNonce;
-    void refreshNonce;
-    setLoading(true);
-    setError(null);
-    fetchArticle(path)
-      .then((a) => {
-        if (cancelled) return;
-        setArticle(a);
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : "Failed to load article");
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [path, externalRefreshNonce, refreshNonce]);
 
   useEffect(() => {
     let cancelled = false;
@@ -365,9 +423,31 @@ export default function WikiArticle({
     [resolver, onNavigate],
   );
 
-  if (loading) return <div className="wk-loading">Loading article…</div>;
-  if (error) return <div className="wk-error">Error: {error}</div>;
-  if (!article) return <div className="wk-error">Article not found.</div>;
+  if (loading && !timedOut) {
+    return (
+      <div className="wk-loading" role="status" aria-busy="true">
+        Loading article…
+      </div>
+    );
+  }
+  if (loading && timedOut) {
+    return (
+      <ArticleErrorState
+        message="Still waiting on the broker. The request has not responded in 5 seconds."
+        onRetry={handleRetry}
+      />
+    );
+  }
+  if (error) {
+    return (
+      <ArticleErrorState message={`Error: ${error}`} onRetry={handleRetry} />
+    );
+  }
+  if (!article) {
+    return (
+      <ArticleErrorState message="Article not found." onRetry={handleRetry} />
+    );
+  }
 
   const toc = buildTocFromMarkdown(article.content);
   const entity = detectEntity(article.path);
@@ -466,6 +546,28 @@ export default function WikiArticle({
         />
       )}
     </>
+  );
+}
+
+function ArticleErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="wk-error" role="alert">
+      <p className="wk-error-msg">{message}</p>
+      <button
+        type="button"
+        className="wk-retry-btn"
+        onClick={onRetry}
+        aria-label="Retry loading article"
+      >
+        Retry
+      </button>
+    </div>
   );
 }
 

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -327,6 +327,26 @@ interface WikiSurfaceProps {
   route: CurrentRoute;
 }
 
+/**
+ * When a wiki splat path collides with a sibling Wiki-surface tab
+ * (`/wiki/notebooks`, `/wiki/reviews`), redirect to the canonical
+ * top-level route instead of trying to load a non-existent article.
+ * `/wiki/notebooks` used to leave the right pane stuck on
+ * "Loading article…" because fetchArticle would 404 across all
+ * candidate paths and the loader never reconciled — see issue #935.
+ */
+function wikiTabRedirectTarget(
+  articlePath: string | null,
+): "/notebooks" | "/reviews" | null {
+  if (articlePath === "notebooks" || articlePath === "notebooks/") {
+    return "/notebooks";
+  }
+  if (articlePath === "reviews" || articlePath === "reviews/") {
+    return "/reviews";
+  }
+  return null;
+}
+
 function WikiSurface({ current, route }: WikiSurfaceProps) {
   // Pam's onActionDone bumps this; Wiki re-fetches article + history when
   // the prop changes. Lifted to the surface so Pam (in the tab bar) can
@@ -334,6 +354,29 @@ function WikiSurface({ current, route }: WikiSurfaceProps) {
   const [articleRefreshNonce, setArticleRefreshNonce] = useState(0);
 
   const articlePath = route.kind === "wiki-article" ? route.articlePath : null;
+  const tabRedirect = wikiTabRedirectTarget(articlePath);
+  useEffect(() => {
+    if (!tabRedirect) return;
+    void router.navigate({ to: tabRedirect, replace: true });
+  }, [tabRedirect]);
+  if (tabRedirect) {
+    return (
+      <div className="wiki-shell" data-testid="wiki-tab-redirect">
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flex: 1,
+            color: "var(--text-tertiary)",
+            fontSize: 14,
+          }}
+        >
+          Redirecting…
+        </div>
+      </div>
+    );
+  }
   const pamArticlePath = current === "wiki" ? articlePath : null;
   const notebookAgentSlug =
     route.kind === "notebook-agent" || route.kind === "notebook-entry"

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1188,6 +1188,27 @@
 .wk-error {
   color: var(--wk-wikilink-broken);
 }
+.wk-error-msg {
+  margin: 0 0 12px;
+}
+.wk-retry-btn {
+  display: inline-block;
+  padding: 6px 14px;
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  color: var(--wk-text);
+  background: var(--wk-paper);
+  border: 1px solid var(--wk-border);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.wk-retry-btn:hover {
+  background: var(--wk-border-light);
+}
+.wk-retry-btn:focus-visible {
+  outline: 2px solid var(--wk-wikilink);
+  outline-offset: 2px;
+}
 
 /* Subtle spinner used for in-flight modal actions. Sized to sit inline with
  * 13px button text without forcing a layout reflow. Wiki-surface scoped —


### PR DESCRIPTION
## Summary

Closes #935. The wiki app shipped two related loader hangs:

- **B-08 — article fetch**: `#/wiki/team/about/README.md` rendered "Loading article…" with no progress and no error. `WikiArticle` had no timeout, so a stalled or 404-saturated request left the placeholder visible forever.
- **B-17 — notebooks tab**: `#/wiki/notebooks` collided with the wiki article splat. `fetchArticle("notebooks")` walked all six candidate paths, every one 404'd, and the same loader hung.

### Fix 1 — `useArticleFetch` hook with 5s timeout + retry

Extracted the article-fetch lifecycle into `useArticleFetch`. After `WIKI_ARTICLE_FETCH_TIMEOUT_MS` (5s) the loader transitions to a real error state with a Retry button and a one-line cause. The fetch is not aborted — a late response is still picked up — but the user is never stuck on the placeholder. Error and not-found branches use the same `ArticleErrorState` component so Retry is available everywhere.

### Fix 2 — `WikiSurface` redirect for reserved tab names

When the wiki splat path equals `notebooks` or `reviews`, `WikiSurface` redirects to the canonical top-level route (`/notebooks`, `/reviews`). Same pattern as the existing `InboxRedirect`/`IssuesRedirect` for legacy URLs.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check src/components/wiki/WikiArticle.tsx src/components/wiki/WikiArticle.test.tsx src/routes/RootRoute.tsx src/styles/wiki.css` clean
- [x] `bash scripts/test-web.sh web/src/components/wiki/` — 349/349 passing
- [x] `bash scripts/test-web.sh` (full web suite) — 1617/1619 passing (2 pre-existing skips)
- [x] New test `transitions Loading article… to an error+retry state on timeout and retries on click` covers the timeout → retry → recovery loop with fake timers
- [ ] Manual smoke (broker): open `#/wiki/team/about/README.md` after onboarding → article renders within 1s
- [ ] Manual smoke: open `#/wiki/notebooks` → redirects to `/notebooks` and renders the bookshelf (or empty state) — no "Loading article…" hang
- [ ] Manual smoke: simulate a stalled broker → loader flips to error+Retry after 5s; Retry recovers when the broker comes back

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-wiki-article-loaded](https://github.com/nex-crm/wuphf/raw/screenshots/pr-971/01-wiki-article-loaded.png)

![02-wiki-article-timeout-retry](https://github.com/nex-crm/wuphf/raw/screenshots/pr-971/02-wiki-article-timeout-retry.png)

![03-wiki-notebooks-redirect](https://github.com/nex-crm/wuphf/raw/screenshots/pr-971/03-wiki-notebooks-redirect.png)

