### PR TITLE
[release] fix(workspaces): auto-pause running workspace on shred

### DIFF
--- a/internal/workspaces/orchestrator.go
+++ b/internal/workspaces/orchestrator.go
@@ -394,7 +394,16 @@ func Shred(ctx context.Context, name string, permanent bool) (string, error) {
 	// behind shred keeps the UX promise that a confirmed shred actually
 	// teardown everything (process + port + tree).
 	if target.State == StateRunning || target.State == StateStarting || probePort(target.BrokerPort) {
-		if err := Pause(ctx, name); err != nil {
+		// Detach Pause from the caller's context. A canceled request (browser
+		// tab closed, network hiccup) mid-teardown would abort Pause inside
+		// its SIGTERM/SIGKILL poll loop and leave the workspace in
+		// StateStopping with the broker still alive — exactly the half-dead
+		// state this auto-pause exists to prevent. The bounded timeout still
+		// caps how long Pause can hang; it just doesn't ride on ctx.
+		pauseCtx, cancel := context.WithTimeout(context.Background(), pauseWallClockTimeout+15*time.Second)
+		err := Pause(pauseCtx, name)
+		cancel()
+		if err != nil {
 			return "", fmt.Errorf("workspaces: shred %q: pause running broker: %w", name, err)
 		}
 		// Re-read the registry so target reflects the post-pause state

--- a/internal/workspaces/orchestrator.go
+++ b/internal/workspaces/orchestrator.go
@@ -386,11 +386,33 @@ func Shred(ctx context.Context, name string, permanent bool) (string, error) {
 		return "", ErrWorkspaceNotFound
 	}
 
-	// Refuse to shred a running workspace. Deleting the runtime tree while the
-	// broker holds open files and sockets leaves a zombie process and can cause
-	// AllocatePortPair to hand the same ports to a new workspace immediately.
+	// Auto-pause a running workspace before shredding. Deleting the runtime
+	// tree while the broker holds open files and sockets leaves a zombie
+	// process and can cause AllocatePortPair to hand the same ports to a new
+	// workspace immediately. Pause's SIGTERM/SIGKILL ladder is the same
+	// machinery the explicit `wuphf workspace pause` path runs; surfacing it
+	// behind shred keeps the UX promise that a confirmed shred actually
+	// teardown everything (process + port + tree).
 	if target.State == StateRunning || target.State == StateStarting || probePort(target.BrokerPort) {
-		return "", fmt.Errorf("workspaces: shred %q: workspace is running (port %d); pause it first", name, target.BrokerPort)
+		if err := Pause(ctx, name); err != nil {
+			return "", fmt.Errorf("workspaces: shred %q: pause running broker: %w", name, err)
+		}
+		// Re-read the registry so target reflects the post-pause state
+		// (BrokerPort is stable, but State moved Running → Paused).
+		reg, err = Read()
+		if err != nil {
+			return "", err
+		}
+		target = nil
+		for _, ws := range reg.Workspaces {
+			if ws.Name == name {
+				target = ws
+				break
+			}
+		}
+		if target == nil {
+			return "", ErrWorkspaceNotFound
+		}
 	}
 
 	// Token file and the ~/.wuphf compatibility symlink live at the real user

--- a/internal/workspaces/orchestrator_test.go
+++ b/internal/workspaces/orchestrator_test.go
@@ -488,6 +488,58 @@ func TestShredMovesToTrashByDefault(t *testing.T) {
 	_ = home
 }
 
+// TestShredAutoPausesRunningWorkspace verifies that Shred no longer rejects a
+// workspace whose registry row is StateRunning. The user-facing promise of
+// "shred this office" is end-to-end teardown — the prior behavior of erroring
+// with "pause it first" left the icon in the sidebar and the broker port
+// bound, surprising the user who already typed the name to confirm.
+//
+// Uses an unbound port so the Pause SIGTERM/SIGKILL ladder collapses to the
+// fail-open path; the contract under test is only that StateRunning no longer
+// blocks Shred.
+func TestShredAutoPausesRunningWorkspace(t *testing.T) {
+	withOrchestratorHome(t)
+	withShortPauseTimeouts(t)
+	withTmuxKillerStub(t)
+
+	sd, _ := spacesDir()
+	runtimeHome := filepath.Join(sd, "running-to-shred")
+	wuphfDir := filepath.Join(runtimeHome, ".wuphf")
+	if err := os.MkdirAll(wuphfDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	now := time.Now().UTC()
+	if err := Write(&Registry{
+		Version:    Version,
+		CLICurrent: "main",
+		Workspaces: []*Workspace{
+			{Name: "main", RuntimeHome: filepath.Join(sd, "main"),
+				BrokerPort: MainBrokerPort, WebPort: MainWebPort,
+				State: StatePaused, CreatedAt: now, LastUsedAt: now},
+			{Name: "running-to-shred", RuntimeHome: runtimeHome,
+				BrokerPort: 29984, WebPort: 29985,
+				State: StateRunning, CreatedAt: now, LastUsedAt: now},
+		},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := Shred(context.Background(), "running-to-shred", false); err != nil {
+		t.Fatalf("Shred running workspace: %v", err)
+	}
+
+	reg, _ := Read()
+	for _, ws := range reg.Workspaces {
+		if ws.Name == "running-to-shred" {
+			t.Error("running-to-shred still in registry after shred")
+		}
+	}
+	if _, err := os.Stat(runtimeHome); !os.IsNotExist(err) {
+		t.Error("runtime home should have been removed")
+	}
+}
+
 // ---- Doctor tests ----------------------------------------------------------
 
 func TestDoctorDetectsOrphanTree(t *testing.T) {


### PR DESCRIPTION
## Summary

Shredding a workspace from the rail used to silently fail when its broker was still running — the icon stayed in the sidebar, the broker kept the port bound, and the toast was easy to miss against the modal backdrop.

The `Shred()` orchestrator already knew the right answer (call `Pause`, which runs the SIGTERM → SIGKILL → tmux ladder) but punted back to the caller with `"workspace is running; pause it first"`. No UI surface wired up that two-step, so confirmed shreds on a live workspace just bounced.

This collapses the two-step into the one intent. Confirmed shred now:
1. Calls `Pause` if the workspace is running or its port still answers.
2. Re-reads the registry post-pause so state is fresh.
3. Continues with the existing backup + registry-removal flow.

If pause genuinely can't kill the broker (survives SIGKILL), Shred surfaces a wrapped error instead of leaving the workspace half-dead.

## Test plan

- [x] `go test -race ./internal/workspaces/ -run "Shred|Pause"` — all green, including the new `TestShredAutoPausesRunningWorkspace`
- [ ] Live verify: spawn a non-main workspace, confirm shred from the rail, verify icon disappears and `lsof -iTCP:<port>` shows the port released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace deletion now automatically pauses running workspaces so removal proceeds without error; if the workspace disappears during this step, deletion reports it as not found.
* **Tests**
  * Added automated coverage verifying deletion succeeds for workspaces that were running and ensures runtime data is removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->