### PR TITLE
fix(tasks): restore Tasks sidebar entry + /tasks surface

### DIFF
--- a/web/e2e/screenshots/tasks-visibility.mjs
+++ b/web/e2e/screenshots/tasks-visibility.mjs
@@ -1,0 +1,116 @@
+// Capture the restored Tasks sidebar entry + /tasks board. PR #972 made
+// the Issues kanban spec-only; this PR brings back the standalone Tasks
+// surface so non-issue tasks (research, follow_up, launch, feature) stay
+// visible.
+//
+// Run via:
+//   web/e2e/screenshots/publish.sh tasks-visibility <pr-number>
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const TASKS = [
+  {
+    id: "task-follow-up-001",
+    channel: "product",
+    title: "Reply to Lenny with status note",
+    details: "Quick follow-up after yesterday's call.",
+    owner: "engineer",
+    status: "open",
+    task_type: "follow_up",
+  },
+  {
+    id: "task-research-002",
+    channel: "research",
+    title: "Audit billing latency over the last 30 days",
+    owner: "analyst",
+    status: "in_progress",
+    task_type: "research",
+  },
+  {
+    id: "task-launch-003",
+    channel: "gtm",
+    title: "Ship the Q3 pricing-page launch checklist",
+    owner: "marketing",
+    status: "review",
+    task_type: "launch",
+  },
+  {
+    id: "task-feature-004",
+    channel: "product",
+    title: "Implement webhook retry backoff",
+    owner: "engineer",
+    status: "blocked",
+    task_type: "feature",
+  },
+  {
+    id: "task-done-005",
+    channel: "product",
+    title: "Cut release v0.84.0",
+    owner: "ceo",
+    status: "done",
+    task_type: "launch",
+  },
+];
+
+async function installTasksMocks(context) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      await ctx.route("**/api/review/list?scope=all", (route) =>
+        route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ reviews: [] }),
+        }),
+      );
+      await ctx.route(/\/api\/tasks(?:[/?]|$)/, (route) =>
+        route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ tasks: TASKS }),
+        }),
+      );
+    },
+  });
+}
+
+async function gotoRoute(page, hash, selector) {
+  await page.goto(`${DEFAULT_BASE}/${hash}`, { waitUntil: "load" });
+  await page.waitForSelector(".status-bar", { timeout: 15_000 });
+  await flipStore(page);
+  await page.waitForSelector(selector, { timeout: 10_000 });
+  await page.waitForTimeout(400);
+}
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1400, height: 900 },
+});
+
+await installTasksMocks(context);
+
+// 1. /tasks now mounts the TasksApp board with the sidebar entry highlighted.
+await gotoRoute(page, "#/tasks", "[data-testid='app-page-tasks']");
+await shotPage(page, OUT, "01-tasks-board-restored");
+
+// 2. /issues remains spec-only (empty in this seed — no issue-spec tasks).
+await gotoRoute(page, "#/issues", "[data-testid='issues-list-empty']");
+await shotPage(page, OUT, "02-issues-still-spec-only");
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+
+console.log(`captured 2 screenshots to ${OUT}`);
+await browser.close();

--- a/web/e2e/tests/app-routes.spec.ts
+++ b/web/e2e/tests/app-routes.spec.ts
@@ -12,8 +12,11 @@ const APP_CASES = [
     label: "Console",
     content: /wuphf office|Slash/i,
   },
