### PR TITLE
[release] [codex] fix stuck CEO onboarding recovery

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -894,7 +894,6 @@ var legalPhaseTransitions = map[string]map[string]bool{
 		PhaseBridge: true,
 	},
 	PhaseBridge: {
-		PhaseDraft:    true, // "start an issue"
 		PhaseComplete: true, // "look around first"
 	},
 	PhaseDraft: {
@@ -1065,7 +1064,7 @@ func applyFormAnswer(s *State, field string, value interface{}) error {
 	case "owner_role":
 		s.FormAnswers.OwnerRole = sanitizeStr(value)
 	case "blueprint_id":
-		s.FormAnswers.BlueprintID = sanitizeStr(value)
+		s.FormAnswers.BlueprintID = normalizeBlueprintAnswer(sanitizeStr(value))
 	case "picked_agents":
 		raw, ok := value.([]interface{})
 		if !ok {
@@ -1094,6 +1093,15 @@ func applyFormAnswer(s *State, field string, value interface{}) error {
 		return fmt.Errorf("unknown field %q", field)
 	}
 	return nil
+}
+
+func normalizeBlueprintAnswer(value string) string {
+	switch strings.TrimSpace(value) {
+	case blankSlateStarterTemplateID, "from-scratch", "blank-slate":
+		return ""
+	default:
+		return strings.TrimSpace(value)
+	}
 }
 
 // onboardingSanitizeString collapses structural delimiters that could be used

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -372,6 +372,20 @@ func TestHandleCompleteBackwardCompatWithLegacyClient(t *testing.T) {
 	})
 }
 
+func TestApplyFormAnswerNormalizesScratchBlueprintIDs(t *testing.T) {
+	for _, raw := range []string{blankSlateStarterTemplateID, "from-scratch", "blank-slate"} {
+		t.Run(raw, func(t *testing.T) {
+			s := &State{}
+			if err := applyFormAnswer(s, "blueprint_id", raw); err != nil {
+				t.Fatalf("applyFormAnswer: %v", err)
+			}
+			if s.FormAnswers.BlueprintID != "" {
+				t.Fatalf("BlueprintID: got %q, want empty", s.FormAnswers.BlueprintID)
+			}
+		})
+	}
+}
+
 // TestHandleCompleteReturns500OnCompleteFnError verifies that if
 // completeFn returns an error (e.g. LoadBlueprint failed), the handler
 // returns HTTP 500 so the wizard can surface the error to the user.

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -240,7 +240,29 @@ func Load() (*State, error) {
 	if len(s.Checklist) == 0 {
 		s.Checklist = DefaultChecklist()
 	}
+	if recoverUnwiredPhase(&s) {
+		if writeErr := Save(&s); writeErr != nil {
+			log.Printf("onboarding: unwired phase recovery persist failed: %v", writeErr)
+		}
+	}
 	return &s, nil
+}
+
+func recoverUnwiredPhase(s *State) bool {
+	if s == nil || s.CompletedAt != "" {
+		return false
+	}
+	switch s.Phase {
+	case PhaseDraft, PhaseApprove, PhaseKickoff:
+	default:
+		return false
+	}
+	log.Printf("onboarding: recovering from unwired phase %q by completing onboarding", s.Phase)
+	s.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	s.Phase = PhaseComplete
+	s.PendingSuggestion = nil
+	s.Version = currentStateVersion
+	return true
 }
 
 // migrateV1ToV2 upgrades a v1 State in-place to v2.

--- a/internal/onboarding/state_test.go
+++ b/internal/onboarding/state_test.go
@@ -149,6 +149,49 @@ func TestSaveRoundtrip(t *testing.T) {
 	})
 }
 
