### PR TITLE
fix(inbox): blocked-card actions + unread filter

### DIFF
--- a/internal/team/broker_inbox.go
+++ b/internal/team/broker_inbox.go
@@ -49,6 +49,12 @@ const (
 	InboxFilterBlocked          InboxFilter = "blocked"
 	InboxFilterApproved         InboxFilter = "approved"
 	InboxFilterAll              InboxFilter = "all"
+	// InboxFilterUnread narrows the unified inbox to items the caller
+	// has not yet acknowledged (item.updatedAt > cursor.lastSeenAt).
+	// Applied post-fetch in the /inbox/items handler because the
+	// cursor is per-actor, not per-bucket; the lifecycle bucket index
+	// has no notion of read state.
+	InboxFilterUnread InboxFilter = "unread"
 )
 
 // ErrInboxFilterUnknown is returned by Inbox when the caller passes a
@@ -96,6 +102,20 @@ type InboxRow struct {
 	SeveritySummary SeveritySummary `json:"severitySummary"`
 	ElapsedMs       int64           `json:"elapsedMs"`
 	ReviewerSummary ReviewerSummary `json:"reviewerSummary"`
+	// BlockedOn surfaces the task's typed-blocker list verbatim from
+	// teamTask.BlockedOn. Populated regardless of lifecycle state so the
+	// row can render dependency chips for any blocked-ish task; the
+	// frontend chooses when to show them.
+	BlockedOn []string `json:"blockedOn,omitempty"`
+	// Details is the free-text reason the broker last attached to the
+	// task. For blocked tasks this carries the actual "why" (agent
+	// timeout, agent error, manual block reason) so the inbox card does
+	// not have to guess. Truncated by the broker for inbox payload size.
+	Details string `json:"details,omitempty"`
+	// UpdatedAt is the RFC3339 timestamp of the task's last mutation.
+	// Used by the unread cursor on the client to mark rows whose latest
+	// change happened after the caller's LastSeenAt.
+	UpdatedAt string `json:"updatedAt,omitempty"`
 }
 
 // InboxCounts is the cardinality summary that the inbox header renders.
@@ -111,6 +131,11 @@ type InboxCounts struct {
 	Running          int `json:"running"`
 	Blocked          int `json:"blocked"`
 	ApprovedToday    int `json:"approvedToday"`
+	// Unread is the number of items in the caller's unified inbox
+	// whose latest activity post-dates their InboxCursor.LastSeenAt.
+	// Computed by the /inbox/items handler from the auth-filtered item
+	// list — the lifecycle index has no per-actor read state.
+	Unread int `json:"unread"`
 }
 
 // InboxPayload is the full response to GET /tasks/inbox.
@@ -135,7 +160,11 @@ func inboxFilterToStates(filter InboxFilter) ([]LifecycleState, error) {
 		return []LifecycleState{LifecycleStateBlockedOnPRMerge}, nil
 	case InboxFilterApproved:
 		return []LifecycleState{LifecycleStateApproved}, nil
-	case InboxFilterAll:
+	case InboxFilterAll, InboxFilterUnread:
+		// Unread is post-filtered against the caller's cursor in
+		// inboxItemsForActor; from the lifecycle-bucket perspective it
+		// behaves as InboxFilterAll. ErrInboxFilterUnknown stays
+		// reserved for genuinely unknown strings.
 		return CanonicalLifecycleStates(), nil
 	default:
 		return nil, ErrInboxFilterUnknown
@@ -295,6 +324,11 @@ func (b *Broker) buildInboxRowLocked(task *teamTask) InboxRow {
 		ReviewerSummary: ReviewerSummary{
 			Total: len(task.Reviewers),
 		},
+		UpdatedAt: task.UpdatedAt,
+		Details:   truncateSummary(strings.TrimSpace(task.Details), 280),
+	}
+	if len(task.BlockedOn) > 0 {
+		row.BlockedOn = append(row.BlockedOn, task.BlockedOn...)
 	}
 	if created := parseBrokerTimestamp(task.CreatedAt); !created.IsZero() {
 		row.ElapsedMs = time.Since(created).Milliseconds()

--- a/internal/team/broker_inbox.go
+++ b/internal/team/broker_inbox.go
@@ -160,12 +160,17 @@ func inboxFilterToStates(filter InboxFilter) ([]LifecycleState, error) {
 		return []LifecycleState{LifecycleStateBlockedOnPRMerge}, nil
 	case InboxFilterApproved:
 		return []LifecycleState{LifecycleStateApproved}, nil
-	case InboxFilterAll, InboxFilterUnread:
-		// Unread is post-filtered against the caller's cursor in
-		// inboxItemsForActor; from the lifecycle-bucket perspective it
-		// behaves as InboxFilterAll. ErrInboxFilterUnknown stays
-		// reserved for genuinely unknown strings.
+	case InboxFilterAll:
 		return CanonicalLifecycleStates(), nil
+	case InboxFilterUnread:
+		// Unread is a per-actor cursor-driven filter; the legacy
+		// task-only Inbox/inboxForActor path has no cursor context and
+		// would silently degrade to filter=all. The unified
+		// /inbox/items handler unwraps unread to all-states + a
+		// post-filter before calling here, so the only callers that
+		// can reach this branch are legacy entry points — return
+		// ErrInboxFilterUnknown for them.
+		return nil, ErrInboxFilterUnknown
 	default:
 		return nil, ErrInboxFilterUnknown
 	}

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -104,6 +104,9 @@ func (b *Broker) handleTaskByID(w http.ResponseWriter, r *http.Request) {
 			case "block":
 				b.handleTaskBlock(w, r, actor, taskID)
 				return
+			case "resume":
+				b.handleTaskResume(w, r, actor, taskID)
+				return
 			case "decision":
 				b.handleTaskDecision(w, r, actor, taskID)
 				return
@@ -225,6 +228,73 @@ func (b *Broker) handleTaskBlock(w http.ResponseWriter, r *http.Request, actor r
 		return
 	}
 	writeJSON(w, http.StatusOK, task)
+}
+
+// handleTaskResume serves POST /tasks/{id}/resume. Body shape:
+//
+//	{"actor": "<slug>", "reason": "<text>"}
+//
+// Manually clears a blocked_on_pr_merge (or otherwise paused) task so
+// the owner agent picks it up again. Wraps Broker.ResumeTask, which the
+// watchdog scheduler also calls on retry. Humans with reviewer access on
+// the task may resume it; everyone else gets 403. The action is
+// idempotent — a re-issued resume on an already-running task returns
+// 200 with changed=false in the response body.
+func (b *Broker) handleTaskResume(w http.ResponseWriter, r *http.Request, actor requestActor, id string) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if id == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "task id required"})
+		return
+	}
+	var body struct {
+		Actor  string `json:"actor"`
+		Reason string `json:"reason"`
+	}
+	// Body is optional; ignore decode errors so an empty-POST resume
+	// from a UI button without a JSON payload still works.
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	// Auth: snapshot reviewers under the lock so the check races no
+	// reviewer-routing write. Broker token bypasses the reviewer set.
+	b.mu.Lock()
+	task := b.findTaskByIDLocked(id)
+	if task == nil {
+		b.mu.Unlock()
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		return
+	}
+	reviewers := append([]string(nil), task.Reviewers...)
+	b.mu.Unlock()
+	if !taskAccessAllowed(actor, reviewers) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+
+	actorSlug := strings.TrimSpace(body.Actor)
+	if actorSlug == "" {
+		actorSlug = strings.TrimSpace(actor.Slug)
+	}
+	if actorSlug == "" {
+		actorSlug = "human"
+	}
+	reason := strings.TrimSpace(body.Reason)
+	if reason == "" {
+		reason = "Manual resume from inbox."
+	}
+	resumed, changed, err := b.ResumeTask(id, actorSlug, reason)
+	if err != nil {
+		log.Printf("broker: resume task %q: %v", id, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"task":    resumed,
+		"changed": changed,
+	})
 }
 
 // handleTaskDecision serves POST /tasks/{id}/decision. Body shape:

