### PR TITLE
chore(broker): silence boot + scanner noise on unconfigured workspaces

### DIFF
--- a/internal/team/notebook_signal_scanner.go
+++ b/internal/team/notebook_signal_scanner.go
@@ -12,7 +12,9 @@ package team
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -171,6 +173,13 @@ type notebookEntry struct {
 // files are skipped.
 func (s *NotebookSignalScanner) collectNotebookEntries(wikiRoot string) ([]notebookEntry, error) {
 	root := filepath.Join(wikiRoot, agentsDirPrefix[:len(agentsDirPrefix)-1])
+	// No agents seeded yet → the agents/ directory simply doesn't exist on
+	// disk. filepath.Walk would surface that as an ENOENT walk-error for the
+	// root path and we'd log one WARN per 30-min cron tick. Return silently
+	// so a quiet first-boot stays quiet. Closes #982.
+	if _, err := os.Stat(root); errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
 	var out []notebookEntry
 	walkErr := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/internal/team/notebook_signal_scanner_missing_agents_test.go
+++ b/internal/team/notebook_signal_scanner_missing_agents_test.go
@@ -1,0 +1,49 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNotebookSignalScanner_MissingAgentsDirSilent verifies that scanning a
+// wiki that has no team/agents/ directory yet — the steady state on a fresh
+// install before any agents are seeded — returns cleanly without emitting a
+// walk-error log. Regression for #982.
+func TestNotebookSignalScanner_MissingAgentsDirSilent(t *testing.T) {
+	b, root, teardown := newNotebookScannerHarness(t)
+	defer teardown()
+
+	// Belt-and-suspenders: explicitly ensure the agents dir does NOT exist.
+	// Repo.Init seeds team/{people,companies,…} but not team/agents/.
+	agentsDir := filepath.Join(root, "team", "agents")
+	if _, err := os.Stat(agentsDir); err == nil {
+		if err := os.RemoveAll(agentsDir); err != nil {
+			t.Fatalf("remove agents dir: %v", err)
+		}
+	}
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	scanner := NewNotebookSignalScanner(b)
+	cands, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates from missing agents dir, got %d", len(cands))
+	}
+	if got := buf.String(); strings.Contains(got, "walk error") {
+		t.Fatalf("expected no walk-error log line, got:\n%s", got)
+	}
+	if got := buf.String(); strings.Contains(got, "no such file or directory") {
+		t.Fatalf("expected no ENOENT log line, got:\n%s", got)
+	}
+}

--- a/internal/team/skill_scanner.go
+++ b/internal/team/skill_scanner.go
@@ -664,17 +664,21 @@ func (p *defaultLLMProvider) AskIsSkill(ctx context.Context, articlePath, articl
 			slog.Warn("skill_scanner: LLM call timed out", "path", articlePath, "timeout", timeout)
 			return false, SkillFrontmatter{}, "", "", nil
 		}
-		// When the LLM provider fails before producing assistant output —
-		// classic symptom of an unauthed/uninstalled CLI — every article
-		// in the pass returns the same opaque error (e.g. bare "exit
-		// status 1"). Surface ErrLLMNotConfigured + the underlying detail
-		// so the scan loop can choose to bail with one summary line
-		// instead of logging per-article. The legacy per-article WARN
-		// downgrades to DEBUG so the diagnostic is still accessible when
-		// debug logging is enabled. #980.
+		// Only wrap with ErrLLMNotConfigured when the underlying error is a
+		// concrete unauthenticated/unconfigured signal (matched by the same
+		// classifier the SystemErrorCard fork uses in agent_issue.go). A
+		// transient CLI/provider/network failure must NOT trigger the
+		// llmCalls==1 bailout in Scan — that would skip the rest of the
+		// pass even when auth is fine. CodeRabbit on PR #987.
+		//
+		// Both branches keep the per-article diagnostic at DEBUG so the
+		// detail is still accessible when debug logging is enabled. #980.
 		slog.Debug("skill_scanner: LLM call failed, skipping article",
 			"path", articlePath, "err", callErr)
-		return false, SkillFrontmatter{}, "", "", fmt.Errorf("%w: %w", ErrLLMNotConfigured, callErr)
+		if probe := classifyProviderAuthError(callErr.Error()); probe.IsAuthError {
+			return false, SkillFrontmatter{}, "", "", fmt.Errorf("%w: %w", ErrLLMNotConfigured, callErr)
+		}
+		return false, SkillFrontmatter{}, "", "", fmt.Errorf("skill_scanner: %w", callErr)
 	}
 	if callCtx.Err() != nil {
 		slog.Warn("skill_scanner: LLM call timed out", "path", articlePath, "timeout", timeout)

--- a/internal/team/skill_scanner.go
+++ b/internal/team/skill_scanner.go
@@ -61,9 +61,19 @@ const agentsDirPrefix = "team/agents/"
 type llmProvider interface {
 	// AskIsSkill classifies an article. existingSkillsSummary is injected
 	// into the user prompt for deduplication (may be empty). enhanceSlug is
-	// non-empty when the LLM returns an "enhance" directive.
+	// non-empty when the LLM returns an "enhance" directive. Returning
+	// ErrLLMNotConfigured signals that no LLM auth is available; the scan
+	// loop bails out of the per-article walk and emits a single summary
+	// log line instead of logging once per article (#980).
 	AskIsSkill(ctx context.Context, articlePath, articleContent, existingSkillsSummary string) (isSkill bool, fm SkillFrontmatter, body, enhanceSlug string, err error)
 }
+
+// ErrLLMNotConfigured is the sentinel a provider returns from AskIsSkill when
+// the underlying LLM CLI is unavailable or unauthenticated. The scanner
+// converts a single occurrence into one summary log and stops the loop —
+// no point asking the same dead provider N times in a row. Tests in
+// skill_scanner_no_auth_test.go pin the behavior.
+var ErrLLMNotConfigured = errors.New("skill_scanner: no LLM configured")
 
 // SkillSpec is the canonical in-memory representation the scanner produces
 // before handing off to writeSkillProposalLocked. It bundles the parsed
@@ -229,6 +239,26 @@ func (s *SkillScanner) Scan(ctx context.Context, scopePath string, dryRun bool, 
 		llmCalls++
 
 		isSkill, fm, body, enhanceSlug, err := s.provider.AskIsSkill(ctx, c.relPath, c.content, existingSkillsSummary)
+		if errors.Is(err, ErrLLMNotConfigured) {
+			// On the very first call this is almost always an
+			// unauthed/missing LLM CLI — every subsequent article would
+			// just emit the same opaque error. Bail with one summary line
+			// so a freshly-installed unauthed broker doesn't fill the log
+			// with N copies of `exit status 1`. The next scan tick retries
+			// from scratch once the user signs in. Mid-pass occurrences
+			// (llmCalls > 1) might be transient, so we fall through to the
+			// per-article error path. #980.
+			if llmCalls == 1 {
+				remaining := len(candidates) - res.Scanned
+				slog.Warn("skill_scanner: no LLM configured; skipping scan",
+					"articles_remaining", remaining,
+					"hint", "run `claude login` (or your provider's sign-in) to enable",
+					"underlying", err.Error())
+				res.Errors = append(res.Errors, ScanError{Slug: "", Reason: "llm_not_configured"})
+				delete(updatedCache, c.relPath)
+				break
+			}
+		}
 		if err != nil {
 			res.Errors = append(res.Errors, ScanError{Slug: c.relPath, Reason: "llm: " + err.Error()})
 			// Leave the cache entry unset so we retry next pass.
@@ -634,9 +664,17 @@ func (p *defaultLLMProvider) AskIsSkill(ctx context.Context, articlePath, articl
 			slog.Warn("skill_scanner: LLM call timed out", "path", articlePath, "timeout", timeout)
 			return false, SkillFrontmatter{}, "", "", nil
 		}
-		slog.Warn("skill_scanner: LLM call failed, skipping article",
+		// When the LLM provider fails before producing assistant output —
+		// classic symptom of an unauthed/uninstalled CLI — every article
+		// in the pass returns the same opaque error (e.g. bare "exit
+		// status 1"). Surface ErrLLMNotConfigured + the underlying detail
+		// so the scan loop can choose to bail with one summary line
+		// instead of logging per-article. The legacy per-article WARN
+		// downgrades to DEBUG so the diagnostic is still accessible when
+		// debug logging is enabled. #980.
+		slog.Debug("skill_scanner: LLM call failed, skipping article",
 			"path", articlePath, "err", callErr)
-		return false, SkillFrontmatter{}, "", "", nil
+		return false, SkillFrontmatter{}, "", "", fmt.Errorf("%w: %w", ErrLLMNotConfigured, callErr)
 	}
 	if callCtx.Err() != nil {
 		slog.Warn("skill_scanner: LLM call timed out", "path", articlePath, "timeout", timeout)

--- a/internal/team/skill_scanner_no_auth_test.go
+++ b/internal/team/skill_scanner_no_auth_test.go
@@ -116,3 +116,40 @@ func TestErrLLMNotConfiguredIsWrappable(t *testing.T) {
 		t.Fatalf("wrapped error should match ErrLLMNotConfigured via errors.Is")
 	}
 }
+
+// TestSkillScannerOnlyWrapsAuthErrors locks in the CodeRabbit fix on PR #987:
+// defaultLLMProvider.AskIsSkill must only wrap with ErrLLMNotConfigured when
+// the underlying error is a concrete auth signal. A transient/network/exec
+// failure (e.g. bare "exit status 1") must NOT trigger the llmCalls==1
+// bailout in Scan, otherwise a single hiccup on the first article would skip
+// the rest of the pass even when auth is fine.
+func TestSkillScannerOnlyWrapsAuthErrors(t *testing.T) {
+	authSamples := []string{
+		"Not logged in - Please run /login",
+		"Please run `claude login`",
+		"Codex CLI requires login. Run `codex login`",
+		"authentication required",
+		"Unauthorized",
+	}
+	for _, sample := range authSamples {
+		probe := classifyProviderAuthError(sample)
+		if !probe.IsAuthError {
+			t.Errorf("expected IsAuthError=true for %q", sample)
+		}
+	}
+	nonAuthSamples := []string{
+		"exit status 1",
+		"context deadline exceeded",
+		"connection refused",
+		"unexpected EOF",
+		"signal: killed",
+		"",
+	}
+	for _, sample := range nonAuthSamples {
+		probe := classifyProviderAuthError(sample)
+		if probe.IsAuthError {
+			t.Errorf("expected IsAuthError=false for %q (got Provider=%q SignInCommand=%q)",
+				sample, probe.Provider, probe.SignInCommand)
+		}
+	}
+}

--- a/internal/team/skill_scanner_no_auth_test.go
+++ b/internal/team/skill_scanner_no_auth_test.go
@@ -1,0 +1,118 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// noAuthProvider is an llmProvider that simulates an unauthed/uninstalled
+// LLM CLI by returning ErrLLMNotConfigured from AskIsSkill. It tracks the
+// number of times it was invoked so the test can assert the scan loop bails
+// after the very first call instead of hammering the dead provider for every
+// article in the wiki.
+type noAuthProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *noAuthProvider) AskIsSkill(_ context.Context, path, _, _ string) (bool, SkillFrontmatter, string, string, error) {
+	p.mu.Lock()
+	p.calls++
+	p.mu.Unlock()
+	return false, SkillFrontmatter{}, "", "", fmt.Errorf("%w: %w", ErrLLMNotConfigured, errors.New("exit status 1"))
+}
+
+func (p *noAuthProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// TestSkillScanner_NoLLMConfigured_BailsAfterFirstCall pins the #980 fix:
+// when the LLM provider is unconfigured/unauthed, the scanner emits one
+// summary WARN line and stops the per-article loop instead of logging
+// "LLM call failed, skipping article" once per file in the wiki.
+func TestSkillScanner_NoLLMConfigured_BailsAfterFirstCall(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Skipf("git unavailable: %v", err)
+	}
+
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	worker.Start(context.Background())
+	defer worker.Stop()
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	// Seed three articles — the same shape as the QA-reported boot:
+	// team/about/{README,company,owner}.md, all with no auth available.
+	for _, name := range []string{"README", "company", "owner"} {
+		rel := filepath.Join("team", "about", name+".md")
+		if _, _, err := repo.Commit(context.Background(), "ceo", rel,
+			"# "+name+"\n\nseed body\n", "create", "seed "+name); err != nil {
+			t.Fatalf("seed %s: %v", name, err)
+		}
+	}
+
+	var logBuf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	prov := &noAuthProvider{}
+	scanner := NewSkillScanner(b, prov, 100)
+	res, err := scanner.Scan(context.Background(), "", true, "manual")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if got := prov.callCount(); got != 1 {
+		t.Fatalf("unauthed provider should be invoked exactly once, was called %d times", got)
+	}
+
+	if res.Scanned != 1 {
+		t.Fatalf("scanned = %d, want 1 (loop should break after first auth failure)", res.Scanned)
+	}
+
+	logText := logBuf.String()
+	const summaryNeedle = "skipping scan"
+	if !strings.Contains(logText, summaryNeedle) {
+		t.Fatalf("expected single summary line containing %q, got:\n%s",
+			summaryNeedle, logText)
+	}
+	if n := strings.Count(logText, summaryNeedle); n != 1 {
+		t.Fatalf("expected exactly one summary line, got %d:\n%s", n, logText)
+	}
+	if strings.Contains(logText, "LLM call failed, skipping article") {
+		// The legacy per-article WARN must be gone — it would put us back
+		// to the original behaviour of 3 WARNs per pass.
+		t.Fatalf("did not expect per-article WARN line, log was:\n%s", logText)
+	}
+
+	// The summary error should be attached so callers can see why the scan
+	// short-circuited.
+	if len(res.Errors) == 0 || res.Errors[0].Reason != "llm_not_configured" {
+		t.Fatalf("expected llm_not_configured in res.Errors, got %+v", res.Errors)
+	}
+}
+
+// TestErrLLMNotConfiguredIsWrappable confirms the sentinel composes cleanly
+// with fmt.Errorf("%w: %w", …) so callers can attach the underlying provider
+// detail without losing errors.Is matching.
+func TestErrLLMNotConfiguredIsWrappable(t *testing.T) {
+	wrapped := fmt.Errorf("%w: %w", ErrLLMNotConfigured, errors.New("exit status 1"))
+	if !errors.Is(wrapped, ErrLLMNotConfigured) {
+		t.Fatalf("wrapped error should match ErrLLMNotConfigured via errors.Is")
+	}
+}

--- a/internal/team/wiki_boot_reconcile_no_bak_test.go
+++ b/internal/team/wiki_boot_reconcile_no_bak_test.go
@@ -1,0 +1,93 @@
+package team
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestBackupMirrorSkipsEmptyWiki verifies that BackupMirror is a no-op on a
+// freshly initialised wiki where only the .gitkeep scaffolding exists. The
+// observable effect is no ~/.wuphf/wiki.bak/ directory next to ~/.wuphf/wiki/
+// until at least one real article lands. Regression for #981.
+func TestBackupMirrorSkipsEmptyWiki(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	// Init seeded team/{people,companies,…}/.gitkeep — no real articles yet.
+	if err := repo.BackupMirror(ctx); err != nil {
+		t.Fatalf("backup mirror: %v", err)
+	}
+	if _, err := os.Stat(repo.BackupRoot()); !os.IsNotExist(err) {
+		t.Fatalf("expected no wiki.bak/ on empty wiki, stat err = %v", err)
+	}
+}
+
+// TestBackupMirrorRunsAfterFirstArticle verifies the guard is one-shot:
+// once a real article exists the backup proceeds normally.
+func TestBackupMirrorRunsAfterFirstArticle(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "ceo", "team/people/nazz.md", "# Nazz\n", "create", "seed"); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := repo.BackupMirror(ctx); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(repo.BackupRoot(), "team/people/nazz.md")); err != nil {
+		t.Fatalf("expected mirrored article after first write: %v", err)
+	}
+}
+
+// TestTeamSubtreeHasArticleIgnoresDotFiles confirms that .gitkeep and other
+// dot-prefixed scaffolding do not count as articles. The semantics matter:
+// the boot guard keys on real content, not git-layout placeholders.
+func TestTeamSubtreeHasArticleIgnoresDotFiles(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "team")
+	if err := os.MkdirAll(filepath.Join(dir, "people"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "people", ".gitkeep"), nil, 0o600); err != nil {
+		t.Fatalf("write keep: %v", err)
+	}
+	has, err := teamSubtreeHasArticle(dir)
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if has {
+		t.Fatal("expected .gitkeep not to count as an article")
+	}
+
+	// Now add a real .md article — has should flip true.
+	if err := os.WriteFile(filepath.Join(dir, "people", "nazz.md"), []byte("# N\n"), 0o600); err != nil {
+		t.Fatalf("write md: %v", err)
+	}
+	has, err = teamSubtreeHasArticle(dir)
+	if err != nil {
+		t.Fatalf("walk 2: %v", err)
+	}
+	if !has {
+		t.Fatal("expected .md article to count")
+	}
+}
+
+// TestTeamSubtreeHasArticleMissingDir treats a never-created team/ as
+// "empty" rather than an error — fresh boot with the worker still
+// initialising should not surface a walk failure.
+func TestTeamSubtreeHasArticleMissingDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does-not-exist")
+	has, err := teamSubtreeHasArticle(dir)
+	if err != nil {
+		t.Fatalf("missing dir should be silent, got err: %v", err)
+	}
+	if has {
+		t.Fatal("expected missing dir to count as empty")
+	}
+}

