### PR TITLE
fix(wiki): resolve relative .md links to the wiki hash route

### DIFF
--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -419,8 +419,8 @@ export default function WikiArticle({
   );
   const rehypePlugins: PluggableList = useMemo(() => buildRehypePlugins(), []);
   const markdownComponents = useMemo(
-    () => buildMarkdownComponents({ resolver, onNavigate }),
-    [resolver, onNavigate],
+    () => buildMarkdownComponents({ resolver, onNavigate, articlePath: path }),
+    [resolver, onNavigate, path],
   );
 
   if (loading && !timedOut) {

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -257,8 +257,8 @@ export default function WikiEditor({
   const remarkPlugins = useMemo(() => buildRemarkPlugins(resolver), [resolver]);
   const rehypePlugins = useMemo(() => buildRehypePlugins(), []);
   const markdownComponents = useMemo(
-    () => buildMarkdownComponents({ resolver }),
-    [resolver],
+    () => buildMarkdownComponents({ resolver, articlePath: path }),
+    [resolver, path],
   );
 
   // Per-article editor mode — persists across sessions so a user who picks

--- a/web/src/lib/wikiMarkdownConfig.test.tsx
+++ b/web/src/lib/wikiMarkdownConfig.test.tsx
@@ -1,4 +1,3 @@
-import type { ReactElement } from "react";
 import ReactMarkdown from "react-markdown";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -65,11 +64,30 @@ describe("resolveRelativeWikiPath", () => {
       resolveRelativeWikiPath("nested/page.md", "team/about/README.md"),
     ).toBe("team/about/nested/page.md");
   });
+
+  it("strips query strings and fragments from relative links", () => {
+    expect(
+      resolveRelativeWikiPath("company.md?foo=bar", "team/about/README.md"),
+    ).toBe("team/about/company.md");
+    expect(
+      resolveRelativeWikiPath("company.md#section", "team/about/README.md"),
+    ).toBe("team/about/company.md");
+  });
+
+  it("returns null for empty hrefs and directory-only relative paths", () => {
+    expect(resolveRelativeWikiPath("", "team/about/README.md")).toBeNull();
+    expect(resolveRelativeWikiPath("./", "team/about/README.md")).toBeNull();
+    expect(resolveRelativeWikiPath("../", "team/about/README.md")).toBeNull();
+  });
 });
 
-function renderMd(md: string, articlePath: string, onNavigate?: () => void) {
+function renderMd(
+  md: string,
+  articlePath: string,
+  onNavigate?: (slug: string) => void,
+): void {
   const resolver = () => true;
-  return render(
+  render(
     <ReactMarkdown
       remarkPlugins={buildRemarkPlugins(resolver)}
       components={
@@ -82,7 +100,7 @@ function renderMd(md: string, articlePath: string, onNavigate?: () => void) {
     >
       {md}
     </ReactMarkdown>,
-  ) as unknown as ReactElement;
+  );
 }
 
 describe("buildMarkdownComponents anchor override", () => {
@@ -109,6 +127,12 @@ describe("buildMarkdownComponents anchor override", () => {
     const link = screen.getByRole("link", { name: "company.md" });
     link.click();
     expect(onNavigate).toHaveBeenCalledWith("team/about/company.md");
+  });
+
+  it("rewrites the href even when onNavigate is not provided", () => {
+    renderMd("[company.md](company.md)", "team/about/README.md");
+    const link = screen.getByRole("link", { name: "company.md" });
+    expect(link.getAttribute("href")).toBe("#/wiki/team/about/company.md");
   });
 
   it("is a no-op when articlePath is not supplied", () => {

--- a/web/src/lib/wikiMarkdownConfig.test.tsx
+++ b/web/src/lib/wikiMarkdownConfig.test.tsx
@@ -1,0 +1,127 @@
+import type { ReactElement } from "react";
+import ReactMarkdown from "react-markdown";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildMarkdownComponents,
+  buildRemarkPlugins,
+  resolveRelativeWikiPath,
+} from "./wikiMarkdownConfig";
+
+describe("resolveRelativeWikiPath", () => {
+  it("resolves a sibling .md link against the article directory", () => {
+    expect(resolveRelativeWikiPath("company.md", "team/about/README.md")).toBe(
+      "team/about/company.md",
+    );
+  });
+
+  it("resolves an explicit current-directory link", () => {
+    expect(resolveRelativeWikiPath("./owner.md", "team/about/README.md")).toBe(
+      "team/about/owner.md",
+    );
+  });
+
+  it("walks parent segments for ../ paths", () => {
+    expect(
+      resolveRelativeWikiPath("../people/nazz.md", "team/about/README.md"),
+    ).toBe("team/people/nazz.md");
+  });
+
+  it("returns null for absolute URLs", () => {
+    expect(
+      resolveRelativeWikiPath("https://example.com/x.md", "team/about/x.md"),
+    ).toBeNull();
+  });
+
+  it("returns null for mailto: and other schemes", () => {
+    expect(
+      resolveRelativeWikiPath("mailto:foo@bar.com", "team/about/x.md"),
+    ).toBeNull();
+  });
+
+  it("returns null for in-page anchors", () => {
+    expect(resolveRelativeWikiPath("#section", "team/about/x.md")).toBeNull();
+  });
+
+  it("returns null for server-absolute paths", () => {
+    expect(
+      resolveRelativeWikiPath("/static/file.md", "team/about/x.md"),
+    ).toBeNull();
+  });
+
+  it("returns null for non-.md targets", () => {
+    expect(
+      resolveRelativeWikiPath("logo.png", "team/about/README.md"),
+    ).toBeNull();
+  });
+
+  it("returns null when .. would escape the wiki root", () => {
+    expect(resolveRelativeWikiPath("../../escape.md", "team/x.md")).toBeNull();
+  });
+
+  it("preserves the rest of the article path when the link adds segments", () => {
+    expect(
+      resolveRelativeWikiPath("nested/page.md", "team/about/README.md"),
+    ).toBe("team/about/nested/page.md");
+  });
+});
+
+function renderMd(md: string, articlePath: string, onNavigate?: () => void) {
+  const resolver = () => true;
+  return render(
+    <ReactMarkdown
+      remarkPlugins={buildRemarkPlugins(resolver)}
+      components={
+        buildMarkdownComponents({
+          resolver,
+          articlePath,
+          onNavigate,
+        }) as never
+      }
+    >
+      {md}
+    </ReactMarkdown>,
+  ) as unknown as ReactElement;
+}
+
+describe("buildMarkdownComponents anchor override", () => {
+  it("rewrites relative .md links to the wiki hash route", () => {
+    renderMd(
+      "- [company.md](company.md)\n- [owner](./owner.md)\n",
+      "team/about/README.md",
+    );
+    const company = screen.getByRole("link", { name: "company.md" });
+    expect(company.getAttribute("href")).toBe("#/wiki/team/about/company.md");
+    const owner = screen.getByRole("link", { name: "owner" });
+    expect(owner.getAttribute("href")).toBe("#/wiki/team/about/owner.md");
+  });
+
+  it("leaves external links untouched", () => {
+    renderMd("[Anthropic](https://anthropic.com)", "team/about/README.md");
+    const link = screen.getByRole("link", { name: "Anthropic" });
+    expect(link.getAttribute("href")).toBe("https://anthropic.com");
+  });
+
+  it("intercepts clicks on rewritten links when onNavigate is provided", () => {
+    const onNavigate = vi.fn();
+    renderMd("[company.md](company.md)", "team/about/README.md", onNavigate);
+    const link = screen.getByRole("link", { name: "company.md" });
+    link.click();
+    expect(onNavigate).toHaveBeenCalledWith("team/about/company.md");
+  });
+
+  it("is a no-op when articlePath is not supplied", () => {
+    const resolver = () => true;
+    render(
+      <ReactMarkdown
+        remarkPlugins={buildRemarkPlugins(resolver)}
+        components={buildMarkdownComponents({ resolver }) as never}
+      >
+        {"[company.md](company.md)"}
+      </ReactMarkdown>,
+    );
+    const link = screen.getByRole("link", { name: "company.md" });
+    expect(link.getAttribute("href")).toBe("company.md");
+  });
+});

--- a/web/src/lib/wikiMarkdownConfig.tsx
+++ b/web/src/lib/wikiMarkdownConfig.tsx
@@ -32,6 +32,59 @@ export interface WikiMarkdownOptions {
    * When omitted, links render as ordinary anchors.
    */
   onNavigate?: (slug: string) => void;
+  /**
+   * Wiki path of the article being rendered (e.g. `team/about/README.md`).
+   * When provided, plain markdown links to `.md` files (e.g.
+   * `[Company](company.md)`) are resolved relative to the article's
+   * directory and rewritten to point at the hash-router wiki route
+   * instead of leaking to the document base URL.
+   */
+  articlePath?: string;
+}
+
+/**
+ * Resolve a markdown link href against the article's path and return the
+ * destination wiki slug when the href is a relative `.md` link that should
+ * route through the wiki SPA. Returns null for absolute URLs, anchors,
+ * hash routes, non-`.md` targets, or paths that escape the wiki root.
+ */
+const NON_WIKI_HREF_RE = /^([a-z][a-z0-9+.-]*:|[#/])/i;
+
+function joinWikiSegments(
+  baseSegments: string[],
+  relative: string,
+): string[] | null {
+  const out = [...baseSegments];
+  for (const raw of relative.split("/")) {
+    if (raw === "" || raw === ".") continue;
+    if (raw === "..") {
+      if (out.length === 0) return null;
+      out.pop();
+      continue;
+    }
+    out.push(raw);
+  }
+  return out;
+}
+
+export function resolveRelativeWikiPath(
+  href: string,
+  articlePath: string,
+): string | null {
+  if (!(href && articlePath)) return null;
+  if (NON_WIKI_HREF_RE.test(href)) return null;
+
+  const [pathOnly] = href.split(/[?#]/);
+  if (!pathOnly.endsWith(".md")) return null;
+
+  const lastSlash = articlePath.lastIndexOf("/");
+  const baseDir = lastSlash >= 0 ? articlePath.slice(0, lastSlash) : "";
+  const segments = joinWikiSegments(
+    baseDir ? baseDir.split("/") : [],
+    pathOnly,
+  );
+  if (!segments || segments.length === 0) return null;
+  return segments.join("/");
 }
 
 /** Remark plugins — remark-gfm + wikilinks + Obsidian callouts. */
@@ -57,7 +110,7 @@ type ImageProps = ComponentProps<"img">;
 export function buildMarkdownComponents(
   options: WikiMarkdownOptions,
 ): Partial<Components> {
-  const { onNavigate } = options;
+  const { onNavigate, articlePath } = options;
   return {
     blockquote: CalloutBlockquote,
     a: (props: AnchorProps): ReactElement => {
@@ -76,6 +129,24 @@ export function buildMarkdownComponents(
             }}
           />
         );
+      }
+      if (!isWikilink && articlePath && typeof props.href === "string") {
+        const resolved = resolveRelativeWikiPath(props.href, articlePath);
+        if (resolved) {
+          const encoded = resolved.split("/").map(encodeURIComponent).join("/");
+          const nextProps = { ...props, href: `#/wiki/${encoded}` };
+          return (
+            <a
+              {...nextProps}
+              onClick={(e) => {
+                if (onNavigate) {
+                  e.preventDefault();
+                  onNavigate(resolved);
+                }
+              }}
+            />
+          );
+        }
       }
       return <a {...props} />;
     },

--- a/web/src/lib/wikiMarkdownConfig.tsx
+++ b/web/src/lib/wikiMarkdownConfig.tsx
@@ -74,6 +74,10 @@ export function resolveRelativeWikiPath(
   if (!(href && articlePath)) return null;
   if (NON_WIKI_HREF_RE.test(href)) return null;
 
+  // Fragments and query strings are dropped: the hash-router cannot nest a
+  // second `#section` inside the wiki route, and articles do not expose a
+  // query surface today. If section-anchors inside the wiki become a real
+  // demand, route them through onNavigate instead of the href.
   const [pathOnly] = href.split(/[?#]/);
   if (!pathOnly.endsWith(".md")) return null;
 


### PR DESCRIPTION
## Summary

- Seeded wiki articles (e.g. `team/about/README.md`) link to siblings with plain markdown: `[company.md](company.md)`. The renderer only intercepted `[[wikilinks]]`, so these fell through to the default anchor and the browser resolved them against the document URL (`http://localhost:PORT/company.md`) instead of the SPA route.
- New `resolveRelativeWikiPath` helper in `web/src/lib/wikiMarkdownConfig.tsx` resolves relative `.md` hrefs against the current article's directory (handles `./`, `../`, refuses absolute URLs, `mailto:`, anchors, paths that escape the wiki root) and the `a` component override rewrites them to `#/wiki/<encoded-path>` with click interception through `onNavigate`.
- `articlePath` is threaded into `buildMarkdownComponents` from `WikiArticle` and `WikiEditor`. `CitedAnswer` is left as-is — citation answers don't render against a specific article.

## Why

Repro: open `#/wiki/team/about/README.md` (or `team/about/index.md` after seeding) and click the `company.md` / `owner.md` bullets. Before this change the browser jumps to `http://localhost:7890/company.md` (404). After, the SPA navigates to the right article.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check src/lib/wikiMarkdownConfig.tsx` clean (complexity stays under 15)
- [x] New unit tests: `bash scripts/test-web.sh web/src/lib/wikiMarkdownConfig.test.tsx` — 14 pass
- [x] Wiki suite: `bash scripts/test-web.sh web/src/components/wiki/ web/src/lib/wikiMarkdownConfig.test.tsx web/src/lib/wikilink.test.ts` — 376 pass across 46 files
- [ ] Manual: open `team/about/README.md` in the running app, click `[company.md](company.md)` and `[owner.md](owner.md)` — both should navigate within the SPA

## Screenshots

This is a behavior fix (href value + click interception), not a visual delta — the bullets look identical, only the navigation target changes. Happy to attach before/after navigation screenshots if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki articles and editor now resolve and support relative Markdown links (e.g., ../other-article.md, ./sibling.md). Relative links are rewritten to internal wiki routes so they navigate seamlessly between articles.

* **Tests**
  * Added tests covering relative-link resolution, path normalization, edge cases, and navigation behavior when clicking rewritten links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->