### PR TITLE
fix(onboarding+issues): echo wizard answers + recoverable scan + issue event timeline

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -879,6 +879,9 @@ var legalPhaseTransitions = map[string]map[string]bool{
 	},
 	PhaseScan: {
 		PhaseBlueprint: true,
+		// Recovery path after a scan failure: re-enter PhaseWebsite so the
+		// user can supply a different URL. (#934)
+		PhaseWebsite: true,
 	},
 	PhaseBlueprint: {
 		PhaseTeam: true,

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -559,7 +559,26 @@ func ceoDeterministicMessages(phase string, s *onboarding.State) []ceoMessagePay
 		}}
 
 	case onboarding.PhaseBlueprint:
-		return []ceoMessagePayload{{
+		out := make([]ceoMessagePayload, 0, 2)
+		// If we arrived here from a failed scan (URL was set but scan never
+		// completed), acknowledge the skip so the user isn't left wondering
+		// why the wiki update line never appeared. (#934)
+		if s != nil {
+			websiteURL := strings.TrimSpace(s.FormAnswers.WebsiteURL)
+			if websiteURL != "" && !s.FormAnswers.ScanComplete {
+				ack := "OK, skipping the scan"
+				if companyName != "" {
+					ack += " — we'll go with what you told me about " + companyName + "."
+				} else {
+					ack += " — we'll work with what you've already told me."
+				}
+				out = append(out, ceoMessagePayload{
+					Kind:    "text",
+					Content: ack,
+				})
+			}
+		}
+		out = append(out, ceoMessagePayload{
 			Kind:         "ceo_chip_row",
 			Content:      "Pick a starter template, or start from scratch:",
 			SuggestionID: "blueprint-pick",
@@ -573,7 +592,8 @@ func ceoDeterministicMessages(phase string, s *onboarding.State) []ceoMessagePay
 					{"id": "", "label": "Start from scratch"},
 				},
 			}),
-		}}
+		})
+		return out
 
 	case onboarding.PhaseTeam:
 		// The team trim checklist is built from the blueprint's agent roster.

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -220,6 +220,13 @@ func (b *Broker) postScanChipUpdate(dmSlug, websiteURL, status, label string) {
 // The reason string is the verbatim warning surfaced from operations
 // (scanFailureReason); the frontend renders it as plain text under the chip.
 func (b *Broker) postScanChipFailure(dmSlug, websiteURL, label, reason string) {
+	// Ignore stale failure writes once onboarding has moved past PhaseScan.
+	// Otherwise a slow scan returning failure after the user already advanced
+	// (e.g. via "Skip the scan") would resurrect the recovery UI and overwrite
+	// the newer pending suggestion. CodeRabbit on PR #988.
+	if s, loadErr := onboarding.Load(); loadErr == nil && s.Phase != onboarding.PhaseScan {
+		return
+	}
 	rawPayload := mustMarshalRaw(map[string]interface{}{
 		"url":          websiteURL,
 		"status":       "failed",

--- a/internal/team/broker_onboarding_scan.go
+++ b/internal/team/broker_onboarding_scan.go
@@ -52,13 +52,12 @@ func (b *Broker) runScanPhase(dmSlug string) {
 	s, err := onboarding.Load()
 	if err != nil {
 		// Don't strand the user on a spinning "Scanning…" chip. Post a
-		// generic failed terminal chip + try to advance out of PhaseScan
-		// even though advanceAfterScan will likely hit the same Load
-		// failure — at minimum the chat shows the failure state.
-		// (CodeRabbit on #911.)
+		// failed chip with recovery CTAs — the load failure is local to
+		// our state file and skipping is the only safe path forward.
 		log.Printf("onboarding scan: load state: %v", err)
-		b.postScanChipUpdate(dmSlug, "", "failed", "Couldn’t read onboarding state — skipping the scan.")
-		b.advanceAfterScan("", false)
+		b.postScanChipFailure(dmSlug, "",
+			"Couldn’t read onboarding state.",
+			"Local state file is unreadable; skip the scan to continue.")
 		return
 	}
 	websiteURL := strings.TrimSpace(s.FormAnswers.WebsiteURL)
@@ -94,9 +93,12 @@ func (b *Broker) runScanPhase(dmSlug string) {
 		if scanErr != nil {
 			log.Printf("onboarding scan: %v", scanErr)
 		}
-		b.postScanChipUpdate(dmSlug, websiteURL, "failed",
-			fmt.Sprintf("Couldn’t read %s — skipping the scan.", displayURL(websiteURL)))
-		b.advanceAfterScan(websiteURL, false)
+		reason := scanFailureReason(scanErr, result)
+		// Surface the reason inline on the failed chip so the user knows
+		// what went wrong, and leave them in PhaseScan with recovery CTAs
+		// rather than silently advancing to PhaseBlueprint. (#934)
+		label := fmt.Sprintf("Couldn’t read %s.", displayURL(websiteURL))
+		b.postScanChipFailure(dmSlug, websiteURL, label, reason)
 		return
 	}
 
@@ -164,6 +166,9 @@ func (b *Broker) phaseStillScan() bool {
 // reflecting the terminal status of the scan (done | failed). It is a new
 // message (not an in-place mutation of the original chip) so the existing
 // SSE/append-only message log stays append-only.
+//
+// Used by the success path only. The failure path takes postScanChipFailure,
+// which adds the error_reason field + leaves the user with recovery CTAs.
 func (b *Broker) postScanChipUpdate(dmSlug, websiteURL, status, label string) {
 	rawPayload := mustMarshalRaw(map[string]interface{}{
 		"url":          websiteURL,
@@ -200,6 +205,94 @@ func (b *Broker) postScanChipUpdate(dmSlug, websiteURL, status, label string) {
 	if err := b.saveLocked(); err != nil {
 		log.Printf("onboarding scan: persist chip update: %v", err)
 	}
+}
+
+// postScanChipFailure appends a terminal ceo_scan_chip with status="failed",
+// surfaces the underlying error reason inline, and leaves the user in
+// PhaseScan with recovery CTAs (#934).
+//
+// Unlike the success path, this does NOT call advanceAfterScan: the frontend
+// renders a "Try another URL" CTA (→ POST /onboarding/transition phase=website)
+// and a "Skip and continue" CTA (→ POST /onboarding/transition phase=blueprint)
+// so the user controls the next step. PendingSuggestion is updated to this
+// failed chip so resume re-emits the same recovery UI.
+//
+// The reason string is the verbatim warning surfaced from operations
+// (scanFailureReason); the frontend renders it as plain text under the chip.
+func (b *Broker) postScanChipFailure(dmSlug, websiteURL, label, reason string) {
+	rawPayload := mustMarshalRaw(map[string]interface{}{
+		"url":          websiteURL,
+		"status":       "failed",
+		"failed_label": label,
+		"error_reason": reason,
+	})
+	payload := ceoMessagePayload{
+		Kind:              "ceo_scan_chip",
+		Content:           label,
+		SuggestionID:      "scan-progress-" + urlToSuggestionID(websiteURL) + "-failed",
+		SuggestionPayload: rawPayload,
+	}
+	sanitized, err := sanitizeCEOPayload(payload)
+	if err != nil {
+		log.Printf("onboarding scan: sanitize chip failure: %v", err)
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "ceo",
+		Channel:   dmSlug,
+		Kind:      payload.Kind,
+		Content:   payload.Content,
+		Payload:   sanitized,
+		Tagged:    []string{},
+		Timestamp: now,
+	})
+	// Persist the failed chip as the pending suggestion so a tab refresh
+	// resumes on the same recovery UI rather than re-firing a fresh scan.
+	if s, loadErr := onboarding.Load(); loadErr == nil {
+		s.PendingSuggestion = &onboarding.Suggestion{
+			ID:       payload.SuggestionID,
+			Phase:    onboarding.PhaseScan,
+			Kind:     payload.Kind,
+			Payload:  sanitized,
+			IssuedAt: time.Now().UTC(),
+		}
+		if saveErr := onboarding.Save(s); saveErr != nil {
+			log.Printf("onboarding scan: persist failed pending: %v", saveErr)
+		}
+	} else {
+		log.Printf("onboarding scan: load for failed pending: %v", loadErr)
+	}
+	if err := b.saveLocked(); err != nil {
+		log.Printf("onboarding scan: persist chip failure: %v", err)
+	}
+}
+
+// scanFailureReason returns a short, plain-English description of why the
+// website scan failed. It pulls verbatim from operations.CompanySeedResult's
+// warnings array when available (e.g. "URL fetch failed: ...",
+// "LLM extraction failed: ...") and falls back to the raw error otherwise.
+//
+// Per #934's failure-mode guidance, we do NOT invent a new typed taxonomy
+// here — we surface what the underlying layer already produced.
+func scanFailureReason(scanErr error, result *operations.CompanySeedResult) string {
+	if result != nil {
+		for _, w := range result.Warnings {
+			w = strings.TrimSpace(w)
+			if w != "" {
+				return w
+			}
+		}
+	}
+	if scanErr != nil {
+		return scanErr.Error()
+	}
+	return "The scanner returned no readable content."
 }
 
 // postScanArticleLine appends a single CEO text bubble announcing one wiki

--- a/internal/team/broker_onboarding_scan_test.go
+++ b/internal/team/broker_onboarding_scan_test.go
@@ -1,0 +1,132 @@
+package team
+
+// broker_onboarding_scan_test.go — unit tests for the website-scan recovery
+// path (#934).
+//
+// Covers:
+//   - scanFailureReason returns the first non-empty warning when present
+//   - scanFailureReason falls back to the raw scan error
+//   - scanFailureReason returns a generic message when both are empty
+//   - ceoDeterministicMessages(PhaseBlueprint) acknowledges a skipped scan
+//   - PhaseScan → PhaseWebsite is a legal transition (retry path)
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/onboarding"
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+func TestScanFailureReason_PrefersFirstWarning(t *testing.T) {
+	result := &operations.CompanySeedResult{
+		Warnings: []string{
+			"URL fetch failed: 404 Not Found",
+			"LLM extraction failed: empty body",
+		},
+	}
+	got := scanFailureReason(errors.New("wrapper error"), result)
+	want := "URL fetch failed: 404 Not Found"
+	if got != want {
+		t.Errorf("scanFailureReason = %q, want %q", got, want)
+	}
+}
+
+func TestScanFailureReason_SkipsEmptyWarnings(t *testing.T) {
+	result := &operations.CompanySeedResult{
+		Warnings: []string{"   ", "", "the real reason"},
+	}
+	got := scanFailureReason(nil, result)
+	if got != "the real reason" {
+		t.Errorf("scanFailureReason = %q, want %q", got, "the real reason")
+	}
+}
+
+func TestScanFailureReason_FallsBackToErr(t *testing.T) {
+	got := scanFailureReason(errors.New("dial tcp: i/o timeout"), nil)
+	if got != "dial tcp: i/o timeout" {
+		t.Errorf("scanFailureReason = %q, want raw error", got)
+	}
+}
+
+func TestScanFailureReason_NoWarningsNoErr(t *testing.T) {
+	got := scanFailureReason(nil, &operations.CompanySeedResult{})
+	if got == "" {
+		t.Errorf("scanFailureReason returned empty; want fallback message")
+	}
+	// Should not panic; should be a complete sentence.
+	if !strings.HasSuffix(got, ".") {
+		t.Errorf("scanFailureReason fallback %q should end with a period", got)
+	}
+}
+
+func TestCeoDeterministicMessages_BlueprintAcksSkippedScan(t *testing.T) {
+	s := &onboarding.State{
+		FormAnswers: onboarding.FormAnswers{
+			CompanyName:  "Acme Test QA",
+			WebsiteURL:   "acme.test",
+			ScanComplete: false,
+		},
+	}
+	msgs := ceoDeterministicMessages(onboarding.PhaseBlueprint, s)
+	if len(msgs) != 2 {
+		t.Fatalf("expected ack + chip row (2 messages); got %d", len(msgs))
+	}
+	if msgs[0].Kind != "text" {
+		t.Fatalf("expected first message to be plain text; got kind=%s", msgs[0].Kind)
+	}
+	if !strings.Contains(msgs[0].Content, "skipping the scan") {
+		t.Errorf("ack should mention skipping the scan; got %q", msgs[0].Content)
+	}
+	if !strings.Contains(msgs[0].Content, "Acme Test QA") {
+		t.Errorf("ack should mention the company name; got %q", msgs[0].Content)
+	}
+	if msgs[1].Kind != "ceo_chip_row" {
+		t.Errorf("expected second message to be ceo_chip_row; got %s", msgs[1].Kind)
+	}
+}
+
+func TestCeoDeterministicMessages_BlueprintNoAckOnSuccess(t *testing.T) {
+	s := &onboarding.State{
+		FormAnswers: onboarding.FormAnswers{
+			CompanyName:  "Acme",
+			WebsiteURL:   "acme.test",
+			ScanComplete: true,
+		},
+	}
+	msgs := ceoDeterministicMessages(onboarding.PhaseBlueprint, s)
+	if len(msgs) != 1 {
+		t.Fatalf("expected only the chip row when scan succeeded; got %d", len(msgs))
+	}
+	if msgs[0].Kind != "ceo_chip_row" {
+		t.Errorf("got kind=%s, want ceo_chip_row", msgs[0].Kind)
+	}
+}
+
+func TestCeoDeterministicMessages_BlueprintNoAckWhenNoUrl(t *testing.T) {
+	// The "skip website" path enters PhaseBlueprint with no URL ever set;
+	// the ack should not fire because there was no scan to skip.
+	s := &onboarding.State{
+		FormAnswers: onboarding.FormAnswers{
+			CompanyName: "Acme",
+			WebsiteURL:  "",
+		},
+	}
+	msgs := ceoDeterministicMessages(onboarding.PhaseBlueprint, s)
+	if len(msgs) != 1 {
+		t.Fatalf("expected only the chip row when no URL was provided; got %d", len(msgs))
+	}
+}
+
+func TestLegalPhaseTransitions_PhaseScanToPhaseWebsite(t *testing.T) {
+	// Recovery: PhaseScan → PhaseWebsite must be legal so the user can
+	// retry with a different URL after a scan failure. (#934)
+	if !onboarding.IsLegalTransition(onboarding.PhaseScan, onboarding.PhaseWebsite) {
+		t.Errorf("expected PhaseScan → PhaseWebsite to be legal for retry")
+	}
+	// Skip path is unchanged.
+	if !onboarding.IsLegalTransition(onboarding.PhaseScan, onboarding.PhaseBlueprint) {
+		t.Errorf("expected PhaseScan → PhaseBlueprint to be legal")
+	}
+}

--- a/web/src/components/lifecycle/IssueDocument.test.tsx
+++ b/web/src/components/lifecycle/IssueDocument.test.tsx
@@ -227,6 +227,44 @@ describe("<IssueDocument>", () => {
     expect(authors).toEqual(["ceo", "engineer", "human"]);
   });
 
+  // ── Timeline shape (#937) ──────────────────────────────────────────────
+
+  it("renders the timeline as a semantic ordered list (#937)", () => {
+    renderDoc(BASE_DOC);
+    const list = screen.getByTestId("issue-comments-list");
+    expect(list.tagName.toLowerCase()).toBe("ol");
+    expect(list).toHaveAttribute(
+      "aria-label",
+      "Timeline entries (chronological)",
+    );
+    // Each entry is wrapped in an <li> for assistive-tech step counting.
+    expect(list.querySelectorAll("li").length).toBe(BASE_DOC.comments.length);
+  });
+
+  it("labels the timeline section 'Timeline' (#937)", () => {
+    renderDoc(BASE_DOC);
+    expect(
+      screen.getByRole("heading", { name: /timeline/i }),
+    ).toBeInTheDocument();
+    // Aria-label on the section uses the same vocabulary.
+    expect(screen.getByLabelText(/^Timeline$/i)).toBeInTheDocument();
+  });
+
+  it("empty state explains the timeline purpose in drafting state (#937)", () => {
+    renderDoc({ ...BASE_DOC, comments: [] });
+    const empty = screen.getByTestId("issue-comments-empty");
+    expect(empty).toBeInTheDocument();
+    expect(empty.textContent).toMatch(/CEO will start asking questions/i);
+    expect(empty.textContent).toMatch(/Answer inline/i);
+  });
+
+  it("empty state uses a non-drafting copy for approved issues (#937)", () => {
+    renderDoc({ ...APPROVED_DOC, comments: [] });
+    const empty = screen.getByTestId("issue-comments-empty");
+    expect(empty.textContent).toMatch(/Nothing on the timeline yet/i);
+    expect(empty.textContent).toMatch(/Status changes/i);
+  });
+
   it("renders a human comment form", () => {
     renderDoc(BASE_DOC);
     expect(screen.getByTestId("issue-comment-form")).toBeInTheDocument();

--- a/web/src/components/lifecycle/IssueDocument.tsx
+++ b/web/src/components/lifecycle/IssueDocument.tsx
@@ -749,21 +749,40 @@ function CommentsTimeline({
   return (
     <section
       className="issue-doc-comments"
-      aria-label="Comments"
+      aria-label="Timeline"
       aria-live="polite"
       ref={timelineRef}
     >
-      <h3 className="issue-comments-heading">Comments</h3>
+      <h3 className="issue-comments-heading">Timeline</h3>
       {comments.length === 0 ? (
-        <p className="issue-comments-empty" data-testid="issue-comments-empty">
-          No comments yet.
-        </p>
-      ) : (
-        <div className="issue-comments-list" data-testid="issue-comments-list">
-          {comments.map((c) => (
-            <CommentItem key={c.id} comment={c} />
-          ))}
+        <div
+          className="issue-comments-empty"
+          data-testid="issue-comments-empty"
+          role="note"
+        >
+          <p className="issue-comments-empty-title">
+            {isDrafting
+              ? "CEO will start asking questions here."
+              : "Nothing on the timeline yet."}
+          </p>
+          <p className="issue-comments-empty-hint">
+            {isDrafting
+              ? "Answer inline to refine the spec. Each turn from the CEO, the team, and you lands here as a card."
+              : "Status changes, reviewer comments, and human↔CEO replies will appear here as they happen."}
+          </p>
         </div>
+      ) : (
+        <ol
+          className="issue-comments-list"
+          data-testid="issue-comments-list"
+          aria-label="Timeline entries (chronological)"
+        >
+          {comments.map((c) => (
+            <li key={c.id} className="issue-comments-list-item">
+              <CommentItem comment={c} />
+            </li>
+          ))}
+        </ol>
       )}
       {/*
        * Drafting-state comment helper. Lets reviewers know they can

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -43,16 +43,22 @@ vi.mock("../../api/client", async () => {
     await vi.importActual<typeof import("../../api/client")>(
       "../../api/client",
     );
-  return { ...actual, get: vi.fn(), post: vi.fn() };
+  return {
+    ...actual,
+    get: vi.fn(),
+    post: vi.fn(),
+    postMessage: vi.fn(),
+  };
 });
 
 vi.mock("../../hooks/useRequests", () => ({
   useRequests: () => ({ pending: [] }),
 }));
 
-import { post } from "../../api/client";
+import { post, postMessage } from "../../api/client";
 
 const postMock = vi.mocked(post);
+const postMessageMock = vi.mocked(postMessage);
 
 // ── Context helper ────────────────────────────────────────────────────────
 
@@ -76,6 +82,14 @@ function makeWrapper(suggestion: CeoSuggestion | null) {
 beforeEach(() => {
   postMock.mockReset();
   postMock.mockResolvedValue({});
+  postMessageMock.mockReset();
+  postMessageMock.mockResolvedValue({
+    id: "msg-stub",
+    from: "human",
+    channel: "ceo__human",
+    content: "",
+    timestamp: new Date().toISOString(),
+  });
 });
 
 afterEach(() => {
@@ -651,6 +665,101 @@ describe("CeoCardSection", () => {
     };
     render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
     expect(screen.getByTestId("ceo-scan-chip")).toBeInTheDocument();
+  });
+
+  // ── Human-echo (#978) ──────────────────────────────────────────────────
+  //
+  // After the user commits a form-field / chip / checklist answer, the
+  // wizard mirrors that answer back into the CEO DM as a human chat bubble
+  // so the transcript reads like a real conversation. The non-conversational
+  // bridge_choice action is excluded.
+
+  it("echoes a form-field answer into the CEO DM after submit", async () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-echo-form",
+      phase: "greet",
+      kind: "ceo_form_field",
+      payload: { field: "company_name", label: "Office name?" },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Acme Test QA" },
+    });
+    fireEvent.click(screen.getByText("Submit"));
+
+    await waitFor(() =>
+      expect(postMessageMock).toHaveBeenCalledWith(
+        "Acme Test QA",
+        "ceo__human",
+      ),
+    );
+  });
+
+  it("echoes a chip-row choice as its human-readable label", async () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-echo-chip",
+      phase: "blueprint",
+      kind: "ceo_chip_row",
+      payload: {
+        field: "blueprint_id",
+        label: "Pick a template",
+        options: [{ id: "niche-crm", label: "Niche CRM" }],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.click(screen.getByText("Niche CRM"));
+
+    await waitFor(() =>
+      expect(postMessageMock).toHaveBeenCalledWith("Niche CRM", "ceo__human"),
+    );
+  });
+
+  it("does NOT echo bridge_choice into the CEO DM", async () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-echo-bridge",
+      phase: "bridge",
+      kind: "ceo_chip_row",
+      payload: {
+        field: "bridge_choice",
+        label: "What next?",
+        options: [{ id: "look_around", label: "Look around first" }],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.click(screen.getByText("Look around first"));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+        phase: "complete",
+      }),
+    );
+    expect(postMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("survives an echo postMessage failure without blocking the wizard", async () => {
+    postMessageMock.mockRejectedValueOnce(new Error("network down"));
+    const suggestion: CeoSuggestion = {
+      id: "sug-echo-fail",
+      phase: "greet",
+      kind: "ceo_form_field",
+      payload: { field: "company_name", label: "Office name?" },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByText("Submit"));
+
+    // The transition still fires even though the echo POST failed.
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+        phase: "identity",
+      }),
+    );
   });
 });
 

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -836,6 +836,33 @@ describe("CeoCardSection", () => {
       }),
     );
   });
+
+  // Regression guard for CodeRabbit on PR #988: the echo must be detached
+  // from the submit critical path. If postMessage hangs indefinitely the
+  // wizard must still advance — onboarding state is already committed via
+  // /onboarding/answer; the echo is best-effort UI sugar.
+  it("does not block wizard advance when echo postMessage hangs", async () => {
+    // Never resolves — simulates a hung /messages call.
+    postMessageMock.mockImplementationOnce(() => new Promise(() => {}));
+    const suggestion: CeoSuggestion = {
+      id: "sug-echo-hang",
+      phase: "greet",
+      kind: "ceo_form_field",
+      payload: { field: "company_name", label: "Office name?" },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "Acme" },
+    });
+    fireEvent.click(screen.getByText("Submit"));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+        phase: "identity",
+      }),
+    );
+  });
 });
 
 // ── InterviewBar integration ──────────────────────────────────────────────

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -420,6 +420,81 @@ describe("CeoScanChip", () => {
     expect(chip.textContent).toContain("read that URL");
   });
 
+  it("surfaces the error reason inline on failure (#934)", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "failed",
+      error_reason: "URL fetch failed: 404 Not Found",
+    };
+    render(<CeoScanChip payload={payload} />);
+    expect(screen.getByTestId("ceo-scan-chip-reason")).toHaveTextContent(
+      "URL fetch failed: 404 Not Found",
+    );
+  });
+
+  it("renders Try another URL and Skip CTAs on failure (#934)", () => {
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "failed",
+    };
+    render(<CeoScanChip payload={payload} />);
+    expect(screen.getByTestId("ceo-scan-chip-retry")).toBeInTheDocument();
+    expect(screen.getByTestId("ceo-scan-chip-skip")).toBeInTheDocument();
+  });
+
+  it("does NOT render CTAs on the scanning or done chip", () => {
+    const scanning: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "scanning",
+    };
+    const { unmount } = render(<CeoScanChip payload={scanning} />);
+    expect(screen.queryByTestId("ceo-scan-chip-actions")).toBeNull();
+    unmount();
+
+    const done: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "done",
+    };
+    render(<CeoScanChip payload={done} />);
+    expect(screen.queryByTestId("ceo-scan-chip-actions")).toBeNull();
+  });
+
+  it("clicking Try another URL transitions back to PhaseWebsite (#934)", async () => {
+    postMock.mockResolvedValue({ ok: true, phase: "website" });
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "failed",
+    };
+    render(<CeoScanChip payload={payload} />);
+    fireEvent.click(screen.getByTestId("ceo-scan-chip-retry"));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+        phase: "website",
+      }),
+    );
+  });
+
+  it("clicking Skip and continue transitions to PhaseBlueprint (#934)", async () => {
+    postMock.mockResolvedValue({ ok: true, phase: "blueprint" });
+    const payload: CeoScanChipPayload = {
+      field: "website_url",
+      url: "acme.com",
+      status: "failed",
+    };
+    render(<CeoScanChip payload={payload} />);
+    fireEvent.click(screen.getByTestId("ceo-scan-chip-skip"));
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+        phase: "blueprint",
+      }),
+    );
+  });
+
   it("uses custom labels when provided", () => {
     const payload: CeoScanChipPayload = {
       field: "website_url",

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -10,6 +10,7 @@ import {
   type InterviewOption,
   patchSkill,
   post,
+  postMessage,
   type Skill,
   type SkillSimilarRef,
 } from "../../api/client";
@@ -19,8 +20,9 @@ import {
   requestOptionNeedsText,
   requestOptionTextHint,
 } from "../../lib/requestOptions";
-import { useAppStore } from "../../stores/app";
+import { directChannelSlug, useAppStore } from "../../stores/app";
 import { SkillCompareView } from "../apps/SkillCompareView";
+import { humanEchoForCeoAnswer } from "../onboarding/humanEcho";
 import { useOnboardingDMContext } from "../onboarding/OnboardingDMRoute";
 import type { CardStage, CeoSuggestion } from "../onboarding/types";
 import { SidePanel } from "../ui/SidePanel";
@@ -709,6 +711,23 @@ export function CeoCardSection() {
     try {
       if (shouldPersistOnboardingAnswer(field)) {
         await post("/onboarding/answer", { field, value });
+      }
+      // Mirror the human's committed answer into the CEO DM as a chat
+      // bubble. The /messages endpoint persists it the same as any typed
+      // message so a tab reload still shows the transcript. See #978.
+      const echo = humanEchoForCeoAnswer(pendingSuggestion, field, value);
+      if (echo !== null) {
+        try {
+          await postMessage(echo, directChannelSlug("ceo"));
+          await queryClient.invalidateQueries({
+            queryKey: ["messages", directChannelSlug("ceo")],
+          });
+        } catch (echoErr: unknown) {
+          // A failed echo must not block the wizard advancing. The next
+          // CEO message will still arrive; the user just loses the visible
+          // mirror of their own answer for that turn.
+          console.warn("onboarding: failed to echo human answer", echoErr);
+        }
       }
       await advanceOnboardingAfterAnswer(field, value, phase);
       // Refresh onboarding state so the next suggestion appears.

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -717,17 +717,22 @@ export function CeoCardSection() {
       // message so a tab reload still shows the transcript. See #978.
       const echo = humanEchoForCeoAnswer(pendingSuggestion, field, value);
       if (echo !== null) {
-        try {
-          await postMessage(echo, directChannelSlug("ceo"));
-          await queryClient.invalidateQueries({
-            queryKey: ["messages", directChannelSlug("ceo")],
+        // Detached: don't await the echo work. The echo is best-effort UI
+        // sugar (mirror the human's answer back in chat); awaiting it
+        // would let a slow/hung /messages call freeze the wizard in
+        // "submitting" even though /onboarding/answer has already
+        // committed the real state. CodeRabbit on PR #988.
+        void postMessage(echo, directChannelSlug("ceo"))
+          .then(() =>
+            queryClient.invalidateQueries({
+              queryKey: ["messages", directChannelSlug("ceo")],
+            }),
+          )
+          .catch((echoErr: unknown) => {
+            // The next CEO message will still arrive; the user just loses
+            // the visible mirror of their own answer for that turn.
+            console.warn("onboarding: failed to echo human answer", echoErr);
           });
-        } catch (echoErr: unknown) {
-          // A failed echo must not block the wizard advancing. The next
-          // CEO message will still arrive; the user just loses the visible
-          // mirror of their own answer for that turn.
-          console.warn("onboarding: failed to echo human answer", echoErr);
-        }
       }
       await advanceOnboardingAfterAnswer(field, value, phase);
       // Refresh onboarding state so the next suggestion appears.

--- a/web/src/components/messages/cards/CeoScanChip.tsx
+++ b/web/src/components/messages/cards/CeoScanChip.tsx
@@ -1,8 +1,13 @@
 /**
  * CeoScanChip — displays async website scan status.
  *
- * Read-only (no keyboard interaction per spec — Tab focus but no Enter/Space).
- * Status transitions: scanning → done | failed, driven by SSE updates.
+ * Read-only for `scanning` and `done`. The `failed` status surfaces the
+ * underlying error reason and exposes two recovery CTAs (#934):
+ *   - "Try another URL" — re-enters PhaseWebsite so the user can supply a
+ *     different URL. The form-field still holds the previous URL string
+ *     in /onboarding/state so the user can edit it inline.
+ *   - "Skip and continue" — advances to PhaseBlueprint, same destination
+ *     as the prior silent auto-skip.
  *
  * Three status strings per spec (backend sets payload.status):
  *   scanning → payload.scanning_label or "Scanning…"
@@ -12,6 +17,10 @@
  * All strings rendered as text, never innerHTML.
  */
 
+import { useState } from "react";
+
+import { post } from "../../../api/client";
+import { showNotice } from "../../ui/Toast";
 import type { CeoScanChipPayload, ScanStatus } from "../../onboarding/types";
 
 interface CeoScanChipProps {
@@ -32,6 +41,24 @@ function scanLabel(payload: CeoScanChipPayload, status: ScanStatus): string {
 export function CeoScanChip({ payload }: CeoScanChipProps) {
   const { status } = payload;
   const label = scanLabel(payload, status);
+  const [recovering, setRecovering] = useState<"retry" | "skip" | null>(null);
+
+  async function transitionTo(next: "website" | "blueprint") {
+    if (recovering) return;
+    setRecovering(next === "website" ? "retry" : "skip");
+    try {
+      await post("/onboarding/transition", { phase: next });
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Could not advance the onboarding flow.";
+      showNotice(message, "error");
+      setRecovering(null);
+    }
+    // Leave `recovering` set on success — the broker will swap the pending
+    // suggestion to the new phase's card and this chip will unmount.
+  }
 
   return (
     <div
@@ -40,18 +67,52 @@ export function CeoScanChip({ payload }: CeoScanChipProps) {
       aria-live="polite"
       aria-label={label}
     >
-      {status === "scanning" ? (
-        <span className="ceo-scan-chip-spinner" aria-hidden="true" />
-      ) : (
-        <span
-          className={`ceo-scan-chip-icon ceo-scan-chip-icon--${status}`}
-          aria-hidden="true"
+      <div className="ceo-scan-chip-row">
+        {status === "scanning" ? (
+          <span className="ceo-scan-chip-spinner" aria-hidden="true" />
+        ) : (
+          <span
+            className={`ceo-scan-chip-icon ceo-scan-chip-icon--${status}`}
+            aria-hidden="true"
+          >
+            {status === "done" ? "✓" : "✗"}
+          </span>
+        )}
+        {/* Render URL and label as plain text — never as HTML */}
+        <span className="ceo-scan-chip-label">{label}</span>
+      </div>
+      {status === "failed" && payload.error_reason ? (
+        <p
+          className="ceo-scan-chip-reason"
+          data-testid="ceo-scan-chip-reason"
         >
-          {status === "done" ? "✓" : "✗"}
-        </span>
-      )}
-      {/* Render URL and label as plain text — never as HTML */}
-      <span className="ceo-scan-chip-label">{label}</span>
+          {payload.error_reason}
+        </p>
+      ) : null}
+      {status === "failed" ? (
+        <div className="ceo-scan-chip-actions" data-testid="ceo-scan-chip-actions">
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            disabled={recovering !== null}
+            onClick={() => transitionTo("website")}
+            data-testid="ceo-scan-chip-retry"
+            aria-label="Try a different website URL"
+          >
+            {recovering === "retry" ? "Reopening…" : "Try another URL"}
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            disabled={recovering !== null}
+            onClick={() => transitionTo("blueprint")}
+            data-testid="ceo-scan-chip-skip"
+            aria-label="Skip the website scan and continue"
+          >
+            {recovering === "skip" ? "Skipping…" : "Skip and continue"}
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/messages/cards/CeoScanChip.tsx
+++ b/web/src/components/messages/cards/CeoScanChip.tsx
@@ -20,8 +20,8 @@
 import { useState } from "react";
 
 import { post } from "../../../api/client";
-import { showNotice } from "../../ui/Toast";
 import type { CeoScanChipPayload, ScanStatus } from "../../onboarding/types";
+import { showNotice } from "../../ui/Toast";
 
 interface CeoScanChipProps {
   payload: CeoScanChipPayload;
@@ -82,15 +82,15 @@ export function CeoScanChip({ payload }: CeoScanChipProps) {
         <span className="ceo-scan-chip-label">{label}</span>
       </div>
       {status === "failed" && payload.error_reason ? (
-        <p
-          className="ceo-scan-chip-reason"
-          data-testid="ceo-scan-chip-reason"
-        >
+        <p className="ceo-scan-chip-reason" data-testid="ceo-scan-chip-reason">
           {payload.error_reason}
         </p>
       ) : null}
       {status === "failed" ? (
-        <div className="ceo-scan-chip-actions" data-testid="ceo-scan-chip-actions">
+        <div
+          className="ceo-scan-chip-actions"
+          data-testid="ceo-scan-chip-actions"
+        >
           <button
             type="button"
             className="btn btn-ghost btn-sm"

--- a/web/src/components/onboarding/humanEcho.test.ts
+++ b/web/src/components/onboarding/humanEcho.test.ts
@@ -84,17 +84,15 @@ const executionLineup: CeoExecutionLineupSuggestion = {
   kind: "ceo_execution_lineup",
   payload: {
     suggestion_id: "execution-lineup",
-    agents: [
-      { slug: "engineer", role: "Eng", reason: "ships features" },
-    ],
+    agents: [{ slug: "engineer", role: "Eng", reason: "ships features" }],
   },
 };
 
 describe("humanEchoForCeoAnswer", () => {
   it("echoes a form-field free-text answer verbatim", () => {
-    expect(humanEchoForCeoAnswer(formField, "company_name", "Acme Test QA")).toBe(
-      "Acme Test QA",
-    );
+    expect(
+      humanEchoForCeoAnswer(formField, "company_name", "Acme Test QA"),
+    ).toBe("Acme Test QA");
   });
 
   it("trims whitespace from a form-field answer", () => {
@@ -109,9 +107,9 @@ describe("humanEchoForCeoAnswer", () => {
   });
 
   it("resolves chip-row id into the human-readable label", () => {
-    expect(
-      humanEchoForCeoAnswer(chipRow, "blueprint_id", "niche-crm"),
-    ).toBe("Niche CRM");
+    expect(humanEchoForCeoAnswer(chipRow, "blueprint_id", "niche-crm")).toBe(
+      "Niche CRM",
+    );
   });
 
   it("renders the 'start from scratch' chip even when its id is empty", () => {
@@ -121,9 +119,9 @@ describe("humanEchoForCeoAnswer", () => {
   });
 
   it("falls back to the raw id when chip option is unknown", () => {
-    expect(
-      humanEchoForCeoAnswer(chipRow, "blueprint_id", "unknown-bp"),
-    ).toBe("unknown-bp");
+    expect(humanEchoForCeoAnswer(chipRow, "blueprint_id", "unknown-bp")).toBe(
+      "unknown-bp",
+    );
   });
 
   it("joins picked checklist labels with commas", () => {
@@ -136,9 +134,9 @@ describe("humanEchoForCeoAnswer", () => {
   });
 
   it("handles a team-trim suggestion the same as a checklist", () => {
-    expect(
-      humanEchoForCeoAnswer(teamTrim, "picked_agents", ["designer"]),
-    ).toBe("Designer");
+    expect(humanEchoForCeoAnswer(teamTrim, "picked_agents", ["designer"])).toBe(
+      "Designer",
+    );
   });
 
   it("renders an explicit '(nobody)' when no items are picked", () => {
@@ -154,16 +152,12 @@ describe("humanEchoForCeoAnswer", () => {
   });
 
   it("returns null for scan_complete", () => {
-    expect(
-      humanEchoForCeoAnswer(formField, "scan_complete", true),
-    ).toBeNull();
+    expect(humanEchoForCeoAnswer(formField, "scan_complete", true)).toBeNull();
   });
 
   it("returns null when there is no pending suggestion", () => {
     expect(humanEchoForCeoAnswer(null, "company_name", "Acme")).toBeNull();
-    expect(
-      humanEchoForCeoAnswer(undefined, "company_name", "Acme"),
-    ).toBeNull();
+    expect(humanEchoForCeoAnswer(undefined, "company_name", "Acme")).toBeNull();
   });
 
   it("returns null for the read-only scan chip", () => {

--- a/web/src/components/onboarding/humanEcho.test.ts
+++ b/web/src/components/onboarding/humanEcho.test.ts
@@ -1,0 +1,180 @@
+/**
+ * humanEcho — unit tests.
+ *
+ * Pins the "echo human answer into the CEO DM" rules:
+ *   - form-field free text bubbles back verbatim
+ *   - chip rows resolve id → human-readable label
+ *   - checklists resolve all picked ids → comma list
+ *   - non-conversational fields (bridge_choice, scan_complete) return null
+ *   - read-only kinds (scan chip, execution lineup) return null
+ *   - empty / skipped answers return null
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { humanEchoForCeoAnswer } from "./humanEcho";
+import type {
+  CeoChecklistSuggestion,
+  CeoChipRowSuggestion,
+  CeoExecutionLineupSuggestion,
+  CeoFormFieldSuggestion,
+  CeoScanChipSuggestion,
+  CeoTeamTrimSuggestion,
+} from "./types";
+
+const formField: CeoFormFieldSuggestion = {
+  id: "greet-company-name",
+  phase: "greet",
+  kind: "ceo_form_field",
+  payload: {
+    field: "company_name",
+    label: "Office name",
+  },
+};
+
+const chipRow: CeoChipRowSuggestion = {
+  id: "blueprint-pick",
+  phase: "blueprint",
+  kind: "ceo_chip_row",
+  payload: {
+    field: "blueprint_id",
+    label: "Pick a starter template",
+    options: [
+      { id: "bookkeeping-invoicing-service", label: "Bookkeeping" },
+      { id: "niche-crm", label: "Niche CRM" },
+      { id: "", label: "Start from scratch" },
+    ],
+  },
+};
+
+const checklist: CeoChecklistSuggestion = {
+  id: "team-trim",
+  phase: "team",
+  kind: "ceo_checklist",
+  payload: {
+    field: "picked_agents",
+    label: "Keep or trim",
+    items: [
+      { id: "engineer", label: "Engineer" },
+      { id: "designer", label: "Designer" },
+      { id: "marketer", label: "Marketer" },
+    ],
+  },
+};
+
+const teamTrim: CeoTeamTrimSuggestion = {
+  ...checklist,
+  kind: "ceo_team_trim",
+};
+
+const scanChip: CeoScanChipSuggestion = {
+  id: "scan-progress",
+  phase: "scan",
+  kind: "ceo_scan_chip",
+  payload: {
+    field: "scan_progress",
+    url: "acme.com",
+    status: "scanning",
+  },
+};
+
+const executionLineup: CeoExecutionLineupSuggestion = {
+  id: "execution-lineup",
+  phase: "team",
+  kind: "ceo_execution_lineup",
+  payload: {
+    suggestion_id: "execution-lineup",
+    agents: [
+      { slug: "engineer", role: "Eng", reason: "ships features" },
+    ],
+  },
+};
+
+describe("humanEchoForCeoAnswer", () => {
+  it("echoes a form-field free-text answer verbatim", () => {
+    expect(humanEchoForCeoAnswer(formField, "company_name", "Acme Test QA")).toBe(
+      "Acme Test QA",
+    );
+  });
+
+  it("trims whitespace from a form-field answer", () => {
+    expect(humanEchoForCeoAnswer(formField, "company_name", "  Acme  ")).toBe(
+      "Acme",
+    );
+  });
+
+  it("returns null when a form-field answer is empty", () => {
+    expect(humanEchoForCeoAnswer(formField, "description", "")).toBeNull();
+    expect(humanEchoForCeoAnswer(formField, "description", "   ")).toBeNull();
+  });
+
+  it("resolves chip-row id into the human-readable label", () => {
+    expect(
+      humanEchoForCeoAnswer(chipRow, "blueprint_id", "niche-crm"),
+    ).toBe("Niche CRM");
+  });
+
+  it("renders the 'start from scratch' chip even when its id is empty", () => {
+    expect(humanEchoForCeoAnswer(chipRow, "blueprint_id", "")).toBe(
+      "Start from scratch",
+    );
+  });
+
+  it("falls back to the raw id when chip option is unknown", () => {
+    expect(
+      humanEchoForCeoAnswer(chipRow, "blueprint_id", "unknown-bp"),
+    ).toBe("unknown-bp");
+  });
+
+  it("joins picked checklist labels with commas", () => {
+    expect(
+      humanEchoForCeoAnswer(checklist, "picked_agents", [
+        "engineer",
+        "marketer",
+      ]),
+    ).toBe("Engineer, Marketer");
+  });
+
+  it("handles a team-trim suggestion the same as a checklist", () => {
+    expect(
+      humanEchoForCeoAnswer(teamTrim, "picked_agents", ["designer"]),
+    ).toBe("Designer");
+  });
+
+  it("renders an explicit '(nobody)' when no items are picked", () => {
+    expect(humanEchoForCeoAnswer(checklist, "picked_agents", [])).toBe(
+      "(nobody)",
+    );
+  });
+
+  it("returns null for bridge_choice", () => {
+    expect(
+      humanEchoForCeoAnswer(chipRow, "bridge_choice", "start_issue"),
+    ).toBeNull();
+  });
+
+  it("returns null for scan_complete", () => {
+    expect(
+      humanEchoForCeoAnswer(formField, "scan_complete", true),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no pending suggestion", () => {
+    expect(humanEchoForCeoAnswer(null, "company_name", "Acme")).toBeNull();
+    expect(
+      humanEchoForCeoAnswer(undefined, "company_name", "Acme"),
+    ).toBeNull();
+  });
+
+  it("returns null for the read-only scan chip", () => {
+    expect(
+      humanEchoForCeoAnswer(scanChip, "scan_progress", "anything"),
+    ).toBeNull();
+  });
+
+  it("returns null for the execution-lineup confirmation card", () => {
+    expect(
+      humanEchoForCeoAnswer(executionLineup, "picked_agents", ["engineer"]),
+    ).toBeNull();
+  });
+});

--- a/web/src/components/onboarding/humanEcho.ts
+++ b/web/src/components/onboarding/humanEcho.ts
@@ -1,0 +1,84 @@
+/**
+ * humanEcho — format a CEO card answer as a chat-bubble friendly string.
+ *
+ * After the user commits a wizard answer (form field, chip, checklist), we
+ * mirror that answer back into the CEO DM as a "from: human" chat bubble so
+ * the transcript reads like an actual conversation rather than a one-sided
+ * monologue from the CEO (#978).
+ *
+ * Returns null when the field/value pair should NOT be echoed:
+ *   - bridge_choice: the terminal "Start an issue" / "Look around" action
+ *     transitions the user out of onboarding; echoing creates a stray bubble
+ *     in the new office shell.
+ *   - scan_complete: internal boolean flip on the website-scan handshake; no
+ *     human action to mirror.
+ *   - empty values: e.g. an optional field skipped via the "Skip" chip.
+ *
+ * The returned string is plain text — the caller persists it via the normal
+ * /messages endpoint which already sanitises. We never embed payload markup.
+ */
+
+import type { CeoSuggestion } from "./types";
+
+/**
+ * Returns the chat-bubble text for the human's just-committed answer, or
+ * null if the answer should not be echoed.
+ */
+export function humanEchoForCeoAnswer(
+  suggestion: CeoSuggestion | null | undefined,
+  field: string,
+  value: unknown,
+): string | null {
+  if (!suggestion) return null;
+
+  // Skip non-user-facing transitions.
+  if (field === "bridge_choice" || field === "scan_complete") return null;
+
+  if (suggestion.kind === "ceo_scan_chip") {
+    // The scan chip is read-only; the broker drives its committed state.
+    return null;
+  }
+
+  if (suggestion.kind === "ceo_chip_row") {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      // Empty id (e.g. "Start from scratch") still has a meaningful label.
+      const match = suggestion.payload.options.find((o) => o.id === "");
+      return match ? match.label : null;
+    }
+    const match = suggestion.payload.options.find((o) => o.id === trimmed);
+    return match ? match.label : trimmed;
+  }
+
+  if (
+    suggestion.kind === "ceo_checklist" ||
+    suggestion.kind === "ceo_team_trim"
+  ) {
+    if (!Array.isArray(value)) return null;
+    const labels = value
+      .map((id) => {
+        if (typeof id !== "string") return "";
+        const match = suggestion.payload.items.find((item) => item.id === id);
+        return match ? match.label : id;
+      })
+      .filter((label) => label.trim() !== "");
+    if (labels.length === 0) return "(nobody)";
+    return labels.join(", ");
+  }
+
+  if (suggestion.kind === "ceo_execution_lineup") {
+    // The execution lineup is a confirmation card; the broker handles the
+    // resulting roster mutation. No human-typed value to mirror.
+    return null;
+  }
+
+  // ceo_form_field — the canonical text-bubble case.
+  if (suggestion.kind === "ceo_form_field") {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+  }
+
+  return null;
+}

--- a/web/src/components/onboarding/humanEcho.ts
+++ b/web/src/components/onboarding/humanEcho.ts
@@ -18,7 +18,15 @@
  * /messages endpoint which already sanitises. We never embed payload markup.
  */
 
-import type { CeoSuggestion } from "./types";
+import type {
+  CeoChecklistSuggestion,
+  CeoChipRowSuggestion,
+  CeoFormFieldSuggestion,
+  CeoSuggestion,
+  CeoTeamTrimSuggestion,
+} from "./types";
+
+const NON_CONVERSATIONAL_FIELDS = new Set(["bridge_choice", "scan_complete"]);
 
 /**
  * Returns the chat-bubble text for the human's just-committed answer, or
@@ -30,55 +38,60 @@ export function humanEchoForCeoAnswer(
   value: unknown,
 ): string | null {
   if (!suggestion) return null;
+  if (NON_CONVERSATIONAL_FIELDS.has(field)) return null;
 
-  // Skip non-user-facing transitions.
-  if (field === "bridge_choice" || field === "scan_complete") return null;
-
-  if (suggestion.kind === "ceo_scan_chip") {
-    // The scan chip is read-only; the broker drives its committed state.
-    return null;
+  switch (suggestion.kind) {
+    case "ceo_form_field":
+      return echoFormField(suggestion, value);
+    case "ceo_chip_row":
+      return echoChipRow(suggestion, value);
+    case "ceo_checklist":
+    case "ceo_team_trim":
+      return echoChecklist(suggestion, value);
+    case "ceo_scan_chip":
+    case "ceo_execution_lineup":
+      // Read-only / confirmation cards — the broker drives the committed
+      // state; there is no human text or chip to mirror.
+      return null;
   }
+}
 
-  if (suggestion.kind === "ceo_chip_row") {
-    if (typeof value !== "string") return null;
-    const trimmed = value.trim();
-    if (trimmed === "") {
-      // Empty id (e.g. "Start from scratch") still has a meaningful label.
-      const match = suggestion.payload.options.find((o) => o.id === "");
-      return match ? match.label : null;
-    }
-    const match = suggestion.payload.options.find((o) => o.id === trimmed);
-    return match ? match.label : trimmed;
+function echoFormField(
+  _suggestion: CeoFormFieldSuggestion,
+  value: unknown,
+): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function echoChipRow(
+  suggestion: CeoChipRowSuggestion,
+  value: unknown,
+): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    // The "Start from scratch" chip carries id="" but still has a label.
+    const match = suggestion.payload.options.find((o) => o.id === "");
+    return match ? match.label : null;
   }
+  const match = suggestion.payload.options.find((o) => o.id === trimmed);
+  return match ? match.label : trimmed;
+}
 
-  if (
-    suggestion.kind === "ceo_checklist" ||
-    suggestion.kind === "ceo_team_trim"
-  ) {
-    if (!Array.isArray(value)) return null;
-    const labels = value
-      .map((id) => {
-        if (typeof id !== "string") return "";
-        const match = suggestion.payload.items.find((item) => item.id === id);
-        return match ? match.label : id;
-      })
-      .filter((label) => label.trim() !== "");
-    if (labels.length === 0) return "(nobody)";
-    return labels.join(", ");
-  }
-
-  if (suggestion.kind === "ceo_execution_lineup") {
-    // The execution lineup is a confirmation card; the broker handles the
-    // resulting roster mutation. No human-typed value to mirror.
-    return null;
-  }
-
-  // ceo_form_field — the canonical text-bubble case.
-  if (suggestion.kind === "ceo_form_field") {
-    if (typeof value !== "string") return null;
-    const trimmed = value.trim();
-    return trimmed === "" ? null : trimmed;
-  }
-
-  return null;
+function echoChecklist(
+  suggestion: CeoChecklistSuggestion | CeoTeamTrimSuggestion,
+  value: unknown,
+): string | null {
+  if (!Array.isArray(value)) return null;
+  const labels = value
+    .map((id) => {
+      if (typeof id !== "string") return "";
+      const match = suggestion.payload.items.find((item) => item.id === id);
+      return match ? match.label : id;
+    })
+    .filter((label) => label.trim() !== "");
+  if (labels.length === 0) return "(nobody)";
+  return labels.join(", ");
 }

--- a/web/src/components/onboarding/types.ts
+++ b/web/src/components/onboarding/types.ts
@@ -160,6 +160,13 @@ export interface CeoScanChipPayload {
   done_label?: string;
   /** Message shown on failure */
   failed_label?: string;
+  /**
+   * Underlying reason for a `failed` status. Plain-English, surfaced from
+   * the Go scan layer (operations.CompanySeedResult.Warnings or the raw
+   * error). Rendered as text under the failed chip so the user can decide
+   * whether to retry with a different URL or skip. (#934)
+   */
+  error_reason?: string;
 }
 
 // ── Card lifecycle state ───────────────────────────────────────────────────

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -3233,6 +3233,40 @@ html[data-theme="noir-gold"] {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.issue-comments-list-item {
+  list-style: none;
+}
+
+/* Timeline empty state (#937) — stacked title + hint so the user knows
+   the timeline is where the CEO interview turns will land, not just a
+   passive "no comments yet" message. */
+.issue-comments-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px;
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-warm, var(--bg-card));
+}
+
+.issue-comments-empty-title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 650;
+}
+
+.issue-comments-empty-hint {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
 }
 
 .issue-comment {

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2525,7 +2525,8 @@
   font-size: 12px;
   color: var(--text-secondary);
   line-height: 1.4;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 
 .ceo-scan-chip-actions {

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2501,6 +2501,40 @@
   font-weight: 600;
 }
 
+/* Failure state expands into a stacked card: chip row + reason + CTAs.
+   The `--failed` modifier flips the outer container from inline-flex to a
+   block-level column so the reason and action row layout correctly. (#934) */
+.ceo-scan-chip--failed {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md, 6px);
+  max-width: 420px;
+}
+
+.ceo-scan-chip-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ceo-scan-chip-reason {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.ceo-scan-chip-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 /* ─── Sidebar preview overlay (Phase 2 onboarding) ────────────────────────
    Shows during greet/identity/scan/blueprint/team phases.
    Dashed lavender border signals "staged, not committed yet."


### PR DESCRIPTION
## Summary

Wave-5 bundle that fixes three onboarding + issue UX gaps reported in QA:

### #978 — Echo human's submitted wizard answers in chat transcript
After the user submits an answer in the onboarding wizard, post a "from: human" chat bubble into the CEO DM mirroring what they just answered. The transcript now reads like a real conversation rather than a one-sided CEO monologue. Non-conversational fields (`bridge_choice`, `scan_complete`) and read-only kinds (`ceo_scan_chip`, `ceo_execution_lineup`) are intentionally skipped. The echo is best-effort — a failing `postMessage` logs a warning but does not block the wizard advancing.

### #934 — Surface website-scan failure reason; make scan recoverable
Previously the scan chip silently went to a terminal "Couldn't read that URL" state and the broker auto-advanced to `PhaseBlueprint`, stranding the user with no reason and no retry. Now the Go layer extracts the first non-empty warning from `CompanySeedResult.Warnings` (or falls back to the raw error) and stamps it as a new `error_reason` field on the failed chip. `postScanChipFailure` keeps the user in `PhaseScan` with this chip pinned as `PendingSuggestion` so refresh resumes on the same UI. The frontend renders the reason inline plus two CTAs — **Try another URL** (transitions back to `PhaseWebsite`) and **Skip and continue** (transitions to `PhaseBlueprint`). `PhaseScan → PhaseWebsite` was added to `legalPhaseTransitions` for the retry path, and `ceoDeterministicMessages(PhaseBlueprint)` now prepends an "OK, skipping the scan — we'll go with what you told me about \<company\>." text bubble when the user arrives with a URL set but `ScanComplete=false`.

### #937 — Render issue document event timeline + empty state (partial)
Reshape the issue-document comments section into a proper timeline: section heading renamed to "Timeline", list rendered as a semantic `<ol>` with chronological aria-labeling, and empty-state expanded into a dashed-border card with a title + hint. In drafting state it says "CEO will start asking questions here. Answer inline to refine the spec." matching the spec; non-drafting copy explains what kinds of events will land here. The `event_type=ceo_question` wire-shape work is deferred per failure-mode guidance — it would touch `packages/protocol` and the intake event schema which is out of scope for this bundled fix.

## Test plan

- [ ] Unit: `bash scripts/test-web.sh web/src/components/onboarding` (64 passed)
- [ ] Unit: `bash scripts/test-web.sh web/src/components/lifecycle` (81 passed, 2 skipped)
- [ ] Unit: `bash scripts/test-web.sh web/src/components/messages/InterviewBar.ceoKinds.test.tsx` (44 passed)
- [ ] Unit: `bash scripts/test-go.sh ./internal/team` (full suite green)
- [ ] Unit: `bash scripts/test-go.sh ./internal/onboarding` (full suite green)
- [ ] Type check: `cd web && bunx tsc --noEmit` (clean)
- [ ] Lint: `cd web && bunx biome check` (no errors; 2 pre-existing warnings)
- [ ] Smoke: walk wizard → confirm each submitted answer echoes as chat bubble
- [ ] Smoke: submit bad URL → confirm reason + retry/skip CTAs appear
- [ ] Smoke: file an issue → confirm timeline empty state, then post comment

Closes #934
Closes #937
Closes #978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan failures show a plain-text reason, offer “Try another URL” and “Skip and continue”, and persist recovery UI.
  * Onboarding echoes human-readable commits into the CEO DM transcript (best-effort, non-blocking).
  * Short acknowledgment message when a scan is skipped.

* **Bug Fixes**
  * Scan flow preserves a safe recovery path (no unexpected auto-advance) after failures.

* **UI**
  * Issue timeline converted to an ordered list with improved empty-state copy; new styles for failed scan chip.

* **Tests**
  * Expanded tests for scan recovery, human-echo logic, deterministic messages, and timeline rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->