### PR TITLE
fix(auth): probe provider session + system error card + repair-phase guard

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -449,7 +449,7 @@ func HandlePrereqs(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	results := CheckAll()
+	results := CheckAll(r.Context())
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(results)
 }

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -29,6 +29,26 @@ type PrereqResult struct {
 
 	// InstallURL is the canonical install page for this binary.
 	InstallURL string `json:"install_url,omitempty"`
+
+	// SessionProbed is true when the runtime supports a session-status
+	// subcommand and the probe ran to completion (regardless of result).
+	// False means "we did not attempt the probe" — either because the
+	// binary has no session, or no probe is wired for this runtime.
+	// Issue #932: distinguishes "we asked and got no session" (block the
+	// tile, show a sign-in CTA) from "we don't know" (let the user click
+	// and learn from the agent loop, the legacy behavior).
+	SessionProbed bool `json:"session_probed,omitempty"`
+
+	// SignedIn is true when the runtime reports an active auth session.
+	// Only meaningful when SessionProbed is true. For CLI runtimes
+	// (claude, codex, opencode) this is the result of the per-runtime
+	// session-status subcommand; see runtimeSessionProbes in prereqs.go.
+	SignedIn bool `json:"signed_in,omitempty"`
+
+	// SignInCommand is the suggested shell command for the user to run
+	// when SessionProbed is true and SignedIn is false. Frontend renders
+	// this in a copy-to-clipboard "Sign in" CTA. Empty when irrelevant.
+	SignInCommand string `json:"sign_in_command,omitempty"`
 }
 
 // prereqSpec defines static metadata for each required binary.