+func TestLoadRecoversUnwiredDraftPhase(t *testing.T) {
+	withTempHome(t, func(home string) {
+		dir := filepath.Join(home, ".wuphf")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		state := &State{
+			Version: currentStateVersion,
+			Phase:   PhaseDraft,
+			PendingSuggestion: &Suggestion{
+				ID:    "draft-first-issue",
+				Phase: PhaseDraft,
+				Kind:  "ceo_form_field",
+			},
+			Checklist: DefaultChecklist(),
+		}
+		data, err := json.Marshal(state)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "onboarded.json"), data, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		loaded, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !loaded.Onboarded() {
+			t.Fatal("unwired draft phase should recover to onboarded")
+		}
+		if loaded.Phase != PhaseComplete {
+			t.Fatalf("Phase: got %q, want %q", loaded.Phase, PhaseComplete)
+		}
+		if loaded.CompletedAt == "" {
+			t.Fatal("CompletedAt should be set during recovery")
+		}
+		if loaded.PendingSuggestion != nil {
+			t.Fatal("PendingSuggestion should be cleared during recovery")
+		}
+	})
+}
+
 func TestSaveProgressMergesCorrectly(t *testing.T) {
 	withTempHome(t, func(_ string) {
 		// First save progress for welcome step.

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -637,7 +637,7 @@ func ceoDeterministicMessages(phase string, s *onboarding.State) []ceoMessagePay
 				"field": "bridge_choice",
 				"label": "All set up. What would you like to do?",
 				"options": []map[string]interface{}{
-					{"id": "start_issue", "label": "Start an issue", "action": "transition", "phase": "draft"},
+					{"id": "start_issue", "label": "Start an issue", "action": "transition", "phase": "complete"},
 					{"id": "look_around", "label": "Look around first", "action": "transition", "phase": "complete"},
 				},
 			}),

--- a/internal/team/broker_onboarding_sanitize_test.go
+++ b/internal/team/broker_onboarding_sanitize_test.go
@@ -483,7 +483,6 @@ func TestPhase2TransitionTableValidation(t *testing.T) {
 		{onboarding.PhaseBlueprint, onboarding.PhaseSeed, true},
 		{onboarding.PhaseTeam, onboarding.PhaseSeed, true},
 		{onboarding.PhaseSeed, onboarding.PhaseBridge, true},
-		{onboarding.PhaseBridge, onboarding.PhaseDraft, true},
 		{onboarding.PhaseBridge, onboarding.PhaseComplete, true},
 		// Invalid jumps (must be rejected with 400 by the handler).
 		{"", onboarding.PhaseSeed, false},
@@ -491,6 +490,7 @@ func TestPhase2TransitionTableValidation(t *testing.T) {
 		{onboarding.PhaseIdentity, onboarding.PhaseScan, false},      // must go through PhaseWebsite first
 		{onboarding.PhaseIdentity, onboarding.PhaseBlueprint, false}, // must go through PhaseWebsite first
 		{onboarding.PhaseIdentity, onboarding.PhaseComplete, false},
+		{onboarding.PhaseBridge, onboarding.PhaseDraft, false},   // draft is not wired yet
 		{onboarding.PhaseComplete, onboarding.PhaseGreet, false}, // cannot restart
 	}
 

--- a/web/src/components/agents/AgentProfilePanel.test.tsx
+++ b/web/src/components/agents/AgentProfilePanel.test.tsx
@@ -138,6 +138,24 @@ describe("<AgentProfilePanel>", () => {
     expect(screen.getByText("No recent tasks")).toBeInTheDocument();
   });
 
+  it("filters malformed entries from list responses", async () => {
+    getSkillsListMock.mockResolvedValue({ skills: [null] });
+    getChannelsMock.mockResolvedValue({ channels: [null] });
+    getOfficeTasksMock.mockResolvedValue({ tasks: [null] });
+    listAgentLogTasksMock.mockResolvedValue({ tasks: [null] });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("No skills yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No channels")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No runs yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No recent tasks")).toBeInTheDocument();
+  });
+
   it("renders skills owned by this agent", async () => {
     getSkillsListMock.mockResolvedValue({
       skills: [

--- a/web/src/components/agents/AgentProfilePanel.test.tsx
+++ b/web/src/components/agents/AgentProfilePanel.test.tsx
@@ -120,6 +120,24 @@ describe("<AgentProfilePanel>", () => {
     expect(screen.getByText("No recent tasks")).toBeInTheDocument();
   });
 
+  it("treats malformed list responses as empty lists", async () => {
+    getSkillsListMock.mockResolvedValue({ skills: { broken: true } });
+    getChannelsMock.mockResolvedValue({ channels: { broken: true } });
+    getOfficeTasksMock.mockResolvedValue({ tasks: { broken: true } });
+    listAgentLogTasksMock.mockResolvedValue({ tasks: { broken: true } });
+
+    render(wrap(<AgentProfilePanel agent={baseAgent} onClose={vi.fn()} />));
+
+    await waitFor(() => {
+      expect(screen.getByText("No skills yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No channels")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("No runs yet")).toBeInTheDocument();
+    });
+    expect(screen.getByText("No recent tasks")).toBeInTheDocument();
+  });
+
   it("renders skills owned by this agent", async () => {
     getSkillsListMock.mockResolvedValue({
       skills: [

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -22,7 +22,10 @@ interface AgentProfilePanelProps {
 }
 
 function arrayOrEmpty<T>(value: unknown): T[] {
-  return Array.isArray(value) ? (value as T[]) : [];
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is T => item !== null && typeof item === "object",
+  );
 }
 
 function SectionTitle({ children }: { children: React.ReactNode }) {
@@ -317,7 +320,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
   const { data: skills = [] } = useQuery({
     queryKey: ["skills-list"],
     queryFn: () =>
-      getSkillsList("all").then((r) => arrayOrEmpty<Skill>(r.skills)),
+      getSkillsList("all").then((r) => arrayOrEmpty<Skill>(r?.skills)),
     refetchInterval: 30_000,
   });
 
@@ -326,7 +329,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
     queryFn: () =>
       getChannels().then((r) =>
         arrayOrEmpty<{ slug: string; name: string; members?: string[] }>(
-          r.channels,
+          r?.channels,
         ),
       ),
     refetchInterval: 30_000,
@@ -336,7 +339,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
     queryKey: ["office-tasks-profile"],
     queryFn: () =>
       getOfficeTasks({ includeDone: true }).then((r) =>
-        arrayOrEmpty<Task>(r.tasks),
+        arrayOrEmpty<Task>(r?.tasks),
       ),
     refetchInterval: 30_000,
   });
@@ -345,7 +348,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
     queryKey: ["agent-log-tasks", agent.slug],
     queryFn: () =>
       listAgentLogTasks({ limit: 8, agentSlug: agent.slug }).then((r) =>
-        arrayOrEmpty<TaskLogSummary>(r.tasks),
+        arrayOrEmpty<TaskLogSummary>(r?.tasks),
       ),
     refetchInterval: 30_000,
   });

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -21,6 +21,10 @@ interface AgentProfilePanelProps {
   onClose: () => void;
 }
 
+function arrayOrEmpty<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
 function SectionTitle({ children }: { children: React.ReactNode }) {
   return <div className="agent-profile-section-title">{children}</div>;
 }
@@ -312,28 +316,36 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
 
   const { data: skills = [] } = useQuery({
     queryKey: ["skills-list"],
-    queryFn: () => getSkillsList("all").then((r) => r.skills ?? []),
+    queryFn: () =>
+      getSkillsList("all").then((r) => arrayOrEmpty<Skill>(r.skills)),
     refetchInterval: 30_000,
   });
 
   const { data: channels = [] } = useQuery({
     queryKey: ["channels"],
-    queryFn: () => getChannels().then((r) => r.channels ?? []),
+    queryFn: () =>
+      getChannels().then((r) =>
+        arrayOrEmpty<{ slug: string; name: string; members?: string[] }>(
+          r.channels,
+        ),
+      ),
     refetchInterval: 30_000,
   });
 
   const { data: allTasks = [] } = useQuery({
     queryKey: ["office-tasks-profile"],
     queryFn: () =>
-      getOfficeTasks({ includeDone: true }).then((r) => r.tasks ?? []),
+      getOfficeTasks({ includeDone: true }).then((r) =>
+        arrayOrEmpty<Task>(r.tasks),
+      ),
     refetchInterval: 30_000,
   });
 
   const { data: runs = [], isLoading: runsLoading } = useQuery({
     queryKey: ["agent-log-tasks", agent.slug],
     queryFn: () =>
-      listAgentLogTasks({ limit: 8, agentSlug: agent.slug }).then(
-        (r) => r.tasks ?? [],
+      listAgentLogTasks({ limit: 8, agentSlug: agent.slug }).then((r) =>
+        arrayOrEmpty<TaskLogSummary>(r.tasks),
       ),
     refetchInterval: 30_000,
   });

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -603,6 +603,60 @@ describe("CeoCardSection", () => {
     });
   });
 
+  it("advances the empty blueprint id as the scratch path", async () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-blueprint-scratch",
+      phase: "blueprint",
+      kind: "ceo_chip_row",
+      payload: {
+        field: "blueprint_id",
+        label: "Pick a template:",
+        options: [{ id: "", label: "Start from scratch" }],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.click(screen.getByText("Start from scratch"));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/answer", {
+        field: "blueprint_id",
+        value: "",
+      }),
+    );
+    expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+      phase: "seed",
+    });
+    expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+      phase: "bridge",
+    });
+  });
+
+  it("advances legacy scratch blueprint ids as the scratch path", async () => {
+    const suggestion: CeoSuggestion = {
+      id: "sug-blueprint-legacy-scratch",
+      phase: "blueprint",
+      kind: "ceo_chip_row",
+      payload: {
+        field: "blueprint_id",
+        label: "Pick a template:",
+        options: [{ id: "from-scratch", label: "Start from scratch" }],
+      },
+    };
+    render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
+
+    fireEvent.click(screen.getByText("Start from scratch"));
+
+    await waitFor(() =>
+      expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+        phase: "seed",
+      }),
+    );
+    expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
+      phase: "bridge",
+    });
+  });
+
   it("transitions bridge choices without posting them as form answers", async () => {
     const suggestion: CeoSuggestion = {
       id: "sug-bridge",

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -683,7 +683,7 @@ describe("CeoCardSection", () => {
     });
   });
 
-  it("starts the issue-draft phase from the start-issue bridge chip", async () => {
+  it("completes onboarding from the start-issue bridge chip", async () => {
     const suggestion: CeoSuggestion = {
       id: "sug-bridge-start",
       phase: "bridge",
@@ -700,7 +700,7 @@ describe("CeoCardSection", () => {
 
     await waitFor(() =>
       expect(postMock).toHaveBeenCalledWith("/onboarding/transition", {
-        phase: "draft",
+        phase: "complete",
       }),
     );
   });
@@ -717,9 +717,12 @@ describe("CeoCardSection", () => {
     };
     render(<CeoCardSection />, { wrapper: makeWrapper(suggestion) });
 
-    fireEvent.change(screen.getByLabelText("What should the team tackle first?"), {
-      target: { value: "Build Stripe webhooks" },
-    });
+    fireEvent.change(
+      screen.getByLabelText("What should the team tackle first?"),
+      {
+        target: { value: "Build Stripe webhooks" },
+      },
+    );
     fireEvent.click(screen.getByText("Submit"));
 
     await waitFor(() =>

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -790,6 +790,13 @@ function shouldPersistOnboardingAnswer(field: string) {
   return field !== "bridge_choice";
 }
 
+function isScratchBlueprintID(value: unknown) {
+  if (typeof value !== "string") return true;
+  return ["", "__blank_slate__", "from-scratch", "blank-slate"].includes(
+    value.trim(),
+  );
+}
+
 /**
  * Narrows an unknown CEO card value to the union the answer endpoint accepts.
  * Strings pass through; arrays are coerced to string[]; everything else
@@ -827,15 +834,14 @@ async function advanceOnboardingAfterAnswer(
       await post("/onboarding/transition", { phase: "website" });
       return;
     case "blueprint_id":
-      // Strict trimmed-string check: an unknown payload can be a whitespace
-      // string, a number, or any other truthy non-string value. Only a real
-      // blueprint id (non-empty after trim) routes to "team"; everything
-      // else is the scratch path.
-      if (typeof value === "string" && value.trim() !== "") {
-        await post("/onboarding/transition", { phase: "team" });
-      } else {
+      // Only a real blueprint id routes to "team". Empty string is the
+      // current scratch wire value; the named values are legacy/cached-client
+      // sentinels that the backend also normalizes to scratch.
+      if (isScratchBlueprintID(value)) {
         await post("/onboarding/transition", { phase: "seed" });
         await post("/onboarding/transition", { phase: "bridge" });
+      } else {
+        await post("/onboarding/transition", { phase: "team" });
       }
       return;
     case "picked_agents":

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -739,7 +739,7 @@ export function CeoCardSection() {
       await queryClient.invalidateQueries({ queryKey: ["onboarding-state"] });
       setCommittedValue(committedOnboardingValue(value));
       setStage("committed");
-      if (completesOnboarding(field, value)) {
+      if (completesOnboarding(field)) {
         setOnboardingComplete(true);
       }
     } catch (err: unknown) {
@@ -811,8 +811,8 @@ function committedOnboardingValue(
 }
 
 /** Returns true when answering this field terminates the onboarding loop. */
-function completesOnboarding(field: string, value: unknown) {
-  return field === "bridge_choice" && value !== "start_issue";
+function completesOnboarding(field: string) {
+  return field === "bridge_choice";
 }
 
 /**
@@ -849,9 +849,7 @@ async function advanceOnboardingAfterAnswer(
       await post("/onboarding/transition", { phase: "bridge" });
       return;
     case "bridge_choice":
-      await post("/onboarding/transition", {
-        phase: value === "start_issue" ? "draft" : "complete",
-      });
+      await post("/onboarding/transition", { phase: "complete" });
       return;
     case "task_prompt":
       await post("/onboarding/transition", {


### PR DESCRIPTION
## Summary

Fixes the onboarding dead-end reported from the CEO profile flow and hardens the CEO profile panel against malformed list payloads.

## Root cause

The onboarding bridge could route `Start an issue` into the `draft` phase even though draft/approve/kickoff are not wired in this deterministic onboarding path yet. Once persisted there, `/onboarding/state` kept returning a phase with no pending suggestion, so the UI rendered only the "CEO is composing" hint indefinitely. The profile crash came from panel code assuming API list fields were arrays before calling `.filter()`.

## Changes

- Block `bridge -> draft` until the draft phase is actually wired, and make the bridge `Start an issue` option complete onboarding instead of entering the dead phase.
- Recover existing users persisted in unwired `draft`, `approve`, or `kickoff` phases by completing onboarding and clearing the stale pending suggestion.
- Normalize scratch blueprint sentinels (`from-scratch`, `blank-slate`, `__blank_slate__`) to the scratch path on both frontend and backend.
- Guard CEO profile panel list data so malformed `skills`, `channels`, `tasks`, or `agent-logs` responses render empty states instead of crashing.

## Validation

- `bash scripts/test-go.sh ./internal/onboarding ./internal/team`
- `bash scripts/test-go.sh ./internal/onboarding`
- `bash scripts/test-web.sh web/src/components/messages/InterviewBar.ceoKinds.test.tsx web/src/components/agents/AgentProfilePanel.test.tsx`
- `bash scripts/test-web.sh`
- `cd web && bunx tsc --noEmit`
- Browser smoke on `http://127.0.0.1:5174/`: loaded with 0 console errors

## Screenshots

Skipped: this is a crash/recovery fix with no intended visible UI delta.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize "start from scratch" blueprint identifiers so blank/legacy values are treated consistently.
  * Bridge choice now completes onboarding (no longer routes to draft).
  * Auto-recover certain incomplete onboarding states and persist the recovered state.
  * Handle malformed agent profile API responses by falling back to empty-state displays.

* **Tests**
  * Added tests covering blueprint normalization, bridge transition behavior, onboarding recovery, and agent-profile error cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->