--- a/internal/team/wiki_boot_reconcile_no_bak_test.go
+++ b/internal/team/wiki_boot_reconcile_no_bak_test.go
@@ -78,6 +78,33 @@ func TestTeamSubtreeHasArticleIgnoresDotFiles(t *testing.T) {
 	}
 }
 
+// TestTeamSubtreeHasArticleAcceptsUppercaseExtension regression-guards the
+// CodeRabbit fix on PR #987: validateArticlePath accepts .MD/.Md, so the
+// scanner must too — otherwise BackupMirror would skip the snapshot on a
+// wiki that has perfectly valid articles. Closes #987 follow-up.
+func TestTeamSubtreeHasArticleAcceptsUppercaseExtension(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "team")
+	if err := os.MkdirAll(filepath.Join(dir, "people"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range []string{"NAZZ.MD", "alex.Md"} {
+		if err := os.WriteFile(filepath.Join(dir, "people", name), []byte("# N\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		has, err := teamSubtreeHasArticle(dir)
+		if err != nil {
+			t.Fatalf("walk after %s: %v", name, err)
+		}
+		if !has {
+			t.Fatalf("expected %s to count as a markdown article", name)
+		}
+		// Clean up between iterations so the next file is the only signal.
+		if err := os.Remove(filepath.Join(dir, "people", name)); err != nil {
+			t.Fatalf("cleanup %s: %v", name, err)
+		}
+	}
+}
+
 // TestTeamSubtreeHasArticleMissingDir treats a never-created team/ as
 // "empty" rather than an error — fresh boot with the worker still
 // initialising should not surface a walk failure.

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -818,7 +818,11 @@ func teamSubtreeHasArticle(teamDir string) (bool, error) {
 		if strings.HasPrefix(name, ".") {
 			return nil
 		}
-		if strings.HasSuffix(name, ".md") {
+		// Case-insensitive match: validateArticlePath accepts mixed-case
+		// extensions (.MD, .Md) so we must too, otherwise BackupMirror
+		// could skip the snapshot for a wiki that has perfectly valid
+		// articles. CodeRabbit on PR #987.
+		if strings.EqualFold(filepath.Ext(name), ".md") {
 			found = true
 			return filepath.SkipDir
 		}

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -778,7 +778,11 @@ func (r *Repo) regenerateIndexLocked() error {
 func (r *Repo) BackupMirror(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if hasArticle, err := teamSubtreeHasArticle(filepath.Join(r.root, "team")); err == nil && !hasArticle {
+	hasArticle, err := teamSubtreeHasArticle(filepath.Join(r.root, "team"))
+	if err != nil {
+		return fmt.Errorf("wiki: inspect team subtree for backup: %w", err)
+	}
+	if !hasArticle {
 		// Nothing to back up yet. The backup mirror will appear after the
 		// first real article write.
 		return nil

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -768,13 +768,62 @@ func (r *Repo) regenerateIndexLocked() error {
 
 // BackupMirror copies the wiki repo to ~/.wuphf/wiki.bak/ skipping git object
 // packs for speed. The worker calls this asynchronously and debounced.
+//
+// First-boot guard: on a freshly initialised wiki the layout is just
+// .gitkeep stubs under team/{people,companies,…}/ — there are no real
+// articles to back up. Creating ~/.wuphf/wiki.bak/ in that case puts a
+// surprising empty directory next to ~/.wuphf/wiki/ on every fresh
+// install. Skip the copy until at least one article exists.
+// Closes #981.
 func (r *Repo) BackupMirror(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if hasArticle, err := teamSubtreeHasArticle(filepath.Join(r.root, "team")); err == nil && !hasArticle {
+		// Nothing to back up yet. The backup mirror will appear after the
+		// first real article write.
+		return nil
+	}
 	if err := copyTree(r.root, r.backupRoot); err != nil {
 		return fmt.Errorf("wiki: backup mirror: %w", err)
 	}
 	return nil
+}
+
+// teamSubtreeHasArticle reports whether teamDir contains at least one *.md
+// article (recursively). Dot-prefixed dirs and files are ignored so .gitkeep
+// and .obsidian-style scaffolding do not count as content. Returns (false,
+// nil) when teamDir does not exist so a never-initialised wiki degrades to
+// "empty".
+func teamSubtreeHasArticle(teamDir string) (bool, error) {
+	found := false
+	walkErr := filepath.Walk(teamDir, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return filepath.SkipDir
+			}
+			return err
+		}
+		if info.IsDir() {
+			base := filepath.Base(p)
+			if strings.HasPrefix(base, ".") && p != teamDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := info.Name()
+		if strings.HasPrefix(name, ".") {
+			return nil
+		}
+		if strings.HasSuffix(name, ".md") {
+			found = true
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if walkErr != nil && !os.IsNotExist(walkErr) {
+		return found, walkErr
+	}
+	return found, nil
 }
 
 // RestoreFromBackup swaps the corrupt repo for the backup mirror.


### PR DESCRIPTION
Bundled cleanup of three small Go-side broker log/boot noise findings
from the QA epic #930. Each issue has its own commit so the
disposition is easy to follow.

## Changes

### #980 — collapse skill-scanner no-auth spam (`744125b9`)

When the broker boots without an LLM auth surface, the skill scanner
walked every `team/about/*.md` article and emitted a per-article WARN:

```
WARN skill_scanner: LLM call failed, skipping article path=…/README.md  err="exit status 1"
WARN skill_scanner: LLM call failed, skipping article path=…/company.md err="exit status 1"
WARN skill_scanner: LLM call failed, skipping article path=…/owner.md   err="exit status 1"
```

Same root cause, N copies. The raw error from `RunConfiguredOneShotCtx`
doesn't carry the auth signal directly (claude oneshot reduces "Not
logged in" + stderr to a bare exit status), so the scanner now
introduces an `ErrLLMNotConfigured` sentinel: on the first per-pass
LLM failure it logs one summary line and breaks the loop:

```
WARN skill_scanner: no LLM configured; skipping scan articles_remaining=2
     hint="run `claude login` (or your provider's sign-in) to enable"
```

The per-article diagnostic downgrades to DEBUG so it's still accessible
under `slog` debug logging. Mid-pass failures (`llmCalls > 1`) take the
legacy per-article ScanError path — one transient blip shouldn't halve
a pass. Next cron tick (default 30m) retries from scratch.

### #981 — don't create wiki.bak/ on first boot of an empty home (`4714deec`)

Booting under a fresh HOME used to create `~/.wuphf/wiki.bak/` next to
`~/.wuphf/wiki/` before any real article was ever written. The mirror
was a copy of just the `.gitkeep` scaffolding `Repo.Init` seeds — a
surprising empty directory that looks like state leakage.

`BackupMirror` now short-circuits with a one-shot article-count walk
of `team/`. If zero non-dot `*.md` articles exist, the copy is a no-op
and the backup simply appears the first time a real article lands.
`RestoreFromBackup` and the existing post-write backup path are
unchanged.

### #982 — silence notebook-signal-scanner walk-error spam (`94032eb8`)

Every 30 minutes the broker logged:

```
WARN notebook_signal_scanner: skipping path due to walk error
  path=…/wiki/team/agents err="lstat …: no such file or directory"
```

Pure noise — the directory was never created because no agents are
seeded yet. `collectNotebookEntries` now `os.Stat`s the agents dir
first and returns silently when `errors.Is(err, fs.ErrNotExist)`.
The walk-error log line is retained for genuinely broken sub-paths
once the dir does exist.

## Verification

```bash
gofmt -l ./... && go vet ./...           # clean
golangci-lint run ./internal/team/...    # 0 issues
bash scripts/test-go.sh ./internal/team  # 101s — green
```

Live boot under a fresh HOME with a fast compile cron, then seeded
`team/about/{README,company,owner}.md`:

```
WARN skill_scanner: no LLM configured; skipping scan articles_remaining=2 …
WARN skill_scanner: no LLM configured; skipping scan articles_remaining=2 …
```

One summary line per cron tick (previously 3 WARNs per tick).
`grep -c "LLM call failed"`, `grep -c "walk error"` → 0.
`~/.wuphf/wiki.bak/` absent.

Closes #980
Closes #981
Closes #982

## Test plan

- [x] `bash scripts/test-go.sh ./internal/team` green
- [x] `golangci-lint run ./internal/team/...` clean
- [x] Live boot under fresh HOME confirms single summary line per pass
- [x] `wiki.bak/` absent after fresh boot
- [x] `notebook_signal_scanner` walk-error line absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed spurious warnings during first boot when agent directories are absent.
  * Skill scanner now bails cleanly after the first unconfigured/auth-failure with a single warning and one scan error entry.
  * Wiki backups only run when a real article exists; dot-prefixed scaffold files are ignored and markdown extensions are matched case-insensitively.

* **Tests**
  * Added regression tests covering missing agent dirs, unconfigured LLM behavior, and wiki backup/no-article scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->