### PR TITLE
feat(wiki): wire ObsidianWatcher into broker lifecycle

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -699,6 +699,21 @@ func (b *Broker) Stop() {
 			close(b.stopCh)
 		})
 	}
+
+	// Snapshot the obsidian watcher and stop it BEFORE cancelling the
+	// lifecycle context. The watcher has trailing-edge debounce timers
+	// that fire callbacks via time.AfterFunc; those callbacks call
+	// Repo.Commit with the lifecycle context, so cancelling first would
+	// drop in-flight Obsidian-side edits at the commit step. The watcher's
+	// own Stop drains pending timers + commit goroutines under the
+	// pending WaitGroup, so this is the only correct order.
+	b.mu.Lock()
+	obsidianWatcher := b.obsidianWatcher
+	b.mu.Unlock()
+	if obsidianWatcher != nil {
+		_ = obsidianWatcher.Stop()
+	}
+
 	if b.lifecycleCancel != nil {
 		b.lifecycleCancel()
 	}
@@ -717,7 +732,6 @@ func (b *Broker) Stop() {
 	compressor := b.wikiCompressor
 	autoWriter := b.autoNotebookWriter
 	humanWikiWriter := b.humanWikiWriter
-	obsidianWatcher := b.obsidianWatcher
 	channelIntent := b.channelIntentDispatcher
 	promotionSweep := b.promotionSweep
 	b.mu.Unlock()
@@ -738,9 +752,6 @@ func (b *Broker) Stop() {
 	}
 	if humanWikiWriter != nil {
 		humanWikiWriter.Stop(2 * time.Second)
-	}
-	if obsidianWatcher != nil {
-		_ = obsidianWatcher.Stop()
 	}
 	if channelIntent != nil {
 		channelIntent.Stop(2 * time.Second)

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -134,6 +134,7 @@ type Broker struct {
 	wikiInitErr             error
 	autoNotebookWriter      *AutoNotebookWriter
 	humanWikiWriter         *HumanWikiIntentWriter
+	obsidianWatcher         *ObsidianWatcher
 	demandIndex             *NotebookDemandIndex
 	channelIntentDispatcher *ChannelIntentDispatcher
 	promotionSweep          *PromotionSweep
@@ -716,6 +717,7 @@ func (b *Broker) Stop() {
 	compressor := b.wikiCompressor
 	autoWriter := b.autoNotebookWriter
 	humanWikiWriter := b.humanWikiWriter
+	obsidianWatcher := b.obsidianWatcher
 	channelIntent := b.channelIntentDispatcher
 	promotionSweep := b.promotionSweep
 	b.mu.Unlock()
@@ -736,6 +738,9 @@ func (b *Broker) Stop() {
 	}
 	if humanWikiWriter != nil {
 		humanWikiWriter.Stop(2 * time.Second)
+	}
+	if obsidianWatcher != nil {
+		_ = obsidianWatcher.Stop()
 	}
 	if channelIntent != nil {
 		channelIntent.Stop(2 * time.Second)

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -91,6 +91,12 @@ func (b *Broker) initWikiWorker() {
 	worker := NewWikiWorkerWithIndex(repo, b, idx)
 	worker.Start(lifecycleCtx)
 
+	// Obsidian round-trip: fsnotify watcher that catches external edits to
+	// <wiki-root>/team/ and routes them through Repo.Commit under the
+	// per-human identity. Spec: WIKI-OBSIDIAN-COMPATIBILITY.md §6. Toggle
+	// off with WUPHF_OBSIDIAN_WATCHER=0. Non-fatal on failure.
+	b.ensureObsidianWatcher(lifecycleCtx, worker, idx)
+
 	// Wire the extraction loop: artifact commits → extract_entities_lite →
 	// WikiIndex. DLQ lives under <wiki>/.dlq/. Extractor failures never
 	// fail the commit path — DLQ absorbs everything per §11.13.

--- a/internal/team/broker_wiki_obsidian.go
+++ b/internal/team/broker_wiki_obsidian.go
@@ -1,0 +1,135 @@
+package team
+
+// broker_wiki_obsidian.go wires the ObsidianWatcher into the broker's wiki
+// lifecycle. Phase 3+4 of WIKI-OBSIDIAN-COMPATIBILITY landed the daemon,
+// frontmatter sentinel writer, loose-link normalizer, and image-embed
+// ingester as building blocks; this file connects them to the runtime so
+// edits made in an Obsidian editor against `<wiki-root>/team/` flow back
+// through Repo.Commit under the user's per-human git identity.
+//
+// Boot order, from initWikiWorker:
+//
+//	1. Repo.Init succeeds
+//	2. WikiWorker.Start(lifecycleCtx)
+//	3. <-- ensureObsidianWatcher mounts here -->
+//	4. extractor + auxiliary loops
+//
+// Disabled via WUPHF_OBSIDIAN_WATCHER=0 (off) for operators who want to
+// keep the historical "single-writer through WikiWorker" posture while
+// they evaluate the feature. Default ON because the spec treats the
+// watcher as the load-bearing layer of the Obsidian round-trip; without
+// it the rest of Phase 3+4 (sentinel, normalizer, embed) is dead code.
+
+import (
+	"context"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+// obsidianNormalizerTimeout bounds each signal-index lookup the watcher's
+// normalizer issues per loose `[[...]]` it encounters. The index is local
+// (sqlite or in-memory) so milliseconds suffice; the timeout exists to keep
+// a stuck index from blocking the watcher's commit pipeline.
+const obsidianNormalizerTimeout = 250 * time.Millisecond
+
+// ensureObsidianWatcher instantiates and starts the ObsidianWatcher when
+// (a) the worker is up, (b) WUPHF_OBSIDIAN_WATCHER is not "0"/"off"/"false".
+// Non-fatal: a watcher start failure logs and continues — wiki writes via
+// WikiWorker still work; only the external-edit round-trip is degraded.
+//
+// Wiring:
+//
+//	identity   → HumanIdentityRegistry.Local() (real git user.name/email,
+//	             or the v1.4 "human" fallback when unset)
+//	normalizer → signal index → kinded form (Phase 4 §5)
+//	embed      → IngestImageEmbeds (Phase 4 §7.2)
+func (b *Broker) ensureObsidianWatcher(ctx context.Context, worker *WikiWorker, idx *WikiIndex) {
+	if !obsidianWatcherEnabled() {
+		return
+	}
+	if worker == nil || worker.Repo() == nil {
+		return
+	}
+	watcher := NewObsidianWatcher(worker.Repo(), worker)
+	watcher.SetIdentity(brokerObsidianIdentity(brokerHumanIdentityRegistry()))
+	if idx != nil {
+		watcher.SetNormalizer(brokerObsidianNormalizer(NewWikiIndexSignalAdapter(idx)))
+	}
+	watcher.SetEmbedIngester(IngestImageEmbeds)
+
+	if err := watcher.Start(ctx); err != nil {
+		log.Printf("obsidian watcher: start failed (round-trip disabled): %v", err)
+		return
+	}
+
+	b.mu.Lock()
+	b.obsidianWatcher = watcher
+	b.mu.Unlock()
+}
+
+// obsidianWatcherEnabled returns false only when the env var explicitly
+// opts out. Empty / unset → enabled.
+func obsidianWatcherEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("WUPHF_OBSIDIAN_WATCHER"))) {
+	case "0", "off", "false", "no", "disabled":
+		return false
+	}
+	return true
+}
+
+// brokerObsidianIdentity adapts the per-human registry to the watcher's
+// identity callback. Returns ok=false only when no slug can be resolved at
+// all — the v1.4 fallback identity (`human`) IS resolved and counts as a
+// valid attribution target, matching how human_commit.go treats it.
+func brokerObsidianIdentity(reg *HumanIdentityRegistry) ObsidianWatcherIdentity {
+	return func() (string, bool) {
+		if reg == nil {
+			return "", false
+		}
+		id := reg.Local()
+		slug := strings.TrimSpace(id.Slug)
+		if slug == "" {
+			return "", false
+		}
+		return slug, true
+	}
+}
+
+// brokerObsidianNormalizer adapts a SignalIndex to the watcher's
+// loose-link resolver. The watcher hands us either a bare slug (`acme`)
+// or a display string (`Acme Corp`) extracted from a non-kinded
+// `[[...]]`; we resolve via EntityBySlug first, then EntityByName with
+// strict single-match semantics. Ambiguity (zero or multiple matches)
+// returns ok=false so the link stays loose — the basename-collision
+// guard required by WIKI-OBSIDIAN-COMPATIBILITY §5.
+func brokerObsidianNormalizer(idx SignalIndex) ObsidianLooseLinkResolver {
+	if idx == nil {
+		return nil
+	}
+	return func(input string) (EntityKind, string, bool) {
+		trimmed := strings.TrimSpace(input)
+		if trimmed == "" {
+			return "", "", false
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), obsidianNormalizerTimeout)
+		defer cancel()
+
+		// 1. Treat the input as a canonical slug. EntityBySlug is keyed by
+		// `slug` only (kind is not part of the lookup), so a match here
+		// gives us the entity's actual kind too.
+		if ent, ok, err := idx.EntityBySlug(ctx, slugify(trimmed)); err == nil && ok {
+			return ent.Kind, ent.Slug, true
+		}
+
+		// 2. Treat the input as a display string. EntityByName returns the
+		// candidate set; require a single match. Multiple matches (e.g. a
+		// person and a project both named "Acme") stay loose.
+		hits, err := idx.EntityByName(ctx, trimmed)
+		if err != nil || len(hits) != 1 {
+			return "", "", false
+		}
+		return hits[0].Kind, hits[0].Slug, true
+	}
+}

--- a/internal/team/broker_wiki_obsidian.go
+++ b/internal/team/broker_wiki_obsidian.go
@@ -113,20 +113,24 @@ func brokerObsidianNormalizer(idx SignalIndex) ObsidianLooseLinkResolver {
 		if trimmed == "" {
 			return "", "", false
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), obsidianNormalizerTimeout)
-		defer cancel()
 
 		// 1. Treat the input as a canonical slug. EntityBySlug is keyed by
 		// `slug` only (kind is not part of the lookup), so a match here
-		// gives us the entity's actual kind too.
-		if ent, ok, err := idx.EntityBySlug(ctx, slugify(trimmed)); err == nil && ok {
+		// gives us the entity's actual kind too. Each lookup gets its own
+		// timeout budget so a slow first call cannot starve the second.
+		slugCtx, slugCancel := context.WithTimeout(context.Background(), obsidianNormalizerTimeout)
+		ent, ok, err := idx.EntityBySlug(slugCtx, slugify(trimmed))
+		slugCancel()
+		if err == nil && ok {
 			return ent.Kind, ent.Slug, true
 		}
 
 		// 2. Treat the input as a display string. EntityByName returns the
 		// candidate set; require a single match. Multiple matches (e.g. a
 		// person and a project both named "Acme") stay loose.
-		hits, err := idx.EntityByName(ctx, trimmed)
+		nameCtx, nameCancel := context.WithTimeout(context.Background(), obsidianNormalizerTimeout)
+		defer nameCancel()
+		hits, err := idx.EntityByName(nameCtx, trimmed)
 		if err != nil || len(hits) != 1 {
 			return "", "", false
 		}

--- a/internal/team/broker_wiki_obsidian_test.go
+++ b/internal/team/broker_wiki_obsidian_test.go
@@ -1,0 +1,114 @@
+package team
+
+import (
+	"testing"
+)
+
+func TestObsidianWatcherEnabled_DefaultOn(t *testing.T) {
+	t.Setenv("WUPHF_OBSIDIAN_WATCHER", "")
+	if !obsidianWatcherEnabled() {
+		t.Fatalf("default should be enabled when env unset")
+	}
+}
+
+func TestObsidianWatcherEnabled_OptOut(t *testing.T) {
+	cases := []string{"0", "off", "OFF", "false", "False", "no", "disabled", "  off  "}
+	for _, v := range cases {
+		t.Setenv("WUPHF_OBSIDIAN_WATCHER", v)
+		if obsidianWatcherEnabled() {
+			t.Errorf("env=%q should disable", v)
+		}
+	}
+}
+
+func TestObsidianWatcherEnabled_UnknownValuesEnable(t *testing.T) {
+	cases := []string{"1", "on", "true", "yes", "anything"}
+	for _, v := range cases {
+		t.Setenv("WUPHF_OBSIDIAN_WATCHER", v)
+		if !obsidianWatcherEnabled() {
+			t.Errorf("env=%q should leave watcher enabled (only explicit opt-out disables)", v)
+		}
+	}
+}
+
+func TestBrokerObsidianIdentity_ResolvesLocalSlug(t *testing.T) {
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	reg := NewHumanIdentityRegistryAt(t.TempDir())
+	// Observe a real identity so registry.Local() returns it instead of
+	// probing the host's git config (CI may or may not have one set).
+	if _, err := reg.Observe("Sarah Chen", "sarah@acme.com"); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	fn := brokerObsidianIdentity(reg)
+	slug, ok := fn()
+	if !ok {
+		t.Fatalf("expected ok=true; got false")
+	}
+	if slug == "" {
+		t.Fatalf("expected non-empty slug")
+	}
+}
+
+func TestBrokerObsidianIdentity_NilRegistryReturnsFalse(t *testing.T) {
+	fn := brokerObsidianIdentity(nil)
+	if _, ok := fn(); ok {
+		t.Fatalf("nil registry should return ok=false")
+	}
+}
+
+func TestBrokerObsidianNormalizer_SlugWins(t *testing.T) {
+	idx := newSpyIndex()
+	idx.add(resolverEntity{Slug: "acme-corp", Kind: EntityKindCompanies, Name: "Acme Corp"})
+	fn := brokerObsidianNormalizer(idx)
+	kind, slug, ok := fn("acme-corp")
+	if !ok || kind != EntityKindCompanies || slug != "acme-corp" {
+		t.Fatalf("slug lookup: kind=%q slug=%q ok=%v", kind, slug, ok)
+	}
+}
+
+func TestBrokerObsidianNormalizer_DisplayStringSingleMatch(t *testing.T) {
+	idx := newSpyIndex()
+	idx.add(resolverEntity{Slug: "acme-corp", Kind: EntityKindCompanies, Name: "Acme Corp"})
+	fn := brokerObsidianNormalizer(idx)
+	kind, slug, ok := fn("Acme Corp")
+	if !ok || kind != EntityKindCompanies || slug != "acme-corp" {
+		t.Fatalf("display-string lookup: kind=%q slug=%q ok=%v", kind, slug, ok)
+	}
+}
+
+func TestBrokerObsidianNormalizer_AmbiguousReturnsFalse(t *testing.T) {
+	idx := newSpyIndex()
+	idx.add(resolverEntity{Slug: "acme", Kind: EntityKindPeople, Name: "Acme"})
+	idx.add(resolverEntity{Slug: "acme-corp", Kind: EntityKindCompanies, Name: "Acme"})
+	fn := brokerObsidianNormalizer(idx)
+	// Both entities have Name "Acme" — a display-string lookup must NOT
+	// silently pick one. This is the basename-collision guard surfaced at
+	// the normalizer layer.
+	if _, _, ok := fn("Unrelated-Slug-That-Hits-Name-Search-Acme"); ok {
+		t.Fatalf("ambiguous name match must not resolve")
+	}
+}
+
+func TestBrokerObsidianNormalizer_NotFoundReturnsFalse(t *testing.T) {
+	idx := newSpyIndex()
+	idx.add(resolverEntity{Slug: "acme-corp", Kind: EntityKindCompanies, Name: "Acme Corp"})
+	fn := brokerObsidianNormalizer(idx)
+	if _, _, ok := fn("nonexistent"); ok {
+		t.Fatalf("unknown input should not resolve")
+	}
+}
+
+func TestBrokerObsidianNormalizer_NilIndexReturnsNilCallback(t *testing.T) {
+	if fn := brokerObsidianNormalizer(nil); fn != nil {
+		t.Fatalf("nil signal index should return nil callback so watcher.SetNormalizer is a no-op")
+	}
+}
+
+func TestBrokerObsidianNormalizer_EmptyInputReturnsFalse(t *testing.T) {
+	fn := brokerObsidianNormalizer(newSpyIndex())
+	for _, in := range []string{"", "   ", "\t"} {
+		if _, _, ok := fn(in); ok {
+			t.Errorf("empty/whitespace input %q should not resolve", in)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR #905 shipped the `ObsidianWatcher` daemon plus the frontmatter sentinel writer, loose-link normalizer, and image-embed ingester as building blocks — but `NewObsidianWatcher` was never instantiated outside tests, so Phase 3+4 of the Obsidian round-trip sat dormant in production. This PR mounts the watcher on broker startup so edits made in an Obsidian editor against `<wiki-root>/team/` flow back through `Repo.Commit` under the user's per-human git identity.

## Wiring

- **Identity** → `HumanIdentityRegistry.Local()` — same per-human slug used by `/wiki/write-human`. The v1.4 `human` fallback identity counts as a valid attribution target, matching how `human_commit.go` treats it.
- **Normalizer** → `SignalIndex` via `WikiIndexSignalAdapter`. Bare slugs and display strings resolve to the canonical kinded form; ambiguous matches stay loose, preserving the [WIKI-OBSIDIAN-COMPATIBILITY §5](docs/specs/WIKI-OBSIDIAN-COMPATIBILITY.md) basename-collision guard at the normalizer layer too.
- **Embed ingester** → `IngestImageEmbeds` directly (its signature already matches `ObsidianEmbedIngester`).

## Lifecycle

- `ensureObsidianWatcher` mounts after `WikiWorker.Start` in `Broker.initWikiWorker` and stores the watcher on the broker for shutdown.
- `Broker.Stop` calls `watcher.Stop` — drains in-flight debounce timers before the broker's lifecycle context cancels (same pattern as `HumanWikiIntentWriter` / `ChannelIntentDispatcher`).
- Start failure is **non-fatal**: logs and continues. WikiWorker writes still work; only the external-edit round-trip is degraded.

## Toggle

Set `WUPHF_OBSIDIAN_WATCHER` to `0` / `off` / `false` / `no` / `disabled` to disable the watcher. Default **ON** because Phase 3+4 is dead code without it.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l` / `go vet ./internal/team/` clean
- [x] `golangci-lint run ./internal/team/` — 0 issues
- [x] `scripts/check-no-new-sleeps-in-tests.sh` — passes
- [x] 9 new unit tests cover env toggle, identity adapter, normalizer (slug-wins / single-match name / ambiguity-stays-loose / nil guards / empty-input)
- [x] Existing `TestEnsureWikiWorker*` and `TestNotebook*` lifecycle tests still pass with the watcher active in every broker-init path — doubles as integration coverage
- [ ] Manual: open `~/.wuphf/wiki/team/` in Obsidian on a real machine, edit a brief, confirm `git log` shows the commit attributed to the local human identity within ~2s

## Follow-ups still open (from WIKI-OBSIDIAN-COMPATIBILITY.md §10)

- Insights-layer schema drift (`wiki/insights/*`)
- Relationship between `graph.log` and `team/entities/.graph.jsonl`
- Structured-callout extractor semantics (`> [!fact]` as a filing primitive)
- Per-vault git identity for multi-tenant setups

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ntdewy7tu1ysB4XYiso8ao)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Obsidian-compatible wiki watcher to detect external edits, route them into repo history, normalize links/images, and attribute commits to human identities; enabled by default with opt-out via environment variable.

* **Bug Fixes**
  * Watcher is now cleanly stopped during shutdown to avoid lingering background activity.

* **Tests**
  * Added tests for watcher enablement, identity resolution, and normalization edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/989?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->