### PR TITLE
fix(broker): re-exec process on restart so new binary takes effect

### DIFF
--- a/internal/team/broker_reexec_unix.go
+++ b/internal/team/broker_reexec_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package team
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// platformReExecBroker replaces the running process image with a fresh exec of
+// the binary at os.Executable() — picking up whatever `npm install -g
+// wuphf@latest` (or any other installer) has written to that path.
+//
+// Same PID as before, so the npm shim parent (`npm/bin/wuphf.js`) never sees a
+// child exit; it just keeps waiting on the same pid which is now running the
+// new binary. Go opens listeners with O_CLOEXEC by default, so the old TCP
+// listener is closed by the kernel during exec — the new binary re-binds it
+// when its broker comes up.
+//
+// On success this function does not return.
+func platformReExecBroker() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+	argv := append([]string(nil), os.Args...)
+	if len(argv) == 0 {
+		argv = []string{exe}
+	} else {
+		argv[0] = exe
+	}
+	if err := syscall.Exec(exe, argv, os.Environ()); err != nil {
+		return fmt.Errorf("exec %s: %w", exe, err)
+	}
+	// Unreachable: syscall.Exec only returns on failure.
+	return nil
+}

--- a/internal/team/broker_reexec_unix.go
+++ b/internal/team/broker_reexec_unix.go
@@ -3,14 +3,18 @@
 package team
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"syscall"
 )
 
 // platformReExecBroker replaces the running process image with a fresh exec of
-// the binary at os.Executable() — picking up whatever `npm install -g
-// wuphf@latest` (or any other installer) has written to that path.
+// the binary that lives at the path we were launched from — picking up
+// whatever `npm install -g wuphf@latest` (or any other installer) has just
+// written there.
 //
 // Same PID as before, so the npm shim parent (`npm/bin/wuphf.js`) never sees a
 // child exit; it just keeps waiting on the same pid which is now running the