@@ -106,7 +126,124 @@ func CheckOne(name string) PrereqResult {
 	if err == nil {
 		r.Version = parseVersion(string(out))
 	}
+
+	// Issue #932: session-status probe. Run the per-runtime auth-status
+	// subcommand. The goal is to distinguish "claude installed" (current
+	// behavior) from "claude installed AND signed in" — the latter is the
+	// actually-load-bearing state for an agent loop's first LLM call.
+	//
+	// Probe failure modes are intentionally lenient: a non-zero exit, parse
+	// error, or timeout all set SignedIn=false (which the SPA renders as
+	// a "sign in" CTA) rather than blocking the user. The cost of a false
+	// negative is a friction-y but recoverable click; the cost of a false
+	// positive (current behavior) is letting the user complete onboarding
+	// only to fail on the first agent call.
+	probe, ok := runtimeSessionProbes[name]
+	if ok && probe != nil {
+		probeCtx, probeCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer probeCancel()
+		signedIn := probe(probeCtx, path)
+		r.SessionProbed = true
+		r.SignedIn = signedIn
+		if !signedIn {
+			r.SignInCommand = sessionSignInCommands[name]
+		}
+	}
 	return r
+}
+
+// runtimeSessionProbes maps a binary name to the per-runtime session probe.
+// The probe returns true only when the runtime reports an active auth
+// session; any non-zero exit, parse error, or timeout returns false. CLIs
+// without a session-status surface (cursor, windsurf) have no entry — the
+// frontend renders them with SessionProbed=false and treats picking as
+// always-allowed.
+var runtimeSessionProbes = map[string]func(ctx context.Context, path string) bool{
+	"claude":   probeClaudeSession,
+	"codex":    probeCodexSession,
+	"opencode": probeOpencodeSession,
+}
+
+// sessionSignInCommands maps a binary name to the shell command the user
+// should run to sign in. Returned to the SPA so the "Sign in" CTA can
+// copy the command to the clipboard. Keep these in sync with the CLI
+// surface — these are documented login flows, not best-guesses.
+var sessionSignInCommands = map[string]string{
+	"claude":   "claude auth login",
+	"codex":    "codex login",
+	"opencode": "opencode auth login",
+}
+
+// probeClaudeSession runs `claude auth status` and reports whether the
+// CLI is signed in. Claude Code emits a JSON document on stdout with a
+// `loggedIn` boolean; non-zero exit, malformed JSON, or `loggedIn: false`
+// all return false.
+func probeClaudeSession(ctx context.Context, path string) bool {
+	out, err := exec.CommandContext(ctx, path, "auth", "status").Output()
+	if err != nil {
+		return false
+	}
+	text := strings.ToLower(strings.TrimSpace(string(out)))
+	// Claude Code emits structured JSON; this substring match avoids a
+	// JSON parser dependency for a tiny payload. The negative case
+	// `"loggedin": false` is matched first so it doesn't false-positive
+	// on the substring `"loggedin": true`.
+	if strings.Contains(text, `"loggedin": false`) || strings.Contains(text, `"loggedin":false`) {
+		return false
+	}
+	return strings.Contains(text, `"loggedin": true`) || strings.Contains(text, `"loggedin":true`)
+}
+
+// probeCodexSession runs `codex login status` and reports whether the
+// CLI is signed in. Codex prints a single line like "Logged in using
+// ChatGPT" / "Logged in using API key" on success; a "not logged in" or
+// equivalent message on failure. Exit code is 0 in both cases (as of
+// codex 0.55), so we have to text-classify.
+func probeCodexSession(ctx context.Context, path string) bool {
+	out, err := exec.CommandContext(ctx, path, "login", "status").CombinedOutput()
+	if err != nil {
+		// Some codex versions exit non-zero on "not logged in" — that's
+		// still an unambiguous unauthenticated state.
+		return false
+	}
+	text := strings.ToLower(string(out))
+	if strings.Contains(text, "not logged in") ||
+		strings.Contains(text, "no auth") ||
+		strings.Contains(text, "no credentials") {
+		return false
+	}
+	return strings.Contains(text, "logged in")
+}
+
+// probeOpencodeSession runs `opencode providers list` and reports whether
+// any provider has stored credentials. The CLI prints a banner with a
+// count like "0 credentials" / "2 credentials". Zero-count or parse
+// failure → not signed in.
+func probeOpencodeSession(ctx context.Context, path string) bool {
+	out, err := exec.CommandContext(ctx, path, "providers", "list").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	text := strings.ToLower(string(out))
+	if strings.Contains(text, "0 credentials") {
+		return false
+	}
+	// Match "<N> credential" where N >= 1. The trailing space (or "s")
+	// disambiguates from "0 credentials".
+	for _, n := range []string{"1 credential", "2 credential", "3 credential", "4 credential", "5 credential", "6 credential", "7 credential", "8 credential", "9 credential"} {
+		if strings.Contains(text, n) {
+			return true
+		}
+	}
+	// Fallback: any provider name in the rendered table implies a session.
+	// Suppress noise from the "Credentials ~/.local/share/..." header by
+	// requiring a known provider label.
+	for _, name := range []string{"anthropic", "openai", "google", "mistral", "groq", "openrouter"} {
+		if strings.Contains(text, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // parseVersion trims whitespace and returns the first non-empty line from

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -79,7 +79,12 @@ var prereqSpecs = map[string]prereqSpec{
 // would mean worst-case wall-clock = 7 × 10s = 70s, far past any sane HTTP
 // budget. Concurrent probes cap wall-clock at max(probe), well under the
 // client timeout. Order of `names` is preserved in the returned slice.
-func CheckAll() []PrereqResult {
+//
+// ctx is the parent (request-scoped) context; per-probe timeouts derive from
+// it so a cancelled HTTP request stops in-flight subprocess probes instead
+// of leaking them. Pass context.Background() only from tests or boot paths
+// that have no request lifecycle.
+func CheckAll(ctx context.Context) []PrereqResult {
 	names := []string{"node", "git", "claude", "codex", "opencode", "cursor", "windsurf"}
 	results := make([]PrereqResult, len(names))
 	var wg sync.WaitGroup
@@ -87,7 +92,7 @@ func CheckAll() []PrereqResult {
 	for i, name := range names {
 		go func(i int, name string) {
 			defer wg.Done()
-			results[i] = CheckOne(name)
+			results[i] = CheckOne(ctx, name)
 		}(i, name)
 	}
 	wg.Wait()
@@ -98,7 +103,10 @@ func CheckAll() []PrereqResult {
 // CLI install directories, then invokes `<name> --version` to capture the
 // version string. If resolution fails the binary is considered absent and the
 // version field is left empty.
-func CheckOne(name string) PrereqResult {
+//
+// ctx is the parent (request-scoped) context; per-call timeouts derive from
+// it so probe subprocesses can't outlive a cancelled HTTP request.
+func CheckOne(ctx context.Context, name string) PrereqResult {
 	spec := prereqSpecs[name]
 	r := PrereqResult{
 		Name:       name,
@@ -120,9 +128,9 @@ func CheckOne(name string) PrereqResult {
 	// calls, and a 3s window was flaky on a developer laptop running the
 	// pre-push hook. This is a one-shot `--version` probe, not a hot path;
 	// the timeout is a floor on machine health, not on binary response time.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	out, err := exec.CommandContext(ctx, path, "--version").Output()
+	versionCtx, versionCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer versionCancel()
+	out, err := exec.CommandContext(versionCtx, path, "--version").Output()
 	if err == nil {
 		r.Version = parseVersion(string(out))
 	}
@@ -140,7 +148,7 @@ func CheckOne(name string) PrereqResult {
 	// only to fail on the first agent call.
 	probe, ok := runtimeSessionProbes[name]
 	if ok && probe != nil {
-		probeCtx, probeCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		probeCtx, probeCancel := context.WithTimeout(ctx, 3*time.Second)
 		defer probeCancel()
 		signedIn := probe(probeCtx, path)
 		r.SessionProbed = true

--- a/internal/onboarding/prereqs_test.go
+++ b/internal/onboarding/prereqs_test.go
@@ -1,6 +1,7 @@
 package onboarding
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,7 +9,7 @@ import (
 )
 
 func TestCheckOneGitFound(t *testing.T) {
-	r := CheckOne("git")
+	r := CheckOne(context.Background(), "git")
 	if !r.Found {
 		t.Fatal("expected git to be found on PATH in CI/dev environment")
 	}
@@ -24,7 +25,7 @@ func TestCheckOneGitFound(t *testing.T) {
 }
 
 func TestCheckOneNonexistentBinary(t *testing.T) {
-	r := CheckOne("nonexistent-binary-xyz-wuphf")
+	r := CheckOne(context.Background(), "nonexistent-binary-xyz-wuphf")
 	if r.Found {
 		t.Fatal("expected Found=false for nonexistent binary")
 	}
@@ -38,7 +39,7 @@ func TestCheckOneNonexistentBinary(t *testing.T) {
 }
 
 func TestCheckAllReturnsSevenItems(t *testing.T) {
-	results := CheckAll()
+	results := CheckAll(context.Background())
 	if len(results) != 7 {
 		t.Fatalf("CheckAll: got %d results, want 7", len(results))
 	}
@@ -62,7 +63,7 @@ func TestCheckAllRequiredFlags(t *testing.T) {
 		"cursor":   false,
 		"windsurf": false,
 	}
-	for _, r := range CheckAll() {
+	for _, r := range CheckAll(context.Background()) {
 		want, ok := wantRequired[r.Name]
 		if !ok {
 			continue
@@ -83,7 +84,7 @@ func TestCheckAllInstallURLs(t *testing.T) {
 		"cursor":   "https://cursor.com/",
 		"windsurf": "https://codeium.com/windsurf",
 	}
-	for _, r := range CheckAll() {
+	for _, r := range CheckAll(context.Background()) {
 		want, ok := wantURLs[r.Name]
 		if !ok {
 			continue
@@ -96,7 +97,7 @@ func TestCheckAllInstallURLs(t *testing.T) {
 
 func TestCheckOneResultFields(t *testing.T) {
 	// node may or may not be installed; just verify field consistency.
-	r := CheckOne("node")
+	r := CheckOne(context.Background(), "node")
 	if r.Name != "node" {
 		t.Errorf("Name: got %q, want %q", r.Name, "node")
 	}
@@ -125,7 +126,7 @@ func TestCheckOneFindsOpencodeInCommonUserBinWhenPATHIsMinimal(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("PATH", filepath.Join(home, "minimal-path"))
 
-	r := CheckOne("opencode")
+	r := CheckOne(context.Background(), "opencode")
 	if !r.Found {
 		t.Fatal("expected fallback opencode to be found")
 	}

--- a/internal/team/agent_issue.go
+++ b/internal/team/agent_issue.go
@@ -277,6 +277,11 @@ func (b *Broker) postSystemAuthError(agentSlug, targetChannel, replyTo, safeDeta
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" {
+		agentSlug = "agent"
+	}
+
 	channel := normalizeChannelSlug(targetChannel)
 	if channel == "" {
 		channel = "general"
@@ -290,6 +295,13 @@ func (b *Broker) postSystemAuthError(agentSlug, targetChannel, replyTo, safeDeta
 		if b.findChannelLocked(channel) == nil {
 			return channelMessage{}, agentIssueRecord{}, false, fmt.Errorf("channel not found")
 		}
+	}
+	// Channel ACL gate, mirroring ReportAgentIssue. Without this, an agent
+	// could surface a system-auth banner into a channel it has no business
+	// in (e.g. another agent's DM) just because the LLM happened to fail
+	// while resolving it.
+	if !b.canAccessChannelLocked(agentSlug, channel) {
+		return channelMessage{}, agentIssueRecord{}, false, fmt.Errorf("channel access denied")
 	}
 
 	// Dedup: if the most recent message in the channel is already a

--- a/internal/team/agent_issue.go
+++ b/internal/team/agent_issue.go
@@ -13,6 +13,13 @@ import (
 
 const agentIssueMessageKind = "agent_issue"
 
+// systemAuthErrorMessageKind is the message kind emitted when the agent
+// loop hits a provider auth failure (e.g. "Not logged in - Please run
+// /login"). The SPA renders these as a SystemErrorCard banner (system
+// authored, distinct visual treatment) instead of an agent-authored
+// chat bubble. Issue #933.
+const systemAuthErrorMessageKind = "system_auth_error"
+
 var agentIssueWhitespacePattern = regexp.MustCompile(`\s+`)
 
 type agentIssueClassification struct {
@@ -35,6 +42,16 @@ func (b *Broker) ReportAgentIssue(agentSlug, targetChannel, replyTo, detail stri
 		return channelMessage{}, agentIssueRecord{}, false, nil
 	}
 	safeDetail := redactSecretsInText(detail)
+
+	// Issue #933: provider auth failures (e.g. claude returning "Not logged
+	// in - Please run /login") would otherwise post as agent-authored chat
+	// bubbles — visually indistinguishable from in-character agent output
+	// and confusing because the agent isn't speaking. Detect the auth
+	// signal and route through a dedicated system-authored card that
+	// carries a structured payload the SPA renders as a SystemErrorCard.
+	if authProbe := classifyProviderAuthError(safeDetail); authProbe.IsAuthError {
+		return b.postSystemAuthError(agentSlug, targetChannel, replyTo, safeDetail, authProbe)
+	}
 
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -176,6 +193,162 @@ func (b *Broker) pruneAgentIssuesByChannelAndAgentLocked(channelSlug, agentSlug 
 	}
 	b.requests = requests
 	b.pendingInterview = firstBlockingRequest(b.requests)
+}
+
+// providerAuthErrorProbe captures the classification + suggested remediation
+// for a detected provider auth failure. Used by ReportAgentIssue to fork
+// into the SystemErrorCard rendering path (issue #933).
+type providerAuthErrorProbe struct {
+	IsAuthError   bool
+	Provider      string
+	SignInCommand string
+}
+
+// classifyProviderAuthError matches detail strings that signal a runtime
+// provider's auth/login surface is the proximate cause (e.g. the Claude
+// CLI's "Not logged in - Please run /login"). Returns Provider="" when
+// the auth signal is detected but the runtime is ambiguous; the SPA
+// renders a generic "Sign in" CTA in that case.
+//
+// Substring matching is intentional — the upstream messages differ across
+// providers and across versions. Mirrors the test surface in
+// internal/provider/claude.go::isClaudeLoginRequired.
+func classifyProviderAuthError(detail string) providerAuthErrorProbe {
+	text := strings.ToLower(strings.TrimSpace(detail))
+	if text == "" {
+		return providerAuthErrorProbe{}
+	}
+	// Auth signal set. Keep this list in sync with isClaudeLoginRequired
+	// in internal/provider/claude.go and the equivalent check in codex.go.
+	authSignals := []string{
+		"not logged in",
+		"please log in",
+		"please run `claude login`",
+		"please run claude login",
+		"please run `codex login`",
+		"please run codex login",
+		"please run /login",
+		"login required",
+		"requires login",
+		"authentication required",
+		"unauthorized",
+		"requires login. run",
+	}
+	matched := false
+	for _, signal := range authSignals {
+		if strings.Contains(text, signal) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return providerAuthErrorProbe{}
+	}
+
+	probe := providerAuthErrorProbe{IsAuthError: true}
+	// Identify the provider from the surrounding text so the SPA can
+	// surface a runtime-specific sign-in CTA. The detection here mirrors
+	// the patterns describeClaude/Codex/Opencode emit through provider
+	// error paths.
+	switch {
+	case strings.Contains(text, "claude"):
+		probe.Provider = "claude-code"
+		probe.SignInCommand = "claude auth login"
+	case strings.Contains(text, "codex"):
+		probe.Provider = "codex"
+		probe.SignInCommand = "codex login"
+	case strings.Contains(text, "opencode"):
+		probe.Provider = "opencode"
+		probe.SignInCommand = "opencode auth login"
+	}
+	return probe
+}
+
+// postSystemAuthError emits a system-authored message with kind
+// systemAuthErrorMessageKind into the target channel. Payload carries the
+// provider name + suggested sign-in command so the SPA's SystemErrorCard
+// can render a copy-to-clipboard CTA. Returns (msg, _, posted=true, nil)
+// on success so the call site doesn't have to special-case dispatch.
+//
+// Idempotency: collapses repeated auth errors from the same provider+
+// channel within a short window. The chat doesn't need three identical
+// banners in a row.
+func (b *Broker) postSystemAuthError(agentSlug, targetChannel, replyTo, safeDetail string, probe providerAuthErrorProbe) (channelMessage, agentIssueRecord, bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	channel := normalizeChannelSlug(targetChannel)
+	if channel == "" {
+		channel = "general"
+	}
+	if b.findChannelLocked(channel) == nil {
+		if IsDMSlug(channel) {
+			if dm := b.ensureDMConversationLocked(channel); dm != nil {
+				channel = dm.Slug
+			}
+		}
+		if b.findChannelLocked(channel) == nil {
+			return channelMessage{}, agentIssueRecord{}, false, fmt.Errorf("channel not found")
+		}
+	}
+
+	// Dedup: if the most recent message in the channel is already a
+	// system_auth_error for the same provider, suppress the repeat. The
+	// SPA's existing banner is still up; emitting a duplicate would just
+	// stack identical cards.
+	if probe.Provider != "" {
+		for i := len(b.messages) - 1; i >= 0; i-- {
+			m := b.messages[i]
+			if m.Channel != channel {
+				continue
+			}
+			if m.Kind != systemAuthErrorMessageKind {
+				break
+			}
+			// Last message in channel IS a system_auth_error — check provider.
+			if strings.Contains(string(m.Payload), `"provider":"`+probe.Provider+`"`) {
+				return m, agentIssueRecord{}, false, nil
+			}
+			break
+		}
+	}
+
+	payloadMap := map[string]string{
+		"provider":        probe.Provider,
+		"sign_in_command": probe.SignInCommand,
+		"detail":          truncate(safeDetail, 600),
+		"reporter":        strings.TrimSpace(agentSlug),
+	}
+	payloadBytes, err := json.Marshal(payloadMap)
+	if err != nil {
+		// json.Marshal of a map[string]string never fails in practice,
+		// but if it ever did we'd rather post a degraded banner than
+		// drop the auth signal entirely.
+		payloadBytes = []byte("{}")
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	displayContent := "Sign in required"
+	if probe.Provider != "" {
+		displayContent = "Sign in required for " + probe.Provider
+	}
+
+	b.counter++
+	msg := channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   channel,
+		Kind:      systemAuthErrorMessageKind,
+		Content:   displayContent,
+		Payload:   payloadBytes,
+		ReplyTo:   strings.TrimSpace(replyTo),
+		Timestamp: now,
+	}
+	msg = b.appendMessageLocked(msg)
+	if err := b.saveLocked(); err != nil {
+		return channelMessage{}, agentIssueRecord{}, false, err
+	}
+	return msg, agentIssueRecord{}, true, nil
 }
 
 func classifyAgentIssue(detail string) agentIssueClassification {

--- a/internal/team/agent_issue_auth_test.go
+++ b/internal/team/agent_issue_auth_test.go
@@ -1,0 +1,114 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReportAgentIssueRoutesAuthErrorThroughSystemCard verifies that
+// "Not logged in" failures from the agent loop are routed through the
+// system-authored SystemErrorCard path instead of being posted as an
+// agent_issue bubble. Issue #933 — runtime/auth failures must look
+// different from in-character CEO output.
+func TestReportAgentIssueRoutesAuthErrorThroughSystemCard(t *testing.T) {
+	b := newTestBroker(t)
+
+	msg, _, posted, err := b.ReportAgentIssue("ceo", "general", "", "Claude CLI requires login. Run `claude login` or use /init to choose a different provider.")
+	if err != nil {
+		t.Fatalf("ReportAgentIssue: %v", err)
+	}
+	if !posted {
+		t.Fatal("expected the auth-error path to post a system card")
+	}
+	if msg.From != "system" {
+		t.Errorf("expected From=system (banner card), got %q", msg.From)
+	}
+	if msg.Kind != "system_auth_error" {
+		t.Errorf("expected Kind=system_auth_error, got %q", msg.Kind)
+	}
+	if !strings.Contains(string(msg.Payload), `"provider":"claude-code"`) {
+		t.Errorf("expected payload to include provider=claude-code, got %s", string(msg.Payload))
+	}
+	if !strings.Contains(string(msg.Payload), `"sign_in_command":"claude auth login"`) {
+		t.Errorf("expected payload to include sign_in_command, got %s", string(msg.Payload))
+	}
+	// The legacy agent_issue records list must be empty — the auth path
+	// short-circuits before the issue table is touched.
+	if len(b.AgentIssues()) != 0 {
+		t.Errorf("auth error must not populate AgentIssues, got %+v", b.AgentIssues())
+	}
+}
+
+// TestReportAgentIssueAuthErrorIdentifiesCodex covers the codex variant
+// of the runtime-specific sign-in CTA.
+func TestReportAgentIssueAuthErrorIdentifiesCodex(t *testing.T) {
+	b := newTestBroker(t)
+
+	msg, _, posted, err := b.ReportAgentIssue("eng", "general", "", "Codex CLI requires login. Run `codex login` or use /provider to choose a different provider.")
+	if err != nil {
+		t.Fatalf("ReportAgentIssue: %v", err)
+	}
+	if !posted {
+		t.Fatal("expected the auth-error path to post a system card")
+	}
+	if msg.Kind != "system_auth_error" {
+		t.Errorf("expected Kind=system_auth_error, got %q", msg.Kind)
+	}
+	if !strings.Contains(string(msg.Payload), `"provider":"codex"`) {
+		t.Errorf("expected payload to include provider=codex, got %s", string(msg.Payload))
+	}
+	if !strings.Contains(string(msg.Payload), `"sign_in_command":"codex login"`) {
+		t.Errorf("expected payload to include codex sign_in_command, got %s", string(msg.Payload))
+	}
+}
+
+// TestReportAgentIssueAuthErrorDedupesWithinChannel ensures that
+// repeated auth errors from the same provider don't stack identical
+// banners. The first one stays visible; subsequent emits are suppressed.
+func TestReportAgentIssueAuthErrorDedupesWithinChannel(t *testing.T) {
+	b := newTestBroker(t)
+
+	_, _, posted1, err := b.ReportAgentIssue("ceo", "general", "", "claude requires login. run `claude login`")
+	if err != nil || !posted1 {
+		t.Fatalf("first auth error: posted=%v err=%v", posted1, err)
+	}
+	_, _, posted2, err := b.ReportAgentIssue("ceo", "general", "", "claude requires login. run `claude login`")
+	if err != nil {
+		t.Fatalf("second auth error: %v", err)
+	}
+	if posted2 {
+		t.Error("second identical auth banner should be deduped")
+	}
+
+	// Exactly one system_auth_error in the channel.
+	count := 0
+	for _, m := range b.ChannelMessages("general") {
+		if m.Kind == "system_auth_error" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one system_auth_error banner, got %d", count)
+	}
+}
+
+// TestReportAgentIssueLeavesNonAuthErrorsAsAgentIssue verifies the fork
+// is precise: non-auth visible issues still take the legacy agent_issue
+// path so self-heal approval flows aren't broken.
+func TestReportAgentIssueLeavesNonAuthErrorsAsAgentIssue(t *testing.T) {
+	b := newTestBroker(t)
+
+	msg, _, posted, err := b.ReportAgentIssue("ceo", "general", "", "browser access is not available")
+	if err != nil || !posted {
+		t.Fatalf("non-auth issue: posted=%v err=%v", posted, err)
+	}
+	if msg.From != "ceo" {
+		t.Errorf("expected non-auth issue to stay agent-authored, got From=%q", msg.From)
+	}
+	if msg.Kind != "agent_issue" {
+		t.Errorf("expected Kind=agent_issue for non-auth path, got %q", msg.Kind)
+	}
+	if len(b.AgentIssues()) != 1 {
+		t.Errorf("expected one entry in AgentIssues, got %d", len(b.AgentIssues()))
+	}
+}

--- a/internal/team/agent_issue_auth_test.go
+++ b/internal/team/agent_issue_auth_test.go
@@ -44,7 +44,12 @@ func TestReportAgentIssueRoutesAuthErrorThroughSystemCard(t *testing.T) {
 func TestReportAgentIssueAuthErrorIdentifiesCodex(t *testing.T) {
 	b := newTestBroker(t)
 
-	msg, _, posted, err := b.ReportAgentIssue("eng", "general", "", "Codex CLI requires login. Run `codex login` or use /provider to choose a different provider.")
+	// "ceo" is the agent slug; the test asserts on provider=codex detected
+	// from the message text (the Codex CLI's auth-error string), not on the
+	// agent's identity. Using "ceo" keeps the canAccessChannelLocked gate
+	// happy in a fresh broker where non-built-in agents aren't channel
+	// members yet.
+	msg, _, posted, err := b.ReportAgentIssue("ceo", "general", "", "Codex CLI requires login. Run `codex login` or use /provider to choose a different provider.")
 	if err != nil {
 		t.Fatalf("ReportAgentIssue: %v", err)
 	}
@@ -89,6 +94,27 @@ func TestReportAgentIssueAuthErrorDedupesWithinChannel(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("expected exactly one system_auth_error banner, got %d", count)
+	}
+}
+
+// TestReportAgentIssueAuthErrorEnforcesChannelACL regression-guards
+// the CodeRabbit finding on PR #985: the system-auth fork must respect
+// canAccessChannelLocked just like the legacy agent_issue path, so an
+// agent that isn't a member of a channel can't surface an auth banner
+// in it via the auth fork.
+func TestReportAgentIssueAuthErrorEnforcesChannelACL(t *testing.T) {
+	b := newTestBroker(t)
+	// "eng" is not a built-in, not channel ceo/system/nex/human, and not
+	// a member of the default #general channel created at boot.
+	_, _, posted, err := b.ReportAgentIssue("eng", "general", "", "Claude CLI requires login. Run `claude login`.")
+	if err == nil {
+		t.Fatal("expected ACL denial on auth-fork path for non-member agent")
+	}
+	if !strings.Contains(err.Error(), "channel access denied") {
+		t.Errorf("expected channel-access-denied error, got %v", err)
+	}
+	if posted {
+		t.Error("expected posted=false when ACL denies")
 	}
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -329,6 +329,23 @@ export interface Message {
   from: string;
   channel: string;
   content: string;
+  /**
+   * Server-assigned message kind. Empty/absent for plain chat. Known kinds:
+   *  - "agent_issue"        legacy agent-authored issue banner
+   *  - "system_auth_error"  system-authored provider-auth failure card (#933)
+   *  - "issue_draft_section" CEO-authored issue draft section
+   *  - "ceo_*"              onboarding cards (form_field, chip_row, etc.)
+   * The SPA's MessageBubble dispatches on this field to pick a renderer.
+   */
+  kind?: string;
+  /**
+   * Structured card payload for kinds that carry one. The broker marshals
+   * this from a Go json.RawMessage so consumers receive an inline JSON
+   * object (or array) — not a string. Consumers must treat every string
+   * field inside as plain text (defense in depth on top of the broker-side
+   * sanitizeContextValue).
+   */
+  payload?: unknown;
   redacted?: boolean;
   redaction_count?: number;
   redaction_reasons?: string[];

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -22,6 +22,10 @@ import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
 import { RedactedBadge } from "../ui/RedactedBadge";
 import { showNotice } from "../ui/Toast";
+import {
+  parseSystemAuthErrorPayload,
+  SystemErrorCard,
+} from "./cards/SystemErrorCard";
 import MessageArtifactReferences from "./MessageArtifactReferences";
 
 interface MessageBubbleProps {
@@ -114,6 +118,16 @@ export function MessageBubble({
   if (message.content?.startsWith("[STATUS]")) {
     const statusText = message.content.replace(/^\[STATUS\]\s*/, "");
     return <div className="message-status animate-fade">{statusText}</div>;
+  }
+
+  // Issue #933: system-authored auth-failure card. Renders OUTSIDE the
+  // standard message-bubble container so it's visually distinct from
+  // agent chat — banner-style with a sign-in CTA rather than an avatar +
+  // speech bubble. The broker emits these in place of the legacy
+  // agent_issue bubble when a provider returns "Not logged in".
+  if (message.kind === "system_auth_error") {
+    const payload = parseSystemAuthErrorPayload(message.payload);
+    return <SystemErrorCard payload={payload} />;
   }
 
   return (

--- a/web/src/components/messages/cards/SystemErrorCard.stories.tsx
+++ b/web/src/components/messages/cards/SystemErrorCard.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { SystemErrorCard } from "./SystemErrorCard";
+
+const meta: Meta<typeof SystemErrorCard> = {
+  title: "Messages / Cards / SystemErrorCard",
+  component: SystemErrorCard,
+  parameters: { layout: "padded" },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SystemErrorCard>;
+
+export const ClaudeCode: Story = {
+  args: {
+    payload: {
+      provider: "claude-code",
+      sign_in_command: "claude auth login",
+      detail:
+        "Claude CLI requires login. Run `claude login` or use /init to choose a different provider.",
+      reporter: "ceo",
+    },
+  },
+};
+
+export const Codex: Story = {
+  args: {
+    payload: {
+      provider: "codex",
+      sign_in_command: "codex login",
+      detail:
+        "Codex CLI requires login. Run `codex login` or use /provider to choose a different provider.",
+      reporter: "eng",
+    },
+  },
+};
+
+export const Opencode: Story = {
+  args: {
+    payload: {
+      provider: "opencode",
+      sign_in_command: "opencode auth login",
+      detail: "Opencode reports no provider credentials configured.",
+    },
+  },
+};
+
+export const WithRetry: Story = {
+  args: {
+    payload: {
+      provider: "claude-code",
+      sign_in_command: "claude auth login",
+      detail: "Claude CLI requires login.",
+    },
+    onRetry: () => {
+      // Storybook noop — wire to a real handler in production.
+    },
+  },
+};
+
+export const NoProvider: Story = {
+  args: {
+    payload: {
+      detail: "Provider authentication required.",
+    },
+  },
+};
+
+export const NoCommand: Story = {
+  args: {
+    payload: {
+      provider: "unknown",
+      detail: "We can't determine the sign-in flow for this provider.",
+    },
+  },
+};

--- a/web/src/components/messages/cards/SystemErrorCard.test.tsx
+++ b/web/src/components/messages/cards/SystemErrorCard.test.tsx
@@ -1,0 +1,138 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  parseSystemAuthErrorPayload,
+  SystemErrorCard,
+} from "./SystemErrorCard";
+
+describe("parseSystemAuthErrorPayload", () => {
+  it("narrows a valid payload object to typed string fields", () => {
+    const out = parseSystemAuthErrorPayload({
+      provider: "claude-code",
+      sign_in_command: "claude auth login",
+      detail: "Not logged in",
+      reporter: "ceo",
+    });
+    expect(out).toEqual({
+      provider: "claude-code",
+      sign_in_command: "claude auth login",
+      detail: "Not logged in",
+      reporter: "ceo",
+    });
+  });
+
+  it("returns an empty object for non-object payloads (defense in depth)", () => {
+    expect(parseSystemAuthErrorPayload(null)).toEqual({});
+    expect(parseSystemAuthErrorPayload("malicious")).toEqual({});
+    expect(parseSystemAuthErrorPayload(42)).toEqual({});
+    expect(parseSystemAuthErrorPayload(["a", "b"])).toEqual({});
+  });
+
+  it("drops non-string fields silently", () => {
+    const out = parseSystemAuthErrorPayload({
+      provider: 123,
+      sign_in_command: { nested: "obj" },
+      detail: "valid string",
+    });
+    expect(out).toEqual({ detail: "valid string" });
+  });
+});
+
+describe("SystemErrorCard", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  it("renders the provider name, detail, and sign-in command", () => {
+    render(
+      <SystemErrorCard
+        payload={{
+          provider: "claude-code",
+          sign_in_command: "claude auth login",
+          detail: "Claude CLI requires login.",
+        }}
+      />,
+    );
+    const card = screen.getByTestId("system-error-card");
+    expect(card.getAttribute("data-provider")).toBe("claude-code");
+    expect(card.textContent).toMatch(/Sign in required/);
+    expect(card.textContent).toMatch(/claude-code/);
+    expect(card.textContent).toMatch(/Claude CLI requires login/);
+    expect(screen.getByTestId("system-error-card-command")).toHaveTextContent(
+      "claude auth login",
+    );
+  });
+
+  it("copies the sign-in command on click and flips to 'Copied' briefly", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: { writeText },
+    });
+    render(
+      <SystemErrorCard
+        payload={{
+          provider: "codex",
+          sign_in_command: "codex login",
+          detail: "Codex CLI requires login.",
+        }}
+      />,
+    );
+
+    const copyBtn = screen.getByTestId("system-error-card-copy");
+    fireEvent.click(copyBtn);
+
+    expect(writeText).toHaveBeenCalledWith("codex login");
+    await waitFor(() => expect(copyBtn.textContent).toBe("Copied"));
+  });
+
+  it("uses role=alert so screen readers announce the banner", () => {
+    render(
+      <SystemErrorCard
+        payload={{
+          provider: "opencode",
+          sign_in_command: "opencode auth login",
+        }}
+      />,
+    );
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+
+  it("renders a Retry button when onRetry is supplied", () => {
+    const onRetry = vi.fn();
+    render(
+      <SystemErrorCard
+        payload={{ provider: "claude-code" }}
+        onRetry={onRetry}
+      />,
+    );
+    const retry = screen.getByTestId("system-error-card-retry");
+    fireEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders gracefully when payload fields are missing", () => {
+    render(<SystemErrorCard payload={{}} />);
+    const card = screen.getByTestId("system-error-card");
+    // Falls back to a generic provider label without crashing
+    expect(card.textContent).toMatch(/Sign in to provider/);
+    // No command means no copy button
+    expect(screen.queryByTestId("system-error-card-copy")).toBeNull();
+  });
+});

--- a/web/src/components/messages/cards/SystemErrorCard.tsx
+++ b/web/src/components/messages/cards/SystemErrorCard.tsx
@@ -1,0 +1,125 @@
+/**
+ * SystemErrorCard — banner-style card for system-authored runtime errors.
+ *
+ * Issue #933. Provider auth failures ("Not logged in - Please run /login")
+ * previously surfaced as agent-authored chat bubbles inside `#general`,
+ * conflating in-character agent output with a system-level error. The
+ * broker now emits these as system-authored messages with
+ * kind="system_auth_error" carrying a structured payload; the SPA dispatches
+ * here so they read as a clearly-separate "the system needs you to do
+ * something" banner, not a CEO line.
+ *
+ * Security: payload fields are plain-text only — no innerHTML, no link
+ * rendering, no rich content. The broker-side sanitizer is the authoritative
+ * line; this component is the defense-in-depth render path.
+ */
+
+import { useState } from "react";
+
+export interface SystemAuthErrorPayload {
+  /** Provider id (e.g. "claude-code", "codex", "opencode"). May be empty. */
+  provider?: string;
+  /** Suggested shell command for the user to copy. May be empty. */
+  sign_in_command?: string;
+  /** Truncated detail from the upstream error. Plain text. */
+  detail?: string;
+  /** Slug of the agent whose loop surfaced the auth failure. Plain text. */
+  reporter?: string;
+}
+
+export interface SystemErrorCardProps {
+  payload: SystemAuthErrorPayload;
+  /** Optional retry handler — surfaces a "Retry" button after sign-in. */
+  onRetry?: () => void;
+}
+
+function isStringField(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Defensive payload parser. The Go side guarantees the shape but the wire is
+ * `unknown`, so narrow each field before rendering. Returns a safe empty
+ * payload when the input is not a plain object.
+ */
+export function parseSystemAuthErrorPayload(
+  raw: unknown,
+): SystemAuthErrorPayload {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const r = raw as Record<string, unknown>;
+  const out: SystemAuthErrorPayload = {};
+  if (isStringField(r.provider)) out.provider = r.provider;
+  if (isStringField(r.sign_in_command)) out.sign_in_command = r.sign_in_command;
+  if (isStringField(r.detail)) out.detail = r.detail;
+  if (isStringField(r.reporter)) out.reporter = r.reporter;
+  return out;
+}
+
+export function SystemErrorCard({ payload, onRetry }: SystemErrorCardProps) {
+  const [copied, setCopied] = useState(false);
+  const providerLabel = payload.provider ? payload.provider : "provider";
+  const command = payload.sign_in_command ?? "";
+  const detail = payload.detail ?? "";
+
+  function copyCommand(): void {
+    if (!command) return;
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      // No clipboard surface — keep the command visible in the card so the
+      // user can select-and-copy manually. Do not throw.
+      return;
+    }
+    navigator.clipboard
+      .writeText(command)
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1800);
+      })
+      .catch(() => {
+        // Permission denied or insecure context — same fallback as above.
+      });
+  }
+
+  return (
+    <div
+      role="alert"
+      className="system-error-card"
+      data-testid="system-error-card"
+      data-provider={payload.provider ?? ""}
+    >
+      <div className="system-error-card-head">
+        <span className="system-error-card-eyebrow">Sign in required</span>
+        <h4 className="system-error-card-title">
+          {`Sign in to ${providerLabel} to keep working`}
+        </h4>
+      </div>
+      {detail ? <p className="system-error-card-detail">{detail}</p> : null}
+      {command ? (
+        <div className="system-error-card-command">
+          <code data-testid="system-error-card-command">{command}</code>
+          <button
+            type="button"
+            className="system-error-card-copy-btn"
+            data-testid="system-error-card-copy"
+            onClick={copyCommand}
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+      ) : null}
+      {onRetry ? (
+        <div className="system-error-card-actions">
+          <button
+            type="button"
+            className="system-error-card-retry-btn"
+            data-testid="system-error-card-retry"
+            onClick={onRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -270,6 +270,37 @@ describe("PrePickScreen", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(/codex login/);
   });
 
+  // Regression guard for CodeRabbit #985 (#3284960848 + #3284960843): even
+  // when sign_in_command is missing from the prereq payload, an un-signed-in
+  // tile must still block the pick. Falling through to onPick would land
+  // the user in an office that fails on the first agent LLM call.
+  it("blocks pick when signed_in=false and sign_in_command is missing", async () => {
+    mockPrereqs(
+      { codex: true },
+      {},
+      { codex: { session_probed: true, signed_in: false } },
+    );
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: { writeText },
+    });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-codex");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(
+      postMock.mock.calls.find((call) => call[0] === "/onboarding/transition"),
+    ).toBeUndefined();
+    // Clipboard not touched when there's no command to copy.
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
   it("renders Signed in label when session_probed=true and signed_in=true", async () => {
     mockPrereqs(
       { claude: true },

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -43,22 +43,48 @@ afterEach(() => {
   cleanup();
 });
 
-function mockPrereqs(found: Record<string, boolean>) {
-  getMock.mockResolvedValue([
+function mockPrereqs(
+  found: Record<string, boolean>,
+  onboardingState: { onboarded?: boolean; phase?: string } = {},
+  sessions: Record<
+    string,
+    { session_probed?: boolean; signed_in?: boolean; sign_in_command?: string }
+  > = {},
+) {
+  const prereqs = [
     {
       name: "claude",
       required: false,
       found: found.claude ?? false,
       version: "v1.2.3",
+      ...(sessions.claude ?? {}),
     },
     {
       name: "codex",
       required: false,
       found: found.codex ?? false,
       version: "v0.8.1",
+      ...(sessions.codex ?? {}),
     },
-    { name: "opencode", required: false, found: found.opencode ?? false },
-  ]);
+    {
+      name: "opencode",
+      required: false,
+      found: found.opencode ?? false,
+      ...(sessions.opencode ?? {}),
+    },
+  ];
+  // Route the GET mock by path. The /onboarding/state probe added for the
+  // #979 phase-complete guard runs on every click; default it to a fresh
+  // install (no phase set) unless the test overrides it.
+  getMock.mockImplementation(async (path: string) => {
+    if (path === "/onboarding/prereqs") {
+      return prereqs;
+    }
+    if (path === "/onboarding/state") {
+      return onboardingState;
+    }
+    return {};
+  });
 }
 
 describe("PrePickScreen", () => {
@@ -183,6 +209,116 @@ describe("PrePickScreen", () => {
         value: originalOpen,
       });
     }
+  });
+
+  // Issue #932 regression guard: when the broker probes a runtime and
+  // reports it installed but not signed in, the tile must show a
+  // "Not signed in" label, NOT advance onboarding when clicked, and
+  // surface a copy-the-sign-in-command CTA.
+  it("renders Not signed in label when session_probed=true and signed_in=false", async () => {
+    mockPrereqs(
+      { claude: true },
+      {},
+      {
+        claude: {
+          session_probed: true,
+          signed_in: false,
+          sign_in_command: "claude auth login",
+        },
+      },
+    );
+    render(<PrePickScreen onComplete={vi.fn()} />);
+
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card.textContent).toMatch(/Not signed in/));
+    expect(card.getAttribute("data-signed-in")).toBe("false");
+  });
+
+  it("does not POST /onboarding/transition when clicking an un-signed-in tile (copies sign-in command instead)", async () => {
+    mockPrereqs(
+      { codex: true },
+      {},
+      {
+        codex: {
+          session_probed: true,
+          signed_in: false,
+          sign_in_command: "codex login",
+        },
+      },
+    );
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: { writeText },
+    });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-codex");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    // Critical: clicking an unauthed tile must NOT advance onboarding.
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(
+      postMock.mock.calls.find((call) => call[0] === "/onboarding/transition"),
+    ).toBeUndefined();
+    // Sign-in command should be copied to clipboard.
+    expect(writeText).toHaveBeenCalledWith("codex login");
+    // And an inline hint should appear with the same command.
+    expect(await screen.findByRole("alert")).toHaveTextContent(/codex login/);
+  });
+
+  it("renders Signed in label when session_probed=true and signed_in=true", async () => {
+    mockPrereqs(
+      { claude: true },
+      {},
+      { claude: { session_probed: true, signed_in: true } },
+    );
+    render(<PrePickScreen onComplete={vi.fn()} />);
+
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card.textContent).toMatch(/Signed in/));
+    expect(card.getAttribute("data-signed-in")).toBe("true");
+  });
+
+  it("falls back to Detected label when broker did not probe (session_probed undefined)", async () => {
+    mockPrereqs({ claude: true });
+    render(<PrePickScreen onComplete={vi.fn()} />);
+
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card.textContent).toMatch(/Detected/));
+    expect(card.getAttribute("data-signed-in")).toBe("unknown");
+  });
+
+  // Issue #979 regression guard: a session-loss recovery that lands the
+  // user back on PrePickScreen with the broker already in phase=complete
+  // must NOT POST /onboarding/transition (broker rejects "complete → greet"
+  // as an invalid transition). PrePickScreen must signal onComplete with
+  // phaseAlreadyComplete=true so RootRoute routes straight to the office.
+  it("skips /onboarding/transition when broker reports phase=complete (session-loss recovery)", async () => {
+    mockPrereqs({ claude: true }, { onboarded: true, phase: "complete" });
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card).not.toBeDisabled());
+    fireEvent.click(card);
+
+    await waitFor(() =>
+      expect(onComplete).toHaveBeenCalledWith({ phaseAlreadyComplete: true }),
+    );
+
+    // Critical: the buggy path POSTed phase=greet which the broker rejected
+    // with "invalid transition from \"complete\" to \"greet\"". The fix is to
+    // not POST at all in this state.
+    expect(
+      postMock.mock.calls.find((call) => call[0] === "/onboarding/transition"),
+    ).toBeUndefined();
+    expect(
+      postMock.mock.calls.find((call) => call[0] === "/config"),
+    ).toBeUndefined();
   });
 
   it("surfaces an error if /onboarding/transition fails and does not invoke onComplete", async () => {

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -135,8 +135,16 @@ function RuntimeCard({
           onInstall(spec.installUrl);
           return;
         }
-        if (isUnauthed && signInCommand) {
-          onCopySignIn(signInCommand);
+        // Auth gate: when the runtime probed and reported NOT signed in,
+        // never fall through to onPick — even if sign_in_command is
+        // missing/empty. Falling through would advance onboarding to an
+        // un-authed runtime, which the agent loop's first LLM call would
+        // immediately reject. Copy the command when we have it; otherwise
+        // just no-op (the inline "not signed in" hint stays visible).
+        if (isUnauthed) {
+          if (signInCommand) {
+            onCopySignIn(signInCommand);
+          }
           return;
         }
         onPick(spec);

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -22,15 +22,30 @@ import { RUNTIMES } from "./runtimes";
 // `onComplete` is invoked after runtime config is saved and the deterministic
 // CEO onboarding state machine has entered the greet phase. RootRoute then
 // renders the Shell around the CEO DM instead of marking onboarding complete.
+//
+// `phaseAlreadyComplete` flag (issue #979): if the broker reports phase=complete
+// at click time the user is in a "session-loss" recovery state — they have
+// finished onboarding before but the SPA's boot-time /onboarding/state fetch
+// failed and dumped them back here. Bypass POST /onboarding/transition entirely
+// (the broker would reject "complete → greet" with a 400 invalid transition)
+// and signal the caller to route straight to the office.
 
 interface PrePickScreenProps {
-  onComplete: () => void;
+  onComplete: (info?: { phaseAlreadyComplete?: boolean }) => void;
 }
 
 interface RuntimeCardState {
   spec: RuntimeSpec;
   detected: PrereqResult | undefined;
   available: boolean;
+  /**
+   * Issue #932: when the broker session-probed this runtime and it
+   * reported no active session, `signedIn` is explicitly false. When
+   * the runtime supports no probe, `signedIn` is undefined — fall back
+   * to legacy "Detected" behavior.
+   */
+  signedIn: boolean | undefined;
+  signInCommand: string | undefined;
 }
 
 interface RuntimeCardProps {
@@ -40,19 +55,32 @@ interface RuntimeCardProps {
   anySubmitting: boolean;
   onPick: (spec: RuntimeSpec) => void;
   onInstall: (url: string) => void;
+  onCopySignIn: (command: string) => void;
 }
 
 function cardStatusLabel({
   prereqsLoaded,
   available,
   version,
+  signedIn,
 }: {
   prereqsLoaded: boolean;
   available: boolean;
   version: string | undefined;
+  signedIn: boolean | undefined;
 }): string {
   if (!prereqsLoaded) return "Checking…";
   if (!available) return "Not installed";
+  // Issue #932: when the runtime supports a session probe and we got a
+  // definite "not signed in", surface that as the primary status. The user
+  // would otherwise complete onboarding believing they were connected,
+  // then hit "Not logged in" on the agent loop's first call.
+  if (signedIn === false) {
+    return version ? `Not signed in · ${version}` : "Not signed in";
+  }
+  if (signedIn === true) {
+    return version ? `Signed in · ${version}` : "Signed in";
+  }
   return version ? `Detected · ${version}` : "Detected";
 }
 
@@ -63,33 +91,52 @@ function RuntimeCard({
   anySubmitting,
   onPick,
   onInstall,
+  onCopySignIn,
 }: RuntimeCardProps) {
-  const { spec, detected, available } = state;
+  const { spec, detected, available, signedIn, signInCommand } = state;
   const statusLabel = isSubmitting
     ? "Starting your office…"
     : cardStatusLabel({
         prereqsLoaded,
         available,
         version: detected?.version,
+        signedIn,
       });
+  // Issue #932: if the runtime is installed but the broker probed and found
+  // no active session, block picking and surface a "Sign in" CTA. Clicking
+  // copies the suggested command (e.g. `claude auth login`) to the
+  // clipboard so the user can paste it into a terminal. We do not launch
+  // a terminal — that's platform-specific and brittle.
+  const isUnauthed = available && signedIn === false;
   const installHint =
     !available && prereqsLoaded ? (
       <div className="pre-pick-card-install">Install &rarr;</div>
+    ) : null;
+  const signInHint =
+    isUnauthed && prereqsLoaded ? (
+      <div className="pre-pick-card-install">Copy sign-in command</div>
     ) : null;
   return (
     <button
       key={spec.label}
       type="button"
-      className={`pre-pick-card${available ? " available" : " missing"}`}
+      className={`pre-pick-card${available ? " available" : " missing"}${isUnauthed ? " unauthed" : ""}`}
       data-testid={`pre-pick-card-${spec.provider}`}
+      data-signed-in={signedIn === undefined ? "unknown" : String(signedIn)}
       // CodeRabbit fix (PR #889): guard against clicks during prereq detection
       // and any in-flight submission. Both disable conditions must hold.
+      // Issue #932: don't fully disable when unauthed — we still want clicks
+      // to fire the sign-in CTA. The pick path early-returns instead.
       disabled={anySubmitting || !prereqsLoaded}
       onClick={() => {
         // Belt-and-suspenders guard: early-return if prereqs haven't settled.
         if (!prereqsLoaded) return;
         if (!available) {
           onInstall(spec.installUrl);
+          return;
+        }
+        if (isUnauthed && signInCommand) {
+          onCopySignIn(signInCommand);
           return;
         }
         onPick(spec);
@@ -101,6 +148,7 @@ function RuntimeCard({
       </div>
       <div className="pre-pick-card-status">{statusLabel}</div>
       {installHint}
+      {signInHint}
     </button>
   );
 }
@@ -249,10 +297,18 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
     () =>
       DISPATCHABLE_RUNTIMES.map((spec) => {
         const detected = prereqs.find((p) => p.name === spec.binary);
+        // Issue #932: signedIn is undefined when the broker didn't probe
+        // this runtime (no session-status subcommand wired). Cards
+        // distinguish that "unknown" case from a definite "not signed in".
+        const signedIn = detected?.session_probed
+          ? Boolean(detected?.signed_in)
+          : undefined;
         return {
           spec,
           detected,
           available: Boolean(detected?.found),
+          signedIn,
+          signInCommand: detected?.sign_in_command,
         };
       }),
     [prereqs],
@@ -273,6 +329,23 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
     setApiKeys((prev) => ({ ...prev, [key]: value }));
   }
 
+  // Issue #979 guard: best-effort probe of /onboarding/state at click time.
+  // If the broker reports phase=complete, the SPA is in a session-loss
+  // recovery state — POSTing /onboarding/transition with phase=greet would
+  // be rejected as "invalid transition" and leave the user stuck on the
+  // picker. Endpoint errors fall through to the normal pick path so a
+  // fresh install still works without runtime-dependent probe success.
+  async function probePhaseAlreadyComplete(): Promise<boolean> {
+    try {
+      const state = await get<{ onboarded?: boolean; phase?: string }>(
+        "/onboarding/state",
+      );
+      return state?.onboarded === true || state?.phase === "complete";
+    } catch {
+      return false;
+    }
+  }
+
   async function commitChoice(
     provider: RuntimeSpec["provider"] | string,
     runtimeLabel: string,
@@ -280,6 +353,13 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
     setSubmitError("");
     setSubmitting(runtimeLabel);
     try {
+      if (await probePhaseAlreadyComplete()) {
+        // Recovery path: skip /config and /onboarding/transition entirely
+        // and signal the caller to route into the office.
+        onComplete({ phaseAlreadyComplete: true });
+        return;
+      }
+
       const isCli = isCliProvider(provider);
       // Skip path ("I'll add one later") must NOT persist anything the user
       // typed into the form sections — the contract is "sandbox until you
@@ -315,6 +395,23 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
     window.open(url, "_blank", "noopener,noreferrer");
   }
 
+  // Issue #932: copy the suggested sign-in command (e.g. `claude auth login`)
+  // to the clipboard when the user clicks an un-signed-in runtime tile.
+  // navigator.clipboard.writeText resolves only in secure contexts; on the
+  // null fallback we still surface the command via setSubmitError so the
+  // user can copy it manually.
+  function handleCopySignIn(command: string): void {
+    setSubmitError("");
+    const message = `Run \`${command}\` in a terminal, then click the tile again.`;
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      navigator.clipboard.writeText(command).catch(() => {
+        // Clipboard denied (e.g. iframe without permission) — fall through
+        // to the inline message below.
+      });
+    }
+    setSubmitError(message);
+  }
+
   const anySubmitting = Boolean(submitting);
 
   return (
@@ -340,6 +437,7 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               anySubmitting={anySubmitting}
               onPick={(spec) => void commitChoice(spec.provider, spec.label)}
               onInstall={openInstallPage}
+              onCopySignIn={handleCopySignIn}
             />
           ))}
         </div>

--- a/web/src/components/onboarding/runtimes.ts
+++ b/web/src/components/onboarding/runtimes.ts
@@ -24,6 +24,23 @@ export interface PrereqResult {
   ok?: boolean;
   version?: string;
   install_url?: string;
+  /**
+   * True when the broker ran the runtime's session-status subcommand
+   * (claude auth status, codex login status, opencode providers list).
+   * False means "no probe wired" — frontend should fall back to legacy
+   * "Detected" behavior. See issue #932.
+   */
+  session_probed?: boolean;
+  /**
+   * True only when session_probed === true AND the runtime reports an
+   * active auth session.
+   */
+  signed_in?: boolean;
+  /**
+   * Suggested shell command to copy to clipboard when session_probed
+   * is true and signed_in is false (the "Sign in" CTA).
+   */
+  sign_in_command?: string;
 }
 
 export const RUNTIMES: readonly RuntimeSpec[] = [

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -840,10 +840,18 @@ export default function RootRoute() {
       // After they pick, setInCeoOnboarding(true) to enter the CEO DM.
       body = (
         <PrePickScreen
-          onComplete={() => {
-            // PrePickScreen transitions directly to CEO DM.
-            // The broker sets state.Phase = "greet" after /onboarding/transition.
-            // We enter the in-CEO state here so the Shell renders immediately.
+          onComplete={(info) => {
+            // Issue #979: when the broker reports phase=complete at pick time
+            // (session-loss recovery), skip the CEO DM hand-off entirely and
+            // route straight into the office. Otherwise enter the normal CEO
+            // onboarding hand-off: PrePickScreen has just POSTed
+            // /onboarding/transition phase=greet, so the Shell renders the
+            // OnboardingDMRoute around the CEO DM until the broker flips
+            // onboarded=true.
+            if (info?.phaseAlreadyComplete) {
+              setOnboardingComplete(true);
+              return;
+            }
             setInCeoOnboarding(true);
           }}
         />

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -1487,6 +1487,79 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   color: var(--accent);
 }
 
+/* ─── SystemErrorCard (issue #933) ─── */
+/* Banner-style system-authored card for runtime auth failures. Lives
+   outside the normal message-bubble flow so it reads as system surface,
+   not in-character agent output. */
+.system-error-card {
+  margin: 8px 0 8px 0;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--amber-600, #d97706) 8%, var(--bg-card));
+  border: 1px solid var(--amber-600, #d97706);
+  border-radius: var(--radius-md, 8px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.system-error-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.system-error-card-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--amber-600, #d97706);
+}
+.system-error-card-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text);
+}
+.system-error-card-detail {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+.system-error-card-command {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 6px);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.system-error-card-command code {
+  flex: 1;
+  background: transparent;
+  white-space: pre;
+  overflow-x: auto;
+}
+.system-error-card-copy-btn,
+.system-error-card-retry-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  cursor: pointer;
+}
+.system-error-card-copy-btn:hover,
+.system-error-card-retry-btn:hover {
+  background: var(--bg-warm);
+}
+.system-error-card-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* ─── Feed loading / empty states ─── */
 .messages-loading-label {
   display: flex;

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2126,6 +2126,14 @@
   color: var(--green-600, #16a34a);
 }
 
+/* Issue #932: installed-but-not-signed-in state — keep the tile visually
+   present (not the "missing" treatment) but recolor the status as warning so
+   the user can tell the card is in a blocking state without reading the
+   label. */
+.pre-pick-card.available.unauthed .pre-pick-card-status {
+  color: var(--amber-600, #d97706);
+}
+
 .pre-pick-card-install {
   font-size: 12px;
   color: var(--accent);


### PR DESCRIPTION
## Summary

Three related wave-4 QA bugs (epic #930) that all surface around "no
LLM auth" or "session invalidated after onboarding". Bundled because
they share a single architectural concern: how the system distinguishes
agent voice from runtime errors.

### #932 — Provider auth probe (P0)
The pre-pick screen used to mark a runtime "Detected" purely on
`claude --version` succeeding. A user who hadn't run `claude login`
would complete onboarding believing they were connected, then the
agent loop's first LLM call would fail with "Not logged in - Please
run /login". `PrereqResult` now carries a per-runtime session probe
(`claude auth status`, `codex login status`, `opencode providers
list`) so the SPA can disable un-signed-in tiles and surface a
copy-the-command sign-in CTA.

### #933 — Auth UX as system card (P1)
Auth failures from the agent loop were posting as agent-authored chat
bubbles in `#general`, conflating in-character agent output with
system errors. `ReportAgentIssue` now detects the auth signal up-front
and forks into a system-authored message with kind
`system_auth_error`. The SPA renders these through a new
`SystemErrorCard` — banner-style, runtime-named, with a
copy-to-clipboard sign-in command. Repeated emits dedupe inside a
channel so the banner doesn't stack.

### #979 — Provider re-pick after phase=complete (P1, F3)
When the SPA's boot fetch failed and dumped an already-onboarded user
back on `PrePickScreen`, clicking a tile POSTed
`/onboarding/transition phase=greet` — which the broker correctly
rejected as `invalid transition from "complete" to "greet"`. Fixed
SPA-side per the task brief: PrePickScreen best-effort probes
`/onboarding/state` at click time and, on `phase=complete`, signals
RootRoute to skip the CEO hand-off and route straight to the office.
Endpoint errors fall through to the normal pick path so fresh
installs still work.

Closes #932
Closes #933
Closes #979

## Test plan

- [x] `bash scripts/test-go.sh ./internal/team ./internal/onboarding` — all green (200+ tests including 4 new auth-card tests)
- [x] `bash scripts/test-web.sh web/src/components/onboarding/ web/src/components/messages/` — 199 tests pass including 4 new PrePickScreen + 8 new SystemErrorCard tests
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check` — no new errors introduced (one pre-existing test-file warning)
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./internal/team/... ./internal/onboarding/...` — 0 issues
- [x] `go build -o ./wuphf ./cmd/wuphf` + `(cd web && bun run build)` both succeed
- [x] Smoke-tested broker `/onboarding/prereqs` with `HOME=~/.wuphf-qa-icp-wave4` — all 3 CLI runtimes now return `session_probed: true` + provider-specific `sign_in_command`
- [ ] Screenshots: provider tile with "Not signed in" state, SystemErrorCard, phase-complete recovery path (pushed via `web/e2e/screenshots/publish.sh` after PR opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Probes provider sessions and surfaces explicit "Signed in"/"Not signed in" status for runtimes.
  * Adds system-auth error cards showing provider, sign-in command (copyable), optional details, and a Retry action.
  * Onboarding suggests sign-in commands and blocks picks when auth is required, with clipboard copy fallback.

* **Bug Fixes**
  * Handles session-loss during onboarding to avoid re-triggering flows and skips completion steps when already complete.
  * Suppresses duplicate auth banners per channel.

* **Tests**
  * Added tests covering auth detection, system card rendering, deduplication, ACLs, and onboarding recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/985?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->