--- a/internal/team/broker_inbox_handler.go
+++ b/internal/team/broker_inbox_handler.go
@@ -29,6 +29,7 @@ package team
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -251,12 +252,15 @@ func (b *Broker) handleTaskResume(w http.ResponseWriter, r *http.Request, actor 
 		return
 	}
 	var body struct {
-		Actor  string `json:"actor"`
 		Reason string `json:"reason"`
 	}
-	// Body is optional; ignore decode errors so an empty-POST resume
-	// from a UI button without a JSON payload still works.
-	_ = json.NewDecoder(r.Body).Decode(&body)
+	// Body is optional — the UI button posts with no payload when no
+	// reason is provided. Treat EOF as a valid empty body; reject any
+	// other decode error so malformed JSON cannot silently mutate state.
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil && !errors.Is(err, io.EOF) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+		return
+	}
 
 	// Auth: snapshot reviewers under the lock so the check races no
 	// reviewer-routing write. Broker token bypasses the reviewer set.
@@ -274,9 +278,13 @@ func (b *Broker) handleTaskResume(w http.ResponseWriter, r *http.Request, actor 
 		return
 	}
 
-	actorSlug := strings.TrimSpace(body.Actor)
-	if actorSlug == "" {
-		actorSlug = strings.TrimSpace(actor.Slug)
+	// Derive actor identity from auth context only. The body used to
+	// accept an "actor" field; that would let any caller spoof the
+	// audit trail on a task they otherwise have permission to resume,
+	// so drop the field outright.
+	actorSlug := strings.TrimSpace(actor.Slug)
+	if actor.Kind == requestActorKindBroker {
+		actorSlug = "owner"
 	}
 	if actorSlug == "" {
 		actorSlug = "human"

--- a/internal/team/broker_inbox_handler_phase2.go
+++ b/internal/team/broker_inbox_handler_phase2.go
@@ -53,6 +53,7 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 	if rawFilter == "" {
 		rawFilter = string(InboxFilterAll)
 	}
+	cursor := b.InboxCursor(inboxCursorKeyForActor(actor))
 	// Always pull the unfiltered union for the caller so counts cover
 	// every visible kind, regardless of the kind=<kind> trim below.
 	allItems, err := b.inboxItemsForActor(actor, InboxFilterAll)
@@ -60,6 +61,7 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	stampUnread(allItems, cursor)
 	counts := inboxCountsForItems(allItems, startOfTodayUTC())
 
 	items, err := b.inboxItemsForActor(actor, InboxFilter(rawFilter))
@@ -70,6 +72,21 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+	stampUnread(items, cursor)
+
+	// InboxFilterUnread narrows the bucket-passed rows to items whose
+	// IsUnread flag is set. The lifecycle index has no per-actor read
+	// state so this is a post-fetch trim; it operates only on rows
+	// already authorized by inboxItemsForActor above.
+	if InboxFilter(rawFilter) == InboxFilterUnread {
+		filtered := items[:0]
+		for _, item := range items {
+			if item.IsUnread {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
 	}
 
 	kind := strings.TrimSpace(r.URL.Query().Get("kind"))
@@ -91,6 +108,30 @@ func (b *Broker) handleInboxItems(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// stampUnread populates each item's IsUnread flag against the actor's
+// cursor. An item is unread when its UpdatedAt (or CreatedAt fallback)
+// is strictly after cursor.LastSeenAt — a zero cursor marks everything
+// unread so a brand-new user sees the full backlog highlighted on
+// first load.
+func stampUnread(items []InboxItem, cursor InboxCursor) {
+	lastSeen := cursor.LastSeenAt
+	for i := range items {
+		ts := parseBrokerTimestamp(items[i].UpdatedAt)
+		if ts.IsZero() {
+			ts = parseBrokerTimestamp(items[i].CreatedAt)
+		}
+		if ts.IsZero() {
+			items[i].IsUnread = false
+			continue
+		}
+		if lastSeen.IsZero() {
+			items[i].IsUnread = true
+			continue
+		}
+		items[i].IsUnread = ts.After(lastSeen)
+	}
+}
+
 // inboxCountsForItems derives the badge counts from the caller's
 // auth-filtered item list. The counts only cover task-kind items —
 // requests and reviews live in their own counters and v1's
@@ -101,6 +142,9 @@ func inboxCountsForItems(items []InboxItem, todayCutoff time.Time) InboxCounts {
 	var counts InboxCounts
 	cutoffMs := todayCutoff.UnixMilli()
 	for _, item := range items {
+		if item.IsUnread {
+			counts.Unread++
+		}
 		if item.Kind != InboxItemKindTask || item.TaskRow == nil {
 			continue
 		}
@@ -155,7 +199,7 @@ func (b *Broker) handleInboxCursor(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	b.SetInboxCursor(actor.Slug, InboxCursor{
+	b.SetInboxCursor(inboxCursorKeyForActor(actor), InboxCursor{
 		LastSeenAt:        body.LastSeenAt,
 		AcknowledgedKinds: body.AcknowledgedKinds,
 	})

--- a/internal/team/broker_inbox_handler_phase2_test.go
+++ b/internal/team/broker_inbox_handler_phase2_test.go
@@ -477,6 +477,112 @@ func TestHandleTaskResume(t *testing.T) {
 	}
 }
 
+// TestHandleTaskResume_NonReviewerForbidden locks the authorization
+// contract: a human session whose slug is NOT in the task's Reviewers
+// list cannot resume the task. The broker-token happy path is exercised
+// in TestHandleTaskResume above; this case fills the other half of the
+// auth matrix.
+func TestHandleTaskResume_NonReviewerForbidden(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-blocked", Title: "Blocked", CreatedAt: now, UpdatedAt: now, Reviewers: []string{"mira"}, status: "blocked"},
+	}
+	if _, err := b.transitionLifecycleLocked("task-blocked", LifecycleStateBlockedOnPRMerge, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	// Mint a human session for Alex — not in the Reviewers list.
+	inviteToken, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+	sessionToken, _, err := b.acceptHumanInvite(inviteToken, "Alex", "browser")
+	if err != nil {
+		t.Fatalf("accept invite: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tasks/task-blocked/resume", strings.NewReader(`{}`))
+	req.AddCookie(&http.Cookie{Name: humanSessionCookie, Value: sessionToken})
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("resume request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("non-reviewer status = %d, want 403", resp.StatusCode)
+	}
+
+	// Lifecycle state must not have moved — auth gate runs before the
+	// ResumeTask call, so the task should still be blocked.
+	b.mu.Lock()
+	state := LifecycleStateUnknown
+	for _, task := range b.tasks {
+		if task.ID == "task-blocked" {
+			state = task.LifecycleState
+		}
+	}
+	b.mu.Unlock()
+	if state != LifecycleStateBlockedOnPRMerge {
+		t.Fatalf("state should remain blocked after 403; got %s", state)
+	}
+}
+
+// TestHandleTaskResume_RejectsMalformedJSON guards the decoder
+// hardening: a non-empty body that fails to parse must yield 400 and
+// must not mutate the task.
+func TestHandleTaskResume_RejectsMalformedJSON(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-blocked", Title: "Blocked", CreatedAt: now, UpdatedAt: now, Reviewers: []string{"owner"}, status: "blocked"},
+	}
+	if _, err := b.transitionLifecycleLocked("task-blocked", LifecycleStateBlockedOnPRMerge, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tasks/task-blocked/resume", strings.NewReader(`{not json}`))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("resume request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("malformed body status = %d, want 400", resp.StatusCode)
+	}
+
+	b.mu.Lock()
+	state := LifecycleStateUnknown
+	for _, task := range b.tasks {
+		if task.ID == "task-blocked" {
+			state = task.LifecycleState
+		}
+	}
+	b.mu.Unlock()
+	if state != LifecycleStateBlockedOnPRMerge {
+		t.Fatalf("state should remain blocked after 400; got %s", state)
+	}
+}
+
 func TestHandleInboxItems_BadFilterReturns400(t *testing.T) {
 	b := newTestBroker(t)
 	mux := http.NewServeMux()

--- a/internal/team/broker_inbox_handler_phase2_test.go
+++ b/internal/team/broker_inbox_handler_phase2_test.go
@@ -240,6 +240,243 @@ func TestHandleTaskDecision_NoCommentLeavesFeedbackEmpty(t *testing.T) {
 	}
 }
 
+// TestHandleInboxItems_StampsUnreadAndCounts confirms /inbox/items
+// computes IsUnread from the actor's cursor and reflects the same count
+// in payload.Counts.Unread. With no cursor written, every item is
+// unread; after the cursor moves past the items' UpdatedAt, all items
+// flip to read.
+func TestHandleInboxItems_StampsUnreadAndCounts(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC()
+	older := now.Add(-time.Hour).Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-a", Title: "Refactor", CreatedAt: older, UpdatedAt: older, Reviewers: []string{"owner"}},
+	}
+	if _, err := b.transitionLifecycleLocked("task-a", LifecycleStateDecision, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	mux.HandleFunc("/inbox/cursor", b.requireAuth(b.handleInboxCursor))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	get := func() unifiedInboxResponse {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=all", nil)
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		defer resp.Body.Close()
+		var payload unifiedInboxResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return payload
+	}
+
+	// No cursor → every authorized item reads as unread, count matches.
+	before := get()
+	if len(before.Items) != 1 {
+		t.Fatalf("seed item count = %d, want 1", len(before.Items))
+	}
+	if !before.Items[0].IsUnread {
+		t.Fatal("item should be unread before any cursor is written")
+	}
+	if before.Counts.Unread != 1 {
+		t.Fatalf("counts.unread = %d, want 1", before.Counts.Unread)
+	}
+
+	// Advance the cursor past the items' UpdatedAt; everything goes
+	// to read and the counts unread drops to zero.
+	body := strings.NewReader(`{"lastSeenAt":"` + now.Add(time.Minute).UTC().Format(time.RFC3339Nano) + `"}`)
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/inbox/cursor", body)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("cursor post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("cursor status = %d, want 204", resp.StatusCode)
+	}
+
+	after := get()
+	if after.Items[0].IsUnread {
+		t.Fatal("item should be read after cursor advances")
+	}
+	if after.Counts.Unread != 0 {
+		t.Fatalf("counts.unread after = %d, want 0", after.Counts.Unread)
+	}
+}
+
+// TestHandleInboxItems_UnreadFilterTrimsReadItems exercises the
+// post-fetch trim that powers the "Unread" sidebar filter.
+func TestHandleInboxItems_UnreadFilterTrimsReadItems(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC()
+	older := now.Add(-time.Hour).Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-old", Title: "Older", CreatedAt: older, UpdatedAt: older, Reviewers: []string{"owner"}},
+		{ID: "task-new", Title: "Newer", CreatedAt: now.Format(time.RFC3339), UpdatedAt: now.Format(time.RFC3339), Reviewers: []string{"owner"}},
+	}
+	if _, err := b.transitionLifecycleLocked("task-old", LifecycleStateDecision, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed old: %v", err)
+	}
+	if _, err := b.transitionLifecycleLocked("task-new", LifecycleStateDecision, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed new: %v", err)
+	}
+	b.mu.Unlock()
+
+	// Cursor between the two: task-old becomes read, task-new stays unread.
+	b.SetInboxCursor(inboxCursorOwnerKey, InboxCursor{LastSeenAt: now.Add(-30 * time.Minute)})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=unread", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var payload unifiedInboxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Items) != 1 {
+		t.Fatalf("unread filter items = %d, want 1; got %+v", len(payload.Items), payload.Items)
+	}
+	if payload.Items[0].TaskID != "task-new" {
+		t.Fatalf("unread item taskId = %q, want task-new", payload.Items[0].TaskID)
+	}
+}
+
+// TestHandleInboxItems_TaskRowCarriesBlockerAndDetails confirms the
+// blocked-card payload extension (details + blockedOn) actually surfaces
+// on /inbox/items so the PacketPending fallback can render real info.
+func TestHandleInboxItems_TaskRowCarriesBlockerAndDetails(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{
+			ID:        "task-blocked",
+			Title:     "Waits on upstream",
+			Details:   "Automatic timeout recovery: @mira timed out after 5m.",
+			CreatedAt: now,
+			UpdatedAt: now,
+			Reviewers: []string{"owner"},
+			BlockedOn: []string{"task-upstream"},
+		},
+	}
+	if _, err := b.transitionLifecycleLocked("task-blocked", LifecycleStateBlockedOnPRMerge, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=all", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var payload unifiedInboxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Items) != 1 || payload.Items[0].TaskRow == nil {
+		t.Fatalf("expected 1 task item with task row; got %+v", payload.Items)
+	}
+	row := payload.Items[0].TaskRow
+	if row.Details == "" || !strings.Contains(row.Details, "timed out") {
+		t.Fatalf("row details should carry the broker reason; got %q", row.Details)
+	}
+	if len(row.BlockedOn) != 1 || row.BlockedOn[0] != "task-upstream" {
+		t.Fatalf("row.BlockedOn = %v, want [task-upstream]", row.BlockedOn)
+	}
+	if row.UpdatedAt == "" {
+		t.Fatal("row.UpdatedAt must be populated for the unread cursor to work")
+	}
+}
+
+// TestHandleTaskResume covers the POST /tasks/{id}/resume route that
+// the blocked-card "Resume" button posts to. Verifies the lifecycle
+// transitions away from blocked_on_pr_merge and that the JSON envelope
+// carries changed=true.
+func TestHandleTaskResume(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "task-blocked", Title: "Blocked", CreatedAt: now, UpdatedAt: now, Reviewers: []string{"owner"}, status: "blocked"},
+	}
+	if _, err := b.transitionLifecycleLocked("task-blocked", LifecycleStateBlockedOnPRMerge, "seed"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed: %v", err)
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tasks/", b.requireAuth(b.handleTaskByID))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/tasks/task-blocked/resume", strings.NewReader(`{"reason":"manual ping"}`))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("resume request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Changed bool `json:"changed"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !envelope.Changed {
+		t.Fatal("first resume should report changed=true")
+	}
+
+	b.mu.Lock()
+	state := LifecycleStateUnknown
+	for _, task := range b.tasks {
+		if task.ID == "task-blocked" {
+			state = task.LifecycleState
+		}
+	}
+	b.mu.Unlock()
+	if state == LifecycleStateBlockedOnPRMerge {
+		t.Fatalf("task should have left blocked state after resume; still %s", state)
+	}
+}
+
 func TestHandleInboxItems_BadFilterReturns400(t *testing.T) {
 	b := newTestBroker(t)
 	mux := http.NewServeMux()

--- a/internal/team/broker_inbox_handler_phase2_test.go
+++ b/internal/team/broker_inbox_handler_phase2_test.go
@@ -8,6 +8,7 @@ package team
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -580,6 +581,80 @@ func TestHandleTaskResume_RejectsMalformedJSON(t *testing.T) {
 	b.mu.Unlock()
 	if state != LifecycleStateBlockedOnPRMerge {
 		t.Fatalf("state should remain blocked after 400; got %s", state)
+	}
+}
+
+// TestHandleInboxItems_SortsByUpdatedAtDescending guards the contract
+// that recently-updated items surface first regardless of their
+// CreatedAt. An older task that just transitioned must outrank a newer
+// task that has not been touched since creation.
+func TestHandleInboxItems_SortsByUpdatedAtDescending(t *testing.T) {
+	b := newTestBrokerForReview(t)
+	now := time.Now().UTC()
+	older := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	newer := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	justNow := now.Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		// task-old was created longest ago AND just transitioned now.
+		{ID: "task-old-but-active", Title: "Old, just updated", CreatedAt: older, UpdatedAt: justNow, Reviewers: []string{"owner"}},
+		// task-fresh was created more recently but has not moved.
+		{ID: "task-fresh-but-quiet", Title: "Newer, untouched", CreatedAt: newer, UpdatedAt: newer, Reviewers: []string{"owner"}},
+	}
+	for _, id := range []string{"task-old-but-active", "task-fresh-but-quiet"} {
+		if _, err := b.transitionLifecycleLocked(id, LifecycleStateDecision, "seed"); err != nil {
+			b.mu.Unlock()
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	// The lifecycle transition above stamps UpdatedAt with the wall
+	// clock for both, so reset the fixture timestamps explicitly to
+	// recreate the "old created, just-updated" vs "newer created,
+	// untouched" contrast the sort is meant to honor.
+	for i := range b.tasks {
+		switch b.tasks[i].ID {
+		case "task-old-but-active":
+			b.tasks[i].UpdatedAt = justNow
+			b.tasks[i].CreatedAt = older
+		case "task-fresh-but-quiet":
+			b.tasks[i].UpdatedAt = newer
+			b.tasks[i].CreatedAt = newer
+		}
+	}
+	b.mu.Unlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/inbox/items", b.requireAuth(b.handleInboxItems))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/inbox/items?filter=all", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("inbox request: %v", err)
+	}
+	defer resp.Body.Close()
+	var payload unifiedInboxResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Items) < 2 {
+		t.Fatalf("expected at least 2 items; got %d", len(payload.Items))
+	}
+	if payload.Items[0].TaskID != "task-old-but-active" {
+		t.Fatalf("most-recent-activity item = %q, want task-old-but-active; full order = %+v", payload.Items[0].TaskID, payload.Items)
+	}
+}
+
+// TestInboxFilterToStates_RejectsUnreadOnLegacyPath documents the
+// guard that prevents /tasks/inbox?filter=unread from silently behaving
+// like filter=all. The legacy task-only path has no cursor context, so
+// the unread filter must be rejected at the bucket layer. The new
+// /inbox/items handler unwraps unread to all-states before this call.
+func TestInboxFilterToStates_RejectsUnreadOnLegacyPath(t *testing.T) {
+	if _, err := inboxFilterToStates(InboxFilterUnread); !errors.Is(err, ErrInboxFilterUnknown) {
+		t.Fatalf("inboxFilterToStates(unread) err = %v, want ErrInboxFilterUnknown", err)
 	}
 }
 

--- a/internal/team/broker_inbox_phase2.go
+++ b/internal/team/broker_inbox_phase2.go
@@ -122,8 +122,18 @@ func (b *Broker) inboxItemsForActor(actor requestActor, filter InboxFilter) ([]I
 	if b == nil {
 		return nil, nil
 	}
+	// Unread is a per-actor cursor-driven filter, not a lifecycle
+	// bucket. Unwrap it to all-states here so the bucket walk below
+	// returns everything authorized; the /inbox/items handler then
+	// post-filters against the caller's cursor. inboxFilterToStates
+	// itself rejects InboxFilterUnread so the legacy task-only
+	// /tasks/inbox path cannot silently degrade to filter=all.
+	bucketFilter := filter
+	if bucketFilter == InboxFilterUnread {
+		bucketFilter = InboxFilterAll
+	}
 	// Validate the filter up-front so a bad value short-circuits.
-	if _, err := inboxFilterToStates(filter); err != nil {
+	if _, err := inboxFilterToStates(bucketFilter); err != nil {
 		return nil, err
 	}
 
@@ -132,8 +142,8 @@ func (b *Broker) inboxItemsForActor(actor requestActor, filter InboxFilter) ([]I
 	// to that bucket. InboxFilterAll keeps every row. This matches
 	// the existing Inbox(filter) semantics; the new fan-out merges
 	// requests + reviews on top.
-	if filter != InboxFilterAll {
-		states, _ := inboxFilterToStates(filter)
+	if bucketFilter != InboxFilterAll {
+		states, _ := inboxFilterToStates(bucketFilter)
 		allowed := make(map[LifecycleState]struct{}, len(states))
 		for _, s := range states {
 			allowed[s] = struct{}{}
@@ -158,16 +168,18 @@ func (b *Broker) inboxItemsForActor(actor requestActor, filter InboxFilter) ([]I
 	sort.SliceStable(rows, func(i, j int) bool {
 		// Attention-first: items the user can act on now (decision,
 		// request, review) bubble to the top. Within the same priority
-		// tier, sort by CreatedAt desc. This stops approved /
-		// blocked-on-pr-merge tasks from burying the work that needs
-		// the user's eyes.
+		// tier, sort by most-recent-activity descending — UpdatedAt
+		// when present (so an old task that just transitioned bubbles
+		// up), falling back to CreatedAt for artifacts that don't
+		// carry a separate update timestamp. This honors the
+		// "most-recent-activity descending" contract on the function.
 		pi := inboxItemPriority(rows[i])
 		pj := inboxItemPriority(rows[j])
 		if pi != pj {
 			return pi < pj
 		}
-		ti := parseBrokerTimestamp(rows[i].CreatedAt)
-		tj := parseBrokerTimestamp(rows[j].CreatedAt)
+		ti := inboxItemActivityTime(rows[i])
+		tj := inboxItemActivityTime(rows[j])
 		switch {
 		case ti.IsZero() && tj.IsZero():
 			return false
@@ -180,6 +192,16 @@ func (b *Broker) inboxItemsForActor(actor requestActor, filter InboxFilter) ([]I
 		}
 	})
 	return rows, nil
+}
+
+// inboxItemActivityTime returns the timestamp the inbox sort uses for
+// "most recent activity": UpdatedAt when set, otherwise CreatedAt. Both
+// fields are RFC3339 strings on the wire.
+func inboxItemActivityTime(item InboxItem) time.Time {
+	if ts := parseBrokerTimestamp(item.UpdatedAt); !ts.IsZero() {
+		return ts
+	}
+	return parseBrokerTimestamp(item.CreatedAt)
 }
 
 // inboxItemPriority returns a sort key: lower = more attention-y.

--- a/internal/team/broker_inbox_phase2.go
+++ b/internal/team/broker_inbox_phase2.go
@@ -56,12 +56,22 @@ type InboxItem struct {
 	Title     string        `json:"title"`
 	Channel   string        `json:"channel,omitempty"`
 	CreatedAt string        `json:"createdAt,omitempty"`
-	ElapsedMs int64         `json:"elapsedMs,omitempty"`
+	// UpdatedAt is the RFC3339 timestamp of the most recent activity
+	// on the underlying artifact. Mirrors InboxRow.UpdatedAt for tasks;
+	// for requests/reviews the row falls back to the artifact's own
+	// last-mutation timestamp. The unread cursor compares against this.
+	UpdatedAt string `json:"updatedAt,omitempty"`
+	ElapsedMs int64  `json:"elapsedMs,omitempty"`
 	// AgentSlug is the agent who owns / sent / submitted this item.
 	// Phase 3 uses this to group items into per-agent threads. Empty
 	// when the item has no agent attribution (e.g. system-generated
 	// tasks the harness can't trace back to a single agent).
 	AgentSlug string `json:"agentSlug,omitempty"`
+	// IsUnread is true when the item's latest activity post-dates the
+	// caller's InboxCursor.LastSeenAt (or the cursor is zero). Computed
+	// by the /inbox/items handler from the caller's cursor; the broker
+	// inbox helpers never set this field.
+	IsUnread bool `json:"isUnread,omitempty"`
 	// Per-kind enrichments. Populated only when Kind matches.
 	TaskRow *InboxRow    `json:"task,omitempty"`
 	Request *RequestPeek `json:"request,omitempty"`
@@ -249,6 +259,7 @@ func (b *Broker) tasksForInbox(actor requestActor) []InboxItem {
 			Title:     row.Title,
 			Channel:   task.Channel,
 			CreatedAt: task.CreatedAt,
+			UpdatedAt: task.UpdatedAt,
 			ElapsedMs: row.ElapsedMs,
 			AgentSlug: normalizeReviewerSlug(task.Owner),
 			TaskRow:   &row,
@@ -289,12 +300,17 @@ func (b *Broker) requestsForInbox(actor requestActor) []InboxItem {
 		if title == "" {
 			title = strings.TrimSpace(req.Question)
 		}
+		updatedAt := strings.TrimSpace(req.UpdatedAt)
+		if updatedAt == "" {
+			updatedAt = req.CreatedAt
+		}
 		out = append(out, InboxItem{
 			Kind:      InboxItemKindRequest,
 			RequestID: req.ID,
 			Title:     title,
 			Channel:   req.Channel,
 			CreatedAt: req.CreatedAt,
+			UpdatedAt: updatedAt,
 			AgentSlug: normalizeReviewerSlug(req.From),
 			Request: &RequestPeek{
 				Kind:     req.Kind,
@@ -348,11 +364,16 @@ func (b *Broker) reviewsForInbox(actor requestActor) []InboxItem {
 		if t := strings.TrimSpace(p.Rationale); t != "" {
 			title = t
 		}
+		updatedAt := p.CreatedAt.UTC().Format(time.RFC3339)
+		if !p.UpdatedAt.IsZero() {
+			updatedAt = p.UpdatedAt.UTC().Format(time.RFC3339)
+		}
 		out = append(out, InboxItem{
 			Kind:      InboxItemKindReview,
 			ReviewID:  p.ID,
 			Title:     title,
 			CreatedAt: p.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt: updatedAt,
 			AgentSlug: normalizeReviewerSlug(p.SourceSlug),
 			Review: &ReviewPeek{
 				State:        string(p.State),
@@ -441,4 +462,20 @@ func (b *Broker) InboxCursor(humanSlug string) InboxCursor {
 // equality checks across the inbox subsystem stay consistent.
 func normalizeInboxHumanSlug(slug string) string {
 	return strings.ToLower(strings.TrimSpace(slug))
+}
+
+// inboxCursorKeyForActor returns the per-actor key used to look up and
+// write the inbox cursor. Broker/owner tokens carry no Slug field, so
+// without a synthetic key the single most common caller (a local user
+// running `wuphf` against their own broker) would never accumulate any
+// read state. Map the broker actor to the reserved "__owner__" key so
+// the owner gets unread tracking on equal terms with tunnel-human
+// sessions.
+const inboxCursorOwnerKey = "__owner__"
+
+func inboxCursorKeyForActor(actor requestActor) string {
+	if actor.Kind == requestActorKindBroker {
+		return inboxCursorOwnerKey
+	}
+	return normalizeInboxHumanSlug(actor.Slug)
 }

--- a/web/src/api/lifecycle.ts
+++ b/web/src/api/lifecycle.ts
@@ -306,3 +306,27 @@ export async function postTaskReject(
     created_by: "human",
   });
 }
+
+/**
+ * POST a manual Resume on a blocked task. Clears the
+ * blocked_on_pr_merge state and re-queues the owner agent's lane, so the
+ * task picks up where it left off. Mirrors the watchdog's resume path
+ * but exposes the action to humans from the inbox card.
+ *
+ * The optional reason is written into task.Details for audit. A 200
+ * response with changed=false means the task was not in a resumable
+ * state (already running or already terminal) — the caller should
+ * surface that as an info-toast, not an error.
+ */
+export async function postTaskResume(
+  taskId: string,
+  reason?: string,
+): Promise<{ changed: boolean }> {
+  if (USE_MOCKS) {
+    return Promise.resolve({ changed: true });
+  }
+  const body: { reason?: string } = {};
+  const trimmed = (reason ?? "").trim();
+  if (trimmed) body.reason = trimmed;
+  return post(`/tasks/${encodeURIComponent(taskId)}/resume`, body);
+}

--- a/web/src/components/lifecycle/DecisionInbox.test.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.test.tsx
@@ -148,6 +148,33 @@ describe("<DecisionInbox> (mail-style)", () => {
     expect(screen.getAllByText(/inbox zero/i).length).toBeGreaterThanOrEqual(1);
   });
 
+  it("flags unread rows with data-unread + bold subject", () => {
+    const unreadItem: InboxItem = { ...MIRA_TASK, isUnread: true };
+    const readItem: InboxItem = {
+      ...ADA_REQUEST,
+      isUnread: false,
+    };
+    render(wrap(<DecisionInbox initialItems={[unreadItem, readItem]} />));
+    const rows = screen.getAllByRole("button", { name: /^Open|^Unread Open/ });
+    expect(rows[0]).toHaveAttribute("data-unread", "true");
+    expect(rows[1]).toHaveAttribute("data-unread", "false");
+  });
+
+  it("Unread filter chip narrows the list to unread items only", () => {
+    const unreadItem: InboxItem = { ...MIRA_TASK, isUnread: true };
+    const readItem: InboxItem = {
+      ...ADA_REQUEST,
+      isUnread: false,
+    };
+    render(wrap(<DecisionInbox initialItems={[unreadItem, readItem]} />));
+    fireEvent.click(screen.getByTestId("inbox-filter-unread"));
+    // After filter is applied the read request row should disappear.
+    expect(screen.queryAllByText(/Bump Postgres to 17/i).length).toBe(0);
+    expect(
+      screen.getAllByText(/Refactor agent-rail event pill state/i).length,
+    ).toBeGreaterThan(0);
+  });
+
   it("shows a deterministic error when answering a request fails", async () => {
     vi.mocked(answerRequest).mockRejectedValueOnce(
       new Error("Broker unavailable"),

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -15,7 +15,11 @@ import {
   answerRequest,
   getRequests,
 } from "../../api/client";
-import { getInboxItems, type UnifiedInboxResponse } from "../../api/lifecycle";
+import {
+  getInboxItems,
+  postInboxCursor,
+  type UnifiedInboxResponse,
+} from "../../api/lifecycle";
 import {
   fetchReviews,
   type ReviewItem,
@@ -43,10 +47,17 @@ interface DecisionInboxProps {
   onOpenItem?: (item: InboxItem) => void;
 }
 
-type InboxFilter = "all" | "decisions" | "requests" | "reviews" | "approved";
+type InboxFilter =
+  | "all"
+  | "unread"
+  | "decisions"
+  | "requests"
+  | "reviews"
+  | "approved";
 
 const FILTER_ORDER: readonly InboxFilter[] = [
   "all",
+  "unread",
   "decisions",
   "requests",
   "reviews",
@@ -55,6 +66,7 @@ const FILTER_ORDER: readonly InboxFilter[] = [
 
 const FILTER_LABEL: Record<InboxFilter, string> = {
   all: "All",
+  unread: "Unread",
   decisions: "Decisions",
   requests: "Requests",
   reviews: "Reviews",
@@ -70,6 +82,7 @@ const DECISION_STATES = new Set([
 
 function itemMatchesFilter(item: InboxItem, filter: InboxFilter): boolean {
   if (filter === "all") return true;
+  if (filter === "unread") return item.isUnread === true;
   if (filter === "requests") return item.kind === "request";
   if (filter === "reviews") return item.kind === "review";
   if (item.kind !== "task") return false;
@@ -116,6 +129,7 @@ export function DecisionInbox({
           running: 0,
           blocked: 0,
           approvedToday: 0,
+          unread: initialItems.filter((it) => it.isUnread === true).length,
         },
         refreshedAt: new Date().toISOString(),
       }
@@ -152,6 +166,7 @@ export function DecisionInbox({
   const filterCounts = useMemo(() => {
     const counts: Record<InboxFilter, number> = {
       all: allItems.length,
+      unread: 0,
       decisions: 0,
       requests: 0,
       reviews: 0,
@@ -291,6 +306,13 @@ export function DecisionInbox({
                   onSelect={(item) => {
                     setSelectedKey(itemKey(item));
                     onOpenItem?.(item);
+                    // Mark-as-read on open. The cursor is per-actor on
+                    // the broker so the next /inbox/items refresh will
+                    // drop the IsUnread flag for everything older than
+                    // now. Best-effort — the helper swallows errors.
+                    if (item.isUnread === true) {
+                      void postInboxCursor();
+                    }
                   }}
                 />
               </li>
@@ -380,17 +402,24 @@ function MailRow({
   const elapsed = formatElapsed(item.createdAt);
   const kindLabel = kindShortLabel(item.kind);
 
+  const isUnread = item.isUnread === true;
   return (
     <button
       type="button"
       className="inbox-mail-row"
       data-selected={isSelected ? "true" : "false"}
       data-kind={item.kind}
+      data-unread={isUnread ? "true" : "false"}
       tabIndex={tabIndex}
       onClick={() => onSelect(item)}
       onFocus={() => onSelect(item)}
-      aria-label={`Open ${kindLabel} from ${from}: ${subject}`}
+      aria-label={`${isUnread ? "Unread " : ""}Open ${kindLabel} from ${from}: ${subject}`}
     >
+      <span
+        className="inbox-mail-row-unread-dot"
+        aria-hidden="true"
+        data-visible={isUnread ? "true" : "false"}
+      />
       <span className="inbox-mail-row-rail" aria-hidden="true" />
       <span className="inbox-mail-row-main">
         <span className="inbox-mail-row-line">
@@ -546,7 +575,7 @@ function stateExplainer(state: string): string {
     case "review":
       return "Reviewers are grading the work. Decision details surface once enough grades land.";
     case "blocked_on_pr_merge":
-      return "Waiting on an upstream PR merge before this task can land.";
+      return "The owner agent is paused. Resume to retry, or reject to drop the task.";
     case "changes_requested":
       return "You asked for changes. The owner agent is iterating.";
     case "approved":

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -304,12 +304,17 @@ export function DecisionInbox({
                       : -1
                   }
                   onSelect={(item) => {
+                    // Focus-driven: track selection only. No side
+                    // effects — arrow-key nav must not silently mark
+                    // every passed-over row as read.
+                    setSelectedKey(itemKey(item));
+                  }}
+                  onOpen={(item) => {
+                    // User-initiated open (click / Enter / Space). Mark
+                    // as read here so the cursor only advances on
+                    // genuine intent, not keyboard hover.
                     setSelectedKey(itemKey(item));
                     onOpenItem?.(item);
-                    // Mark-as-read on open. The cursor is per-actor on
-                    // the broker so the next /inbox/items refresh will
-                    // drop the IsUnread flag for everything older than
-                    // now. Best-effort — the helper swallows errors.
                     if (item.isUnread === true) {
                       void postInboxCursor();
                     }
@@ -390,11 +395,13 @@ function MailRow({
   isSelected,
   tabIndex,
   onSelect,
+  onOpen,
 }: {
   item: InboxItem;
   isSelected: boolean;
   tabIndex: number;
   onSelect: (item: InboxItem) => void;
+  onOpen: (item: InboxItem) => void;
 }) {
   const from = senderForItem(item);
   const subject = item.title;
@@ -411,7 +418,7 @@ function MailRow({
       data-kind={item.kind}
       data-unread={isUnread ? "true" : "false"}
       tabIndex={tabIndex}
-      onClick={() => onSelect(item)}
+      onClick={() => onOpen(item)}
       onFocus={() => onSelect(item)}
       aria-label={`${isUnread ? "Unread " : ""}Open ${kindLabel} from ${from}: ${subject}`}
     >

--- a/web/src/components/lifecycle/DecisionPacketRoute.tsx
+++ b/web/src/components/lifecycle/DecisionPacketRoute.tsx
@@ -291,11 +291,6 @@ function pendingStateExplainer(state: string, details?: string): string {
   }
 }
 
-function jumpToTask(taskId: string) {
-  if (typeof window === "undefined") return;
-  window.location.hash = `#/task/${encodeURIComponent(taskId)}`;
-}
-
 function PacketPending({
   item,
   onRetry,
@@ -373,16 +368,24 @@ function PacketPending({
                   }}
                 >
                   {blockedOn.map((blockerId) => (
-                    <button
+                    // Real anchor links so middle-click / cmd-click /
+                    // "copy link" / screen-reader announce all behave
+                    // the way users expect for navigation. A button
+                    // with a click handler would force keyboard-only
+                    // open via Enter and break copy-link entirely.
+                    <a
                       key={blockerId}
-                      type="button"
+                      href={`#/task/${encodeURIComponent(blockerId)}`}
                       className="retry"
                       data-testid="packet-pending-blocker"
-                      style={{ padding: "2px 8px", fontSize: 12 }}
-                      onClick={() => jumpToTask(blockerId)}
+                      style={{
+                        padding: "2px 8px",
+                        fontSize: 12,
+                        textDecoration: "none",
+                      }}
                     >
                       {blockerId}
-                    </button>
+                    </a>
                   ))}
                 </dd>
               </>

--- a/web/src/components/lifecycle/DecisionPacketRoute.tsx
+++ b/web/src/components/lifecycle/DecisionPacketRoute.tsx
@@ -7,6 +7,7 @@ import {
   postInboxCursor,
   postTaskComment,
   postTaskReject,
+  postTaskResume,
 } from "../../api/lifecycle";
 import type { InboxItem } from "../../lib/types/inbox";
 import type { DecisionPacket } from "../../lib/types/lifecycle";
@@ -158,6 +159,27 @@ export function DecisionPacketRoute({
           item={fallbackItem}
           onRetry={() => query.refetch()}
           onClose={close}
+          onResume={async (reason?: string) => {
+            try {
+              await postTaskResume(taskId, reason);
+              void postInboxCursor();
+              void queryClient.invalidateQueries({
+                queryKey: ["lifecycle", "task", taskId],
+              });
+              void queryClient.invalidateQueries({
+                queryKey: ["lifecycle", "inbox"],
+              });
+              void queryClient.invalidateQueries({
+                queryKey: ["lifecycle", "inbox-items"],
+              });
+              void queryClient.invalidateQueries({
+                queryKey: ["inbox-badge"],
+              });
+            } catch (err) {
+              console.error("postTaskResume failed", err);
+            }
+          }}
+          onReject={(reason: string) => submitReject(reason)}
         />
       );
     }
@@ -239,7 +261,8 @@ function PacketSkeleton({ onClose: _onClose }: { onClose: () => void }) {
   );
 }
 
-function pendingStateExplainer(state: string): string {
+function pendingStateExplainer(state: string, details?: string): string {
+  const trimmed = (details ?? "").trim();
   switch (state) {
     case "decision":
       return "Waiting on a packet write. The owner agent has flagged this for a human call.";
@@ -248,28 +271,50 @@ function pendingStateExplainer(state: string): string {
     case "changes_requested":
       return "Changes were requested. The owner agent is iterating on the spec.";
     case "blocked_on_pr_merge":
-      return "Waiting on an upstream PR merge before this task can land.";
+      // The lifecycle state name is historical — most real blocks are agent
+      // timeouts, agent errors, or cross-task dependencies, not actual PR
+      // merges. Prefer the broker's own reason when present so the human
+      // sees the real "why" instead of the generic framing.
+      return (
+        trimmed ||
+        "The owner agent is paused. Resume to retry, or reject to drop the task."
+      );
     case "approved":
       return "Approved. The packet write is still in flight.";
     case "rejected":
       return "Rejected. The packet write is still in flight.";
     default:
-      return "The owner agent is still working. Full decision packet will surface here once it lands.";
+      return (
+        trimmed ||
+        "The owner agent is still working. Full decision packet will surface here once it lands."
+      );
   }
+}
+
+function jumpToTask(taskId: string) {
+  if (typeof window === "undefined") return;
+  window.location.hash = `#/task/${encodeURIComponent(taskId)}`;
 }
 
 function PacketPending({
   item,
   onRetry,
   onClose,
+  onResume,
+  onReject,
 }: {
   item: Extract<InboxItem, { kind: "task" }>;
   onRetry: () => void;
   onClose: () => void;
+  onResume?: (reason?: string) => void;
+  onReject?: (reason: string) => void;
 }) {
   const state = item.task?.state ?? "";
-  const explainer = pendingStateExplainer(state);
+  const details = item.task?.details;
+  const blockedOn = item.task?.blockedOn ?? [];
+  const explainer = pendingStateExplainer(state, details);
   const owner = item.agentSlug || item.task?.assignment || "";
+  const isBlocked = state === "blocked_on_pr_merge";
   return (
     <div
       className="packet-shell packet-shell--message"
@@ -277,7 +322,11 @@ function PacketPending({
     >
       <main className="packet-center">
         <div className="packet-error" role="status">
-          <h2>{item.title || "(no subject)"}</h2>
+          <h2>
+            {isBlocked
+              ? `Blocked: ${item.title || "(no subject)"}`
+              : item.title || "(no subject)"}
+          </h2>
           <p>{explainer}</p>
           <dl
             style={{
@@ -312,8 +361,69 @@ function PacketPending({
                 <dd style={{ margin: 0 }}>#{item.channel}</dd>
               </>
             ) : null}
+            {blockedOn.length > 0 ? (
+              <>
+                <dt style={{ color: "var(--text-tertiary)" }}>Blocked on</dt>
+                <dd
+                  style={{
+                    margin: 0,
+                    display: "flex",
+                    flexWrap: "wrap",
+                    gap: 6,
+                  }}
+                >
+                  {blockedOn.map((blockerId) => (
+                    <button
+                      key={blockerId}
+                      type="button"
+                      className="retry"
+                      data-testid="packet-pending-blocker"
+                      style={{ padding: "2px 8px", fontSize: 12 }}
+                      onClick={() => jumpToTask(blockerId)}
+                    >
+                      {blockerId}
+                    </button>
+                  ))}
+                </dd>
+              </>
+            ) : null}
           </dl>
-          <div style={{ display: "flex", gap: 8, justifyContent: "center" }}>
+          <div
+            style={{
+              display: "flex",
+              gap: 8,
+              justifyContent: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            {isBlocked && onResume ? (
+              <button
+                type="button"
+                className="retry"
+                data-testid="packet-pending-resume"
+                onClick={() => onResume()}
+              >
+                Resume
+              </button>
+            ) : null}
+            {isBlocked && onReject ? (
+              <button
+                type="button"
+                className="retry"
+                data-testid="packet-pending-reject"
+                onClick={() => {
+                  if (typeof window === "undefined") return;
+                  const reason = window.prompt(
+                    "Reject this task? Reason (required):",
+                    "Manual reject from inbox.",
+                  );
+                  const trimmed = (reason ?? "").trim();
+                  if (trimmed) onReject(trimmed);
+                }}
+              >
+                Reject
+              </button>
+            ) : null}
             <button type="button" className="retry" onClick={onRetry}>
               Refresh
             </button>

--- a/web/src/lib/mocks/decisionPackets.ts
+++ b/web/src/lib/mocks/decisionPackets.ts
@@ -131,6 +131,7 @@ export const POPULATED_INBOX: InboxPayload = {
     running: 7,
     blocked: 2,
     approvedToday: 11,
+    unread: 3,
   },
   refreshedAt: NOW,
 };
@@ -142,6 +143,7 @@ export const EMPTY_INBOX: InboxPayload = {
     running: 7,
     blocked: 2,
     approvedToday: 11,
+    unread: 0,
   },
   refreshedAt: NOW,
 };

--- a/web/src/lib/types/inbox.ts
+++ b/web/src/lib/types/inbox.ts
@@ -19,26 +19,33 @@ import type { InboxRow } from "./lifecycle";
 
 export type InboxItemKind = "task" | "request" | "review";
 
-export interface InboxItemTask {
-  kind: "task";
-  taskId: string;
-  title: string;
+interface InboxItemBase {
   channel?: string;
   createdAt?: string;
+  /** RFC3339 timestamp of the latest activity on the underlying artifact. */
+  updatedAt?: string;
   elapsedMs?: number;
   /** Agent who owns / sent / submitted this item. Phase 3+. */
   agentSlug?: string;
+  /**
+   * True when the item's latest activity post-dates the caller's
+   * inbox cursor. Stamped by the broker handler; the frontend does
+   * not compute it locally.
+   */
+  isUnread?: boolean;
+}
+
+export interface InboxItemTask extends InboxItemBase {
+  kind: "task";
+  taskId: string;
+  title: string;
   task: InboxRow;
 }
 
-export interface InboxItemRequest {
+export interface InboxItemRequest extends InboxItemBase {
   kind: "request";
   requestId: string;
   title: string;
-  channel?: string;
-  createdAt?: string;
-  elapsedMs?: number;
-  agentSlug?: string;
   request: {
     kind: string;
     question: string;
@@ -47,14 +54,10 @@ export interface InboxItemRequest {
   };
 }
 
-export interface InboxItemReview {
+export interface InboxItemReview extends InboxItemBase {
   kind: "review";
   reviewId: string;
   title: string;
-  channel?: string;
-  createdAt?: string;
-  elapsedMs?: number;
-  agentSlug?: string;
   review: {
     state: string;
     reviewerSlug: string;

--- a/web/src/lib/types/lifecycle.ts
+++ b/web/src/lib/types/lifecycle.ts
@@ -34,7 +34,8 @@ export type InboxFilter =
   | "decision_required"
   | "running"
   | "blocked"
-  | "approved";
+  | "approved"
+  | "unread";
 
 /**
  * One acceptance-criterion checkbox. Toggled by the owner agent during
@@ -175,6 +176,20 @@ export interface InboxRow {
   elapsed: string;
   /** True when elapsed should render in red (decision sitting >5m). */
   isUrgent: boolean;
+  /**
+   * Typed-blocker task IDs from teamTask.BlockedOn. Empty for tasks
+   * that are not blocked; populated for blocked_on_pr_merge and any
+   * other state the broker carries a dependency on.
+   */
+  blockedOn?: string[];
+  /**
+   * Free-text reason the broker attached to the task. For blocked
+   * tasks this is the actual "why" (agent timeout, manual block).
+   * Truncated by the broker for inbox payload size.
+   */
+  details?: string;
+  /** RFC3339 timestamp of the task's last mutation. */
+  updatedAt?: string;
 }
 
 /**
@@ -186,6 +201,12 @@ export interface InboxCounts {
   running: number;
   blocked: number;
   approvedToday: number;
+  /**
+   * Number of items whose latest activity post-dates the caller's
+   * InboxCursor.LastSeenAt. Drives the "Unread" sidebar pill and the
+   * top-bar attention badge.
+   */
+  unread: number;
 }
 
 /** Top-level inbox payload returned by the (mocked, soon-real) API. */
@@ -386,4 +407,8 @@ export const FILTER_TO_STATES: Record<
   running: ["drafting", "intake", "ready", "running", "review"],
   blocked: ["blocked_on_pr_merge", "changes_requested", "rejected"],
   approved: ["approved"],
+  // Unread is post-filtered against the actor's cursor on the server,
+  // not against a fixed state set. Leave the state list empty so any
+  // call site that walks states for "unread" produces no false matches.
+  unread: [],
 };

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -619,9 +619,9 @@ html[data-theme="noir-gold"] {
 
 .inbox-mail-row {
   display: grid;
-  grid-template-columns: 3px 1fr;
-  gap: 14px;
-  padding: 12px 16px 12px 0;
+  grid-template-columns: 12px 3px 1fr;
+  gap: 6px 14px;
+  padding: 12px 16px 12px 4px;
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--border);
@@ -632,6 +632,26 @@ html[data-theme="noir-gold"] {
   width: 100%;
   color: inherit;
   transition: background var(--duration-base);
+}
+
+.inbox-mail-row-unread-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--cyan-500);
+  align-self: center;
+  justify-self: center;
+  visibility: hidden;
+}
+
+.inbox-mail-row-unread-dot[data-visible="true"] {
+  visibility: visible;
+}
+
+.inbox-mail-row[data-unread="true"] .inbox-mail-row-from,
+.inbox-mail-row[data-unread="true"] .inbox-mail-row-subject {
+  font-weight: 700;
+  color: var(--text);
 }
 
 .inbox-mail-row:hover {

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -654,6 +654,19 @@ html[data-theme="noir-gold"] {
   color: var(--text);
 }
 
+/*
+ * The selected-row subject rule below this block sets font-weight: 500,
+ * which would dim a row that is BOTH selected and unread. Re-assert the
+ * unread boldness at higher specificity so a freshly selected unread
+ * row still reads as unread until the cursor write lands and the next
+ * inbox refresh drops the flag.
+ */
+.inbox-mail-row[data-selected="true"][data-unread="true"] .inbox-mail-row-from,
+.inbox-mail-row[data-selected="true"][data-unread="true"]
+  .inbox-mail-row-subject {
+  font-weight: 700;
+}
+
 .inbox-mail-row:hover {
   background: var(--overlay-soft);
 }


### PR DESCRIPTION
## Why

The \`blocked_on_pr_merge\` card in the unified Inbox is a dead end. The screenshot the user is staring at says "Waiting on an upstream PR merge" but the real triggers are mostly agent timeouts, agent errors, and cross-task dependencies — no PR involved. The card surfaces no blocker info and exposes no action other than Refresh / Back to inbox. Same surface also lacked any per-item unread marker or "Unread" filter — owner-token users got no read state at all because the cursor handler keyed off \`actor.Slug\` which is empty for broker auth.

## Changes

**Blocked card (PacketPending)**
- Heading reads "Blocked: <title>"; no more PR framing.
- Body uses \`task.Details\` (the real reason: "agent timed out after 5m", "manual block", etc) and falls back to a generic line.
- \`BlockedOn\` IDs render as clickable chips that route to \`/task/<id>\`.
- **Resume** button posts to new \`POST /tasks/{id}/resume\` → \`Broker.ResumeTask\`. Auth: broker token or reviewer slug.
- **Reject** button reuses \`postTaskReject\` with an inline confirm.

**Unread**
- \`/inbox/items\` stamps \`isUnread\` per item from \`InboxCursor.LastSeenAt\` vs \`item.updatedAt\`.
- Broker actor now keyed as \`__owner__\` for cursor lookup — fixes the silent gap where the owner saw no read state.
- New \`unread\` filter chip + post-fetch trim.
- Blue dot + bold subject when unread; auto-marks-as-read on row click.

**Wire shape** (Go + TS mirrored)
- \`InboxRow\` ← \`blockedOn\`, \`details\`, \`updatedAt\`.
- \`InboxItem\` ← \`updatedAt\`, \`isUnread\`.
- \`InboxCounts\` ← \`unread\`.
- \`InboxFilter\` ← \`"unread"\`.

## Test plan

- [x] \`go test -race ./internal/team\` — package passes (~105s).
- [x] \`bash scripts/test-web.sh\` — 1640 / 1640 pass.
- [x] New Go tests: unread stamping + count, unread filter trim, blocker/details payload, /tasks/{id}/resume route.
- [x] New vitest: unread row marker, unread filter chip.
- [x] \`go vet ./...\`, \`golangci-lint run ./internal/team/...\`, \`bunx tsc --noEmit\`, \`bunx biome check --write\` on touched files.
- [ ] Screenshot harness spec for blocked card + unread row — follow-up (needs dev server + PR # for \`publish.sh\`).
- [ ] Manual verify: click into a blocked task, hit Resume, watch row transition; flip Unread filter and confirm dot/bold render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unread tracking across inbox items with badge totals and per-item unread flag.
  * "Unread" filter to show only unread items (post-filtered from returned results).
  * Manual "Resume" action for blocked tasks with optional reason and UI hooks.
  * Blocked-task details and blocker links surfaced in inbox rows and pending UI.

* **Style**
  * Visual emphasis for unread items (dot, bold text, updated layout).

* **Tests**
  * End-to-end and unit tests covering unread behavior, sorting, blockers, and resume.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->