@@ -18,18 +22,29 @@ import (
 // listener is closed by the kernel during exec — the new binary re-binds it
 // when its broker comes up.
 //
+// We deliberately do NOT use os.Executable() here. On Linux it resolves
+// /proc/self/exe, which is bound to the inode of the running binary; after
+// npm's typical rename-based replacement the original inode is unlinked and
+// the readlink returns a path with a " (deleted)" suffix that no longer
+// exists on disk. Resolving from os.Args[0] via exec.LookPath gives us the
+// path npm/yarn/bun actually wrote the new binary to, which is what we want
+// to exec.
+//
 // On success this function does not return.
 func platformReExecBroker() error {
-	exe, err := os.Executable()
+	if len(os.Args) == 0 || os.Args[0] == "" {
+		return errors.New("resolve executable: argv[0] is empty")
+	}
+	exe, err := exec.LookPath(os.Args[0])
 	if err != nil {
-		return fmt.Errorf("resolve executable: %w", err)
+		return fmt.Errorf("resolve executable from argv[0]: %w", err)
+	}
+	exe, err = filepath.Abs(exe)
+	if err != nil {
+		return fmt.Errorf("resolve absolute executable path: %w", err)
 	}
 	argv := append([]string(nil), os.Args...)
-	if len(argv) == 0 {
-		argv = []string{exe}
-	} else {
-		argv[0] = exe
-	}
+	argv[0] = exe
 	if err := syscall.Exec(exe, argv, os.Environ()); err != nil {
 		return fmt.Errorf("exec %s: %w", exe, err)
 	}

--- a/internal/team/broker_reexec_windows.go
+++ b/internal/team/broker_reexec_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package team
+
+import "fmt"
+
+// platformReExecBroker is a no-op on Windows: there is no `execve` equivalent
+// that keeps the same PID, and the npm shim parent watches our PID, so
+// spawning a detached child and exiting would orphan the new binary and lose
+// the user's terminal session.
+//
+// Returning an error here causes handleWebBrokerRestart to fall back to the
+// in-process listener restart, which at least lets the SSE client reconnect.
+// The user will need to relaunch the CLI from a terminal for the new binary
+// to take effect.
+func platformReExecBroker() error {
+	return fmt.Errorf("re-exec not supported on windows; relaunch the CLI to pick up the new binary")
+}

--- a/internal/team/broker_web_restart.go
+++ b/internal/team/broker_web_restart.go
@@ -89,19 +89,27 @@ func (b *Broker) handleWebBrokerRestart(w http.ResponseWriter, r *http.Request) 
 	reExec, delay := loadReExecHook()
 	go func() {
 		time.Sleep(delay)
-		// syscall.Exec only returns on failure. If it succeeds, the new
-		// binary takes over the process and this goroutine never resumes.
-		// On Windows (or any platform where re-exec isn't supported) we
-		// fall back to the in-process listener restart so the user at
-		// least sees a reconnect, even though the version won't change
-		// until they re-launch the CLI manually.
-		if err := reExec(); err != nil {
-			log.Printf("broker re-exec failed (%v); falling back to listener restart", err)
-			if _, restartErr := b.RestartBrokerListener(); restartErr != nil {
-				log.Printf("broker listener restart fallback failed: %v", restartErr)
-			}
-		}
+		b.performBrokerRestart(reExec)
 	}()
+}
+
+// performBrokerRestart runs the actual restart workflow synchronously. The
+// HTTP handler invokes it on a goroutine (after flushing the 202 and sleeping
+// briefly so the response reaches the client), but it is split out so tests
+// can exercise the fallback path without spawning a goroutine or polling.
+//
+// syscall.Exec only returns on failure: if it succeeds, the new binary takes
+// over the process and this function never returns. On Windows (or any
+// platform where re-exec is not supported) we fall back to the in-process
+// listener restart so the SSE client at least reconnects, even though the
+// version will not change until the user relaunches the CLI manually.
+func (b *Broker) performBrokerRestart(reExec func() error) {
+	if err := reExec(); err != nil {
+		log.Printf("broker re-exec failed (%v); falling back to listener restart", err)
+		if _, restartErr := b.RestartBrokerListener(); restartErr != nil {
+			log.Printf("broker listener restart fallback failed: %v", restartErr)
+		}
+	}
 }
 
 func (b *Broker) RestartBrokerListener() (WebBrokerRestartStatus, error) {

--- a/internal/team/broker_web_restart.go
+++ b/internal/team/broker_web_restart.go
@@ -3,9 +3,12 @@ package team
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/brokeraddr"
 )
@@ -15,18 +18,90 @@ type WebBrokerRestartStatus struct {
 	URL string `json:"url,omitempty"`
 }
 
+// reExecHookMu guards the package-level re-exec hook + delay so tests can
+// swap them without racing the handler goroutine that reads them.
+var (
+	reExecHookMu sync.RWMutex
+
+	// reExecBrokerProcess replaces the current process image with a fresh
+	// exec of the same binary path so a newly-installed version (from
+	// `npm install -g wuphf@latest`) actually takes over. Implemented
+	// per-platform in broker_reexec_*.go.
+	reExecBrokerProcess = platformReExecBroker
+
+	// brokerReExecDelay gives the HTTP response time to flush to the
+	// client before the process image is replaced.
+	brokerReExecDelay = 200 * time.Millisecond
+)
+
+// loadReExecHook captures the current hook + delay under the read lock so the
+// handler goroutine uses a coherent pair even if a test swaps them mid-flight.
+func loadReExecHook() (func() error, time.Duration) {
+	reExecHookMu.RLock()
+	defer reExecHookMu.RUnlock()
+	return reExecBrokerProcess, brokerReExecDelay
+}
+
 func (b *Broker) handleWebBrokerRestart(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
-	status, err := b.RestartBrokerListener()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+	if b == nil {
+		http.Error(w, "broker unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	// Refuse to schedule a re-exec on a broker that is already shutting
+	// down — preserves the legacy behaviour of TestWebBrokerRestartRejectsAfterStop
+	// and avoids racing the lifecycle teardown.
+	if b.stopCh != nil {
+		select {
+		case <-b.stopCh:
+			http.Error(w, "broker is shutting down", http.StatusServiceUnavailable)
+			return
+		default:
+		}
+	}
+	if b.lifecycleCtx != nil {
+		select {
+		case <-b.lifecycleCtx.Done():
+			http.Error(w, "broker is shutting down", http.StatusServiceUnavailable)
+			return
+		default:
+		}
+	}
+
+	status := WebBrokerRestartStatus{
+		OK:  true,
+		URL: "http://" + b.Addr(),
+	}
+	// Confirm to the client first; the actual process replacement happens on
+	// a short delay so the response reaches the browser before the binary is
+	// replaced. The frontend's SSE client reconnects automatically once the
+	// new binary is listening on the same port.
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(status)
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+
+	reExec, delay := loadReExecHook()
+	go func() {
+		time.Sleep(delay)
+		// syscall.Exec only returns on failure. If it succeeds, the new
+		// binary takes over the process and this goroutine never resumes.
+		// On Windows (or any platform where re-exec isn't supported) we
+		// fall back to the in-process listener restart so the user at
+		// least sees a reconnect, even though the version won't change
+		// until they re-launch the CLI manually.
+		if err := reExec(); err != nil {
+			log.Printf("broker re-exec failed (%v); falling back to listener restart", err)
+			if _, restartErr := b.RestartBrokerListener(); restartErr != nil {
+				log.Printf("broker listener restart fallback failed: %v", restartErr)
+			}
+		}
+	}()
 }
 
 func (b *Broker) RestartBrokerListener() (WebBrokerRestartStatus, error) {

--- a/internal/team/broker_web_restart_test.go
+++ b/internal/team/broker_web_restart_test.go
@@ -88,15 +88,11 @@ func TestWebBrokerRestartTriggersReExec(t *testing.T) {
 }
 
 // When the platform re-exec fails (e.g. Windows, or syscall.Exec returned an
-// error), the handler must fall back to the in-process listener restart so
-// the SSE client still reconnects.
-func TestWebBrokerRestartFallsBackToListenerOnReExecFailure(t *testing.T) {
-	var reExecCalled atomic.Bool
-	stubReExec(t, func() error {
-		reExecCalled.Store(true)
-		return errors.New("re-exec not supported in test")
-	})
-
+// error), performBrokerRestart must fall back to the in-process listener
+// restart so the SSE client still reconnects. Call it synchronously to avoid
+// racing the handler's goroutine — the handler is already covered by
+// TestWebBrokerRestartTriggersReExec.
+func TestPerformBrokerRestartFallsBackToListenerOnReExecFailure(t *testing.T) {
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("StartOnPort: %v", err)
@@ -105,46 +101,28 @@ func TestWebBrokerRestartFallsBackToListenerOnReExecFailure(t *testing.T) {
 
 	oldAddr := b.Addr()
 
-	req := httptest.NewRequest(http.MethodPost, "/api/broker/restart", nil)
-	resp := httptest.NewRecorder()
+	var reExecCalled atomic.Bool
+	b.performBrokerRestart(func() error {
+		reExecCalled.Store(true)
+		return errors.New("re-exec not supported in test")
+	})
 
-	b.handleWebBrokerRestart(resp, req)
-
-	if resp.Code != http.StatusAccepted {
-		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusAccepted, resp.Body.String())
+	if !reExecCalled.Load() {
+		t.Fatal("re-exec hook was not called")
 	}
-
-	// Poll until the fallback finishes — the listener restart happens in the
-	// same goroutine that called the re-exec hook.
-	deadline := time.Now().Add(5 * time.Second)
-	client := &http.Client{Timeout: 1 * time.Second}
-	for {
-		if !reExecCalled.Load() {
-			if time.Now().After(deadline) {
-				t.Fatal("re-exec hook was not called before deadline")
-			}
-			time.Sleep(20 * time.Millisecond)
-			continue
-		}
-		// re-exec returned; listener restart should be in flight or done.
-		healthResp, err := client.Get("http://" + b.Addr() + "/health")
-		if err == nil {
-			body, _ := io.ReadAll(healthResp.Body)
-			healthResp.Body.Close()
-			if healthResp.StatusCode == http.StatusOK {
-				break
-			}
-			if time.Now().After(deadline) {
-				t.Fatalf("GET /health status after fallback = %d: %s", healthResp.StatusCode, string(body))
-			}
-		} else if time.Now().After(deadline) {
-			t.Fatalf("GET /health after fallback never succeeded: %v", err)
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-
 	if b.Addr() != oldAddr {
 		t.Fatalf("listener addr after fallback = %q, want %q", b.Addr(), oldAddr)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	healthResp, err := client.Get("http://" + b.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("GET /health after fallback: %v", err)
+	}
+	defer healthResp.Body.Close()
+	body, _ := io.ReadAll(healthResp.Body)
+	if healthResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /health status after fallback = %d: %s", healthResp.StatusCode, string(body))
 	}
 }
 

--- a/internal/team/broker_web_restart_test.go
+++ b/internal/team/broker_web_restart_test.go
@@ -2,16 +2,39 @@ package team
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
+// stubReExec swaps in a no-op re-exec hook so the handler can be exercised
+// without actually replacing the process image. The previous hook + delay are
+// restored on test cleanup, under the same lock the handler uses so the race
+// detector sees a happens-before edge.
+func stubReExec(t *testing.T, fn func() error) {
+	t.Helper()
+	reExecHookMu.Lock()
+	prevHook := reExecBrokerProcess
+	prevDelay := brokerReExecDelay
+	reExecBrokerProcess = fn
+	brokerReExecDelay = 0
+	reExecHookMu.Unlock()
+	t.Cleanup(func() {
+		reExecHookMu.Lock()
+		reExecBrokerProcess = prevHook
+		brokerReExecDelay = prevDelay
+		reExecHookMu.Unlock()
+	})
+}
+
 func TestWebBrokerRestartRejectsGet(t *testing.T) {
+	stubReExec(t, func() error { return nil })
 	b := &Broker{}
 	req := httptest.NewRequest(http.MethodGet, "/api/broker/restart", nil)
 	resp := httptest.NewRecorder()
@@ -23,12 +46,22 @@ func TestWebBrokerRestartRejectsGet(t *testing.T) {
 	}
 }
 
-func TestWebBrokerRestartRestartsListener(t *testing.T) {
+func TestWebBrokerRestartTriggersReExec(t *testing.T) {
+	called := make(chan struct{}, 1)
+	stubReExec(t, func() error {
+		select {
+		case called <- struct{}{}:
+		default:
+		}
+		// Returning nil pretends the exec succeeded; the goroutine in the
+		// handler treats nil as "process gone" and stops there.
+		return nil
+	})
+
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("StartOnPort: %v", err)
 	}
-	oldAddr := b.Addr()
 	defer b.Stop()
 
 	req := httptest.NewRequest(http.MethodPost, "/api/broker/restart", nil)
@@ -36,8 +69,8 @@ func TestWebBrokerRestartRestartsListener(t *testing.T) {
 
 	b.handleWebBrokerRestart(resp, req)
 
-	if resp.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusOK, resp.Body.String())
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusAccepted, resp.Body.String())
 	}
 	var out WebBrokerRestartStatus
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -46,18 +79,72 @@ func TestWebBrokerRestartRestartsListener(t *testing.T) {
 	if !out.OK || out.URL == "" {
 		t.Fatalf("restart response = %+v, want ok with url", out)
 	}
+
+	select {
+	case <-called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("re-exec hook was not called")
+	}
+}
+
+// When the platform re-exec fails (e.g. Windows, or syscall.Exec returned an
+// error), the handler must fall back to the in-process listener restart so
+// the SSE client still reconnects.
+func TestWebBrokerRestartFallsBackToListenerOnReExecFailure(t *testing.T) {
+	var reExecCalled atomic.Bool
+	stubReExec(t, func() error {
+		reExecCalled.Store(true)
+		return errors.New("re-exec not supported in test")
+	})
+
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("StartOnPort: %v", err)
+	}
+	defer b.Stop()
+
+	oldAddr := b.Addr()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/broker/restart", nil)
+	resp := httptest.NewRecorder()
+
+	b.handleWebBrokerRestart(resp, req)
+
+	if resp.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", resp.Code, http.StatusAccepted, resp.Body.String())
+	}
+
+	// Poll until the fallback finishes — the listener restart happens in the
+	// same goroutine that called the re-exec hook.
+	deadline := time.Now().Add(5 * time.Second)
+	client := &http.Client{Timeout: 1 * time.Second}
+	for {
+		if !reExecCalled.Load() {
+			if time.Now().After(deadline) {
+				t.Fatal("re-exec hook was not called before deadline")
+			}
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		// re-exec returned; listener restart should be in flight or done.
+		healthResp, err := client.Get("http://" + b.Addr() + "/health")
+		if err == nil {
+			body, _ := io.ReadAll(healthResp.Body)
+			healthResp.Body.Close()
+			if healthResp.StatusCode == http.StatusOK {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("GET /health status after fallback = %d: %s", healthResp.StatusCode, string(body))
+			}
+		} else if time.Now().After(deadline) {
+			t.Fatalf("GET /health after fallback never succeeded: %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
 	if b.Addr() != oldAddr {
-		t.Fatalf("listener addr = %q, want restart on same address %q", b.Addr(), oldAddr)
-	}
-	client := &http.Client{Timeout: 5 * time.Second}
-	healthResp, err := client.Get("http://" + b.Addr() + "/health")
-	if err != nil {
-		t.Fatalf("GET /health after restart: %v", err)
-	}
-	defer healthResp.Body.Close()
-	body, _ := io.ReadAll(healthResp.Body)
-	if healthResp.StatusCode != http.StatusOK {
-		t.Fatalf("GET /health status = %d, want %d: %s", healthResp.StatusCode, http.StatusOK, string(body))
+		t.Fatalf("listener addr after fallback = %q, want %q", b.Addr(), oldAddr)
 	}
 }
 


### PR DESCRIPTION
## Summary

The version modal's **Restart broker** / **Restart now** buttons claimed to bring up a freshly-installed binary, but the chip in the StatusBar kept showing the old version. Repro from the bug report: install reported `v0.212.3`, restart returned `200 OK`, chip stayed pinned on `v0.212.2`.

Root cause: `/api/broker/restart` called `RestartBrokerListener`, which only `Close`s and re-`StartOnPort`s the HTTP listener inside the same Go process. The binary version is baked into the running process image, so the in-memory process kept serving the old version forever no matter how many times the user restarted.

## Fix

Replace the in-process listener restart with `syscall.Exec` on Unix:

- **Same PID** — the `npm/bin/wuphf.js` shim parent never sees a child exit and the user's session survives.
- **New binary** — the kernel loads the binary that `npm install -g wuphf@latest` just wrote to the path resolved from `os.Args[0]`.
- **Clean port handoff** — Go opens listeners with `O_CLOEXEC` by default, so the old TCP socket is released during exec and the new binary re-binds the same port.
- **No torn HTTP responses** — the handler writes + flushes a `202` before scheduling the re-exec on a 200ms delay so the browser sees the confirmation before its connection drops; the SSE client reconnects on its own.

Resolution uses `exec.LookPath(os.Args[0])` rather than `os.Executable()` because on Linux, npm's rename-based replacement of the global package directory unlinks the original inode — `os.Executable()` then resolves `/proc/self/exe` to a path with a `" (deleted)"` suffix that no longer exists on disk, and `syscall.Exec` would fail with `ENOENT`.

**Windows fallback:** there is no `execve` equivalent that preserves the PID, so `platformReExecBroker` returns an error there and the handler falls back to the existing listener restart with a log line — same behaviour as before on Windows. User has to relaunch the CLI to pick up a new binary.

## Files

- `internal/team/broker_web_restart.go` — handler writes 202, flushes, schedules `performBrokerRestart` on a 200ms delay; falls back to `RestartBrokerListener` if the platform re-exec hook returns an error. Hook + delay are guarded by a `sync.RWMutex` so tests can swap them without racing the goroutine.
- `internal/team/broker_reexec_unix.go` (new, `//go:build !windows`) — `syscall.Exec` of `exec.LookPath(os.Args[0])`.
- `internal/team/broker_reexec_windows.go` (new, `//go:build windows`) — returns an error so the handler falls back to listener restart.
- `internal/team/broker_web_restart_test.go` — adds `TestWebBrokerRestartTriggersReExec` (channel-based, no sleep) and `TestPerformBrokerRestartFallsBackToListenerOnReExecFailure` (synchronous call to the extracted helper, no goroutine, no sleep). Existing shutdown / race tests still cover `RestartBrokerListener` directly.

## Commits

| SHA | Message |
|-----|---------|
| `fd194e19` | fix(broker): re-exec process on restart so new binary takes effect |
| `4f671b14` | test(broker): drop time.Sleep polling from restart fallback test |
| `f615d2ec` | fix(broker): resolve re-exec target from argv[0], not os.Executable() |

## Test plan

- [x] `go test -race -count=1 ./internal/team/` — 114s, all green
- [x] `GOOS=windows go build ./internal/team/` — clean (fallback path compiles)
- [x] `bash scripts/test-web.sh web/src/components/ui/VersionModal.test.tsx` — 11/11 pass (frontend accepts `202` since `fetch.ok` is true for any 2xx)
- [x] `golangci-lint run ./internal/team/...` — 0 issues
- [x] `BASE_SHA=$(git merge-base HEAD origin/main) bash scripts/check-no-new-sleeps-in-tests.sh` — `no-sleep-in-new-tests check OK`
- [ ] Manual end-to-end on macOS: `npm install -g wuphf@<old>`, launch, run `npm install -g wuphf@latest` from another shell, click **Restart now** in the version modal, confirm the StatusBar chip flips to the new version without relaunching the CLI

## CodeRabbit dispositions

| # | Finding | Status | Notes |
|---|---------|--------|-------|
| 1 | Use `os.Args[0]` resolution instead of `os.Executable()` | FIXED | commit `f615d2ec` |

## Screenshots

No `web/` files touched — this is a Go-side fix to the existing `/api/broker/restart` endpoint. The visible delta is exactly the bug-report screenshot the user attached (chip should now update after restart); reproducing that requires a real npm install/upgrade cycle which the screenshot harness isn't wired up to exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)