-  // Tasks sidebar entry was retired; /#/apps/tasks now redirects to
-  // /#/issues. Coverage for that redirect lives in route-matrix.spec.ts.
+  {
+    app: "tasks",
+    label: "Tasks",
+    content: /Office tasks|No tasks|Loading|Could not load/i,
+  },
   // Phase 2b retired the standalone RequestsApp surface; /apps/requests
   // now redirects to /inbox. Coverage moved to the unified-inbox E2E.
   {
@@ -29,7 +32,8 @@ const APP_CASES = [
   {
     app: "calendar",
     label: "Calendar",
-    content: /Loading calendar|Could not load calendar|Nothing scheduled|Mon|Tue|Wed/i,
+    content:
+      /Loading calendar|Could not load calendar|Nothing scheduled|Mon|Tue|Wed/i,
   },
   {
     app: "skills",
@@ -98,8 +102,7 @@ test.describe("app route isolation", () => {
     }
 
     // Switch between two real sidebar apps to confirm app-route swapping
-    // still works. Tasks was retired (now redirects to /issues) so the
-    // round-trip uses Console ↔ Graph instead.
+    // still works.
     await page.goto("/#/apps/console");
     await waitForReactMount(page);
     await page

--- a/web/e2e/tests/route-matrix.spec.ts
+++ b/web/e2e/tests/route-matrix.spec.ts
@@ -68,13 +68,6 @@ test.describe("canonical route matrix", () => {
         await expect(page).toHaveURL(/#\/inbox$/, { timeout: 10_000 });
         continue;
       }
-      // Tasks was retired in favor of the Issues kanban; /#/apps/tasks
-      // now redirects to /#/issues. Verify the redirect, not a panel.
-      if (appId === "tasks") {
-        await page.goto(`/#/apps/${appId}`);
-        await expect(page).toHaveURL(/#\/issues$/, { timeout: 10_000 });
-        continue;
-      }
       await expectCanonicalRoute(page, `/#/apps/${appId}`, async (p) => {
         await expect(p.getByTestId(`app-page-${appId}`)).toBeVisible({
           timeout: 10_000,
@@ -83,37 +76,37 @@ test.describe("canonical route matrix", () => {
     }
   });
 
-  test("legacy task URLs redirect to the Issues surface", async ({ page }) => {
-    // /tasks → /issues. Verifying the redirect URL itself is enough — the
-    // seeded broker may render the kanban, the empty state, or the loading
-    // skeleton depending on timing, and `.or()` chains can trip Playwright
-    // strict mode when more than one testid matches. The not-found surface
-    // testid would mean the redirect failed; assert it's absent.
+  test("task URLs mount the Tasks surface", async ({ page }) => {
+    // /tasks renders the TasksApp kanban directly. The seeded broker may
+    // render the kanban, the empty state, or the loading skeleton depending
+    // on timing, so assert the app-panel test id rather than a specific
+    // sub-surface. The not-found surface testid would mean routing failed.
     await page.goto("/#/tasks");
-    await expect(page).toHaveURL(/#\/issues$/, { timeout: 10_000 });
+    await expect(page.getByTestId("app-page-tasks")).toBeVisible({
+      timeout: 10_000,
+    });
     await expect(page.getByTestId("route-not-found")).toHaveCount(0);
 
-    // /tasks/$id and /apps/tasks/$id → /issues/$id
+    // /tasks/$id and /apps/tasks/$id both mount the TasksApp detail view.
     for (const route of ["/#/tasks/task-7", "/#/apps/tasks/task-7"]) {
       await page.goto(route);
-      await expect(page).toHaveURL(/#\/issues\/task-7$/, { timeout: 10_000 });
-      await expect(page.getByTestId("issue-document-panel")).toBeVisible({
+      await expect(page.getByTestId("app-page-tasks")).toBeVisible({
         timeout: 10_000,
       });
+      await expect(page.getByTestId("route-not-found")).toHaveCount(0);
     }
   });
 
-  test("legacy workbench URLs redirect through to the issue detail", async ({
+  test("legacy workbench URLs redirect through to the task detail", async ({
     page,
   }) => {
     const getErrors = collectReactErrors(page);
     await gotoRoute(page, "/#/apps/workbench/pm/tasks/task-7");
 
-    // workbench → /tasks/task-7 (legacy redirect) → /issues/task-7
-    // (lifecycle redirect). E2E just cares about the final URL.
-    await expect(page).toHaveURL(/#\/issues\/task-7$/, { timeout: 10_000 });
+    // workbench → /tasks/task-7 (legacy redirect) → TasksApp detail.
+    await expect(page).toHaveURL(/#\/tasks\/task-7$/, { timeout: 10_000 });
     await expect(page.getByTestId("route-not-found")).toHaveCount(0);
-    await expect(page.getByTestId("issue-document-panel")).toBeVisible({
+    await expect(page.getByTestId("app-page-tasks")).toBeVisible({
       timeout: 10_000,
     });
     await expectNoReactErrors(

--- a/web/src/lib/sidebarNav.ts
+++ b/web/src/lib/sidebarNav.ts
@@ -21,6 +21,10 @@ export function navigateToSidebarApp(appId: string): void {
     void router.navigate({ to: "/issues" });
     return;
   }
+  if (appId === "tasks") {
+    void router.navigate({ to: "/tasks" });
+    return;
+  }
   void router.navigate({
     to: "/apps/$appId",
     params: { appId },

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -119,6 +119,11 @@ const SkillsApp = lazy(() =>
     default: m.SkillsApp,
   })),
 );
+const TasksApp = lazy(() =>
+  import("../components/apps/TasksApp").then((m) => ({
+    default: m.TasksApp,
+  })),
+);
 const Notebook = lazy(() => import("../components/notebook/Notebook"));
 const DecisionInbox = lazy(() =>
   import("../components/lifecycle/DecisionInbox").then((m) => ({
@@ -297,7 +302,7 @@ function navigateNotebookEntry(
 }
 
 const APP_PANELS = {
-  tasks: IssuesRedirect,
+  tasks: TasksApp,
   requests: InboxRedirect,
   graph: GraphApp,
   policies: PoliciesApp,
@@ -452,47 +457,13 @@ function InboxRedirect() {
 }
 
 /**
- * IssueDetailRedirect routes legacy `/tasks/$taskId` URLs to the
- * canonical issue detail surface so bookmarks keep working without
- * resurfacing the deprecated TasksApp modal.
- */
-function IssueDetailRedirect({ issueId }: { issueId: string }) {
-  useEffect(() => {
-    void router.navigate({
-      to: "/issues/$issueId",
-      params: { issueId },
-      replace: true,
-    });
-  }, [issueId]);
-  return (
-    <div
-      className="app-panel active"
-      data-testid="legacy-redirect-issue-detail"
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flex: 1,
-          color: "var(--text-tertiary)",
-          fontSize: 14,
-        }}
-      >
-        Redirecting to issue…
-      </div>
-    </div>
-  );
-}
-
-/**
  * FirstClassAppRedirect navigates the user from a `/apps/$id` URL whose
  * `$id` is a first-class app (wiki, inbox) to that app's canonical
  * dedicated route. Users who type a sidebar-label-style URL by hand
  * (e.g. `/#/apps/wiki`) used to hit "Page not found" because first-class
  * apps live at `/wiki` and `/inbox`, not under `/apps`. Mirrors
- * `InboxRedirect` and `IssuesRedirect` so the route ↔ sidebar mapping is
- * forgiving without the route registry sprouting alias entries.
+ * `InboxRedirect` so the route ↔ sidebar mapping is forgiving without
+ * the route registry sprouting alias entries.
  */
 function FirstClassAppRedirect({ appId }: { appId: FirstClassAppId }) {
   useEffect(() => {
@@ -523,35 +494,6 @@ function FirstClassAppRedirect({ appId }: { appId: FirstClassAppId }) {
   );
 }
 
-/**
- * IssuesRedirect navigates the user from the deprecated /apps/tasks
- * surface to the unified Issues list. Tasks-as-a-sidebar-app was
- * replaced by the Issues group + dedicated /issues route; this stub
- * keeps existing bookmarks working without surfacing the old
- * TasksApp kanban inside the apps panel.
- */
-function IssuesRedirect() {
-  useEffect(() => {
-    void router.navigate({ to: "/issues", replace: true });
-  }, []);
-  return (
-    <div className="app-panel active" data-testid="legacy-redirect-issues">
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          flex: 1,
-          color: "var(--text-tertiary)",
-          fontSize: 14,
-        }}
-      >
-        Redirecting to Issues…
-      </div>
-    </div>
-  );
-}
-
 function UnknownAppPanel({ appId }: { appId: string }) {
   return (
     <div className="app-panel active" data-testid={`app-page-${appId}`}>
@@ -572,7 +514,6 @@ function UnknownAppPanel({ appId }: { appId: string }) {
 }
 
 function AppPanel({ appId }: { appId: AppPanelId }) {
-  if (appId === "tasks") return <IssuesRedirect />;
   const Panel = APP_PANELS[appId];
   return (
     <div className="app-panel active" data-testid={`app-page-${appId}`}>
@@ -643,9 +584,17 @@ function MainContent() {
       }
       return <AppPanel appId={route.appId} />;
     case "task-board":
-      return <IssuesRedirect />;
+      return (
+        <div className="app-panel active" data-testid="app-page-tasks">
+          <TasksApp />
+        </div>
+      );
     case "task-detail":
-      return <IssueDetailRedirect issueId={route.taskId} />;
+      return (
+        <div className="app-panel active" data-testid="app-page-tasks">
+          <TasksApp taskId={route.taskId} />
+        </div>
+      );
     case "wiki":
     case "wiki-article":
       return <WikiSurface current="wiki" route={route} />;

--- a/web/src/routes/routeRegistry.ts
+++ b/web/src/routes/routeRegistry.ts
@@ -75,6 +75,7 @@ const SIDEBAR_TOOL_EMOJIS: Partial<
 > = {
   overview: "🏠",
   issues: "#",
+  tasks: "✓",
   wiki: "📖",
   console: ">",
   graph: "🕸",
@@ -112,6 +113,7 @@ export interface SidebarTool {
 export const SIDEBAR_TOOLS: readonly SidebarTool[] = [
   { id: "overview", kind: "app-panel" },
   { id: "issues", kind: "first-class" },
+  { id: "tasks", kind: "app-panel" },
   { id: "wiki", kind: "first-class" },
   { id: "console", kind: "app-panel" },
   { id: "graph", kind: "app-panel" },


### PR DESCRIPTION
## Summary

PR #972 made the Issues kanban spec-only by adding an `isIssueSpecTask` filter, and tasks-as-a-sidebar-app had previously been retired in favour of the Issues redirect. The combination hid every non-issue task from the UI: agent-created tasks (`task_type` = research / follow_up / launch / feature) still existed in the broker but had nowhere to render.

This restores the standalone Tasks sidebar entry pointing at the existing `TasksApp` kanban, and turns `/tasks` and `/tasks/$taskId` back into live routes (they no longer redirect to `/issues`). Issues stays spec-only as PR #972 intended; Tasks lives alongside it for the broader execution lane.

## Changes

- `routeRegistry.ts` — add `tasks` back to `SIDEBAR_TOOLS` and its emoji fallback
- `sidebarNav.ts` — clicking the Tasks sidebar entry routes to `/tasks` (canonical) instead of `/apps/tasks`
- `RootRoute.tsx` — lazy-load `TasksApp`, mount it on `task-board` / `task-detail` / `APP_PANELS.tasks`; drop the now-unused `IssuesRedirect` and `IssueDetailRedirect` stubs
- `route-matrix.spec.ts` — assert `/tasks` mounts `TasksApp` instead of asserting a redirect; the workbench legacy redirect now lands on `/tasks/$taskId`
- `app-routes.spec.ts` — add Tasks back to the per-app coverage list
- `web/e2e/screenshots/tasks-visibility.mjs` — new spec for screenshot publishing (see note below)

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bash scripts/test-web.sh` — 173 files / 1638 tests pass
- [x] `bun run build` — TasksApp lazy chunk created (18.71 kB / 5.80 kB gzipped)
- [ ] Verify in browser: sidebar shows Tasks entry; `/tasks` mounts the kanban with cards for agent-created tasks; `/issues` still shows spec-only kanban; `/apps/workbench/...` redirects to `/tasks/$taskId`

## Screenshots

Screenshot harness hit a pre-existing dev-env regression (the same failure reproduces on `origin/main` with the existing `issue-spec-app.mjs` harness — "Maximum update depth exceeded" in vite dev). Spec file added so the screenshots can publish via `bash web/e2e/screenshots/publish.sh tasks-visibility 983` once the harness issue is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored Tasks as a first-class app with its own sidebar entry and icon fallback
  * Routes now navigate directly to the Tasks board and task detail views instead of redirecting to Issues
  * Tasks and Issues remain separate, independent surfaces

* **Tests / E2E**
  * Updated route tests and end-to-end screenshot checks to validate Tasks mounting and task/detail routing and to confirm Issues remains spec-only

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->