### PR TITLE
feat(providers): per-agent runtime picker, global lock, Integrations app

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,23 +42,6 @@ type Config struct {
 	WorkspaceID    string `json:"workspace_id,omitempty"`
 	WorkspaceSlug  string `json:"workspace_slug,omitempty"`
 	LLMProvider    string `json:"llm_provider,omitempty"`
-	// LLMProviderUnlocked toggles the global LLMProvider field between two
-	// semantically distinct modes:
-	//
-	//  - false (default, "locked"): LLMProvider is the default-runtime used at
-	//    agent-creation time and the fallback when an agent has no per-agent
-	//    binding. Existing per-agent ProviderBindings win on the dispatch path.
-	//
-	//  - true ("unlocked override"): LLMProvider is treated as a hard override
-	//    that wins over every per-agent binding on the dispatch path. The UI
-	//    surfaces this as a friction gate: the user must explicitly unlock the
-	//    global runtime setting to flip every current agent at once.
-	//
-	// The default (zero value) is deliberately "locked" so a fresh install
-	// never silently clobbers per-agent picks made through the AgentWizard or
-	// AgentProfilePanel runtime section. JSON encoded with omitempty so an
-	// untoggled install does not write a new field into existing config files.
-	LLMProviderUnlocked bool `json:"llm_provider_unlocked,omitempty"`
 	// LLMProviderPriority is an ordered list of provider identifiers (same
 	// vocabulary as LLMProvider — "claude-code", "codex", "opencode", etc.) that agents
 	// should try in order when picking a runtime. LLMProvider remains the
@@ -303,26 +286,6 @@ func MemoryBackendLabel(backend string) string {
 	default:
 		return "Local-only"
 	}
-}
-
-// ResolveLLMProviderOverride returns the install-wide provider together with a
-// "should override per-agent bindings" flag. The flag is true when the user
-// has unlocked the global runtime setting (Config.LLMProviderUnlocked) AND a
-// non-empty global provider is configured — that combination expresses the
-// explicit "stamp this runtime onto every agent" gesture.
-//
-// Callers on the dispatch path (provider.DefaultStreamFnResolver) check the
-// override flag first and skip per-agent kindResolver lookup when it's true.
-// UI callers (Settings panel, AgentProfilePanel) use it to render a "Locked
-// by global override" read-only state on per-agent runtime pickers.
-//
-// Flag/env overrides do not engage the lock — a transient WUPHF_LLM_PROVIDER
-// only changes the default fallback, not the per-agent precedence.
-func ResolveLLMProviderOverride() (kind string, override bool) {
-	cfg, _ := Load()
-	kind = ResolveLLMProvider("")
-	override = cfg.LLMProviderUnlocked && strings.TrimSpace(cfg.LLMProvider) != ""
-	return kind, override
 }
 
 // ResolveLLMProvider resolves the active LLM provider for this run.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,23 @@ type Config struct {
 	WorkspaceID    string `json:"workspace_id,omitempty"`
 	WorkspaceSlug  string `json:"workspace_slug,omitempty"`
 	LLMProvider    string `json:"llm_provider,omitempty"`
+	// LLMProviderUnlocked toggles the global LLMProvider field between two
+	// semantically distinct modes:
+	//
+	//  - false (default, "locked"): LLMProvider is the default-runtime used at
+	//    agent-creation time and the fallback when an agent has no per-agent
+	//    binding. Existing per-agent ProviderBindings win on the dispatch path.
+	//
+	//  - true ("unlocked override"): LLMProvider is treated as a hard override
+	//    that wins over every per-agent binding on the dispatch path. The UI
+	//    surfaces this as a friction gate: the user must explicitly unlock the
+	//    global runtime setting to flip every current agent at once.
+	//
+	// The default (zero value) is deliberately "locked" so a fresh install
+	// never silently clobbers per-agent picks made through the AgentWizard or
+	// AgentProfilePanel runtime section. JSON encoded with omitempty so an
+	// untoggled install does not write a new field into existing config files.
+	LLMProviderUnlocked bool `json:"llm_provider_unlocked,omitempty"`
 	// LLMProviderPriority is an ordered list of provider identifiers (same
 	// vocabulary as LLMProvider — "claude-code", "codex", "opencode", etc.) that agents
 	// should try in order when picking a runtime. LLMProvider remains the
@@ -286,6 +303,26 @@ func MemoryBackendLabel(backend string) string {
 	default:
 		return "Local-only"
 	}
+}
+
+// ResolveLLMProviderOverride returns the install-wide provider together with a
+// "should override per-agent bindings" flag. The flag is true when the user
+// has unlocked the global runtime setting (Config.LLMProviderUnlocked) AND a
+// non-empty global provider is configured — that combination expresses the
+// explicit "stamp this runtime onto every agent" gesture.
+//
+// Callers on the dispatch path (provider.DefaultStreamFnResolver) check the
+// override flag first and skip per-agent kindResolver lookup when it's true.
+// UI callers (Settings panel, AgentProfilePanel) use it to render a "Locked
+// by global override" read-only state on per-agent runtime pickers.
+//
+// Flag/env overrides do not engage the lock — a transient WUPHF_LLM_PROVIDER
+// only changes the default fallback, not the per-agent precedence.
+func ResolveLLMProviderOverride() (kind string, override bool) {
+	cfg, _ := Load()
+	kind = ResolveLLMProvider("")
+	override = cfg.LLMProviderUnlocked && strings.TrimSpace(cfg.LLMProvider) != ""
+	return kind, override
 }
 
 // ResolveLLMProvider resolves the active LLM provider for this run.

--- a/internal/emoji/emoji.go
+++ b/internal/emoji/emoji.go
@@ -6,6 +6,6 @@ import "strings"
 func ToShortcode(s string) string {
 	s = strings.ReplaceAll(s, "🎉", ":tada:")
 	s = strings.ReplaceAll(s, "🚀", ":rocket:")
-	s = strings.ReplaceAll(s, "✅", ":check:")
+	s = strings.ReplaceAll(s, "✅", ":white_check_mark:")
 	return s
 }

--- a/internal/emoji/emoji.go
+++ b/internal/emoji/emoji.go
@@ -1,0 +1,11 @@
+package emoji
+
+import "strings"
+
+// ToShortcode replaces common emoji with their Slack-style shortcode equivalents.
+func ToShortcode(s string) string {
+	s = strings.ReplaceAll(s, "🎉", ":tada:")
+	s = strings.ReplaceAll(s, "🚀", ":rocket:")
+	s = strings.ReplaceAll(s, "✅", ":check:")
+	return s
+}

--- a/internal/emoji/emoji_test.go
+++ b/internal/emoji/emoji_test.go
@@ -1,0 +1,23 @@
+package emoji
+
+import "testing"
+
+func TestToShortcode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"🎉", ":tada:"},
+		{"🚀", ":rocket:"},
+		{"✅", ":check:"},
+		{"🎉 launch 🚀", ":tada: launch :rocket:"},
+		{"hello world", "hello world"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := ToShortcode(tt.input)
+		if got != tt.want {
+			t.Errorf("ToShortcode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/emoji/emoji_test.go
+++ b/internal/emoji/emoji_test.go
@@ -9,7 +9,7 @@ func TestToShortcode(t *testing.T) {
 	}{
 		{"🎉", ":tada:"},
 		{"🚀", ":rocket:"},
-		{"✅", ":check:"},
+		{"✅", ":white_check_mark:"},
 		{"🎉 launch 🚀", ":tada: launch :rocket:"},
 		{"hello world", "hello world"},
 		{"", ""},

--- a/internal/provider/binding.go
+++ b/internal/provider/binding.go
@@ -68,3 +68,18 @@ func ResolveKind(b ProviderBinding, global func() string) string {
 	}
 	return global()
 }
+
+// IsGatewayKind reports whether kind names a gateway-controlled binding rather
+// than a directly-dispatched LLM runtime. Gateway kinds (openclaw, openclaw-http,
+// hermes-agent) tag agents that were imported through an external gateway; they
+// are managed via the Integrations app, not via the Default Runtime picker.
+// Per-agent provider pickers should hide gateway kinds and surface a
+// "Managed by <Gateway>" badge instead.
+func IsGatewayKind(kind string) bool {
+	switch kind {
+	case KindOpenclaw, KindOpenclawHTTP, KindHermesAgent:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/provider/binding_test.go
+++ b/internal/provider/binding_test.go
@@ -109,3 +109,55 @@ func TestResolveKindFallsBackToGlobal(t *testing.T) {
 		t.Fatalf("explicit Kind should win, got %q", got)
 	}
 }
+
+func TestIsGatewayKind(t *testing.T) {
+	t.Parallel()
+	gateways := []string{KindOpenclaw, KindOpenclawHTTP, KindHermesAgent}
+	for _, k := range gateways {
+		if !IsGatewayKind(k) {
+			t.Errorf("IsGatewayKind(%q) = false, want true", k)
+		}
+	}
+	llms := []string{"", KindClaudeCode, KindCodex, KindOpencode, KindMLXLM, KindOllama, KindExo}
+	for _, k := range llms {
+		if IsGatewayKind(k) {
+			t.Errorf("IsGatewayKind(%q) = true, want false", k)
+		}
+	}
+}
+
+// TestLLMProviderKindsExcludesGateways locks in the picker-source contract:
+// every gateway-registered kind must be excluded from LLMProviderKinds, and
+// every directly-dispatchable LLM must be included. The picker-UIs read this
+// list verbatim — if it leaks "openclaw-http" the SettingsApp dropdown will
+// surface a gateway as a global default and the friction-gate purpose is lost.
+func TestLLMProviderKindsExcludesGateways(t *testing.T) {
+	t.Parallel()
+	llmKinds := LLMProviderKinds()
+	gateway := GatewayKinds()
+	inSet := func(s string, list []string) bool {
+		for _, v := range list {
+			if v == s {
+				return true
+			}
+		}
+		return false
+	}
+	for _, k := range gateway {
+		if inSet(k, llmKinds) {
+			t.Errorf("LLMProviderKinds leaked gateway kind %q: %v", k, llmKinds)
+		}
+	}
+	mustHave := []string{KindClaudeCode, KindCodex}
+	for _, k := range mustHave {
+		if !inSet(k, llmKinds) {
+			t.Errorf("LLMProviderKinds missing %q: %v", k, llmKinds)
+		}
+	}
+	mustGateway := []string{KindOpenclawHTTP, KindHermesAgent}
+	for _, k := range mustGateway {
+		if !inSet(k, gateway) {
+			t.Errorf("GatewayKinds missing %q: %v", k, gateway)
+		}
+	}
+}

--- a/internal/provider/binding_test.go
+++ b/internal/provider/binding_test.go
@@ -132,7 +132,10 @@ func TestIsGatewayKind(t *testing.T) {
 // list verbatim — if it leaks "openclaw-http" the SettingsApp dropdown will
 // surface a gateway as a global default and the friction-gate purpose is lost.
 func TestLLMProviderKindsExcludesGateways(t *testing.T) {
-	t.Parallel()
+	// Intentionally NOT t.Parallel(): LLMProviderKinds() and GatewayKinds()
+	// read the package-level registry, and another test that calls
+	// RegisterTemporary in parallel could mutate the registry between the
+	// two reads. Sequential execution is enough — the test is fast.
 	llmKinds := LLMProviderKinds()
 	gateway := GatewayKinds()
 	inSet := func(s string, list []string) bool {

--- a/internal/provider/claude_sessions.go
+++ b/internal/provider/claude_sessions.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -49,6 +50,27 @@ func ResetClaudeSessions() error {
 	claudeSessionStoreMu.Unlock()
 
 	return store.clearAll()
+}
+
+// ResetClaudeSessionFor clears the persisted Claude resume entry for a
+// single agent slug. Used after a per-agent provider switch so a slug that
+// just moved away from claude-code doesn't carry a stale Claude session id
+// into the new runtime — the next dispatch starts clean.
+//
+// Idempotent: clearing a slug with no recorded session is a no-op.
+func ResetClaudeSessionFor(agentSlug string) {
+	if strings.TrimSpace(agentSlug) == "" {
+		return
+	}
+	claudeSessionStoreMu.Lock()
+	store := claudeSessionStoreInstance
+	if store == nil {
+		store = claudeSessionStoreFactory()
+		claudeSessionStoreInstance = store
+	}
+	claudeSessionStoreMu.Unlock()
+
+	store.clear(agentSlug)
 }
 
 func newClaudeSessionStore() *claudeSessionStore {

--- a/internal/provider/claude_sessions_test.go
+++ b/internal/provider/claude_sessions_test.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestResetClaudeSessionFor_ClearsOnlyTargetSlug locks in the per-slug
+// reset hand-off used by the per-agent runtime picker. Switching one agent
+// from claude-code to codex must not clobber another agent's resume id —
+// they're independent dispatches that just happen to share the same store.
+func TestResetClaudeSessionFor_ClearsOnlyTargetSlug(t *testing.T) {
+	// Isolate the store to a temp file so this test doesn't read or write
+	// the developer's real ~/.wuphf/providers/claude-sessions.json.
+	prev := claudeSessionStoreFactory
+	tmp := filepath.Join(t.TempDir(), "claude-sessions.json")
+	claudeSessionStoreFactory = func() *claudeSessionStore {
+		return newClaudeSessionStoreAt(tmp)
+	}
+	t.Cleanup(func() {
+		claudeSessionStoreMu.Lock()
+		claudeSessionStoreInstance = nil
+		claudeSessionStoreMu.Unlock()
+		claudeSessionStoreFactory = prev
+	})
+	// Re-init the singleton against the temp factory.
+	claudeSessionStoreMu.Lock()
+	claudeSessionStoreInstance = nil
+	claudeSessionStoreMu.Unlock()
+	store := getClaudeSessionStore()
+
+	store.save("outreach", "sess-outreach", "/cwd")
+	store.save("eng", "sess-eng", "/cwd")
+
+	ResetClaudeSessionFor("outreach")
+
+	if got := store.resumeSessionID("outreach", "/cwd"); got != "" {
+		t.Errorf("outreach resume id should be cleared, got %q", got)
+	}
+	if got := store.resumeSessionID("eng", "/cwd"); got != "sess-eng" {
+		t.Errorf("eng resume id should be untouched, got %q", got)
+	}
+}
+
+// TestResetClaudeSessionFor_IdempotentOnUnknownSlug locks in the contract
+// the broker relies on: provider switches publish member_updated events
+// for any field change (name, role, runtime). The launcher calls
+// ResetClaudeSessionFor unconditionally; on a no-runtime-change event
+// (e.g. rename) the slug may not even have a stored session.
+func TestResetClaudeSessionFor_IdempotentOnUnknownSlug(t *testing.T) {
+	prev := claudeSessionStoreFactory
+	tmp := filepath.Join(t.TempDir(), "claude-sessions.json")
+	claudeSessionStoreFactory = func() *claudeSessionStore {
+		return newClaudeSessionStoreAt(tmp)
+	}
+	t.Cleanup(func() {
+		claudeSessionStoreMu.Lock()
+		claudeSessionStoreInstance = nil
+		claudeSessionStoreMu.Unlock()
+		claudeSessionStoreFactory = prev
+	})
+	claudeSessionStoreMu.Lock()
+	claudeSessionStoreInstance = nil
+	claudeSessionStoreMu.Unlock()
+
+	// No save first — clearing an unknown slug must not panic or error.
+	ResetClaudeSessionFor("never-seen")
+	// Empty slug must short-circuit instead of corrupting the store.
+	ResetClaudeSessionFor("")
+}

--- a/internal/provider/hermes_agent.go
+++ b/internal/provider/hermes_agent.go
@@ -16,6 +16,7 @@ func init() {
 		Capabilities: Capabilities{
 			PaneEligible:    false,
 			SupportsOneShot: false,
+			GatewayOnly:     true,
 		},
 	})
 }

--- a/internal/provider/openclaw_http.go
+++ b/internal/provider/openclaw_http.go
@@ -17,6 +17,7 @@ func init() {
 		Capabilities: Capabilities{
 			PaneEligible:    false,
 			SupportsOneShot: false,
+			GatewayOnly:     true,
 		},
 	})
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -30,6 +31,15 @@ type Capabilities struct {
 	// default away from this provider should also wipe the Claude session
 	// store. Today only Claude Code populates that store.
 	RequiresClaudeSessionReset bool
+
+	// GatewayOnly reports whether this kind is a gateway-controlled binding
+	// (OpenClaw, Hermes) rather than a directly-runnable LLM runtime. Gateway
+	// kinds are dispatched the same way at the StreamFn layer but are
+	// managed via the Integrations app — they never appear in the global
+	// "Default Runtime" picker or in per-agent provider pickers. Register
+	// skips config.AllowLLMProviderKind when GatewayOnly is true so the
+	// kind cannot be selected as an install-wide default.
+	GatewayOnly bool
 }
 
 // Entry is a registered provider's runtime hooks plus its capabilities.
@@ -76,7 +86,9 @@ func Register(e *Entry) {
 		panic(fmt.Sprintf("provider: Kind %q already registered", e.Kind))
 	}
 	registry[e.Kind] = e
-	config.AllowLLMProviderKind(e.Kind)
+	if !e.Capabilities.GatewayOnly {
+		config.AllowLLMProviderKind(e.Kind)
+	}
 }
 
 // RegisterTemporary installs e and returns a restore function. It is intended
@@ -96,7 +108,9 @@ func RegisterTemporary(e *Entry) func() {
 	prev, hadPrev := registry[e.Kind]
 	registry[e.Kind] = e
 	registryMu.Unlock()
-	config.AllowLLMProviderKind(e.Kind)
+	if !e.Capabilities.GatewayOnly {
+		config.AllowLLMProviderKind(e.Kind)
+	}
 	return func() {
 		registryMu.Lock()
 		defer registryMu.Unlock()
@@ -116,6 +130,46 @@ func Lookup(kind string) *Entry {
 	registryMu.RLock()
 	defer registryMu.RUnlock()
 	return registry[kind]
+}
+
+// LLMProviderKinds returns the sorted set of registered, non-gateway provider
+// kinds — the runtimes a user can pick as a directly-dispatched LLM (Claude
+// Code, Codex, Opencode, MLX-LM, Ollama, Exo). Gateway kinds (OpenClaw, Hermes)
+// are excluded because they represent agents imported through an external
+// gateway and are managed via the Integrations app, not the runtime picker.
+//
+// UI consumers (Settings default-runtime dropdown, AgentProfilePanel runtime
+// picker, AgentWizard provider field) should read this list to keep gateway
+// kinds out of provider selection surfaces.
+func LLMProviderKinds() []string {
+	registryMu.RLock()
+	out := make([]string, 0, len(registry))
+	for k, e := range registry {
+		if e.Capabilities.GatewayOnly {
+			continue
+		}
+		out = append(out, k)
+	}
+	registryMu.RUnlock()
+	sort.Strings(out)
+	return out
+}
+
+// GatewayKinds returns the sorted set of registered gateway-only kinds — the
+// inverse of LLMProviderKinds. Used by the Integrations app to enumerate which
+// gateways are compiled in.
+func GatewayKinds() []string {
+	registryMu.RLock()
+	out := make([]string, 0, len(registry))
+	for k, e := range registry {
+		if !e.Capabilities.GatewayOnly {
+			continue
+		}
+		out = append(out, k)
+	}
+	registryMu.RUnlock()
+	sort.Strings(out)
+	return out
 }
 
 // CapabilitiesFor returns the capabilities for kind, or the zero value if

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -15,47 +15,32 @@ type ProviderKindResolver func(agentSlug string) string
 // DefaultStreamFnResolver returns a StreamFnResolver that picks a provider's
 // StreamFn factory by Kind. Resolution order:
 //
-//  1. If the global runtime is unlocked (Config.LLMProviderUnlocked) AND a
-//     non-empty global provider is configured, the install-wide kind wins
-//     over every per-agent binding. This is the explicit "stamp this runtime
-//     onto every agent" gesture from the Settings panel.
-//  2. Otherwise, per-agent kind from kindResolver (if non-nil and non-empty).
-//  3. Otherwise, install-wide kind from config.ResolveLLMProvider (the
-//     default-for-new-agents fallback when an agent has no binding).
-//  4. Claude Code (default fallback for unknown / unregistered Kinds).
+//  1. Per-agent kind from kindResolver (if non-nil and returns non-empty).
+//     This is always honored — the global runtime never overrides an
+//     existing agent's per-agent binding.
+//  2. Install-wide kind from config.ResolveLLMProvider — the
+//     default-for-new-agents fallback used at agent creation time and
+//     when an agent has no per-agent binding.
+//  3. Claude Code (default fallback for unknown / unregistered Kinds).
 //
 // kindResolver is what makes per-agent ProviderBindings (an Ollama agent
 // alongside Claude agents in the same team) actually take effect on the
 // streaming dispatch path. Pass nil to use only the install-wide default.
 //
 // Config is re-read on each call so runtime provider changes (e.g., a /provider
-// switch from the TUI, an unlock/lock toggle in Settings) take effect on the
-// next agent turn without restart.
-//
-// Gateway-controlled bindings (OpenClaw, Hermes) are not affected by step (1):
-// kindResolver still wins for those agents because the gateway needs the
-// matching transport to talk to the imported runtime. The override only
-// stamps onto agents whose per-agent kind is itself non-gateway (or empty).
+// switch from the TUI) take effect on the next agent turn without restart.
+// The install-wide LLMProvider is intentionally a default-for-new-agents
+// only — changing it never replays through existing agents' bindings. To
+// change an existing agent's runtime, edit it through the AgentProfilePanel.
 func DefaultStreamFnResolver(client *api.Client, kindResolver ProviderKindResolver) agent.StreamFnResolver {
 	// TODO: thread client into provider-specific StreamFn factories (see issue #186).
 	return func(agentSlug string) agent.StreamFn {
-		globalKind, override := config.ResolveLLMProviderOverride()
-		var perAgentKind string
+		var kind string
 		if kindResolver != nil {
-			perAgentKind = kindResolver(agentSlug)
+			kind = kindResolver(agentSlug)
 		}
-		// Step 1: unlocked global override wins, but never displaces a
-		// gateway binding (the gateway transport is load-bearing for
-		// agents imported through OpenClaw / Hermes).
-		if override && !IsGatewayKind(perAgentKind) {
-			if e := Lookup(globalKind); e != nil {
-				return e.StreamFn(agentSlug)
-			}
-		}
-		// Steps 2-3: per-agent first, then global default.
-		kind := perAgentKind
 		if kind == "" {
-			kind = globalKind
+			kind = config.ResolveLLMProvider("")
 		}
 		if e := Lookup(kind); e != nil {
 			return e.StreamFn(agentSlug)

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -15,25 +15,47 @@ type ProviderKindResolver func(agentSlug string) string
 // DefaultStreamFnResolver returns a StreamFnResolver that picks a provider's
 // StreamFn factory by Kind. Resolution order:
 //
-//  1. Per-agent kind from kindResolver (if non-nil and returns non-empty)
-//  2. Install-wide kind from config.ResolveLLMProvider
-//  3. Claude Code (default fallback for unknown / unregistered Kinds)
+//  1. If the global runtime is unlocked (Config.LLMProviderUnlocked) AND a
+//     non-empty global provider is configured, the install-wide kind wins
+//     over every per-agent binding. This is the explicit "stamp this runtime
+//     onto every agent" gesture from the Settings panel.
+//  2. Otherwise, per-agent kind from kindResolver (if non-nil and non-empty).
+//  3. Otherwise, install-wide kind from config.ResolveLLMProvider (the
+//     default-for-new-agents fallback when an agent has no binding).
+//  4. Claude Code (default fallback for unknown / unregistered Kinds).
 //
 // kindResolver is what makes per-agent ProviderBindings (an Ollama agent
 // alongside Claude agents in the same team) actually take effect on the
 // streaming dispatch path. Pass nil to use only the install-wide default.
 //
 // Config is re-read on each call so runtime provider changes (e.g., a /provider
-// switch from the TUI) take effect on the next agent turn without restart.
+// switch from the TUI, an unlock/lock toggle in Settings) take effect on the
+// next agent turn without restart.
+//
+// Gateway-controlled bindings (OpenClaw, Hermes) are not affected by step (1):
+// kindResolver still wins for those agents because the gateway needs the
+// matching transport to talk to the imported runtime. The override only
+// stamps onto agents whose per-agent kind is itself non-gateway (or empty).
 func DefaultStreamFnResolver(client *api.Client, kindResolver ProviderKindResolver) agent.StreamFnResolver {
 	// TODO: thread client into provider-specific StreamFn factories (see issue #186).
 	return func(agentSlug string) agent.StreamFn {
-		var kind string
+		globalKind, override := config.ResolveLLMProviderOverride()
+		var perAgentKind string
 		if kindResolver != nil {
-			kind = kindResolver(agentSlug)
+			perAgentKind = kindResolver(agentSlug)
 		}
+		// Step 1: unlocked global override wins, but never displaces a
+		// gateway binding (the gateway transport is load-bearing for
+		// agents imported through OpenClaw / Hermes).
+		if override && !IsGatewayKind(perAgentKind) {
+			if e := Lookup(globalKind); e != nil {
+				return e.StreamFn(agentSlug)
+			}
+		}
+		// Steps 2-3: per-agent first, then global default.
+		kind := perAgentKind
 		if kind == "" {
-			kind = config.ResolveLLMProvider("")
+			kind = globalKind
 		}
 		if e := Lookup(kind); e != nil {
 			return e.StreamFn(agentSlug)

--- a/internal/team/broker_config_provider_endpoints_test.go
+++ b/internal/team/broker_config_provider_endpoints_test.go
@@ -403,9 +403,8 @@ func TestHandleConfig_ProviderEndpointsAllowsOpenclawHTTPRuntime(t *testing.T) {
 
 // TestHandleConfig_ExposesGatewayAndLLMSplit locks in the wire shape the
 // frontend's Settings + Integrations apps depend on: the GET response must
-// expose llm_provider_kinds (non-gateway runtimes for the global picker) and
-// gateway_kinds (Integrations app cards) as separate lists, plus a boolean
-// llm_provider_unlocked that mirrors the friction-gate state.
+// expose llm_provider_kinds (non-gateway runtimes for the global picker)
+// and gateway_kinds (Integrations app cards) as separate lists.
 //
 // Without these on the wire, the Settings UI cannot tell which kinds are
 // safe to show in the default-runtime dropdown and the Integrations app
@@ -456,49 +455,4 @@ func TestHandleConfig_ExposesGatewayAndLLMSplit(t *testing.T) {
 	expectIn("hermes-agent", gatewayKinds, true)
 	expectIn("openclaw-http", gatewayKinds, true)
 	expectIn("claude-code", gatewayKinds, false)
-
-	// llm_provider_unlocked default = false (locked) — the safe default that
-	// keeps per-agent picks intact on a fresh install.
-	if unlocked, _ := got["llm_provider_unlocked"].(bool); unlocked {
-		t.Errorf("llm_provider_unlocked default = true, want false (locked)")
-	}
-}
-
-// TestHandleConfig_LLMProviderUnlockedRoundTrips locks in the POST shape:
-// setting llm_provider_unlocked=true persists, and GET reflects the new state.
-// This is what the Settings panel's lock toggle writes.
-func TestHandleConfig_LLMProviderUnlockedRoundTrips(t *testing.T) {
-	withWuphfHomeDir(t)
-	t.Setenv("WUPHF_LLM_PROVIDER", "")
-	b := newTestBroker(t)
-
-	if rec := configRequest(t, b, http.MethodPost, `{"llm_provider_unlocked":true}`); rec.Code != http.StatusOK {
-		t.Fatalf("POST: %d %s", rec.Code, rec.Body.String())
-	}
-	cfg, _ := config.Load()
-	if !cfg.LLMProviderUnlocked {
-		t.Errorf("LLMProviderUnlocked not persisted: cfg.LLMProviderUnlocked=%v", cfg.LLMProviderUnlocked)
-	}
-
-	rec := configRequest(t, b, http.MethodGet, "")
-	if rec.Code != http.StatusOK {
-		t.Fatalf("GET: %d %s", rec.Code, rec.Body.String())
-	}
-	var got map[string]any
-	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-	if unlocked, _ := got["llm_provider_unlocked"].(bool); !unlocked {
-		t.Errorf("GET llm_provider_unlocked = false after POST true")
-	}
-
-	// Re-lock; the inverse must also round-trip so the user can re-engage
-	// the friction gate after a stamp.
-	if rec := configRequest(t, b, http.MethodPost, `{"llm_provider_unlocked":false}`); rec.Code != http.StatusOK {
-		t.Fatalf("POST relock: %d %s", rec.Code, rec.Body.String())
-	}
-	cfg, _ = config.Load()
-	if cfg.LLMProviderUnlocked {
-		t.Errorf("LLMProviderUnlocked not cleared on relock: %v", cfg.LLMProviderUnlocked)
-	}
 }

--- a/internal/team/broker_config_provider_endpoints_test.go
+++ b/internal/team/broker_config_provider_endpoints_test.go
@@ -400,3 +400,105 @@ func TestHandleConfig_ProviderEndpointsAllowsOpenclawHTTPRuntime(t *testing.T) {
 		t.Fatalf("expected 200 for provider_endpoints[openclaw-http], got %d %s", rec.Code, rec.Body.String())
 	}
 }
+
+// TestHandleConfig_ExposesGatewayAndLLMSplit locks in the wire shape the
+// frontend's Settings + Integrations apps depend on: the GET response must
+// expose llm_provider_kinds (non-gateway runtimes for the global picker) and
+// gateway_kinds (Integrations app cards) as separate lists, plus a boolean
+// llm_provider_unlocked that mirrors the friction-gate state.
+//
+// Without these on the wire, the Settings UI cannot tell which kinds are
+// safe to show in the default-runtime dropdown and the Integrations app
+// cannot enumerate which gateways are compiled in.
+func TestHandleConfig_ExposesGatewayAndLLMSplit(t *testing.T) {
+	withWuphfHomeDir(t)
+	t.Setenv("WUPHF_LLM_PROVIDER", "")
+	b := newTestBroker(t)
+
+	rec := configRequest(t, b, http.MethodGet, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	llmKinds, ok := got["llm_provider_kinds"].([]any)
+	if !ok {
+		t.Fatalf("llm_provider_kinds missing or wrong type: %T", got["llm_provider_kinds"])
+	}
+	gatewayKinds, ok := got["gateway_kinds"].([]any)
+	if !ok {
+		t.Fatalf("gateway_kinds missing or wrong type: %T", got["gateway_kinds"])
+	}
+
+	// The non-gateway list must include the directly-dispatchable kinds and
+	// must NOT include the gateway-only kinds. The gateway list is the
+	// inverse — that's the whole point of the split.
+	expectIn := func(name string, list []any, want bool) {
+		t.Helper()
+		found := false
+		for _, v := range list {
+			if s, _ := v.(string); s == name {
+				found = true
+				break
+			}
+		}
+		if found != want {
+			t.Errorf("kind %q in %v: got %v, want %v", name, list, found, want)
+		}
+	}
+	expectIn("claude-code", llmKinds, true)
+	expectIn("codex", llmKinds, true)
+	expectIn("hermes-agent", llmKinds, false)
+	expectIn("openclaw-http", llmKinds, false)
+	expectIn("hermes-agent", gatewayKinds, true)
+	expectIn("openclaw-http", gatewayKinds, true)
+	expectIn("claude-code", gatewayKinds, false)
+
+	// llm_provider_unlocked default = false (locked) — the safe default that
+	// keeps per-agent picks intact on a fresh install.
+	if unlocked, _ := got["llm_provider_unlocked"].(bool); unlocked {
+		t.Errorf("llm_provider_unlocked default = true, want false (locked)")
+	}
+}
+
+// TestHandleConfig_LLMProviderUnlockedRoundTrips locks in the POST shape:
+// setting llm_provider_unlocked=true persists, and GET reflects the new state.
+// This is what the Settings panel's lock toggle writes.
+func TestHandleConfig_LLMProviderUnlockedRoundTrips(t *testing.T) {
+	withWuphfHomeDir(t)
+	t.Setenv("WUPHF_LLM_PROVIDER", "")
+	b := newTestBroker(t)
+
+	if rec := configRequest(t, b, http.MethodPost, `{"llm_provider_unlocked":true}`); rec.Code != http.StatusOK {
+		t.Fatalf("POST: %d %s", rec.Code, rec.Body.String())
+	}
+	cfg, _ := config.Load()
+	if !cfg.LLMProviderUnlocked {
+		t.Errorf("LLMProviderUnlocked not persisted: cfg.LLMProviderUnlocked=%v", cfg.LLMProviderUnlocked)
+	}
+
+	rec := configRequest(t, b, http.MethodGet, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET: %d %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if unlocked, _ := got["llm_provider_unlocked"].(bool); !unlocked {
+		t.Errorf("GET llm_provider_unlocked = false after POST true")
+	}
+
+	// Re-lock; the inverse must also round-trip so the user can re-engage
+	// the friction gate after a stamp.
+	if rec := configRequest(t, b, http.MethodPost, `{"llm_provider_unlocked":false}`); rec.Code != http.StatusOK {
+		t.Fatalf("POST relock: %d %s", rec.Code, rec.Body.String())
+	}
+	cfg, _ = config.Load()
+	if cfg.LLMProviderUnlocked {
+		t.Errorf("LLMProviderUnlocked not cleared on relock: %v", cfg.LLMProviderUnlocked)
+	}
+}

--- a/internal/team/broker_messages.go
+++ b/internal/team/broker_messages.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/emoji"
 )
 
 func (b *Broker) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -464,7 +466,7 @@ func (b *Broker) PostMessage(from, channel, content string, tagged []string, rep
 		Channel:   channel,
 		Kind:      "",
 		Title:     "",
-		Content:   strings.TrimSpace(content),
+		Content:   emoji.ToShortcode(strings.TrimSpace(content)),
 		Tagged:    uniqueSlugs(tagged),
 		ReplyTo:   strings.TrimSpace(replyTo),
 		Timestamp: time.Now().UTC().Format(time.RFC3339),

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -15,6 +15,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/nex"
+	"github.com/nex-crm/wuphf/internal/provider"
 )
 
 func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
@@ -150,14 +151,32 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			"llm_provider":            config.ResolveLLMProvider(""),
 			"llm_provider_configured": llmProviderConfigured,
 			"llm_provider_priority":   cfg.LLMProviderPriority,
-			"provider_endpoints":      cfg.ProviderEndpoints,
-			"memory_backend":          config.ResolveMemoryBackend(""),
-			"action_provider":         config.ResolveActionProvider(),
-			"team_lead_slug":          cfg.TeamLeadSlug,
-			"max_concurrent_agents":   cfg.MaxConcurrent,
-			"default_format":          config.ResolveFormat(""),
-			"default_timeout":         config.ResolveTimeout(""),
-			"blueprint":               cfg.ActiveBlueprint(),
+			// llm_provider_unlocked surfaces the friction-gate state of the
+			// install-wide LLMProvider. Default (false = locked) means the
+			// global field acts as a default-for-new-agents and a fallback
+			// for agents without a per-agent binding. When true the global
+			// kind overrides every per-agent binding on the dispatch path —
+			// the UI must show a clear warning before letting the user flip
+			// it. See config.LLMProviderUnlocked for the full contract.
+			"llm_provider_unlocked": cfg.LLMProviderUnlocked,
+			// llm_provider_kinds is the non-gateway subset of the registered
+			// provider runtimes — the safe set to render in any UI runtime
+			// picker (Settings default-runtime, AgentProfilePanel runtime
+			// section, AgentWizard provider field). Gateway kinds (openclaw,
+			// hermes-agent) are excluded; the Integrations app surfaces them.
+			"llm_provider_kinds": provider.LLMProviderKinds(),
+			// gateway_kinds is the inverse — registered kinds that are
+			// gateway-controlled. Consumed by the Integrations app to
+			// enumerate which gateways are compiled in and connectable.
+			"gateway_kinds":         provider.GatewayKinds(),
+			"provider_endpoints":    cfg.ProviderEndpoints,
+			"memory_backend":        config.ResolveMemoryBackend(""),
+			"action_provider":       config.ResolveActionProvider(),
+			"team_lead_slug":        cfg.TeamLeadSlug,
+			"max_concurrent_agents": cfg.MaxConcurrent,
+			"default_format":        config.ResolveFormat(""),
+			"default_timeout":       config.ResolveTimeout(""),
+			"blueprint":             cfg.ActiveBlueprint(),
 			// Workspace
 			"email":          cfg.Email,
 			"workspace_id":   cfg.WorkspaceID,
@@ -195,6 +214,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		defer b.configMu.Unlock()
 		var body struct {
 			LLMProvider         *string   `json:"llm_provider,omitempty"`
+			LLMProviderUnlocked *bool     `json:"llm_provider_unlocked,omitempty"`
 			LLMProviderPriority *[]string `json:"llm_provider_priority,omitempty"`
 			MemoryBackend       *string   `json:"memory_backend,omitempty"`
 			ActionProvider      *string   `json:"action_provider,omitempty"`
@@ -314,6 +334,15 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		// provider override.
 		if llmProviderSet {
 			cfg.LLMProvider = llmProvider
+			changed = true
+		}
+		// llm_provider_unlocked is a pure boolean toggle. The friction-gate
+		// semantics (read-only-while-locked, requires explicit unlock to
+		// override per-agent bindings) live in the UI — the broker just
+		// persists what the client sent and the resolver consults the flag
+		// at dispatch time via config.ResolveLLMProviderOverride.
+		if body.LLMProviderUnlocked != nil {
+			cfg.LLMProviderUnlocked = *body.LLMProviderUnlocked
 			changed = true
 		}
 		if body.LLMProviderPriority != nil {
@@ -476,14 +505,23 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 				if k == "" {
 					continue
 				}
-				// provider_endpoints keys must be runnable global LLM
-				// kinds (mlx-lm/ollama/exo/claude-code/codex/...) —
-				// openclaw, while a valid per-member binding, has no
-				// HTTP base_url + model concept and must not get a row
-				// in this map.
-				if !config.IsLLMProviderKindAllowed(k) {
+				// provider_endpoints keys must be registered runtime kinds
+				// — that includes both directly-dispatchable LLMs
+				// (claude-code/codex/opencode/mlx-lm/ollama/exo) and
+				// gateway-controlled HTTP runtimes (openclaw-http,
+				// hermes-agent) whose base_url + model the operator may
+				// legitimately want to override. The legacy openclaw
+				// bridge kind has no Register entry (it dispatches via
+				// the WebSocket bridge, not /v1/chat/completions) so
+				// provider.Lookup returns nil and the request is rejected.
+				//
+				// Using provider.Lookup (registry membership) instead of
+				// config.IsLLMProviderKindAllowed (non-gateway subset) is
+				// deliberate: the gateway/non-gateway split lives in the
+				// picker UIs, not in the endpoint-configuration surface.
+				if provider.Lookup(k) == nil {
 					http.Error(w, "unsupported provider_endpoints kind: "+strconv.Quote(k)+
-						" (allowed: "+strings.Join(config.AllowedLLMProviderKinds(), ", ")+")",
+						" (must be a registered runtime kind)",
 						http.StatusBadRequest)
 					return
 				}

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -150,15 +150,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			// Runtime
 			"llm_provider":            config.ResolveLLMProvider(""),
 			"llm_provider_configured": llmProviderConfigured,
-			"llm_provider_priority":   cfg.LLMProviderPriority,
-			// llm_provider_unlocked surfaces the friction-gate state of the
-			// install-wide LLMProvider. Default (false = locked) means the
-			// global field acts as a default-for-new-agents and a fallback
-			// for agents without a per-agent binding. When true the global
-			// kind overrides every per-agent binding on the dispatch path —
-			// the UI must show a clear warning before letting the user flip
-			// it. See config.LLMProviderUnlocked for the full contract.
-			"llm_provider_unlocked": cfg.LLMProviderUnlocked,
+			"llm_provider_priority": cfg.LLMProviderPriority,
 			// llm_provider_kinds is the non-gateway subset of the registered
 			// provider runtimes — the safe set to render in any UI runtime
 			// picker (Settings default-runtime, AgentProfilePanel runtime
@@ -214,7 +206,6 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		defer b.configMu.Unlock()
 		var body struct {
 			LLMProvider         *string   `json:"llm_provider,omitempty"`
-			LLMProviderUnlocked *bool     `json:"llm_provider_unlocked,omitempty"`
 			LLMProviderPriority *[]string `json:"llm_provider_priority,omitempty"`
 			MemoryBackend       *string   `json:"memory_backend,omitempty"`
 			ActionProvider      *string   `json:"action_provider,omitempty"`
@@ -334,15 +325,6 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		// provider override.
 		if llmProviderSet {
 			cfg.LLMProvider = llmProvider
-			changed = true
-		}
-		// llm_provider_unlocked is a pure boolean toggle. The friction-gate
-		// semantics (read-only-while-locked, requires explicit unlock to
-		// override per-agent bindings) live in the UI — the broker just
-		// persists what the client sent and the resolver consults the flag
-		// at dispatch time via config.ResolveLLMProviderOverride.
-		if body.LLMProviderUnlocked != nil {
-			cfg.LLMProviderUnlocked = *body.LLMProviderUnlocked
 			changed = true
 		}
 		if body.LLMProviderPriority != nil {

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -150,7 +150,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			// Runtime
 			"llm_provider":            config.ResolveLLMProvider(""),
 			"llm_provider_configured": llmProviderConfigured,
-			"llm_provider_priority": cfg.LLMProviderPriority,
+			"llm_provider_priority":   cfg.LLMProviderPriority,
 			// llm_provider_kinds is the non-gateway subset of the registered
 			// provider runtimes — the safe set to render in any UI runtime
 			// picker (Settings default-runtime, AgentProfilePanel runtime

--- a/internal/team/broker_office_members.go
+++ b/internal/team/broker_office_members.go
@@ -495,6 +495,21 @@ func (b *Broker) updateOfficeMember(r *http.Request, slug string, body officeMem
 	}
 	responseMember := *member
 	b.mu.Unlock()
+	// Provider-switch hand-off: when the user reroutes an existing agent to a
+	// new runtime, the old runtime's per-agent state must not leak into the
+	// new one. The Claude session store keeps a resume id keyed by slug —
+	// reading that on the next turn would attempt to resume a dead
+	// conversation on a runtime that no longer owns it. Clear it
+	// unconditionally on a provider change (idempotent if the slug has no
+	// stored session) so the next dispatch starts clean.
+	//
+	// OpenClaw transitions are handled separately above (attach/detach the
+	// gateway subscription). Pane teardown for switches off claude-code is
+	// the launcher's job — it sees the same member_updated event we publish
+	// below and reconciles via reconcileMemberRuntime in launcher_reconfigure.
+	if providerChanged && oldBinding.Kind != newBinding.Kind {
+		provider.ResetClaudeSessionFor(slug)
+	}
 	// Match the create/remove paths so SSE subscribers learn about updated
 	// member metadata (provider switch, name changes, channel reassignment)
 	// instead of waiting for a full reload.

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -267,6 +267,28 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 }
 
 func (l *Launcher) headlessClaudeModel(slug string) string {
+	// Per-agent override wins: when the user picks a specific model in the
+	// AgentProfilePanel runtime section (or AgentWizard), that's the
+	// model the next dispatch must use. Without this check the picker
+	// silently rewrote ProviderBinding.Model but every turn still ran
+	// against the hardcoded default — the user-visible symptom was
+	// "I picked a different model and nothing changed."
+	//
+	// The per-agent binding is only consulted when its kind is also
+	// claude-code: if a user moved the agent to codex with model=gpt-4o,
+	// we must not feed gpt-4o to claude on a later switch back. The
+	// runtime-switch flow clears the binding entirely on kind change
+	// (see AgentProfilePanel save path), so the most common edge cases
+	// are already prevented at the source, but the kind check here is
+	// belt-and-suspenders.
+	if l != nil && l.broker != nil {
+		binding := l.broker.MemberProviderBinding(slug)
+		if binding.Kind == "claude-code" {
+			if model := strings.TrimSpace(binding.Model); model != "" {
+				return model
+			}
+		}
+	}
 	if l.opusCEO && slug == l.targeter().LeadSlug() {
 		return "claude-opus-4-6"
 	}

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -289,8 +289,13 @@ func (l *Launcher) headlessClaudeModel(slug string) string {
 			}
 		}
 	}
+	// Anthropic family default (verified 2026-05-29). The lead falls back
+	// to the top opus tier when --opus-ceo is on; everyone else gets the
+	// best-balanced sonnet. claude-opus-4-6 (the previous default here)
+	// is still available but no longer the recommended pick — see
+	// https://platform.claude.com/docs/en/docs/about-claude/models.
 	if l.opusCEO && slug == l.targeter().LeadSlug() {
-		return "claude-opus-4-6"
+		return "claude-opus-4-8"
 	}
 	return "claude-sonnet-4-6"
 }

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -55,7 +55,7 @@ func TestHeadlessClaudeModel_OpusForLeadOnly(t *testing.T) {
 		slug string
 		want string
 	}{
-		{"ceo", "claude-opus-4-6"},
+		{"ceo", "claude-opus-4-8"},
 		{"eng", "claude-sonnet-4-6"},
 		{"pm", "claude-sonnet-4-6"},
 	}
@@ -92,7 +92,7 @@ func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
 		slug string
 		want string
 	}{
-		{"captain", "claude-opus-4-6"},
+		{"captain", "claude-opus-4-8"},
 		{"crew", "claude-sonnet-4-6"},
 	}
 	for _, tc := range tests {

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
 )
 
 // minimalLauncher builds a Launcher with a predictable two-member pack so
@@ -99,6 +100,75 @@ func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
 		t.Run(tc.slug, func(t *testing.T) {
 			if got := l.headlessClaudeModel(tc.slug); got != tc.want {
 				t.Fatalf("slug=%q: want %q, got %q", tc.slug, tc.want, got)
+			}
+		})
+	}
+}
+
+// TestHeadlessClaudeModel_PerAgentBindingOverride covers the broker-driven
+// override path that ships with the AgentProfilePanel runtime picker. When
+// a member has ProviderBinding{Kind: "claude-code", Model: "<custom>"},
+// the next claude turn must dispatch against <custom>, not the hardcoded
+// opus/sonnet default. The kind guard also matters: a stale Model left
+// over from a brief codex sojourn must NOT be fed to claude on a
+// switch-back.
+//
+// Three cases:
+//
+//  1. positive: Kind=claude-code, Model=non-empty → returns the bound model.
+//  2. negative: Kind=codex with a non-empty Model → ignores the binding and
+//     falls back to the default (codex models are not claude-routable).
+//  3. negative: Kind=claude-code with an empty Model → falls back to the
+//     default. The picker writes empty when the user selects "Use runtime
+//     default" and the default must take effect.
+func TestHeadlessClaudeModel_PerAgentBindingOverride(t *testing.T) {
+	makeBoundLauncher := func(t *testing.T, slug string, binding provider.ProviderBinding) *Launcher {
+		t.Helper()
+		b := newTestBroker(t)
+		b.mu.Lock()
+		b.members = append(b.members, officeMember{
+			Slug:     slug,
+			Name:     slug,
+			Provider: binding,
+		})
+		b.memberIndex = nil
+		b.mu.Unlock()
+		l := minimalLauncher(false)
+		l.broker = b
+		return l
+	}
+
+	tests := []struct {
+		name    string
+		slug    string
+		binding provider.ProviderBinding
+		want    string
+	}{
+		{
+			name:    "claude_code_with_model_uses_binding",
+			slug:    "eng",
+			binding: provider.ProviderBinding{Kind: "claude-code", Model: "claude-opus-4-7"},
+			want:    "claude-opus-4-7",
+		},
+		{
+			name:    "non_claude_kind_falls_back_to_default",
+			slug:    "eng",
+			binding: provider.ProviderBinding{Kind: "codex", Model: "gpt-5.5"},
+			want:    "claude-sonnet-4-6",
+		},
+		{
+			name:    "claude_code_empty_model_falls_back_to_default",
+			slug:    "eng",
+			binding: provider.ProviderBinding{Kind: "claude-code", Model: ""},
+			want:    "claude-sonnet-4-6",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			l := makeBoundLauncher(t, tc.slug, tc.binding)
+			if got := l.headlessClaudeModel(tc.slug); got != tc.want {
+				t.Fatalf("headlessClaudeModel(%q) with binding %+v = %q, want %q",
+					tc.slug, tc.binding, got, tc.want)
 			}
 		})
 	}

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -66,7 +66,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		"--color", "never",
 		"--json",
 	)
-	if model := strings.TrimSpace(config.ResolveCodexModel(l.cwd)); model != "" {
+	if model := strings.TrimSpace(l.codexModelForAgent(slug)); model != "" {
 		args = append(args, "--model", model)
 	}
 	for _, override := range overrides {
@@ -277,7 +277,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	emitHeadlessTerminalWithTurn(agentStream, turnID, HeadlessProviderCodex, slug, taskID, summary, "", metrics, codexUsageToTokenUsage(result.Usage))
 	emitHeadlessManifest(agentStream, turnID, HeadlessProviderCodex, slug, taskID, "", turnToolNames, turnTextLen, metrics, codexUsageToTokenUsage(result.Usage))
 	if l.broker != nil && (result.Usage.InputTokens != 0 || result.Usage.OutputTokens != 0 || result.Usage.CacheReadTokens != 0 || result.Usage.CacheCreationTokens != 0 || result.Usage.CostUSD != 0) {
-		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
+		l.broker.RecordAgentUsage(slug, l.codexModelForAgent(slug), result.Usage)
 	}
 	relay.Flush()
 	if text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine)); text != "" {
@@ -792,4 +792,26 @@ func stripEnvKeys(env []string, strip []string) []string {
 		out = append(out, entry)
 	}
 	return out
+}
+
+// codexModelForAgent returns the codex model the next dispatch should use
+// for slug. Per-agent ProviderBinding.Model wins when set and the binding
+// kind is codex; otherwise we fall back to the install-wide codex config
+// resolver (--model flag, $CODEX_MODEL env var, ~/.codex/config.toml).
+//
+// The kind check prevents a stale gpt-4o written when the user briefly
+// switched the agent to codex from being fed to codex on a later
+// switch-back if the per-agent binding wasn't fully cleared. In practice
+// the AgentProfilePanel save flow keeps Model and Kind aligned, but
+// belt-and-suspenders matches how headlessClaudeModel reads its binding.
+func (l *Launcher) codexModelForAgent(slug string) string {
+	if l != nil && l.broker != nil {
+		binding := l.broker.MemberProviderBinding(slug)
+		if binding.Kind == "codex" {
+			if model := strings.TrimSpace(binding.Model); model != "" {
+				return model
+			}
+		}
+	}
+	return strings.TrimSpace(config.ResolveCodexModel(l.cwd))
 }

--- a/internal/team/launcher_member_reconcile.go
+++ b/internal/team/launcher_member_reconcile.go
@@ -1,0 +1,69 @@
+package team
+
+import (
+	"fmt"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// reconcileMemberRuntime runs after the broker publishes a member_updated
+// event. It exists to close the gap exposed by the per-agent runtime picker:
+// switching an existing agent from one runtime to another used to leave the
+// stale runtime's state behind, and the next dispatch could silently land on
+// the wrong path (typically: user picks codex, agent never replies because
+// the dispatch loop is still pointing at a dead claude session).
+//
+// What survives the broker-side update path:
+//
+//   - The per-agent ProviderBinding (member.Provider) is already the new
+//     kind/model, so MemberEffectiveProviderKind returns the new value and
+//     ShouldUseHeadlessForSlug → PaneTargets correctly skips the pane for
+//     non-pane-eligible kinds. The next notification IS routed to the
+//     headless runner.
+//
+//   - The claudeSessionStore entry for the slug is cleared on the broker
+//     side (broker_office_members.go calls provider.ResetClaudeSessionFor
+//     when the kind actually changed).
+//
+// What this method adds:
+//
+//   - A brief system message in the agent's most-likely-visible channel
+//     telling the human that the runtime change landed. Without this the
+//     switch is silent until the next message, which is the exact symptom
+//     ("I changed the agent's provider and it never replied") the picker
+//     exposes when paired with a broker that doesn't echo the new state.
+//
+// reconcileMemberRuntime is idempotent — the event fires on every member
+// update (name, role, runtime) and a no-op runtime change has no side
+// effect because the broker already clears the claude session only when
+// the kind actually changed.
+func (l *Launcher) reconcileMemberRuntime(slug string) {
+	if l == nil || l.broker == nil || slug == "" {
+		return
+	}
+	binding := l.broker.MemberProviderBinding(slug)
+	kind := normalizeProviderKind(binding.Kind)
+	if kind == "" {
+		// Inherit-default: the launcher continues using the install-wide
+		// resolver on the next dispatch, no further work needed.
+		return
+	}
+	// Post a system message in #general so the human sees the switch
+	// landed. We don't try to detect "the user is staring at a different
+	// channel" — getting the signal in one canonical place is better than
+	// a guessing game that risks duplicating across many channels.
+	if l.broker != nil {
+		body := fmt.Sprintf("@%s runtime → %s", slug, kind)
+		if model := binding.Model; model != "" {
+			body = fmt.Sprintf("@%s runtime → %s · %s", slug, kind, model)
+		}
+		l.broker.PostSystemMessage("general", body, "runtime")
+	}
+	// Belt-and-suspenders: re-clear the claude session record for this
+	// slug even though the broker already did it. The store is shared
+	// state and the underlying file write is not transactional with the
+	// broker's state save — racing the launcher's next claude resume
+	// lookup against a half-completed broker write would otherwise let a
+	// stale id leak through. The per-slug clear is idempotent.
+	provider.ResetClaudeSessionFor(slug)
+}

--- a/internal/team/notifier_loops.go
+++ b/internal/team/notifier_loops.go
@@ -156,6 +156,17 @@ func (l *Launcher) notifyOfficeChangesLoop() {
 				l.respawnPanesAfterReseed()
 				return
 			}
+			// member_updated covers per-agent provider switches initiated
+			// from the AgentProfilePanel runtime picker. The launcher needs
+			// to drop any pane that was holding the old runtime so the
+			// next dispatch routes through the headless path the new kind
+			// expects. This is best-effort: the worker that picks up the
+			// next turn already reads MemberEffectiveProviderKind, so a
+			// failed pane kill at most leaves a stale claude window
+			// running silently — it won't intercept future dispatches.
+			if evt.Kind == "member_updated" {
+				l.reconcileMemberRuntime(evt.Slug)
+			}
 			if l.broker.HasPendingInterview() {
 				return
 			}

--- a/internal/team/template.go
+++ b/internal/team/template.go
@@ -17,6 +17,14 @@ type generatedMemberTemplate struct {
 	Expertise      []string `json:"expertise"`
 	Personality    string   `json:"personality"`
 	PermissionMode string   `json:"permission_mode"`
+	// Provider and Model are CEO suggestions for the agent's runtime. The
+	// AgentWizard pre-fills its picker from these when the suggested
+	// provider is in the install's registered LLM provider list (i.e. a
+	// non-gateway kind). When absent or a gateway kind, the wizard falls
+	// back to "Inherit default" — the human always gets the final pick
+	// because the CEO can't reliably reason about local-runtime availability.
+	Provider string `json:"provider,omitempty"`
+	Model    string `json:"model,omitempty"`
 }
 
 func (l *Launcher) GenerateMemberTemplateFromPrompt(request string) (generatedMemberTemplate, error) {
@@ -41,7 +49,9 @@ Required schema:
   "role": "Role / title",
   "expertise": ["area", "area"],
   "personality": "one short paragraph",
-  "permission_mode": "plan"
+  "permission_mode": "plan",
+  "provider": "claude-code | codex | opencode | mlx-lm | ollama | exo",
+  "model": "runtime-specific model identifier or empty"
 }
 
 Constraints:
@@ -50,6 +60,16 @@ Constraints:
 - Pick a role that complements the existing office rather than overlapping heavily.
 - If the prompt is vague, still make a crisp decision.
 - permission_mode should usually be "plan" unless the role clearly needs autonomous editing/coding.
+- "provider" is the LLM runtime the agent should run on. Pick one of:
+  claude-code, codex, opencode (cloud) or mlx-lm, ollama, exo (local).
+  Never suggest "openclaw", "openclaw-http", or "hermes-agent" — those are
+  gateways for importing existing agents, not runtimes for new ones.
+- "model" is the model identifier inside the chosen runtime (for example
+  "claude-3-5-sonnet-latest" for claude-code, "gpt-4o" for codex,
+  "llama3.1:8b" for ollama). Leave empty if you have no opinion — the
+  runtime's default will be used.
+- The human will confirm provider and model in the next step. Your job is
+  to suggest a sensible default, not to lock the choice.
 `
 	userPrompt := "Design a new office teammate from this request:\n\n" + request
 	raw, err := provider.RunConfiguredOneShot(systemPrompt, userPrompt, l.cwd)
@@ -87,6 +107,17 @@ func parseGeneratedMemberTemplate(raw string) (generatedMemberTemplate, error) {
 	if tmpl.PermissionMode == "" {
 		tmpl.PermissionMode = "plan"
 	}
+	// Sanitize provider/model: drop suggestions that name a gateway kind so
+	// the wizard never has to handle them. Per-agent gateway bindings are
+	// established through the Integrations app, not through the CEO
+	// template generator — the wizard's runtime picker only shows the
+	// non-gateway registered LLM kinds.
+	tmpl.Provider = strings.TrimSpace(strings.ToLower(tmpl.Provider))
+	if provider.IsGatewayKind(tmpl.Provider) {
+		tmpl.Provider = ""
+		tmpl.Model = ""
+	}
+	tmpl.Model = strings.TrimSpace(tmpl.Model)
 	return tmpl, nil
 }
 

--- a/web/e2e/screenshots/agent-providers-integrations.mjs
+++ b/web/e2e/screenshots/agent-providers-integrations.mjs
@@ -1,10 +1,10 @@
 // Capture the redesigned provider + Integrations surfaces:
-//   01: Settings → Default runtime (locked, friction gate visible)
-//   02: Settings → Default runtime (unlock confirm dialog)
-//   03: Integrations app — category groups with all three cards
-//   04: Agent profile → Runtime section (editable picker + model field)
-//   05: Agent profile → Runtime section (gateway-managed pill)
-//   06: AgentWizard manual → Runtime + Model fields
+//   01: Settings → Default runtime for new agents (single picker, no lock)
+//   02: Integrations app — list view with branded service marks
+//   03: Integrations app — detail view (OpenClaw config screen)
+//   04: AgentProfilePanel runtime section — editable picker + model
+//   05: AgentProfilePanel runtime section — gateway-managed pill
+//   06: AgentWizard manual → Runtime + Model fields with copy
 //
 // Run via:
 //   web/e2e/screenshots/publish.sh agent-providers-integrations <pr-number>
@@ -15,7 +15,6 @@ import {
   bootShell,
   installCommonMocks,
   launchBrowser,
-  shotElement,
   shotPage,
 } from "./lib.mjs";
 
@@ -28,11 +27,15 @@ if (!OUT) {
 const LLM_KINDS = ["claude-code", "codex", "opencode", "mlx-lm", "ollama", "exo"];
 const GATEWAY_KINDS = ["openclaw", "openclaw-http", "hermes-agent"];
 
-function configResponse({ unlocked = false, provider = "claude-code", openclawUrl = "", openclawTokenSet = false, telegramTokenSet = false } = {}) {
+function configResponse({
+  provider = "claude-code",
+  openclawUrl = "",
+  openclawTokenSet = false,
+  telegramTokenSet = false,
+} = {}) {
   return {
     llm_provider: provider,
     llm_provider_configured: true,
-    llm_provider_unlocked: unlocked,
     llm_provider_priority: [],
     llm_provider_kinds: LLM_KINDS,
     gateway_kinds: GATEWAY_KINDS,
@@ -61,6 +64,9 @@ const HERMES_REACHABLE = {
   platform_supported: true,
 };
 
+// Mock agents. "outreach" is the editable-runtime example used in screenshot
+// 04. "imported-coder" is openclaw-bridged so its runtime section renders the
+// MANAGED BY OpenClaw gateway pill in screenshot 05.
 const MEMBERS_FIXTURE = {
   members: [
     {
@@ -90,7 +96,10 @@ const MEMBERS_FIXTURE = {
       emoji: "🦾",
       status: "idle",
       activity: "idle",
-      provider: { kind: "openclaw", openclaw: { session_key: "wuphf-imported-1", agent_id: "main" } },
+      provider: {
+        kind: "openclaw",
+        openclaw: { session_key: "wuphf-imported-1", agent_id: "main" },
+      },
     },
   ],
   meta: { humanHasPosted: true },
@@ -110,10 +119,38 @@ async function mockProviders(context, hermesReachable = true) {
     r.fulfill({
       contentType: "application/json",
       body: JSON.stringify([
-        hermesReachable ? HERMES_REACHABLE : { ...HERMES_REACHABLE, reachable: false },
-        { kind: "mlx-lm", binary_installed: false, endpoint: "http://127.0.0.1:8080/v1", model: "qwen-30b", reachable: false, probed: true, platform_supported: true },
-        { kind: "ollama", binary_installed: true, binary_version: "0.4.0", endpoint: "http://127.0.0.1:11434/v1", model: "llama3.1:8b", reachable: true, loaded_model: "llama3.1:8b", probed: true, platform_supported: true },
-        { kind: "exo", binary_installed: false, endpoint: "http://127.0.0.1:52415/v1", model: "llama-3.2-3b", reachable: false, probed: true, platform_supported: false },
+        hermesReachable
+          ? HERMES_REACHABLE
+          : { ...HERMES_REACHABLE, reachable: false },
+        {
+          kind: "mlx-lm",
+          binary_installed: false,
+          endpoint: "http://127.0.0.1:8080/v1",
+          model: "qwen-30b",
+          reachable: false,
+          probed: true,
+          platform_supported: true,
+        },
+        {
+          kind: "ollama",
+          binary_installed: true,
+          binary_version: "0.4.0",
+          endpoint: "http://127.0.0.1:11434/v1",
+          model: "llama3.1:8b",
+          reachable: true,
+          loaded_model: "llama3.1:8b",
+          probed: true,
+          platform_supported: true,
+        },
+        {
+          kind: "exo",
+          binary_installed: false,
+          endpoint: "http://127.0.0.1:52415/v1",
+          model: "llama-3.2-3b",
+          reachable: false,
+          probed: true,
+          platform_supported: false,
+        },
       ]),
     }),
   );
@@ -121,7 +158,10 @@ async function mockProviders(context, hermesReachable = true) {
 
 async function mockMembers(context) {
   await context.route("**/api/office-members", (r) =>
-    r.fulfill({ contentType: "application/json", body: JSON.stringify(MEMBERS_FIXTURE) }),
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(MEMBERS_FIXTURE),
+    }),
   );
 }
 
@@ -129,55 +169,7 @@ const { browser, context, page } = await launchBrowser({
   viewport: { width: 1440, height: 960 },
 });
 
-// ── 01: Settings → Default runtime (locked) ─────────────────────────
-await installCommonMocks(context, {
-  extra: async (ctx) => {
-    await mockCfg(ctx, { unlocked: false });
-    await mockProviders(ctx);
-    await mockMembers(ctx);
-  },
-});
-await bootShell(page, { afterFlipSelector: ".status-bar" });
-await page.getByLabel("Open settings").click();
-await page.getByRole("button", { name: "General", exact: true }).click();
-await page.waitForTimeout(400);
-await shotPage(page, OUT, "01-settings-default-runtime-locked");
-
-// ── 02: Settings → Default runtime (unlock confirm dialog) ──────────
-// Click (not check) — the checkbox opens an inline confirm panel without
-// flipping its own checked state, so check() rightly complains. We want
-// the confirm panel visible in the capture.
-await page.getByLabel(/Unlock to override all current agents/i).click();
-await page.waitForTimeout(300);
-await shotPage(page, OUT, "02-settings-unlock-confirm");
-
-// ── 03: Integrations app — category groups ──────────────────────────
-await installCommonMocks(context, {
-  extra: async (ctx) => {
-    await mockCfg(ctx, {
-      openclawUrl: "ws://127.0.0.1:18789",
-      openclawTokenSet: true,
-      telegramTokenSet: false,
-    });
-    await mockProviders(ctx, true);
-    await mockMembers(ctx);
-  },
-});
-// Boot the shell, then hash-navigate. The router uses createHashHistory
-// so the URL is /#/apps/integrations, not /apps/integrations — going
-// straight to the path bypasses the hash and the SPA falls through to
-// its default channel.
-await bootShell(page, { afterFlipSelector: ".status-bar" });
-await page.evaluate(() => {
-  window.location.hash = "/apps/integrations";
-});
-await page
-  .getByRole("heading", { name: "Integrations" })
-  .waitFor({ timeout: 10_000 });
-await page.waitForTimeout(600);
-await shotPage(page, OUT, "03-integrations-app-categories");
-
-// ── 04: AgentWizard manual mode — Runtime + Model fields ────────────
+// ── 01: Settings → Default runtime for new agents ───────────────────
 await installCommonMocks(context, {
   extra: async (ctx) => {
     await mockCfg(ctx);
@@ -186,14 +178,105 @@ await installCommonMocks(context, {
   },
 });
 await bootShell(page, { afterFlipSelector: ".status-bar" });
-// Open the agent wizard via the sidebar "+ Agent" button. Fall back to
-// clicking the first link/button whose accessible name matches.
+await page.getByLabel("Open settings").click();
+await page.getByRole("button", { name: "General", exact: true }).click();
+await page.waitForTimeout(400);
+await shotPage(page, OUT, "01-settings-default-runtime");
+
+// ── 02: Integrations app — list view ────────────────────────────────
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await mockCfg(ctx, {
+      openclawUrl: "ws://127.0.0.1:18789",
+      openclawTokenSet: true,
+    });
+    await mockProviders(ctx, true);
+    await mockMembers(ctx);
+  },
+});
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await page.evaluate(() => {
+  window.location.hash = "/apps/integrations";
+});
+await page
+  .getByRole("heading", { name: "Integrations" })
+  .waitFor({ timeout: 10_000 });
+await page.waitForTimeout(600);
+await shotPage(page, OUT, "02-integrations-list");
+
+// ── 03: Integrations app — detail view (OpenClaw config) ────────────
+await page
+  .getByRole("button", { name: /Open OpenClaw integration settings/i })
+  .click();
+await page.waitForSelector("text=Gateway URL", { timeout: 5_000 });
+await page.waitForTimeout(300);
+await shotPage(page, OUT, "03-integrations-detail-openclaw");
+
+// ── 04 & 05: AgentProfilePanel runtime sections ─────────────────────
+// Open Outreach to show the editable runtime picker; then Imported Coder
+// to show the gateway-managed pill. The Profile button flips AgentPanel
+// to AgentProfilePanel state.
+async function openProfile(slug) {
+  await page.locator(`[data-agent-slug="${slug}"]`).first().click();
+  // Wait for the AgentPanel summary view to mount (which means the members
+  // query has resolved and `agent` is non-null). Without this the Profile
+  // click can race the panel mount and land on nothing.
+  await page.waitForSelector(".agent-panel", { timeout: 8_000 });
+  await page.waitForTimeout(200);
+  // The Profile button's accessible name comes from its aria-label
+  // (`View full profile for <agent name>`), not its visible text. Match
+  // on the aria-label prefix so the lookup survives roster changes.
+  await page
+    .getByRole("button", { name: /View full profile for/i })
+    .first()
+    .click();
+  await page.waitForTimeout(400);
+}
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await mockCfg(ctx);
+    await mockProviders(ctx);
+    await mockMembers(ctx);
+  },
+});
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await openProfile("outreach");
+// Wait for either runtime-grid (editable) or runtime-managed pill (gateway).
+// Outreach's binding is codex (non-gateway) so we expect the grid; the
+// OR-pattern lets us debug into the panel even if the selector raced.
+await page
+  .waitForSelector(".op-runtime-grid, .op-runtime-managed, .agent-profile-panel", {
+    timeout: 8_000,
+  })
+  .catch(async () => {
+    // Snapshot the page to /tmp so we can see WHY the panel didn't mount.
+    await shotPage(page, OUT, "DEBUG-after-profile-click");
+  });
+await page.waitForTimeout(700);
+await shotPage(page, OUT, "04-agent-runtime-editable");
+
+await openProfile("imported-coder");
+await page.waitForSelector(".op-runtime-managed, .agent-profile-panel", {
+  timeout: 8_000,
+});
+await page.waitForTimeout(700);
+await shotPage(page, OUT, "05-agent-runtime-gateway-managed");
+
+// ── 06: AgentWizard manual mode — Runtime + Model fields ────────────
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await mockCfg(ctx);
+    await mockProviders(ctx);
+    await mockMembers(ctx);
+  },
+});
+await bootShell(page, { afterFlipSelector: ".status-bar" });
 await page
   .getByRole("button", { name: /new agent|add agent|create agent/i })
   .first()
   .click()
   .catch(async () => {
-    // Some shells use an icon-only trigger; try opening via the agent list.
     const newAgent = await page
       .locator('[aria-label*="agent" i], [title*="agent" i]')
       .first();
@@ -204,7 +287,7 @@ await page.getByRole("button", { name: "Manual" }).click();
 await page.waitForTimeout(200);
 await page.getByLabel("Name").fill("Outreach Specialist");
 await page.waitForTimeout(150);
-await shotPage(page, OUT, "04-agent-wizard-runtime-model");
+await shotPage(page, OUT, "06-agent-wizard-runtime-model");
 
 console.log(`captured screenshots to ${OUT}`);
 await browser.close();

--- a/web/e2e/screenshots/agent-providers-integrations.mjs
+++ b/web/e2e/screenshots/agent-providers-integrations.mjs
@@ -1,0 +1,210 @@
+// Capture the redesigned provider + Integrations surfaces:
+//   01: Settings → Default runtime (locked, friction gate visible)
+//   02: Settings → Default runtime (unlock confirm dialog)
+//   03: Integrations app — category groups with all three cards
+//   04: Agent profile → Runtime section (editable picker + model field)
+//   05: Agent profile → Runtime section (gateway-managed pill)
+//   06: AgentWizard manual → Runtime + Model fields
+//
+// Run via:
+//   web/e2e/screenshots/publish.sh agent-providers-integrations <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const LLM_KINDS = ["claude-code", "codex", "opencode", "mlx-lm", "ollama", "exo"];
+const GATEWAY_KINDS = ["openclaw", "openclaw-http", "hermes-agent"];
+
+function configResponse({ unlocked = false, provider = "claude-code", openclawUrl = "", openclawTokenSet = false, telegramTokenSet = false } = {}) {
+  return {
+    llm_provider: provider,
+    llm_provider_configured: true,
+    llm_provider_unlocked: unlocked,
+    llm_provider_priority: [],
+    llm_provider_kinds: LLM_KINDS,
+    gateway_kinds: GATEWAY_KINDS,
+    provider_endpoints: {},
+    memory_backend: "markdown",
+    action_provider: "auto",
+    team_lead_slug: "ceo",
+    company_name: "Acme Co",
+    openclaw_gateway_url: openclawUrl,
+    openclaw_token_set: openclawTokenSet,
+    telegram_token_set: telegramTokenSet,
+    config_path: "/Users/you/.wuphf/config.json",
+  };
+}
+
+const HERMES_REACHABLE = {
+  kind: "hermes-agent",
+  binary_installed: true,
+  binary_path: "/usr/local/bin/hermes",
+  binary_version: "0.6.1",
+  endpoint: "http://127.0.0.1:8642/v1",
+  model: "hermes-agent",
+  reachable: true,
+  loaded_model: "hermes-3",
+  probed: true,
+  platform_supported: true,
+};
+
+const MEMBERS_FIXTURE = {
+  members: [
+    {
+      slug: "ceo",
+      name: "CEO",
+      role: "Office lead",
+      emoji: "🎯",
+      status: "idle",
+      activity: "idle",
+      built_in: true,
+      online: true,
+      provider: { kind: "claude-code", model: "claude-3-5-sonnet-latest" },
+    },
+    {
+      slug: "outreach",
+      name: "Outreach",
+      role: "Cold email SDR",
+      emoji: "📨",
+      status: "idle",
+      activity: "idle",
+      provider: { kind: "codex", model: "gpt-4o" },
+    },
+    {
+      slug: "imported-coder",
+      name: "Imported Coder",
+      role: "Refactor specialist",
+      emoji: "🦾",
+      status: "idle",
+      activity: "idle",
+      provider: { kind: "openclaw", openclaw: { session_key: "wuphf-imported-1", agent_id: "main" } },
+    },
+  ],
+  meta: { humanHasPosted: true },
+};
+
+async function mockCfg(context, opts) {
+  await context.route("**/api/config", (r) =>
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(configResponse(opts)),
+    }),
+  );
+}
+
+async function mockProviders(context, hermesReachable = true) {
+  await context.route("**/api/status/local-providers", (r) =>
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify([
+        hermesReachable ? HERMES_REACHABLE : { ...HERMES_REACHABLE, reachable: false },
+        { kind: "mlx-lm", binary_installed: false, endpoint: "http://127.0.0.1:8080/v1", model: "qwen-30b", reachable: false, probed: true, platform_supported: true },
+        { kind: "ollama", binary_installed: true, binary_version: "0.4.0", endpoint: "http://127.0.0.1:11434/v1", model: "llama3.1:8b", reachable: true, loaded_model: "llama3.1:8b", probed: true, platform_supported: true },
+        { kind: "exo", binary_installed: false, endpoint: "http://127.0.0.1:52415/v1", model: "llama-3.2-3b", reachable: false, probed: true, platform_supported: false },
+      ]),
+    }),
+  );
+}
+
+async function mockMembers(context) {
+  await context.route("**/api/office-members", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(MEMBERS_FIXTURE) }),
+  );
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 960 },
+});
+
+// ── 01: Settings → Default runtime (locked) ─────────────────────────
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await mockCfg(ctx, { unlocked: false });
+    await mockProviders(ctx);
+    await mockMembers(ctx);
+  },
+});
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await page.getByLabel("Open settings").click();
+await page.getByRole("button", { name: "General", exact: true }).click();
+await page.waitForTimeout(400);
+await shotPage(page, OUT, "01-settings-default-runtime-locked");
+
+// ── 02: Settings → Default runtime (unlock confirm dialog) ──────────
+// Click (not check) — the checkbox opens an inline confirm panel without
+// flipping its own checked state, so check() rightly complains. We want
+// the confirm panel visible in the capture.
+await page.getByLabel(/Unlock to override all current agents/i).click();
+await page.waitForTimeout(300);
+await shotPage(page, OUT, "02-settings-unlock-confirm");
+
+// ── 03: Integrations app — category groups ──────────────────────────
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await mockCfg(ctx, {
+      openclawUrl: "ws://127.0.0.1:18789",
+      openclawTokenSet: true,
+      telegramTokenSet: false,
+    });
+    await mockProviders(ctx, true);
+    await mockMembers(ctx);
+  },
+});
+// Boot the shell, then hash-navigate. The router uses createHashHistory
+// so the URL is /#/apps/integrations, not /apps/integrations — going
+// straight to the path bypasses the hash and the SPA falls through to
+// its default channel.
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await page.evaluate(() => {
+  window.location.hash = "/apps/integrations";
+});
+await page
+  .getByRole("heading", { name: "Integrations" })
+  .waitFor({ timeout: 10_000 });
+await page.waitForTimeout(600);
+await shotPage(page, OUT, "03-integrations-app-categories");
+
+// ── 04: AgentWizard manual mode — Runtime + Model fields ────────────
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await mockCfg(ctx);
+    await mockProviders(ctx);
+    await mockMembers(ctx);
+  },
+});
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+// Open the agent wizard via the sidebar "+ Agent" button. Fall back to
+// clicking the first link/button whose accessible name matches.
+await page
+  .getByRole("button", { name: /new agent|add agent|create agent/i })
+  .first()
+  .click()
+  .catch(async () => {
+    // Some shells use an icon-only trigger; try opening via the agent list.
+    const newAgent = await page
+      .locator('[aria-label*="agent" i], [title*="agent" i]')
+      .first();
+    await newAgent.click();
+  });
+await page.waitForSelector("text=Create agent", { timeout: 5_000 });
+await page.getByRole("button", { name: "Manual" }).click();
+await page.waitForTimeout(200);
+await page.getByLabel("Name").fill("Outreach Specialist");
+await page.waitForTimeout(150);
+await shotPage(page, OUT, "04-agent-wizard-runtime-model");
+
+console.log(`captured screenshots to ${OUT}`);
+await browser.close();

--- a/web/e2e/screenshots/agent-providers-integrations.mjs
+++ b/web/e2e/screenshots/agent-providers-integrations.mjs
@@ -245,14 +245,18 @@ await openProfile("outreach");
 // Wait for either runtime-grid (editable) or runtime-managed pill (gateway).
 // Outreach's binding is codex (non-gateway) so we expect the grid; the
 // OR-pattern lets us debug into the panel even if the selector raced.
-await page
-  .waitForSelector(".op-runtime-grid, .op-runtime-managed, .agent-profile-panel", {
-    timeout: 8_000,
-  })
-  .catch(async () => {
-    // Snapshot the page to /tmp so we can see WHY the panel didn't mount.
-    await shotPage(page, OUT, "DEBUG-after-profile-click");
-  });
+// If the wait times out, snapshot the page so we can see the failure
+// state, then re-throw so the harness exits non-zero — silently writing
+// a wrong screenshot 04 would be worse than no screenshot at all.
+try {
+  await page.waitForSelector(
+    ".op-runtime-grid, .op-runtime-managed, .agent-profile-panel",
+    { timeout: 8_000 },
+  );
+} catch (err) {
+  await shotPage(page, OUT, "DEBUG-after-profile-click");
+  throw err;
+}
 await page.waitForTimeout(700);
 await shotPage(page, OUT, "04-agent-runtime-editable");
 

--- a/web/e2e/tests/local-llm-onboarding.spec.ts
+++ b/web/e2e/tests/local-llm-onboarding.spec.ts
@@ -159,24 +159,17 @@ test.describe("Onboarding → Run a local model", () => {
     await expect(ollamaTile.getByText(/Not installed.*Settings/)).toBeVisible();
     await expect(ollamaTile).toBeDisabled();
 
-    // Hermes Agent and OpenClaw Gateway are registered local runtimes too; in
-    // this fixture they are installable but unavailable, so they should match
-    // ollama's disabled "install from Settings" behavior.
-    const hermesTile = page.getByTestId(
-      "onboarding-local-llm-tile-hermes-agent",
-    );
-    await expect(hermesTile).toBeVisible();
-    await expect(hermesTile.getByText(/Not installed.*Settings/)).toBeVisible();
-    await expect(hermesTile).toBeDisabled();
-
-    const openclawTile = page.getByTestId(
-      "onboarding-local-llm-tile-openclaw-http",
-    );
-    await expect(openclawTile).toBeVisible();
+    // Hermes Agent and OpenClaw Gateway used to render here as local runtime
+    // tiles. They were moved to the Integrations app because they are
+    // gateways for importing existing agents, not LLM runtimes for new
+    // ones. The onboarding picker now only lists directly-dispatchable
+    // local LLMs (mlx-lm, ollama, exo).
     await expect(
-      openclawTile.getByText(/Not installed.*Settings/),
-    ).toBeVisible();
-    await expect(openclawTile).toBeDisabled();
+      page.getByTestId("onboarding-local-llm-tile-hermes-agent"),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId("onboarding-local-llm-tile-openclaw-http"),
+    ).toHaveCount(0);
 
     // exo is platform_supported=false → tile is disabled and surfaces
     // "Not supported on this OS".

--- a/web/e2e/tests/local-llm-settings.spec.ts
+++ b/web/e2e/tests/local-llm-settings.spec.ts
@@ -150,14 +150,20 @@ test.describe("Settings → Local LLMs", () => {
     stubLocalProviders(page);
     await goToSettingsLocalLLMs(page);
 
-    // All registered local runtime cards render.
+    // Only directly-dispatchable local runtimes render here. Gateway
+    // runtimes (hermes-agent, openclaw-http) used to appear in this list
+    // but were moved to the Integrations app — they import existing
+    // agents rather than backing a WUPHF-created agent's turns, so they
+    // don't belong in the runtime picker.
     await expect(page.getByTestId("local-llm-card-mlx-lm")).toBeVisible();
     await expect(page.getByTestId("local-llm-card-ollama")).toBeVisible();
     await expect(page.getByTestId("local-llm-card-exo")).toBeVisible();
-    await expect(page.getByTestId("local-llm-card-hermes-agent")).toBeVisible();
+    await expect(
+      page.getByTestId("local-llm-card-hermes-agent"),
+    ).toHaveCount(0);
     await expect(
       page.getByTestId("local-llm-card-openclaw-http"),
-    ).toBeVisible();
+    ).toHaveCount(0);
 
     // MLX-LM is not installed → install command appears verbatim.
     const mlxCard = page.getByTestId("local-llm-card-mlx-lm");

--- a/web/e2e/tests/nex-connect.spec.ts
+++ b/web/e2e/tests/nex-connect.spec.ts
@@ -29,12 +29,14 @@ function stubNexRegister(page: Page, status: number, body: unknown) {
 }
 
 // goToIntegrations lands on the shell and opens Settings → Integrations,
-// where NexConnectPanel renders.
+// where NexConnectPanel renders. The Settings nav button is matched by
+// data-testid so it's not confused with the same-named Integrations app
+// entry in the parent sidebar.
 async function goToIntegrations(page: Page) {
   await page.goto("/");
   await waitForReactMount(page);
   await page.getByLabel("Open settings").click();
-  await page.getByRole("button", { name: "Integrations" }).click();
+  await page.getByTestId("settings-nav-integrations").click();
   await expect(page.getByTestId("nex-connect-panel")).toBeVisible();
 }
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -439,8 +439,35 @@ export function fetchCommands() {
 // ── Members ──
 
 export interface ProviderBinding {
-  kind?: string;
+  // kind tags the runtime or gateway for this agent. Empty string means
+  // "inherit from global default". Use IsGatewayKind on a Kind to decide
+  // whether to render the runtime picker (LLM kinds) or a "Managed by
+  // <Gateway>" badge (gateway kinds) in the agent profile.
+  kind?: LLMProvider | "";
+  // model is the runtime-specific model identifier. Free-form on the wire —
+  // validated by each provider implementation, not at the schema layer.
+  // Common shapes: "claude-3-5-sonnet-latest", "gpt-4o", "llama3.1:8b".
   model?: string;
+  // openclaw is populated only when kind === "openclaw" — it carries the
+  // gateway-side session key + agent id. Set by the OpenClaw bridge bootstrap
+  // path, not by the per-agent runtime picker.
+  openclaw?: {
+    session_key?: string;
+    agent_id?: string;
+  };
+}
+
+// Helper for UI code: returns true when binding.kind is a gateway-controlled
+// tag. Per-agent runtime pickers and the AgentWizard should swap their UI to
+// a read-only "Managed by <Gateway>" pill when this returns true.
+export function isGatewayBinding(
+  binding: ProviderBinding | string | undefined,
+): boolean {
+  if (!binding) return false;
+  const kind = typeof binding === "string" ? binding : binding.kind;
+  return (
+    kind === "openclaw" || kind === "openclaw-http" || kind === "hermes-agent"
+  );
 }
 
 export interface OfficeMember {
@@ -1075,15 +1102,30 @@ export function setMemory(namespace: string, key: string, value: string) {
 
 // ── Config (Settings) ──
 
-export type LLMProvider =
+// LLMRuntimeKind names a directly-dispatchable LLM runtime — the kinds that
+// belong in any runtime picker (Settings default-runtime, AgentProfilePanel
+// Runtime section, AgentWizard provider field). Mirrors the non-gateway
+// subset returned by provider.LLMProviderKinds in the Go layer.
+export type LLMRuntimeKind =
   | "claude-code"
   | "ollama"
   | "codex"
   | "opencode"
   | "mlx-lm"
-  | "exo"
-  | "hermes-agent"
-  | "openclaw-http";
+  | "exo";
+
+// GatewayKind names a runtime that is reached through an integration gateway
+// rather than dispatched directly. Gateway-bound agents are imported via the
+// Integrations app (OpenClaw / Hermes) and never appear in runtime pickers;
+// they receive a "Managed by <Gateway>" badge on the agent profile.
+export type GatewayKind = "openclaw" | "openclaw-http" | "hermes-agent";
+
+// LLMProvider is the union of both — used wherever a value carries either an
+// LLM runtime or a gateway tag (per-agent ProviderBinding.Kind on the wire,
+// ConfigSnapshot.llm_provider for backward compatibility). New UI code should
+// prefer LLMRuntimeKind / GatewayKind and only widen to LLMProvider at the
+// raw-wire boundary.
+export type LLMProvider = LLMRuntimeKind | GatewayKind;
 export type MemoryBackend = "markdown" | "nex" | "gbrain" | "none";
 export type ActionProvider = "auto" | "one" | "composio" | "";
 
@@ -1118,7 +1160,21 @@ export interface ConfigSnapshot {
   // Runtime
   llm_provider?: LLMProvider;
   llm_provider_configured?: boolean;
+  // llm_provider_unlocked mirrors Config.LLMProviderUnlocked. False = locked
+  // (the global runtime is just a default for new agents). True = unlocked
+  // override (the global runtime stamps onto every agent's dispatch). The
+  // Settings panel must show a friction warning before flipping to true.
+  llm_provider_unlocked?: boolean;
   llm_provider_priority?: string[];
+  // llm_provider_kinds is the non-gateway subset of registered runtimes —
+  // the safe list to render in any runtime picker. Read this off the wire
+  // instead of hardcoding the union so a future provider registered on the
+  // Go side appears in the UI without a frontend change.
+  llm_provider_kinds?: LLMRuntimeKind[];
+  // gateway_kinds is the inverse — the registered gateway runtimes. The
+  // Integrations app enumerates these to know which gateway cards (OpenClaw,
+  // Hermes) are compiled in and connectable.
+  gateway_kinds?: GatewayKind[];
   provider_endpoints?: Record<string, ProviderEndpoint>;
   memory_backend?: MemoryBackend;
   action_provider?: ActionProvider;
@@ -1159,6 +1215,7 @@ export interface ConfigSnapshot {
 
 export type ConfigUpdate = Partial<{
   llm_provider: LLMProvider;
+  llm_provider_unlocked: boolean;
   provider_endpoints: Record<string, ProviderEndpoint>;
   memory_backend: MemoryBackend;
   action_provider: ActionProvider;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1160,11 +1160,6 @@ export interface ConfigSnapshot {
   // Runtime
   llm_provider?: LLMProvider;
   llm_provider_configured?: boolean;
-  // llm_provider_unlocked mirrors Config.LLMProviderUnlocked. False = locked
-  // (the global runtime is just a default for new agents). True = unlocked
-  // override (the global runtime stamps onto every agent's dispatch). The
-  // Settings panel must show a friction warning before flipping to true.
-  llm_provider_unlocked?: boolean;
   llm_provider_priority?: string[];
   // llm_provider_kinds is the non-gateway subset of registered runtimes —
   // the safe list to render in any runtime picker. Read this off the wire
@@ -1215,7 +1210,6 @@ export interface ConfigSnapshot {
 
 export type ConfigUpdate = Partial<{
   llm_provider: LLMProvider;
-  llm_provider_unlocked: boolean;
   provider_endpoints: Record<string, ProviderEndpoint>;
   memory_backend: MemoryBackend;
   action_provider: ActionProvider;

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -371,12 +371,13 @@ function RuntimeSection({
   const [draftModel, setDraftModel] = useState<string>(binding.model ?? "");
   const [saveError, setSaveError] = useState<string | null>(null);
 
-  // Built-ins (CEO, lead) cannot have their runtime moved off the install
-  // default — the broker rejects the write — so we hide editing there too.
-  // The user-task says CEO chat must ask for provider on spawn, which is the
-  // wizard's job, not this panel's.
-  const isLead = agent.built_in === true || agent.slug === "ceo";
-  const editable = !(isGateway || isLead);
+  // Lead agents (CEO, other built-ins) can have their runtime changed from
+  // this panel too. The broker's built-in gate only fires on remove, not on
+  // provider updates — there's no broker-side reason to block here.
+  // Gateway-bound agents are the only non-editable case: their gateway
+  // transport is load-bearing, so changing the kind through this panel
+  // would orphan the imported session. Those go through Integrations.
+  const editable = !isGateway;
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -489,12 +490,7 @@ function RuntimeSection({
           />
         </span>
       </div>
-      {isLead && (
-        <p className="op-runtime-note">
-          Lead agents always run on the install default; change it in Settings.
-        </p>
-      )}
-      {!isLead && draftKind === "" && (
+      {draftKind === "" && (
         <p className="op-runtime-note">
           Inheriting the install default ({globalDefault}). Pick a specific
           runtime here to pin this agent.
@@ -539,6 +535,123 @@ function RuntimeSection({
         </div>
       )}
     </div>
+  );
+}
+
+// EditableName replaces the static name display with an inline-edit field.
+// Click the name to edit; Enter or blur saves, Escape cancels. Trimmed
+// empty values are rejected (the name is required at the broker layer
+// anyway). Applies to every agent including the lead — the broker's
+// built-in gate fires only on remove, not on update.
+function EditableName({ agent }: { agent: OfficeMember }) {
+  const queryClient = useQueryClient();
+  const initial = agent.name || agent.slug;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(initial);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Keep the draft in sync when the underlying member name changes from
+  // outside (e.g. another browser tab edited it). React re-mounts the
+  // component on a slug switch (key prop on AgentPanelView), so we only
+  // need to track name changes within the same agent.
+  if (!editing && draft !== initial && draft !== agent.name) {
+    setDraft(initial);
+  }
+
+  const mutation = useMutation({
+    mutationFn: async (name: string) => {
+      await post("/office-members", {
+        action: "update",
+        slug: agent.slug,
+        name,
+      });
+    },
+    onSuccess: () => {
+      setSaveError(null);
+      setEditing(false);
+      void queryClient.invalidateQueries({ queryKey: ["office-members"] });
+    },
+    onError: (err: unknown) => {
+      setSaveError(err instanceof Error ? err.message : "Failed to rename");
+    },
+  });
+
+  const commit = () => {
+    const next = draft.trim();
+    if (!next || next === initial) {
+      setDraft(initial);
+      setEditing(false);
+      setSaveError(null);
+      return;
+    }
+    mutation.mutate(next);
+  };
+
+  if (!editing) {
+    return (
+      <button
+        type="button"
+        className="agent-panel-name"
+        onClick={() => {
+          setDraft(initial);
+          setEditing(true);
+          setSaveError(null);
+        }}
+        title="Click to rename"
+        style={{
+          background: "transparent",
+          border: 0,
+          padding: 0,
+          font: "inherit",
+          color: "inherit",
+          cursor: "text",
+        }}
+      >
+        {initial}
+      </button>
+    );
+  }
+  return (
+    <>
+      <input
+        autoFocus={true}
+        className="input"
+        value={draft}
+        disabled={mutation.isPending}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            commit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setDraft(initial);
+            setEditing(false);
+            setSaveError(null);
+          }
+        }}
+        style={{
+          font: "inherit",
+          padding: "2px 6px",
+          minWidth: 120,
+          maxWidth: 220,
+        }}
+        aria-label="Agent name"
+      />
+      {saveError && (
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--error-400)",
+            marginLeft: 6,
+          }}
+          role="alert"
+        >
+          {saveError}
+        </span>
+      )}
+    </>
   );
 }
 
@@ -625,9 +738,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
             <div
               style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
             >
-              <span className="agent-panel-name">
-                {agent.name || agent.slug}
-              </span>
+              <EditableName agent={agent} />
               <span
                 className={`status-dot ${statusClass}`}
                 style={{ marginLeft: -2 }}

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -1,8 +1,20 @@
-import { useQuery } from "@tanstack/react-query";
-import { Xmark } from "iconoir-react";
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Lock, Xmark } from "iconoir-react";
 
-import type { OfficeMember, Skill } from "../../api/client";
-import { getChannels, getSkillsList } from "../../api/client";
+import type {
+  LLMRuntimeKind,
+  OfficeMember,
+  ProviderBinding,
+  Skill,
+} from "../../api/client";
+import {
+  getChannels,
+  getConfig,
+  getSkillsList,
+  isGatewayBinding,
+  post,
+} from "../../api/client";
 import {
   getOfficeTasks,
   listAgentLogTasks,
@@ -15,6 +27,21 @@ import { resolveHarness } from "../../lib/harness";
 import { router } from "../../lib/router";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
+
+const PROVIDER_LABELS: Record<LLMRuntimeKind, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  opencode: "Opencode",
+  "mlx-lm": "MLX-LM",
+  ollama: "Ollama",
+  exo: "Exo",
+};
+
+const GATEWAY_LABELS: Record<string, string> = {
+  openclaw: "OpenClaw",
+  "openclaw-http": "OpenClaw HTTP",
+  "hermes-agent": "Hermes",
+};
 
 interface AgentProfilePanelProps {
   agent: OfficeMember;
@@ -280,20 +307,149 @@ function PermissionsSection({ agent }: { agent: OfficeMember }) {
   );
 }
 
-function ProviderSection({
+function bindingFromMember(
+  provider: OfficeMember["provider"],
+): ProviderBinding {
+  if (!provider) return {};
+  if (typeof provider === "string") {
+    // String form is a legacy shape carrying just the kind. Widen to the
+    // union so downstream code can read `binding.kind` uniformly.
+    return { kind: provider as ProviderBinding["kind"] };
+  }
+  return provider;
+}
+
+// RuntimeSection is the per-agent runtime picker — the surface the user task
+// description calls out as "enable [provider selection] in the agent's
+// settings in the UI." Three rendering paths:
+//
+//  1. Gateway-bound agent (kind ∈ {openclaw, openclaw-http, hermes-agent}):
+//     no picker. We render a "Managed by <Gateway>" pill instead because the
+//     gateway transport is load-bearing — flipping the kind here would orphan
+//     the agent from its imported session. Editing a gateway-bound agent's
+//     runtime is the Integrations app's job, not this panel's.
+//
+//  2. Global runtime unlocked (Settings.LLMProviderUnlocked === true):
+//     picker rendered but read-only with a "Locked by global override" banner,
+//     because the dispatch resolver will ignore the per-agent binding anyway.
+//     We display the value so the user can see what's stored — they just
+//     can't write while the global is overriding.
+//
+//  3. Normal: editable picker with provider + model fields and a Save button.
+function RuntimeSection({
   agent,
   defaultHarness,
 }: {
   agent: OfficeMember;
   defaultHarness: HarnessKind;
 }) {
+  const queryClient = useQueryClient();
+  const configQuery = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    staleTime: 30_000,
+  });
+  const llmKinds: LLMRuntimeKind[] = (configQuery.data?.llm_provider_kinds ?? [
+    "claude-code",
+    "codex",
+    "opencode",
+    "mlx-lm",
+    "ollama",
+    "exo",
+  ]) as LLMRuntimeKind[];
+  const globalOverrideEngaged =
+    configQuery.data?.llm_provider_unlocked === true;
+  const globalDefault = configQuery.data?.llm_provider ?? "claude-code";
+
+  const binding = bindingFromMember(agent.provider);
+  const isGateway = isGatewayBinding(agent.provider);
   const harness = resolveHarness(agent.provider, defaultHarness);
-  const providerLabel =
-    typeof agent.provider === "string"
-      ? agent.provider
-      : agent.provider?.model
-        ? `${agent.provider.kind ?? harness} / ${agent.provider.model}`
-        : agent.provider?.kind || harness;
+
+  const [draftKind, setDraftKind] = useState<"" | LLMRuntimeKind>(
+    (binding.kind && llmKinds.includes(binding.kind as LLMRuntimeKind)
+      ? (binding.kind as LLMRuntimeKind)
+      : "") as "" | LLMRuntimeKind,
+  );
+  const [draftModel, setDraftModel] = useState<string>(binding.model ?? "");
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Built-ins (CEO, lead) cannot have their runtime moved off the install
+  // default — the broker rejects the write — so we hide editing there too.
+  // The user-task says CEO chat must ask for provider on spawn, which is the
+  // wizard's job, not this panel's.
+  const isLead = agent.built_in === true || agent.slug === "ceo";
+  const editable = !(isGateway || globalOverrideEngaged || isLead);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const body: Record<string, unknown> = {
+        action: "update",
+        slug: agent.slug,
+      };
+      if (draftKind === "") {
+        // Empty kind means "clear per-agent binding, inherit default".
+        // The broker stores ProviderBinding{} which the resolver treats as
+        // "fall back to global default" at dispatch time.
+        body.provider = { kind: "", model: "" };
+      } else {
+        body.provider = { kind: draftKind, model: draftModel.trim() };
+      }
+      await post("/office-members", body);
+    },
+    onSuccess: () => {
+      setSaveError(null);
+      void queryClient.invalidateQueries({ queryKey: ["office-members"] });
+    },
+    onError: (err: unknown) => {
+      setSaveError(err instanceof Error ? err.message : "Failed to save");
+    },
+  });
+
+  if (isGateway) {
+    const gatewayKind =
+      (typeof agent.provider === "string"
+        ? agent.provider
+        : agent.provider?.kind) || "";
+    const gatewayLabel = GATEWAY_LABELS[gatewayKind] || gatewayKind;
+    return (
+      <div className="agent-profile-section">
+        <SectionTitle>runtime</SectionTitle>
+        <div className="agent-profile-permissions">
+          <div className="agent-profile-perm-row">
+            <span className="agent-profile-perm-label">managed by</span>
+            <span
+              className="agent-profile-perm-value"
+              style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+            >
+              <Lock width={12} height={12} />
+              {gatewayLabel} gateway
+            </span>
+          </div>
+          {binding.model && (
+            <div className="agent-profile-perm-row">
+              <span className="agent-profile-perm-label">model</span>
+              <span className="agent-profile-perm-value">{binding.model}</span>
+            </div>
+          )}
+        </div>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--text-tertiary)",
+            marginTop: 8,
+            display: "block",
+          }}
+        >
+          This agent was imported through the {gatewayLabel} gateway. Change its
+          runtime from the Integrations app.
+        </span>
+      </div>
+    );
+  }
+
+  const dirty =
+    draftKind !== ((binding.kind as LLMRuntimeKind | undefined) ?? "") ||
+    draftModel.trim() !== (binding.model ?? "").trim();
 
   return (
     <div className="agent-profile-section">
@@ -303,13 +459,116 @@ function ProviderSection({
           <span className="agent-profile-perm-label">harness</span>
           <span className="agent-profile-perm-value">{harness}</span>
         </div>
-        {providerLabel && providerLabel !== harness && (
-          <div className="agent-profile-perm-row">
-            <span className="agent-profile-perm-label">provider</span>
-            <span className="agent-profile-perm-value">{providerLabel}</span>
-          </div>
-        )}
+        <div
+          className="agent-profile-perm-row"
+          style={{ alignItems: "center" }}
+        >
+          <span className="agent-profile-perm-label">provider</span>
+          <select
+            value={draftKind}
+            disabled={!editable || mutation.isPending}
+            onChange={(e) =>
+              setDraftKind(e.target.value as "" | LLMRuntimeKind)
+            }
+            style={{ flex: 1 }}
+          >
+            <option value="">Inherit default ({globalDefault})</option>
+            {llmKinds.map((kind) => (
+              <option key={kind} value={kind}>
+                {PROVIDER_LABELS[kind] ?? kind}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div
+          className="agent-profile-perm-row"
+          style={{ alignItems: "center" }}
+        >
+          <span className="agent-profile-perm-label">model</span>
+          <input
+            className="input"
+            type="text"
+            placeholder={
+              draftKind === ""
+                ? "Runtime default"
+                : "e.g. claude-3-5-sonnet-latest"
+            }
+            value={draftModel}
+            disabled={!editable || draftKind === "" || mutation.isPending}
+            onChange={(e) => setDraftModel(e.target.value)}
+            style={{ flex: 1 }}
+          />
+        </div>
       </div>
+      {globalOverrideEngaged && (
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--text-tertiary)",
+            marginTop: 8,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
+          <Lock width={11} height={11} />
+          Locked by global override — re-lock the default runtime in Settings to
+          edit per-agent runtimes.
+        </span>
+      )}
+      {isLead && !globalOverrideEngaged && (
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--text-tertiary)",
+            marginTop: 8,
+            display: "block",
+          }}
+        >
+          Lead agents always run on the install default; change it in Settings.
+        </span>
+      )}
+      {saveError && (
+        <div
+          className="agent-wizard-error"
+          style={{ marginTop: 8 }}
+          role="alert"
+        >
+          {saveError}
+        </div>
+      )}
+      {editable && (
+        <div
+          className="agent-wizard-footer"
+          style={{ marginTop: 10, justifyContent: "flex-end" }}
+        >
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm"
+            disabled={!dirty || mutation.isPending}
+            onClick={() => {
+              setDraftKind(
+                (binding.kind &&
+                llmKinds.includes(binding.kind as LLMRuntimeKind)
+                  ? (binding.kind as LLMRuntimeKind)
+                  : "") as "" | LLMRuntimeKind,
+              );
+              setDraftModel(binding.model ?? "");
+              setSaveError(null);
+            }}
+          >
+            Reset
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            disabled={!dirty || mutation.isPending}
+            onClick={() => mutation.mutate()}
+          >
+            {mutation.isPending ? "Saving..." : "Save runtime"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -440,8 +699,8 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
           </div>
         ) : null}
 
-        {/* Provider / runtime */}
-        <ProviderSection agent={agent} defaultHarness={defaultHarness} />
+        {/* Per-agent runtime picker */}
+        <RuntimeSection agent={agent} defaultHarness={defaultHarness} />
 
         {/* Skills */}
         <SkillsSection agentSlug={agent.slug} skills={skills} />

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -4,6 +4,7 @@ import { Lock, Xmark } from "iconoir-react";
 
 import type {
   LLMRuntimeKind,
+  LocalProviderStatus,
   OfficeMember,
   ProviderBinding,
   Skill,
@@ -11,10 +12,17 @@ import type {
 import {
   getChannels,
   getConfig,
+  getLocalProvidersStatus,
   getSkillsList,
   isGatewayBinding,
   post,
 } from "../../api/client";
+import {
+  CUSTOM_MODEL_VALUE,
+  INHERIT_MODEL_VALUE,
+  isCatalogModel,
+  modelOptionsForKind,
+} from "../../lib/modelCatalog";
 import {
   getOfficeTasks,
   listAgentLogTasks,
@@ -336,6 +344,85 @@ function bindingFromMember(
 //     can't write while the global is overriding.
 //
 //  3. Normal: editable picker with provider + model fields and a Save button.
+
+// ModelPicker is a dropdown of curated model ids for the selected runtime,
+// plus a "Custom…" escape hatch that falls back to a text input for power
+// users. Local runtimes (mlx-lm / ollama / exo) pull their model list from
+// the loopback probe (localStatuses) instead of the hardcoded catalog so
+// the dropdown shows what's actually installed.
+//
+// Empty string is the "Use runtime default" sentinel — saving with that
+// value clears ProviderBinding.Model so each runner picks its own default.
+function ModelPicker({
+  kind,
+  value,
+  disabled,
+  onChange,
+  localStatuses,
+}: {
+  kind: LLMRuntimeKind | "";
+  value: string;
+  disabled: boolean;
+  onChange: (next: string) => void;
+  localStatuses: LocalProviderStatus[];
+}) {
+  const options = modelOptionsForKind(kind, localStatuses);
+  // Custom-mode is sticky once entered (selecting Custom… from the
+  // dropdown stays in custom mode even after the underlying text matches
+  // a catalog entry). That avoids the dropdown switching back mid-type
+  // and erasing what the user just keyed.
+  const valueIsCatalog = isCatalogModel(kind, value, localStatuses);
+  const [customMode, setCustomMode] = useState(!valueIsCatalog && value !== "");
+  // selectValue feeds the <select>. While typing in custom mode we keep
+  // CUSTOM_MODEL_VALUE so the dropdown stays on "Custom…" rather than
+  // jumping around as the user types.
+  const selectValue = customMode || !valueIsCatalog
+    ? CUSTOM_MODEL_VALUE
+    : value || INHERIT_MODEL_VALUE;
+  return (
+    <span style={{ display: "inline-flex", gap: 6, width: "100%" }}>
+      <select
+        value={selectValue}
+        disabled={disabled}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (next === CUSTOM_MODEL_VALUE) {
+            setCustomMode(true);
+            // Don't clobber any value the user already had in flight.
+            return;
+          }
+          setCustomMode(false);
+          onChange(next);
+        }}
+        style={{ flex: customMode ? "0 0 130px" : 1 }}
+      >
+        {options.map((o) => (
+          <option key={o.value || "default"} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      {customMode && (
+        <input
+          className="input"
+          type="text"
+          autoFocus={true}
+          placeholder="e.g. claude-3-5-sonnet-latest"
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value)}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            flex: 1,
+          }}
+          aria-label="Custom model id"
+        />
+      )}
+    </span>
+  );
+}
+
 function RuntimeSection({
   agent,
   defaultHarness,
@@ -349,6 +436,15 @@ function RuntimeSection({
     queryFn: getConfig,
     staleTime: 30_000,
   });
+  // localStatuses feeds the ModelPicker with the actual loaded model for
+  // local runtimes (mlx-lm / ollama / exo). The probe is cheap (a single
+  // loopback call) so we share the broker's existing cache key.
+  const localStatusQuery = useQuery({
+    queryKey: ["local-providers-status"],
+    queryFn: getLocalProvidersStatus,
+    staleTime: 30_000,
+  });
+  const localStatuses: LocalProviderStatus[] = localStatusQuery.data ?? [];
   const llmKinds: LLMRuntimeKind[] = (configQuery.data?.llm_provider_kinds ?? [
     "claude-code",
     "codex",
@@ -475,18 +571,12 @@ function RuntimeSection({
         </span>
         <span className="op-runtime-label">model</span>
         <span className="op-runtime-value">
-          <input
-            className="input"
-            type="text"
-            placeholder={
-              draftKind === ""
-                ? "Runtime default"
-                : "e.g. claude-3-5-sonnet-latest"
-            }
+          <ModelPicker
+            kind={draftKind}
             value={draftModel}
             disabled={!editable || draftKind === "" || mutation.isPending}
-            onChange={(e) => setDraftModel(e.target.value)}
-            style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+            onChange={setDraftModel}
+            localStatuses={localStatuses}
           />
         </span>
       </div>

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -412,37 +412,32 @@ function RuntimeSection({
         : agent.provider?.kind) || "";
     const gatewayLabel = GATEWAY_LABELS[gatewayKind] || gatewayKind;
     return (
-      <div className="agent-profile-section">
+      <div className="agent-profile-section op-runtime">
         <SectionTitle>runtime</SectionTitle>
-        <div className="agent-profile-permissions">
-          <div className="agent-profile-perm-row">
-            <span className="agent-profile-perm-label">managed by</span>
-            <span
-              className="agent-profile-perm-value"
-              style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
-            >
-              <Lock width={12} height={12} />
+        <div className="op-runtime-grid">
+          <span className="op-runtime-label">managed by</span>
+          <span className="op-runtime-value">
+            <span className="op-runtime-managed">
+              <Lock width={11} height={11} />
               {gatewayLabel} gateway
             </span>
-          </div>
+          </span>
           {binding.model && (
-            <div className="agent-profile-perm-row">
-              <span className="agent-profile-perm-label">model</span>
-              <span className="agent-profile-perm-value">{binding.model}</span>
-            </div>
+            <>
+              <span className="op-runtime-label">model</span>
+              <span
+                className="op-runtime-value"
+                style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+              >
+                {binding.model}
+              </span>
+            </>
           )}
         </div>
-        <span
-          style={{
-            fontSize: 11,
-            color: "var(--text-tertiary)",
-            marginTop: 8,
-            display: "block",
-          }}
-        >
+        <p className="op-runtime-note">
           This agent was imported through the {gatewayLabel} gateway. Change its
           runtime from the Integrations app.
-        </span>
+        </p>
       </div>
     );
   }
@@ -452,25 +447,24 @@ function RuntimeSection({
     draftModel.trim() !== (binding.model ?? "").trim();
 
   return (
-    <div className="agent-profile-section">
+    <div className="agent-profile-section op-runtime">
       <SectionTitle>runtime</SectionTitle>
-      <div className="agent-profile-permissions">
-        <div className="agent-profile-perm-row">
-          <span className="agent-profile-perm-label">harness</span>
-          <span className="agent-profile-perm-value">{harness}</span>
-        </div>
-        <div
-          className="agent-profile-perm-row"
-          style={{ alignItems: "center" }}
+      <div className="op-runtime-grid">
+        <span className="op-runtime-label">harness</span>
+        <span
+          className="op-runtime-value"
+          style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
         >
-          <span className="agent-profile-perm-label">provider</span>
+          {harness}
+        </span>
+        <span className="op-runtime-label">provider</span>
+        <span className="op-runtime-value">
           <select
             value={draftKind}
             disabled={!editable || mutation.isPending}
             onChange={(e) =>
               setDraftKind(e.target.value as "" | LLMRuntimeKind)
             }
-            style={{ flex: 1 }}
           >
             <option value="">Inherit default ({globalDefault})</option>
             {llmKinds.map((kind) => (
@@ -479,12 +473,9 @@ function RuntimeSection({
               </option>
             ))}
           </select>
-        </div>
-        <div
-          className="agent-profile-perm-row"
-          style={{ alignItems: "center" }}
-        >
-          <span className="agent-profile-perm-label">model</span>
+        </span>
+        <span className="op-runtime-label">model</span>
+        <span className="op-runtime-value">
           <input
             className="input"
             type="text"
@@ -496,37 +487,25 @@ function RuntimeSection({
             value={draftModel}
             disabled={!editable || draftKind === "" || mutation.isPending}
             onChange={(e) => setDraftModel(e.target.value)}
-            style={{ flex: 1 }}
+            style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
           />
-        </div>
+        </span>
       </div>
       {globalOverrideEngaged && (
-        <span
-          style={{
-            fontSize: 11,
-            color: "var(--text-tertiary)",
-            marginTop: 8,
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 4,
-          }}
-        >
-          <Lock width={11} height={11} />
+        <p className="op-runtime-note is-warn">
+          <Lock
+            width={11}
+            height={11}
+            style={{ marginRight: 4, verticalAlign: "text-bottom" }}
+          />
           Locked by global override — re-lock the default runtime in Settings to
           edit per-agent runtimes.
-        </span>
+        </p>
       )}
       {isLead && !globalOverrideEngaged && (
-        <span
-          style={{
-            fontSize: 11,
-            color: "var(--text-tertiary)",
-            marginTop: 8,
-            display: "block",
-          }}
-        >
+        <p className="op-runtime-note">
           Lead agents always run on the install default; change it in Settings.
-        </span>
+        </p>
       )}
       {saveError && (
         <div
@@ -538,10 +517,7 @@ function RuntimeSection({
         </div>
       )}
       {editable && (
-        <div
-          className="agent-wizard-footer"
-          style={{ marginTop: 10, justifyContent: "flex-end" }}
-        >
+        <div className="op-runtime-actions">
           <button
             type="button"
             className="btn btn-ghost btn-sm"

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Lock, Xmark } from "iconoir-react";
 
@@ -18,12 +18,6 @@ import {
   post,
 } from "../../api/client";
 import {
-  CUSTOM_MODEL_VALUE,
-  INHERIT_MODEL_VALUE,
-  isCatalogModel,
-  modelOptionsForKind,
-} from "../../lib/modelCatalog";
-import {
   getOfficeTasks,
   listAgentLogTasks,
   type Task,
@@ -32,6 +26,12 @@ import {
 import { useDefaultHarness } from "../../hooks/useConfig";
 import type { HarnessKind } from "../../lib/harness";
 import { resolveHarness } from "../../lib/harness";
+import {
+  CUSTOM_MODEL_VALUE,
+  INHERIT_MODEL_VALUE,
+  isCatalogModel,
+  modelOptionsForKind,
+} from "../../lib/modelCatalog";
 import { router } from "../../lib/router";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
@@ -373,12 +373,31 @@ function ModelPicker({
   // and erasing what the user just keyed.
   const valueIsCatalog = isCatalogModel(kind, value, localStatuses);
   const [customMode, setCustomMode] = useState(!valueIsCatalog && value !== "");
+  // Re-sync custom mode when the runtime kind switches under us: a
+  // codex→claude-code switch can land on a value that's catalog for
+  // claude-code but custom for codex (or vice versa). Without this the
+  // input gets stuck in the wrong mode after a parent rebinds.
+  useEffect(() => {
+    const shouldBeCustom =
+      !isCatalogModel(kind, value, localStatuses) && value !== "";
+    setCustomMode(shouldBeCustom);
+  }, [kind, value, localStatuses]);
+  // Imperative focus on the custom input when it enters custom mode.
+  // biome's a11y/noAutofocus rule forbids the JSX attribute but permits
+  // useRef-driven focus (same pattern as WipeModal); the immediate-focus
+  // behaviour is load-bearing here because the user just clicked Custom…
+  // and expects to start typing without an extra tab.
+  const customInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (customMode) customInputRef.current?.focus();
+  }, [customMode]);
   // selectValue feeds the <select>. While typing in custom mode we keep
   // CUSTOM_MODEL_VALUE so the dropdown stays on "Custom…" rather than
   // jumping around as the user types.
-  const selectValue = customMode || !valueIsCatalog
-    ? CUSTOM_MODEL_VALUE
-    : value || INHERIT_MODEL_VALUE;
+  const selectValue =
+    customMode || !valueIsCatalog
+      ? CUSTOM_MODEL_VALUE
+      : value || INHERIT_MODEL_VALUE;
   return (
     <span style={{ display: "inline-flex", gap: 6, width: "100%" }}>
       <select
@@ -404,9 +423,9 @@ function ModelPicker({
       </select>
       {customMode && (
         <input
+          ref={customInputRef}
           className="input"
           type="text"
-          autoFocus={true}
           placeholder="e.g. claude-3-5-sonnet-latest"
           value={value}
           disabled={disabled}
@@ -466,6 +485,19 @@ function RuntimeSection({
   );
   const [draftModel, setDraftModel] = useState<string>(binding.model ?? "");
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Re-sync draft state when the agent prop swaps (e.g. user picks a
+  // different agent in the sidebar without unmounting the panel). useState
+  // initialisers run only on mount, so without this the picker would show
+  // the previous agent's kind/model until a manual reset.
+  useEffect(() => {
+    setDraftKind(
+      (binding.kind && llmKinds.includes(binding.kind as LLMRuntimeKind)
+        ? (binding.kind as LLMRuntimeKind)
+        : "") as "" | LLMRuntimeKind,
+    );
+    setDraftModel(binding.model ?? "");
+    setSaveError(null);
+  }, [agent.slug, binding.kind, binding.model, llmKinds]);
 
   // Lead agents (CEO, other built-ins) can have their runtime changed from
   // this panel too. The broker's built-in gate only fires on remove, not on
@@ -639,14 +671,27 @@ function EditableName({ agent }: { agent: OfficeMember }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(initial);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Imperative focus when the user enters edit mode. The JSX autoFocus
+  // attribute would also work but is forbidden by biome's a11y rule;
+  // useRef + useEffect mirrors the WipeModal pattern and keeps the
+  // immediate-focus behaviour the user expects when they click the name.
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
 
   // Keep the draft in sync when the underlying member name changes from
   // outside (e.g. another browser tab edited it). React re-mounts the
   // component on a slug switch (key prop on AgentPanelView), so we only
-  // need to track name changes within the same agent.
-  if (!editing && draft !== initial && draft !== agent.name) {
-    setDraft(initial);
-  }
+  // need to track name changes within the same agent. Use useEffect
+  // rather than a setState during render — the latter works but is
+  // brittle if a future refactor adds a second consumer that reads
+  // `draft` between the render and the re-render.
+  useEffect(() => {
+    if (!editing) {
+      setDraft(initial);
+    }
+  }, [initial, editing]);
 
   const mutation = useMutation({
     mutationFn: async (name: string) => {
@@ -704,7 +749,7 @@ function EditableName({ agent }: { agent: OfficeMember }) {
   return (
     <>
       <input
-        autoFocus={true}
+        ref={inputRef}
         className="input"
         value={draft}
         disabled={mutation.isPending}

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -357,8 +357,6 @@ function RuntimeSection({
     "ollama",
     "exo",
   ]) as LLMRuntimeKind[];
-  const globalOverrideEngaged =
-    configQuery.data?.llm_provider_unlocked === true;
   const globalDefault = configQuery.data?.llm_provider ?? "claude-code";
 
   const binding = bindingFromMember(agent.provider);
@@ -378,7 +376,7 @@ function RuntimeSection({
   // The user-task says CEO chat must ask for provider on spawn, which is the
   // wizard's job, not this panel's.
   const isLead = agent.built_in === true || agent.slug === "ceo";
-  const editable = !(isGateway || globalOverrideEngaged || isLead);
+  const editable = !(isGateway || isLead);
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -491,20 +489,15 @@ function RuntimeSection({
           />
         </span>
       </div>
-      {globalOverrideEngaged && (
-        <p className="op-runtime-note is-warn">
-          <Lock
-            width={11}
-            height={11}
-            style={{ marginRight: 4, verticalAlign: "text-bottom" }}
-          />
-          Locked by global override — re-lock the default runtime in Settings to
-          edit per-agent runtimes.
-        </p>
-      )}
-      {isLead && !globalOverrideEngaged && (
+      {isLead && (
         <p className="op-runtime-note">
           Lead agents always run on the install default; change it in Settings.
+        </p>
+      )}
+      {!isLead && draftKind === "" && (
+        <p className="op-runtime-note">
+          Inheriting the install default ({globalDefault}). Pick a specific
+          runtime here to pin this agent.
         </p>
       )}
       {saveError && (
@@ -560,6 +553,11 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
   });
 
   type ChannelLite = { slug: string; name: string; members?: string[] };
+  // The "channels" cache slot is shared with useChannels() which stores
+  // the full {channels: [...]} envelope, not the array. Normalize on
+  // read so this surface tolerates either shape without crashing — and
+  // without renaming the cache key (which would invite a stale-data
+  // race during the migration).
   const { data: channels = [] as ChannelLite[] } = useQuery<
     ChannelLite[] | { channels?: ChannelLite[] },
     Error,
@@ -568,16 +566,9 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
     queryKey: ["channels"],
     queryFn: () =>
       getChannels().then((r) =>
-        arrayOrEmpty<{ slug: string; name: string; members?: string[] }>(
-          r?.channels,
-        ),
+        arrayOrEmpty<ChannelLite>(r?.channels),
       ),
     refetchInterval: 30_000,
-    // The "channels" cache slot is shared with useChannels() which stores
-    // the full {channels: [...]} envelope, not the array. Normalize on
-    // read so this surface tolerates either shape without crashing — and
-    // without renaming the cache key (which would invite a stale-data
-    // race during the migration).
     select: (data): ChannelLite[] => {
       if (Array.isArray(data)) return data as ChannelLite[];
       const envelope = data as { channels?: ChannelLite[] };

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/a11y/noStaticElementInteractions: Modal backdrop uses pointer hit-testing while dialog controls retain keyboard handling.
 // biome-ignore-all lint/a11y/useKeyWithClickEvents: Backdrop pointer dismissal is paired with a window Escape listener while the modal is open.
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -97,9 +97,24 @@ function WizardModelPicker({
 }) {
   const options = modelOptionsForKind(providerKind, localStatuses);
   const valueIsCatalog = isCatalogModel(providerKind, value, localStatuses);
-  const [customMode, setCustomMode] = useState(
-    !valueIsCatalog && value !== "",
-  );
+  const [customMode, setCustomMode] = useState(!valueIsCatalog && value !== "");
+  // Re-sync custom mode when the runtime kind switches under us.
+  // Without this, picking a different runtime after entering a custom
+  // model leaves the dropdown stuck in custom mode against the new
+  // catalog (or vice versa).
+  useEffect(() => {
+    const shouldBeCustom =
+      !isCatalogModel(providerKind, value, localStatuses) && value !== "";
+    setCustomMode(shouldBeCustom);
+  }, [providerKind, value, localStatuses]);
+  // useRef-driven focus into the custom input. Matches the
+  // AgentProfilePanel ModelPicker pattern: biome forbids the JSX
+  // autoFocus attribute but the imperative form is sanctioned and the
+  // immediate-focus UX is load-bearing after picking Custom….
+  const customInputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (customMode) customInputRef.current?.focus();
+  }, [customMode]);
   const selectValue =
     customMode || !valueIsCatalog
       ? CUSTOM_MODEL_VALUE
@@ -129,9 +144,9 @@ function WizardModelPicker({
       </select>
       {customMode && (
         <input
+          ref={customInputRef}
           className="input"
           type="text"
-          autoFocus={true}
           placeholder="e.g. claude-opus-4-7"
           value={value}
           disabled={disabled}
@@ -493,14 +508,15 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
               </select>
               {form.provider === "inherit" ? (
                 <span className="op-hint">
-                  Inherits the install default. Pick a specific runtime to
-                  pin this agent — you can also change it later from the
-                  agent's profile.
+                  Inherits the install default. Pick a specific runtime to pin
+                  this agent — you can also change it later from the agent's
+                  profile.
                 </span>
               ) : (
                 <span className="op-hint">
-                  This agent will run on {PROVIDER_LABELS[form.provider]} on
-                  every turn. Change anytime from the agent's profile.
+                  This agent will run on{" "}
+                  {PROVIDER_LABELS[form.provider] ?? form.provider} on every
+                  turn. Change anytime from the agent's profile.
                 </span>
               )}
             </div>
@@ -514,18 +530,16 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                 </span>
               </label>
               <WizardModelPicker
-                providerKind={
-                  form.provider === "inherit" ? "" : form.provider
-                }
+                providerKind={form.provider === "inherit" ? "" : form.provider}
                 value={form.model}
                 disabled={form.provider === "inherit"}
                 onChange={(next) => updateField("model", next)}
                 localStatuses={localStatuses}
               />
               <span className="op-hint">
-                Pick from common models for the chosen runtime, or use
-                "Custom…" to type any model id. Leave on "Use runtime
-                default" to let the runtime decide.
+                Pick from common models for the chosen runtime, or use "Custom…"
+                to type any model id. Leave on "Use runtime default" to let the
+                runtime decide.
               </span>
             </div>
 

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -84,9 +84,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
   // Pull the registered runtime list off the wire so the picker stays in sync
   // with whatever providers the Go layer has registered. Falls back to a
   // hardcoded core set on first paint / fetch failure so the wizard is
-  // usable even when /config is briefly unavailable. Lock state surfaces a
-  // banner — when the global override is engaged the per-agent pick is
-  // ignored at dispatch, so the user should know before saving.
+  // usable even when /config is briefly unavailable.
   const configQuery = useQuery({
     queryKey: ["config"],
     queryFn: getConfig,
@@ -101,9 +99,6 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     "ollama",
     "exo",
   ]) as LLMRuntimeKind[];
-  const globalLocked = configQuery.data?.llm_provider_unlocked === false;
-  const globalOverrideEngaged =
-    configQuery.data?.llm_provider_unlocked === true;
 
   async function handleGenerate() {
     const trimmed = prompt.trim();
@@ -411,17 +406,18 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                   </option>
                 ))}
               </select>
-              {globalOverrideEngaged ? (
+              {form.provider === "inherit" ? (
                 <span className="op-hint">
-                  The global runtime is unlocked and overriding every agent —
-                  per-agent picks are ignored until it's re-locked in Settings.
+                  Inherits the install default. Pick a specific runtime to
+                  pin this agent — you can also change it later from the
+                  agent's profile.
                 </span>
-              ) : globalLocked && form.provider === "inherit" ? (
+              ) : (
                 <span className="op-hint">
-                  Inheriting the install default. Change here to pin this agent
-                  to a specific runtime.
+                  This agent will run on {PROVIDER_LABELS[form.provider]} on
+                  every turn. Change anytime from the agent's profile.
                 </span>
-              ) : null}
+              )}
             </div>
             <div className="agent-wizard-field">
               <label className="label" htmlFor="agent-model">

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -1,12 +1,22 @@
 // biome-ignore-all lint/a11y/noStaticElementInteractions: Modal backdrop uses pointer hit-testing while dialog controls retain keyboard handling.
 // biome-ignore-all lint/a11y/useKeyWithClickEvents: Backdrop pointer dismissal is paired with a window Escape listener while the modal is open.
 import { useCallback, useMemo, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { generateAgent, post } from "../../api/client";
+import {
+  generateAgent,
+  getConfig,
+  type LLMRuntimeKind,
+  post,
+} from "../../api/client";
 import { useWindowEscape } from "../../hooks/useWindowEscape";
 
-type Provider = "inherit" | "claude-code" | "codex" | "opencode";
+// "inherit" is the wizard-only sentinel that maps to an absent ProviderBinding
+// in the POST body (the broker then falls back to the install-wide default at
+// dispatch time). Gateway kinds (openclaw / hermes-agent) are deliberately
+// absent — agents bound to a gateway are imported through the Integrations
+// app, not created in this wizard.
+type ProviderChoice = "inherit" | LLMRuntimeKind;
 type WizardMode = "describe" | "manual";
 
 interface AgentFormData {
@@ -14,7 +24,8 @@ interface AgentFormData {
   slug: string;
   role: string;
   emoji: string;
-  provider: Provider;
+  provider: ProviderChoice;
+  model: string;
   expertise: string;
 }
 
@@ -24,15 +35,21 @@ const INITIAL_FORM: AgentFormData = {
   role: "",
   emoji: "",
   provider: "inherit",
+  model: "",
   expertise: "",
 };
 
-const PROVIDERS: { value: Provider; label: string }[] = [
-  { value: "inherit", label: "Default runtime" },
-  { value: "codex", label: "Codex" },
-  { value: "claude-code", label: "Claude Code" },
-  { value: "opencode", label: "Opencode" },
-];
+// Human-readable labels for the runtime picker. Kinds the broker hasn't
+// registered are skipped at render time, so missing labels here aren't fatal —
+// they just fall back to the raw kind string.
+const PROVIDER_LABELS: Record<LLMRuntimeKind, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  opencode: "Opencode",
+  "mlx-lm": "MLX-LM",
+  ollama: "Ollama",
+  exo: "Exo",
+};
 
 function slugify(name: string): string {
   return name
@@ -64,6 +81,30 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
   const [error, setError] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
+  // Pull the registered runtime list off the wire so the picker stays in sync
+  // with whatever providers the Go layer has registered. Falls back to a
+  // hardcoded core set on first paint / fetch failure so the wizard is
+  // usable even when /config is briefly unavailable. Lock state surfaces a
+  // banner — when the global override is engaged the per-agent pick is
+  // ignored at dispatch, so the user should know before saving.
+  const configQuery = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    enabled: open,
+    staleTime: 30_000,
+  });
+  const llmKinds: LLMRuntimeKind[] = (configQuery.data?.llm_provider_kinds ?? [
+    "claude-code",
+    "codex",
+    "opencode",
+    "mlx-lm",
+    "ollama",
+    "exo",
+  ]) as LLMRuntimeKind[];
+  const globalLocked = configQuery.data?.llm_provider_unlocked === false;
+  const globalOverrideEngaged =
+    configQuery.data?.llm_provider_unlocked === true;
+
   async function handleGenerate() {
     const trimmed = prompt.trim();
     if (!trimmed) {
@@ -75,12 +116,20 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     try {
       const tmpl = await generateAgent(trimmed);
       const generatedSlug = tmpl.slug || "";
+      // The CEO-side generator may suggest a runtime/model pair. Only
+      // honor it when the suggested provider is one we'd surface in the
+      // picker (i.e. a non-gateway registered kind) — gateway kinds must
+      // come in through the Integrations app, never through the wizard.
+      const suggestedProvider = tmpl.provider as LLMRuntimeKind | undefined;
+      const providerInList =
+        suggestedProvider && llmKinds.includes(suggestedProvider);
       setForm({
         name: tmpl.name || "",
         slug: generatedSlug,
         role: tmpl.role || "",
         emoji: tmpl.emoji || "",
-        provider: "inherit",
+        provider: providerInList ? suggestedProvider : "inherit",
+        model: tmpl.model || "",
         expertise: (tmpl.expertise || []).join(", "),
       });
       setSlugEdited(generatedSlug.length > 0);
@@ -124,14 +173,24 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     setError(null);
 
     try {
+      // Encode provider as an explicit binding only when the user picked a
+      // specific runtime. "inherit" sends an absent provider field so the
+      // broker leaves Provider zero-valued; the dispatch resolver then
+      // falls back to the install-wide default at turn time.
+      const trimmedModel = form.model.trim();
+      const providerBody =
+        form.provider === "inherit"
+          ? undefined
+          : trimmedModel
+            ? { kind: form.provider, model: trimmedModel }
+            : { kind: form.provider };
       const body = {
         action: "create",
         slug: form.slug,
         name: form.name,
         role: form.role || undefined,
         emoji: form.emoji || undefined,
-        provider:
-          form.provider === "inherit" ? undefined : { kind: form.provider },
+        provider: providerBody,
         expertise: expertiseTags.length > 0 ? expertiseTags : undefined,
       };
 
@@ -330,24 +389,87 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
               />
             </div>
 
-            {/* Provider */}
+            {/* Provider + Model */}
             <div className="agent-wizard-field">
               <label className="label" htmlFor="agent-provider">
-                Provider
+                Runtime
               </label>
               <select
                 id="agent-provider"
                 value={form.provider}
                 onChange={(e) =>
-                  updateField("provider", e.target.value as Provider)
+                  updateField("provider", e.target.value as ProviderChoice)
                 }
               >
-                {PROVIDERS.map((p) => (
-                  <option key={p.value} value={p.value}>
-                    {p.label}
+                <option value="inherit">
+                  Inherit default (
+                  {configQuery.data?.llm_provider ?? "claude-code"})
+                </option>
+                {llmKinds.map((kind) => (
+                  <option key={kind} value={kind}>
+                    {PROVIDER_LABELS[kind] ?? kind}
                   </option>
                 ))}
               </select>
+              {globalOverrideEngaged ? (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--text-tertiary)",
+                    marginTop: 6,
+                    display: "block",
+                  }}
+                >
+                  The global runtime is unlocked and overriding every agent —
+                  per-agent picks are ignored until it's re-locked in Settings.
+                </span>
+              ) : globalLocked && form.provider === "inherit" ? (
+                <span
+                  style={{
+                    fontSize: 11,
+                    color: "var(--text-tertiary)",
+                    marginTop: 6,
+                    display: "block",
+                  }}
+                >
+                  Inheriting the install default. Change here to pin this agent
+                  to a specific runtime.
+                </span>
+              ) : null}
+            </div>
+            <div className="agent-wizard-field">
+              <label className="label" htmlFor="agent-model">
+                Model{" "}
+                <span
+                  style={{ fontWeight: 400, color: "var(--text-tertiary)" }}
+                >
+                  (optional)
+                </span>
+              </label>
+              <input
+                id="agent-model"
+                className="input"
+                type="text"
+                placeholder={
+                  form.provider === "inherit"
+                    ? "Uses the runtime's default model"
+                    : "e.g. claude-3-5-sonnet-latest, llama3.1:8b"
+                }
+                value={form.model}
+                onChange={(e) => updateField("model", e.target.value)}
+                disabled={form.provider === "inherit"}
+              />
+              <span
+                style={{
+                  fontSize: 11,
+                  color: "var(--text-tertiary)",
+                  marginTop: 6,
+                  display: "block",
+                }}
+              >
+                Validated by the runtime, not by WUPHF. Leave blank to use
+                whatever model the runtime selects by default.
+              </span>
             </div>
 
             {/* Expertise */}

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -412,26 +412,12 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                 ))}
               </select>
               {globalOverrideEngaged ? (
-                <span
-                  style={{
-                    fontSize: 11,
-                    color: "var(--text-tertiary)",
-                    marginTop: 6,
-                    display: "block",
-                  }}
-                >
+                <span className="op-hint">
                   The global runtime is unlocked and overriding every agent —
                   per-agent picks are ignored until it's re-locked in Settings.
                 </span>
               ) : globalLocked && form.provider === "inherit" ? (
-                <span
-                  style={{
-                    fontSize: 11,
-                    color: "var(--text-tertiary)",
-                    marginTop: 6,
-                    display: "block",
-                  }}
-                >
+                <span className="op-hint">
                   Inheriting the install default. Change here to pin this agent
                   to a specific runtime.
                 </span>
@@ -458,15 +444,9 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                 value={form.model}
                 onChange={(e) => updateField("model", e.target.value)}
                 disabled={form.provider === "inherit"}
+                style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
               />
-              <span
-                style={{
-                  fontSize: 11,
-                  color: "var(--text-tertiary)",
-                  marginTop: 6,
-                  display: "block",
-                }}
-              >
+              <span className="op-hint">
                 Validated by the runtime, not by WUPHF. Leave blank to use
                 whatever model the runtime selects by default.
               </span>

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -6,10 +6,18 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   generateAgent,
   getConfig,
+  getLocalProvidersStatus,
   type LLMRuntimeKind,
+  type LocalProviderStatus,
   post,
 } from "../../api/client";
 import { useWindowEscape } from "../../hooks/useWindowEscape";
+import {
+  CUSTOM_MODEL_VALUE,
+  INHERIT_MODEL_VALUE,
+  isCatalogModel,
+  modelOptionsForKind,
+} from "../../lib/modelCatalog";
 
 // "inherit" is the wizard-only sentinel that maps to an absent ProviderBinding
 // in the POST body (the broker then falls back to the install-wide default at
@@ -70,6 +78,76 @@ const AGENT_WIZARD_DIALOG_PROPS = {
   "aria-labelledby": "agent-wizard-title",
 } as const;
 
+// WizardModelPicker mirrors AgentProfilePanel's ModelPicker — curated catalog
+// dropdown plus a "Custom…" escape hatch for power users. The wizard's
+// "Inherit default" provider state disables the picker entirely; the field is
+// re-enabled when the user picks a specific runtime.
+function WizardModelPicker({
+  providerKind,
+  value,
+  disabled,
+  onChange,
+  localStatuses,
+}: {
+  providerKind: LLMRuntimeKind | "";
+  value: string;
+  disabled: boolean;
+  onChange: (next: string) => void;
+  localStatuses: LocalProviderStatus[];
+}) {
+  const options = modelOptionsForKind(providerKind, localStatuses);
+  const valueIsCatalog = isCatalogModel(providerKind, value, localStatuses);
+  const [customMode, setCustomMode] = useState(
+    !valueIsCatalog && value !== "",
+  );
+  const selectValue =
+    customMode || !valueIsCatalog
+      ? CUSTOM_MODEL_VALUE
+      : value || INHERIT_MODEL_VALUE;
+  return (
+    <div style={{ display: "flex", gap: 6, width: "100%" }}>
+      <select
+        id="agent-model"
+        value={selectValue}
+        disabled={disabled}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (next === CUSTOM_MODEL_VALUE) {
+            setCustomMode(true);
+            return;
+          }
+          setCustomMode(false);
+          onChange(next);
+        }}
+        style={{ flex: customMode ? "0 0 160px" : 1 }}
+      >
+        {options.map((o) => (
+          <option key={o.value || "default"} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      {customMode && (
+        <input
+          className="input"
+          type="text"
+          autoFocus={true}
+          placeholder="e.g. claude-opus-4-7"
+          value={value}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value)}
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 12,
+            flex: 1,
+          }}
+          aria-label="Custom model id"
+        />
+      )}
+    </div>
+  );
+}
+
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
   const [mode, setMode] = useState<WizardMode>("describe");
@@ -91,6 +169,13 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     enabled: open,
     staleTime: 30_000,
   });
+  const localStatusQuery = useQuery({
+    queryKey: ["local-providers-status"],
+    queryFn: getLocalProvidersStatus,
+    enabled: open,
+    staleTime: 30_000,
+  });
+  const localStatuses: LocalProviderStatus[] = localStatusQuery.data ?? [];
   const llmKinds: LLMRuntimeKind[] = (configQuery.data?.llm_provider_kinds ?? [
     "claude-code",
     "codex",
@@ -428,23 +513,19 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                   (optional)
                 </span>
               </label>
-              <input
-                id="agent-model"
-                className="input"
-                type="text"
-                placeholder={
-                  form.provider === "inherit"
-                    ? "Uses the runtime's default model"
-                    : "e.g. claude-3-5-sonnet-latest, llama3.1:8b"
+              <WizardModelPicker
+                providerKind={
+                  form.provider === "inherit" ? "" : form.provider
                 }
                 value={form.model}
-                onChange={(e) => updateField("model", e.target.value)}
                 disabled={form.provider === "inherit"}
-                style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}
+                onChange={(next) => updateField("model", next)}
+                localStatuses={localStatuses}
               />
               <span className="op-hint">
-                Validated by the runtime, not by WUPHF. Leave blank to use
-                whatever model the runtime selects by default.
+                Pick from common models for the chosen runtime, or use
+                "Custom…" to type any model id. Leave on "Use runtime
+                default" to let the runtime decide.
               </span>
             </div>
 

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -1,359 +1,20 @@
-import { useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Lock, OpenNewWindow, WarningTriangle } from "iconoir-react";
+import { Fragment } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Lock, WarningTriangle } from "iconoir-react";
 
+import { getConfig, getLocalProvidersStatus } from "../../api/client";
+import { INTEGRATIONS } from "./integrations/registry";
 import {
-  type ConfigSnapshot,
-  type ConfigUpdate,
-  type GatewayKind,
-  getConfig,
-  getLocalProvidersStatus,
-  type LocalProviderStatus,
-  updateConfig,
-} from "../../api/client";
-import { useAppStore } from "../../stores/app";
-import { showNotice } from "../ui/Toast";
+  INTEGRATION_CATEGORIES,
+  type IntegrationCategoryMeta,
+  type IntegrationContext,
+  type IntegrationDescriptor,
+} from "./integrations/types";
 
-// IntegrationsApp is the home for gateway-style connections — surfaces that
-// import existing agents or external messaging streams into the team rather
-// than backing a WUPHF-created agent's turns. Three first-class cards today:
-//
-//   - OpenClaw: bridges OpenClaw-controlled sessions into the office. Tokens
-//     and gateway URL live here, not in Settings, so the configuration sits
-//     next to the import action.
-//   - Hermes: connects a local Hermes gateway's /v1 API. Status is read from
-//     the same loopback probe Local LLMs used to use, but framed as
-//     gateway-connected rather than "runtime available."
-//   - Telegram: paste a bot token, pick a chat, get a channel. Wraps the
-//     existing TelegramConnectModal so this app is the single place a user
-//     goes to add an integration.
-//
-// New gateway types should each get their own GatewayCard — they should not
-// be folded into the global LLM provider picker.
-
-interface CardShellProps {
-  icon: React.ReactNode;
-  title: string;
-  status: "connected" | "available" | "unconfigured" | "warning";
-  statusLabel: string;
-  body: React.ReactNode;
-}
-
-function statusColor(status: CardShellProps["status"]): string {
-  switch (status) {
-    case "connected":
-      return "#16a34a";
-    case "available":
-      return "#3b82f6";
-    case "warning":
-      return "#d97706";
-    default:
-      return "var(--text-tertiary)";
-  }
-}
-
-function CardShell({ icon, title, status, statusLabel, body }: CardShellProps) {
-  return (
-    <section
-      style={{
-        border: "1px solid var(--border)",
-        borderRadius: 8,
-        padding: 16,
-        marginBottom: 16,
-        background: "var(--bg-card)",
-      }}
-    >
-      <header
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: 12,
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <span style={{ fontSize: 22 }}>{icon}</span>
-          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{title}</h3>
-        </div>
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            fontSize: 11,
-            color: statusColor(status),
-            fontWeight: 600,
-            textTransform: "uppercase",
-            letterSpacing: 0.4,
-          }}
-        >
-          <span
-            style={{
-              width: 8,
-              height: 8,
-              borderRadius: "50%",
-              background: statusColor(status),
-              display: "inline-block",
-            }}
-          />
-          {statusLabel}
-        </span>
-      </header>
-      <div>{body}</div>
-    </section>
-  );
-}
-
-function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
-  const queryClient = useQueryClient();
-  const [gatewayUrl, setGatewayUrl] = useState(cfg.openclaw_gateway_url ?? "");
-  const [token, setToken] = useState("");
-  const [revealToken, setRevealToken] = useState(false);
-  const tokenSet = Boolean(cfg.openclaw_token_set);
-  const urlSet = Boolean(cfg.openclaw_gateway_url);
-  const connected = tokenSet && urlSet;
-
-  const mutation = useMutation({
-    mutationFn: async () => {
-      const patch: ConfigUpdate = {};
-      if (gatewayUrl.trim()) patch.openclaw_gateway_url = gatewayUrl.trim();
-      if (token.trim()) patch.openclaw_token = token.trim();
-      await updateConfig(patch);
-    },
-    onSuccess: () => {
-      showNotice("OpenClaw connection saved.", "success");
-      setToken("");
-      void queryClient.invalidateQueries({ queryKey: ["config"] });
-    },
-    onError: (err) => {
-      showNotice(
-        err instanceof Error ? err.message : "Failed to save OpenClaw",
-        "error",
-      );
-    },
-  });
-
-  return (
-    <CardShell
-      icon={<span aria-hidden="true">🔌</span>}
-      title="OpenClaw"
-      status={connected ? "connected" : "unconfigured"}
-      statusLabel={connected ? "Connected" : "Not configured"}
-      body={
-        <div>
-          <p
-            style={{
-              margin: "0 0 12px 0",
-              fontSize: 13,
-              color: "var(--text-secondary)",
-            }}
-          >
-            Bridge OpenClaw-controlled agents into the team. Provide your
-            gateway's WebSocket URL and an auth token; new OpenClaw agents can
-            then be onboarded from the gateway's session list.
-          </p>
-          <label
-            style={{
-              display: "block",
-              fontSize: 11,
-              fontWeight: 600,
-              marginBottom: 4,
-              color: "var(--text-secondary)",
-              textTransform: "uppercase",
-              letterSpacing: 0.4,
-            }}
-          >
-            Gateway URL
-          </label>
-          <input
-            className="input"
-            type="text"
-            placeholder="ws://127.0.0.1:18789"
-            value={gatewayUrl}
-            onChange={(e) => setGatewayUrl(e.target.value)}
-            style={{
-              width: "100%",
-              marginBottom: 10,
-              fontFamily: "var(--font-mono)",
-            }}
-          />
-          <label
-            style={{
-              display: "block",
-              fontSize: 11,
-              fontWeight: 600,
-              marginBottom: 4,
-              color: "var(--text-secondary)",
-              textTransform: "uppercase",
-              letterSpacing: 0.4,
-            }}
-          >
-            Token{" "}
-            {tokenSet && !token ? (
-              <span
-                style={{
-                  fontWeight: 400,
-                  textTransform: "none",
-                  letterSpacing: 0,
-                  color: "var(--text-tertiary)",
-                }}
-              >
-                (saved · paste to rotate)
-              </span>
-            ) : null}
-          </label>
-          <input
-            className="input"
-            type={revealToken ? "text" : "password"}
-            placeholder={tokenSet ? "●●●●●●●●" : "oc_..."}
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            style={{ width: "100%", marginBottom: 6 }}
-          />
-          <label
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-              fontSize: 11,
-              color: "var(--text-tertiary)",
-              cursor: "pointer",
-              marginBottom: 14,
-            }}
-          >
-            <input
-              type="checkbox"
-              checked={revealToken}
-              onChange={(e) => setRevealToken(e.target.checked)}
-            />
-            Show token
-          </label>
-          <div style={{ display: "flex", gap: 6 }}>
-            <button
-              type="button"
-              className="btn btn-primary btn-sm"
-              disabled={
-                mutation.isPending ||
-                !(gatewayUrl.trim() || token.trim()) ||
-                (connected &&
-                  !token.trim() &&
-                  gatewayUrl === (cfg.openclaw_gateway_url ?? ""))
-              }
-              onClick={() => mutation.mutate()}
-            >
-              {mutation.isPending
-                ? "Saving..."
-                : connected
-                  ? "Update connection"
-                  : "Connect"}
-            </button>
-          </div>
-        </div>
-      }
-    />
-  );
-}
-
-function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
-  const hermes = statuses.find((s) => s.kind === "hermes-agent");
-  let status: CardShellProps["status"] = "available";
-  let statusLabel = "Not detected";
-  if (hermes?.binary_installed && hermes.reachable) {
-    status = "connected";
-    statusLabel = "Reachable";
-  } else if (hermes?.binary_installed) {
-    status = "warning";
-    statusLabel = "Installed but unreachable";
-  }
-
-  return (
-    <CardShell
-      icon={<span aria-hidden="true">🔌</span>}
-      title="Hermes"
-      status={status}
-      statusLabel={statusLabel}
-      body={
-        <div>
-          <p
-            style={{
-              margin: "0 0 10px 0",
-              fontSize: 13,
-              color: "var(--text-secondary)",
-            }}
-          >
-            Connect to a local Hermes gateway's OpenAI-compatible API server on{" "}
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
-              {hermes?.endpoint ?? "http://127.0.0.1:8642/v1"}
-            </code>
-            . When Hermes is running, imported Hermes-controlled agents route
-            their turns through this gateway.
-          </p>
-          {hermes && !hermes.binary_installed && (
-            <p
-              style={{ margin: 0, fontSize: 12, color: "var(--text-tertiary)" }}
-            >
-              Install Hermes locally (see{" "}
-              <a
-                href="https://hermesagent.com"
-                target="_blank"
-                rel="noreferrer"
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 4,
-                }}
-              >
-                hermesagent.com <OpenNewWindow width={11} height={11} />
-              </a>
-              ) and start its API server. This card auto-detects when the
-              endpoint becomes reachable.
-            </p>
-          )}
-          {hermes?.binary_installed && !hermes.reachable && (
-            <p style={{ margin: 0, fontSize: 12, color: "#d97706" }}>
-              Hermes binary detected but the API server isn't responding. Start
-              it from a terminal and recheck.
-            </p>
-          )}
-        </div>
-      }
-    />
-  );
-}
-
-function TelegramCard({ cfg }: { cfg: ConfigSnapshot }) {
-  const openConnectWizard = useAppStore((s) => s.openConnectWizard);
-  const tokenSet = Boolean(cfg.telegram_token_set);
-  return (
-    <CardShell
-      icon={<span aria-hidden="true">🔌</span>}
-      title="Telegram"
-      status={tokenSet ? "connected" : "unconfigured"}
-      statusLabel={tokenSet ? "Bot connected" : "Not configured"}
-      body={
-        <div>
-          <p
-            style={{
-              margin: "0 0 12px 0",
-              fontSize: 13,
-              color: "var(--text-secondary)",
-            }}
-          >
-            Bring a Telegram chat into the office as a channel. Paste a bot
-            token, pick the chat, and replies route through the bot.
-          </p>
-          <button
-            type="button"
-            className="btn btn-primary btn-sm"
-            onClick={() => openConnectWizard("telegram")}
-          >
-            {tokenSet ? "Connect another chat" : "Connect Telegram"}
-          </button>
-        </div>
-      }
-    />
-  );
-}
+// IntegrationsApp renders the registry from
+// components/apps/integrations/registry.ts grouped by category. Adding a
+// new integration is a single descriptor entry — this file does not
+// hardcode any specific integration.
 
 function HelpBanner() {
   return (
@@ -381,13 +42,56 @@ function HelpBanner() {
           lineHeight: 1.5,
         }}
       >
-        OpenClaw and Hermes are <strong>gateways</strong> — they import existing
-        agents into the team. They are not LLM runtimes you can pick in{" "}
-        <em>Settings → Default runtime</em>. Once an agent is imported, the
-        agent profile shows a "Managed by &lt;Gateway&gt;" badge in its runtime
-        section.
+        Integrations are <strong>gateways</strong> for bringing agents or
+        messaging streams into the team from outside. They are not LLM runtimes
+        — pick those in <em>Settings → Default runtime</em>. Agent-importing
+        gateways (External Agents) tag their imported agents with a "Managed by
+        &lt;Gateway&gt;" badge in the agent profile.
       </div>
     </div>
+  );
+}
+
+function CategorySection({
+  meta,
+  descriptors,
+  ctx,
+}: {
+  meta: IntegrationCategoryMeta;
+  descriptors: IntegrationDescriptor[];
+  ctx: IntegrationContext;
+}) {
+  if (descriptors.length === 0) return null;
+  return (
+    <section style={{ marginBottom: 28 }}>
+      <header style={{ marginBottom: 10 }}>
+        <h3
+          style={{
+            margin: "0 0 4px 0",
+            fontSize: 13,
+            fontWeight: 700,
+            color: "var(--text-secondary)",
+            textTransform: "uppercase",
+            letterSpacing: 0.6,
+          }}
+        >
+          {meta.title}
+        </h3>
+        <p
+          style={{
+            margin: 0,
+            fontSize: 12,
+            color: "var(--text-tertiary)",
+            lineHeight: 1.5,
+          }}
+        >
+          {meta.description}
+        </p>
+      </header>
+      {descriptors.map((d) => (
+        <Fragment key={d.id}>{d.render(ctx)}</Fragment>
+      ))}
+    </section>
   );
 }
 
@@ -407,19 +111,22 @@ export function IntegrationsApp() {
   if (cfgQuery.isLoading) {
     return <div className="app-panel-loading">Loading integrations…</div>;
   }
-  const cfg = cfgQuery.data ?? {};
-  const statuses = statusQuery.data ?? [];
 
-  // gateway_kinds tells the UI which gateway runtimes are compiled in. If a
-  // gateway isn't registered on the Go side we hide its card entirely — the
-  // backend can't dispatch through it, so offering Connect would be a lie.
-  const gateways: GatewayKind[] = (cfg.gateway_kinds ?? [
-    "openclaw",
-    "hermes-agent",
-  ]) as GatewayKind[];
-  const hasOpenClaw =
-    gateways.includes("openclaw") || gateways.includes("openclaw-http");
-  const hasHermes = gateways.includes("hermes-agent");
+  const ctx: IntegrationContext = {
+    cfg: cfgQuery.data ?? {},
+    localStatuses: statusQuery.data ?? [],
+  };
+
+  // Group descriptors by category, applying isAvailable at the same pass
+  // so unsupported integrations vanish entirely (no empty headers).
+  const grouped = new Map<string, IntegrationDescriptor[]>();
+  for (const d of INTEGRATIONS) {
+    if (!d.isAvailable(ctx)) continue;
+    const bucket = grouped.get(d.category) ?? [];
+    bucket.push(d);
+    grouped.set(d.category, bucket);
+  }
+  const anyAvailable = grouped.size > 0;
 
   return (
     <div
@@ -439,17 +146,21 @@ export function IntegrationsApp() {
           color: "var(--text-tertiary)",
         }}
       >
-        Bring agents and messaging streams in from outside the team. Configure
-        gateways here; pick LLM runtimes in Settings.
+        Bring agents and messaging streams in from outside the team.
       </p>
 
       <HelpBanner />
 
-      {hasOpenClaw && <OpenClawCard cfg={cfg} />}
-      {hasHermes && <HermesCard statuses={statuses} />}
-      <TelegramCard cfg={cfg} />
+      {INTEGRATION_CATEGORIES.map((meta) => (
+        <CategorySection
+          key={meta.id}
+          meta={meta}
+          descriptors={grouped.get(meta.id) ?? []}
+          ctx={ctx}
+        />
+      ))}
 
-      {!(hasOpenClaw || hasHermes) && (
+      {!anyAvailable && (
         <p
           style={{ marginTop: 12, fontSize: 12, color: "var(--text-tertiary)" }}
         >
@@ -458,7 +169,7 @@ export function IntegrationsApp() {
             height={12}
             style={{ marginRight: 4, verticalAlign: "text-bottom" }}
           />
-          No OpenClaw or Hermes runtime is registered in this build.
+          No integrations are registered in this build.
         </p>
       )}
     </div>

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -46,9 +46,9 @@ function HelpBanner() {
       <p className="op-lock-body" style={{ marginBottom: 0 }}>
         Integrations bring agents or messaging streams into the team from
         outside. They are not LLM runtimes — pick those in{" "}
-        <em>Settings → Default runtime</em>. Agent-importing gateways
-        (External Agents) tag their imported agents with a "Managed by
-        &lt;Gateway&gt;" badge in the agent profile.
+        <em>Settings → Default runtime</em>. Agent-importing gateways (External
+        Agents) tag their imported agents with a "Managed by &lt;Gateway&gt;"
+        badge in the agent profile.
       </p>
     </div>
   );
@@ -170,7 +170,7 @@ export function IntegrationsApp() {
 
   const available = INTEGRATIONS.filter((d) => d.isAvailable(ctx));
   const selected = selectedId
-    ? available.find((d) => d.id === selectedId) ?? null
+    ? (available.find((d) => d.id === selectedId) ?? null)
     : null;
 
   return (
@@ -216,7 +216,7 @@ export function IntegrationsApp() {
       ) : (
         <ListView
           ctx={ctx}
-          available={[...available]}
+          available={available}
           onOpen={(id) => setSelectedId(id)}
         />
       )}

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -1,8 +1,12 @@
-import { Fragment } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Lock, WarningTriangle } from "iconoir-react";
 
 import { getConfig, getLocalProvidersStatus } from "../../api/client";
+import {
+  IntegrationDetailHeader,
+  IntegrationListRow,
+} from "./integrations/CardShell";
 import { INTEGRATIONS } from "./integrations/registry";
 import {
   INTEGRATION_CATEGORIES,
@@ -11,10 +15,20 @@ import {
   type IntegrationDescriptor,
 } from "./integrations/types";
 
-// IntegrationsApp renders the registry from
-// components/apps/integrations/registry.ts grouped by category. Adding a
-// new integration is a single descriptor entry — this file does not
-// hardcode any specific integration.
+// IntegrationsApp drives a two-mode UX on top of the registry:
+//
+//   1. List mode (default): grid of clickable rows showing logo + title +
+//      one-line summary + status pill, grouped by category. The whole row
+//      is the click target — no per-row buttons compete with it.
+//
+//   2. Detail mode: when a row is selected, the app swaps to a detail view
+//      with a back button, a re-stated header, and the descriptor's
+//      render() body. The body is whatever form / actions that specific
+//      integration needs.
+//
+// Adding a new integration is still a single descriptor entry in
+// registry.tsx plus a logo and a *Detail component — IntegrationsApp has
+// zero per-integration knowledge.
 
 function HelpBanner() {
   return (
@@ -32,22 +46,24 @@ function HelpBanner() {
       <p className="op-lock-body" style={{ marginBottom: 0 }}>
         Integrations bring agents or messaging streams into the team from
         outside. They are not LLM runtimes — pick those in{" "}
-        <em>Settings → Default runtime</em>. Agent-importing gateways (External
-        Agents) tag their imported agents with a "Managed by &lt;Gateway&gt;"
-        badge in the agent profile.
+        <em>Settings → Default runtime</em>. Agent-importing gateways
+        (External Agents) tag their imported agents with a "Managed by
+        &lt;Gateway&gt;" badge in the agent profile.
       </p>
     </div>
   );
 }
 
-function CategorySection({
+function ListSection({
   meta,
   descriptors,
   ctx,
+  onOpen,
 }: {
   meta: IntegrationCategoryMeta;
   descriptors: IntegrationDescriptor[];
   ctx: IntegrationContext;
+  onOpen: (id: string) => void;
 }) {
   if (descriptors.length === 0) return null;
   return (
@@ -56,9 +72,74 @@ function CategorySection({
         <h3 className="op-category-title">{meta.title}</h3>
         <p className="op-category-blurb">{meta.description}</p>
       </header>
-      {descriptors.map((d) => (
-        <Fragment key={d.id}>{d.render(ctx)}</Fragment>
+      <div className="op-list">
+        {descriptors.map((d) => (
+          <IntegrationListRow
+            key={d.id}
+            logo={d.logo()}
+            title={d.title}
+            summary={d.summary}
+            status={d.status(ctx)}
+            onOpen={() => onOpen(d.id)}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ListView({
+  ctx,
+  available,
+  onOpen,
+}: {
+  ctx: IntegrationContext;
+  available: IntegrationDescriptor[];
+  onOpen: (id: string) => void;
+}) {
+  const grouped = useMemo(() => {
+    const map = new Map<string, IntegrationDescriptor[]>();
+    for (const d of available) {
+      const bucket = map.get(d.category) ?? [];
+      bucket.push(d);
+      map.set(d.category, bucket);
+    }
+    return map;
+  }, [available]);
+  return (
+    <>
+      {INTEGRATION_CATEGORIES.map((meta) => (
+        <ListSection
+          key={meta.id}
+          meta={meta}
+          descriptors={grouped.get(meta.id) ?? []}
+          ctx={ctx}
+          onOpen={onOpen}
+        />
       ))}
+    </>
+  );
+}
+
+function DetailView({
+  descriptor,
+  ctx,
+  onBack,
+}: {
+  descriptor: IntegrationDescriptor;
+  ctx: IntegrationContext;
+  onBack: () => void;
+}) {
+  return (
+    <section className="op-detail">
+      <IntegrationDetailHeader
+        logo={descriptor.logo()}
+        title={descriptor.title}
+        summary={descriptor.summary}
+        status={descriptor.status(ctx)}
+        onBack={onBack}
+      />
+      <div className="op-detail-body">{descriptor.render(ctx)}</div>
     </section>
   );
 }
@@ -76,6 +157,8 @@ export function IntegrationsApp() {
     staleTime: 5_000,
   });
 
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
   if (cfgQuery.isLoading) {
     return <div className="app-panel-loading">Loading integrations…</div>;
   }
@@ -85,21 +168,15 @@ export function IntegrationsApp() {
     localStatuses: statusQuery.data ?? [],
   };
 
-  // Group descriptors by category, applying isAvailable at the same pass
-  // so unsupported integrations vanish entirely (no empty headers).
-  const grouped = new Map<string, IntegrationDescriptor[]>();
-  for (const d of INTEGRATIONS) {
-    if (!d.isAvailable(ctx)) continue;
-    const bucket = grouped.get(d.category) ?? [];
-    bucket.push(d);
-    grouped.set(d.category, bucket);
-  }
-  const anyAvailable = grouped.size > 0;
+  const available = INTEGRATIONS.filter((d) => d.isAvailable(ctx));
+  const selected = selectedId
+    ? available.find((d) => d.id === selectedId) ?? null
+    : null;
 
   return (
     <div
       style={{
-        maxWidth: 780,
+        maxWidth: 820,
         margin: "0 auto",
         padding: "28px 24px 56px 24px",
       }}
@@ -128,18 +205,23 @@ export function IntegrationsApp() {
         </p>
       </header>
 
-      <HelpBanner />
+      {!selected && <HelpBanner />}
 
-      {INTEGRATION_CATEGORIES.map((meta) => (
-        <CategorySection
-          key={meta.id}
-          meta={meta}
-          descriptors={grouped.get(meta.id) ?? []}
+      {selected ? (
+        <DetailView
+          descriptor={selected}
           ctx={ctx}
+          onBack={() => setSelectedId(null)}
         />
-      ))}
+      ) : (
+        <ListView
+          ctx={ctx}
+          available={[...available]}
+          onOpen={(id) => setSelectedId(id)}
+        />
+      )}
 
-      {!anyAvailable && (
+      {available.length === 0 && (
         <p
           style={{ marginTop: 12, fontSize: 12, color: "var(--text-tertiary)" }}
         >

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -18,36 +18,24 @@ import {
 
 function HelpBanner() {
   return (
-    <div
-      style={{
-        display: "flex",
-        gap: 10,
-        alignItems: "flex-start",
-        background: "var(--bg-muted, rgba(0,0,0,0.03))",
-        border: "1px solid var(--border)",
-        borderRadius: 6,
-        padding: "10px 12px",
-        marginBottom: 18,
-      }}
-    >
-      <Lock
-        width={16}
-        height={16}
-        style={{ marginTop: 2, color: "var(--text-tertiary)", flexShrink: 0 }}
-      />
-      <div
-        style={{
-          fontSize: 12,
-          color: "var(--text-secondary)",
-          lineHeight: 1.5,
-        }}
-      >
-        Integrations are <strong>gateways</strong> for bringing agents or
-        messaging streams into the team from outside. They are not LLM runtimes
-        — pick those in <em>Settings → Default runtime</em>. Agent-importing
-        gateways (External Agents) tag their imported agents with a "Managed by
-        &lt;Gateway&gt;" badge in the agent profile.
+    <div className="op-lock-card" style={{ marginBottom: 28 }}>
+      <div className="op-lock-head">
+        <div className="op-lock-title">
+          <span className="op-lock-icon" aria-hidden="true">
+            <Lock width={14} height={14} />
+          </span>
+          <span className="op-lock-title-text">
+            Integrations are gateways, not runtimes
+          </span>
+        </div>
       </div>
+      <p className="op-lock-body" style={{ marginBottom: 0 }}>
+        Integrations bring agents or messaging streams into the team from
+        outside. They are not LLM runtimes — pick those in{" "}
+        <em>Settings → Default runtime</em>. Agent-importing gateways (External
+        Agents) tag their imported agents with a "Managed by &lt;Gateway&gt;"
+        badge in the agent profile.
+      </p>
     </div>
   );
 }
@@ -63,30 +51,10 @@ function CategorySection({
 }) {
   if (descriptors.length === 0) return null;
   return (
-    <section style={{ marginBottom: 28 }}>
-      <header style={{ marginBottom: 10 }}>
-        <h3
-          style={{
-            margin: "0 0 4px 0",
-            fontSize: 13,
-            fontWeight: 700,
-            color: "var(--text-secondary)",
-            textTransform: "uppercase",
-            letterSpacing: 0.6,
-          }}
-        >
-          {meta.title}
-        </h3>
-        <p
-          style={{
-            margin: 0,
-            fontSize: 12,
-            color: "var(--text-tertiary)",
-            lineHeight: 1.5,
-          }}
-        >
-          {meta.description}
-        </p>
+    <section className="op-category">
+      <header className="op-category-head">
+        <h3 className="op-category-title">{meta.title}</h3>
+        <p className="op-category-blurb">{meta.description}</p>
       </header>
       {descriptors.map((d) => (
         <Fragment key={d.id}>{d.render(ctx)}</Fragment>
@@ -131,23 +99,34 @@ export function IntegrationsApp() {
   return (
     <div
       style={{
-        maxWidth: 760,
+        maxWidth: 780,
         margin: "0 auto",
-        padding: "24px 24px 48px 24px",
+        padding: "28px 24px 56px 24px",
       }}
     >
-      <h2 style={{ margin: "0 0 6px 0", fontSize: 20, fontWeight: 700 }}>
-        Integrations
-      </h2>
-      <p
-        style={{
-          margin: "0 0 18px 0",
-          fontSize: 13,
-          color: "var(--text-tertiary)",
-        }}
-      >
-        Bring agents and messaging streams in from outside the team.
-      </p>
+      <header style={{ marginBottom: 22 }}>
+        <span className="op-eyebrow op-eyebrow-strong">PATCH BAY</span>
+        <h2
+          style={{
+            margin: "6px 0 4px 0",
+            fontSize: 24,
+            fontWeight: 700,
+            letterSpacing: -0.2,
+          }}
+        >
+          Integrations
+        </h2>
+        <p
+          style={{
+            margin: 0,
+            fontSize: "var(--text-base)",
+            color: "var(--text-tertiary)",
+            lineHeight: 1.5,
+          }}
+        >
+          Bring agents and messaging streams in from outside the team.
+        </p>
+      </header>
 
       <HelpBanner />
 

--- a/web/src/components/apps/IntegrationsApp.tsx
+++ b/web/src/components/apps/IntegrationsApp.tsx
@@ -1,0 +1,466 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Lock, OpenNewWindow, WarningTriangle } from "iconoir-react";
+
+import {
+  type ConfigSnapshot,
+  type ConfigUpdate,
+  type GatewayKind,
+  getConfig,
+  getLocalProvidersStatus,
+  type LocalProviderStatus,
+  updateConfig,
+} from "../../api/client";
+import { useAppStore } from "../../stores/app";
+import { showNotice } from "../ui/Toast";
+
+// IntegrationsApp is the home for gateway-style connections — surfaces that
+// import existing agents or external messaging streams into the team rather
+// than backing a WUPHF-created agent's turns. Three first-class cards today:
+//
+//   - OpenClaw: bridges OpenClaw-controlled sessions into the office. Tokens
+//     and gateway URL live here, not in Settings, so the configuration sits
+//     next to the import action.
+//   - Hermes: connects a local Hermes gateway's /v1 API. Status is read from
+//     the same loopback probe Local LLMs used to use, but framed as
+//     gateway-connected rather than "runtime available."
+//   - Telegram: paste a bot token, pick a chat, get a channel. Wraps the
+//     existing TelegramConnectModal so this app is the single place a user
+//     goes to add an integration.
+//
+// New gateway types should each get their own GatewayCard — they should not
+// be folded into the global LLM provider picker.
+
+interface CardShellProps {
+  icon: React.ReactNode;
+  title: string;
+  status: "connected" | "available" | "unconfigured" | "warning";
+  statusLabel: string;
+  body: React.ReactNode;
+}
+
+function statusColor(status: CardShellProps["status"]): string {
+  switch (status) {
+    case "connected":
+      return "#16a34a";
+    case "available":
+      return "#3b82f6";
+    case "warning":
+      return "#d97706";
+    default:
+      return "var(--text-tertiary)";
+  }
+}
+
+function CardShell({ icon, title, status, statusLabel, body }: CardShellProps) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 16,
+        background: "var(--bg-card)",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 12,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span style={{ fontSize: 22 }}>{icon}</span>
+          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{title}</h3>
+        </div>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 11,
+            color: statusColor(status),
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: statusColor(status),
+              display: "inline-block",
+            }}
+          />
+          {statusLabel}
+        </span>
+      </header>
+      <div>{body}</div>
+    </section>
+  );
+}
+
+function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
+  const queryClient = useQueryClient();
+  const [gatewayUrl, setGatewayUrl] = useState(cfg.openclaw_gateway_url ?? "");
+  const [token, setToken] = useState("");
+  const [revealToken, setRevealToken] = useState(false);
+  const tokenSet = Boolean(cfg.openclaw_token_set);
+  const urlSet = Boolean(cfg.openclaw_gateway_url);
+  const connected = tokenSet && urlSet;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const patch: ConfigUpdate = {};
+      if (gatewayUrl.trim()) patch.openclaw_gateway_url = gatewayUrl.trim();
+      if (token.trim()) patch.openclaw_token = token.trim();
+      await updateConfig(patch);
+    },
+    onSuccess: () => {
+      showNotice("OpenClaw connection saved.", "success");
+      setToken("");
+      void queryClient.invalidateQueries({ queryKey: ["config"] });
+    },
+    onError: (err) => {
+      showNotice(
+        err instanceof Error ? err.message : "Failed to save OpenClaw",
+        "error",
+      );
+    },
+  });
+
+  return (
+    <CardShell
+      icon={<span aria-hidden="true">🔌</span>}
+      title="OpenClaw"
+      status={connected ? "connected" : "unconfigured"}
+      statusLabel={connected ? "Connected" : "Not configured"}
+      body={
+        <div>
+          <p
+            style={{
+              margin: "0 0 12px 0",
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            Bridge OpenClaw-controlled agents into the team. Provide your
+            gateway's WebSocket URL and an auth token; new OpenClaw agents can
+            then be onboarded from the gateway's session list.
+          </p>
+          <label
+            style={{
+              display: "block",
+              fontSize: 11,
+              fontWeight: 600,
+              marginBottom: 4,
+              color: "var(--text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+            }}
+          >
+            Gateway URL
+          </label>
+          <input
+            className="input"
+            type="text"
+            placeholder="ws://127.0.0.1:18789"
+            value={gatewayUrl}
+            onChange={(e) => setGatewayUrl(e.target.value)}
+            style={{
+              width: "100%",
+              marginBottom: 10,
+              fontFamily: "var(--font-mono)",
+            }}
+          />
+          <label
+            style={{
+              display: "block",
+              fontSize: 11,
+              fontWeight: 600,
+              marginBottom: 4,
+              color: "var(--text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+            }}
+          >
+            Token{" "}
+            {tokenSet && !token ? (
+              <span
+                style={{
+                  fontWeight: 400,
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  color: "var(--text-tertiary)",
+                }}
+              >
+                (saved · paste to rotate)
+              </span>
+            ) : null}
+          </label>
+          <input
+            className="input"
+            type={revealToken ? "text" : "password"}
+            placeholder={tokenSet ? "●●●●●●●●" : "oc_..."}
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            style={{ width: "100%", marginBottom: 6 }}
+          />
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontSize: 11,
+              color: "var(--text-tertiary)",
+              cursor: "pointer",
+              marginBottom: 14,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={revealToken}
+              onChange={(e) => setRevealToken(e.target.checked)}
+            />
+            Show token
+          </label>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={
+                mutation.isPending ||
+                !(gatewayUrl.trim() || token.trim()) ||
+                (connected &&
+                  !token.trim() &&
+                  gatewayUrl === (cfg.openclaw_gateway_url ?? ""))
+              }
+              onClick={() => mutation.mutate()}
+            >
+              {mutation.isPending
+                ? "Saving..."
+                : connected
+                  ? "Update connection"
+                  : "Connect"}
+            </button>
+          </div>
+        </div>
+      }
+    />
+  );
+}
+
+function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
+  const hermes = statuses.find((s) => s.kind === "hermes-agent");
+  let status: CardShellProps["status"] = "available";
+  let statusLabel = "Not detected";
+  if (hermes?.binary_installed && hermes.reachable) {
+    status = "connected";
+    statusLabel = "Reachable";
+  } else if (hermes?.binary_installed) {
+    status = "warning";
+    statusLabel = "Installed but unreachable";
+  }
+
+  return (
+    <CardShell
+      icon={<span aria-hidden="true">🔌</span>}
+      title="Hermes"
+      status={status}
+      statusLabel={statusLabel}
+      body={
+        <div>
+          <p
+            style={{
+              margin: "0 0 10px 0",
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            Connect to a local Hermes gateway's OpenAI-compatible API server on{" "}
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+              {hermes?.endpoint ?? "http://127.0.0.1:8642/v1"}
+            </code>
+            . When Hermes is running, imported Hermes-controlled agents route
+            their turns through this gateway.
+          </p>
+          {hermes && !hermes.binary_installed && (
+            <p
+              style={{ margin: 0, fontSize: 12, color: "var(--text-tertiary)" }}
+            >
+              Install Hermes locally (see{" "}
+              <a
+                href="https://hermesagent.com"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                hermesagent.com <OpenNewWindow width={11} height={11} />
+              </a>
+              ) and start its API server. This card auto-detects when the
+              endpoint becomes reachable.
+            </p>
+          )}
+          {hermes?.binary_installed && !hermes.reachable && (
+            <p style={{ margin: 0, fontSize: 12, color: "#d97706" }}>
+              Hermes binary detected but the API server isn't responding. Start
+              it from a terminal and recheck.
+            </p>
+          )}
+        </div>
+      }
+    />
+  );
+}
+
+function TelegramCard({ cfg }: { cfg: ConfigSnapshot }) {
+  const openConnectWizard = useAppStore((s) => s.openConnectWizard);
+  const tokenSet = Boolean(cfg.telegram_token_set);
+  return (
+    <CardShell
+      icon={<span aria-hidden="true">🔌</span>}
+      title="Telegram"
+      status={tokenSet ? "connected" : "unconfigured"}
+      statusLabel={tokenSet ? "Bot connected" : "Not configured"}
+      body={
+        <div>
+          <p
+            style={{
+              margin: "0 0 12px 0",
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            Bring a Telegram chat into the office as a channel. Paste a bot
+            token, pick the chat, and replies route through the bot.
+          </p>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            onClick={() => openConnectWizard("telegram")}
+          >
+            {tokenSet ? "Connect another chat" : "Connect Telegram"}
+          </button>
+        </div>
+      }
+    />
+  );
+}
+
+function HelpBanner() {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 10,
+        alignItems: "flex-start",
+        background: "var(--bg-muted, rgba(0,0,0,0.03))",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+        padding: "10px 12px",
+        marginBottom: 18,
+      }}
+    >
+      <Lock
+        width={16}
+        height={16}
+        style={{ marginTop: 2, color: "var(--text-tertiary)", flexShrink: 0 }}
+      />
+      <div
+        style={{
+          fontSize: 12,
+          color: "var(--text-secondary)",
+          lineHeight: 1.5,
+        }}
+      >
+        OpenClaw and Hermes are <strong>gateways</strong> — they import existing
+        agents into the team. They are not LLM runtimes you can pick in{" "}
+        <em>Settings → Default runtime</em>. Once an agent is imported, the
+        agent profile shows a "Managed by &lt;Gateway&gt;" badge in its runtime
+        section.
+      </div>
+    </div>
+  );
+}
+
+export function IntegrationsApp() {
+  const cfgQuery = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    staleTime: 30_000,
+  });
+  const statusQuery = useQuery({
+    queryKey: ["local-providers-status"],
+    queryFn: getLocalProvidersStatus,
+    refetchInterval: 30_000,
+    staleTime: 5_000,
+  });
+
+  if (cfgQuery.isLoading) {
+    return <div className="app-panel-loading">Loading integrations…</div>;
+  }
+  const cfg = cfgQuery.data ?? {};
+  const statuses = statusQuery.data ?? [];
+
+  // gateway_kinds tells the UI which gateway runtimes are compiled in. If a
+  // gateway isn't registered on the Go side we hide its card entirely — the
+  // backend can't dispatch through it, so offering Connect would be a lie.
+  const gateways: GatewayKind[] = (cfg.gateway_kinds ?? [
+    "openclaw",
+    "hermes-agent",
+  ]) as GatewayKind[];
+  const hasOpenClaw =
+    gateways.includes("openclaw") || gateways.includes("openclaw-http");
+  const hasHermes = gateways.includes("hermes-agent");
+
+  return (
+    <div
+      style={{
+        maxWidth: 760,
+        margin: "0 auto",
+        padding: "24px 24px 48px 24px",
+      }}
+    >
+      <h2 style={{ margin: "0 0 6px 0", fontSize: 20, fontWeight: 700 }}>
+        Integrations
+      </h2>
+      <p
+        style={{
+          margin: "0 0 18px 0",
+          fontSize: 13,
+          color: "var(--text-tertiary)",
+        }}
+      >
+        Bring agents and messaging streams in from outside the team. Configure
+        gateways here; pick LLM runtimes in Settings.
+      </p>
+
+      <HelpBanner />
+
+      {hasOpenClaw && <OpenClawCard cfg={cfg} />}
+      {hasHermes && <HermesCard statuses={statuses} />}
+      <TelegramCard cfg={cfg} />
+
+      {!(hasOpenClaw || hasHermes) && (
+        <p
+          style={{ marginTop: 12, fontSize: 12, color: "var(--text-tertiary)" }}
+        >
+          <WarningTriangle
+            width={12}
+            height={12}
+            style={{ marginRight: 4, verticalAlign: "text-bottom" }}
+          />
+          No OpenClaw or Hermes runtime is registered in this build.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -193,117 +193,76 @@ function GeneralSection({ cfg, save }: SectionProps) {
           )}
         </select>
       </Field>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "flex-start",
-          gap: 10,
-          background: "var(--bg-muted, rgba(0,0,0,0.03))",
-          border: "1px solid var(--border)",
-          borderRadius: 6,
-          padding: "10px 12px",
-          marginBottom: 12,
-        }}
-      >
-        <Lock
-          width={16}
-          height={16}
-          style={{
-            marginTop: 2,
-            color: unlocked
-              ? "var(--danger-500, #c33)"
-              : "var(--text-tertiary)",
-            flexShrink: 0,
-          }}
-        />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              fontSize: 12,
-              fontWeight: 600,
-              color: "var(--text)",
-              marginBottom: 4,
-            }}
-          >
-            {unlocked
-              ? "Unlocked — saving will override every agent's runtime"
-              : "Locked: default-for-new-agents only"}
+      <div className={`op-lock-card${unlocked ? " is-unlocked" : ""}`}>
+        <div className="op-lock-head">
+          <div className="op-lock-title">
+            <span className="op-lock-icon" aria-hidden="true">
+              <Lock width={14} height={14} />
+            </span>
+            <span className="op-lock-title-text">
+              {unlocked
+                ? "Unlocked — saving will override every agent's runtime"
+                : "Locked: default-for-new-agents only"}
+            </span>
           </div>
-          <div
-            style={{
-              fontSize: 11,
-              color: "var(--text-tertiary)",
-              lineHeight: 1.5,
-              marginBottom: 8,
-            }}
+          <span
+            className={`op-status ${unlocked ? "is-warn" : "is-off"}`}
+            aria-hidden="true"
           >
-            {unlocked
-              ? "While unlocked, this runtime will replace every agent's per-agent pick at dispatch time until you re-lock it. Per-agent picks in the AgentProfilePanel are saved but ignored."
-              : "Changing this runtime only affects new agents. Existing agents keep their per-agent picks. Unlock to override every current agent."}
-          </div>
-          <label
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 6,
-              fontSize: 12,
-              cursor: "pointer",
-            }}
-          >
-            <input
-              type="checkbox"
-              checked={unlocked}
-              onChange={(e) => {
-                if (e.target.checked) {
-                  setShowOverrideConfirm(true);
-                } else {
-                  setUnlocked(false);
-                  setShowOverrideConfirm(false);
-                }
-              }}
-            />
-            Unlock to override all current agents
-          </label>
-          {showOverrideConfirm && !unlocked && (
-            <div
-              style={{
-                marginTop: 8,
-                padding: 8,
-                background: "var(--bg-card)",
-                border: "1px solid var(--danger-500, #c33)",
-                borderRadius: 4,
-                fontSize: 12,
-              }}
-            >
-              <div style={{ marginBottom: 6 }}>
-                This will route every agent through{" "}
-                <strong>
-                  {PROVIDER_LABELS[provider as LLMRuntimeKind] ?? provider}
-                </strong>{" "}
-                on their next turn. Confirm to unlock.
-              </div>
-              <div style={{ display: "flex", gap: 6 }}>
-                <button
-                  type="button"
-                  className="btn btn-ghost btn-sm"
-                  onClick={() => setShowOverrideConfirm(false)}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  className="btn btn-primary btn-sm"
-                  onClick={() => {
-                    setUnlocked(true);
-                    setShowOverrideConfirm(false);
-                  }}
-                >
-                  Unlock
-                </button>
-              </div>
-            </div>
-          )}
+            <span className={`op-led ${unlocked ? "is-warn" : "is-off"}`} />
+            {unlocked ? "OVERRIDE ARMED" : "SAFE"}
+          </span>
         </div>
+        <p className="op-lock-body">
+          {unlocked
+            ? "While unlocked, this runtime will replace every agent's per-agent pick at dispatch time until you re-lock it. Per-agent picks are saved but ignored."
+            : "Changing this runtime only affects new agents. Existing agents keep their per-agent picks. Unlock to override every current agent."}
+        </p>
+        <label className="op-lock-toggle">
+          <input
+            type="checkbox"
+            checked={unlocked}
+            onChange={(e) => {
+              if (e.target.checked) {
+                setShowOverrideConfirm(true);
+              } else {
+                setUnlocked(false);
+                setShowOverrideConfirm(false);
+              }
+            }}
+          />
+          Unlock to override all current agents
+        </label>
+        {showOverrideConfirm && !unlocked && (
+          <div className="op-lock-confirm" role="alertdialog">
+            <div className="op-lock-confirm-text">
+              This will route every agent through{" "}
+              <strong>
+                {PROVIDER_LABELS[provider as LLMRuntimeKind] ?? provider}
+              </strong>{" "}
+              on their next turn. Confirm to unlock.
+            </div>
+            <div className="op-lock-confirm-actions">
+              <button
+                type="button"
+                className="btn btn-ghost btn-sm"
+                onClick={() => setShowOverrideConfirm(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={() => {
+                  setUnlocked(true);
+                  setShowOverrideConfirm(false);
+                }}
+              >
+                Unlock
+              </button>
+            </div>
+          </div>
+        )}
       </div>
       <div style={{ ...styles.groupTitle, marginTop: 24 }}>Agents</div>
       <Field label="Team Lead" hint="Default agent that leads operations">

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -1433,6 +1433,12 @@ export function SettingsApp() {
                   key={sec.id}
                   style={styles.navItem(sec.id === section)}
                   onClick={() => setSection(sec.id)}
+                  // testid so e2e can disambiguate the Settings section
+                  // buttons from buttons with the same name that live in
+                  // the parent sidebar (e.g. the Integrations sidebar app
+                  // entry shares the "Integrations" accessible name with
+                  // the Settings → Integrations section button).
+                  data-testid={`settings-nav-${sec.id}`}
                 >
                   <Icon style={styles.navIcon} />
                   <span>{sec.name}</span>

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Lock, Refresh, WarningTriangle } from "iconoir-react";
+import { Refresh, WarningTriangle } from "iconoir-react";
 
 import {
   type ConfigSnapshot,
@@ -86,16 +86,6 @@ function GeneralSection({ cfg, save }: SectionProps) {
   const [provider, setProvider] = useState<LLMRuntimeKind | "">(
     (cfg.llm_provider as LLMRuntimeKind | undefined) ?? "claude-code",
   );
-  // unlocked mirrors Config.LLMProviderUnlocked on the wire. False (default) =
-  // friction-gated: the global runtime is the default for new agents and the
-  // fallback when an agent has no per-agent binding. True = the global
-  // runtime overrides every per-agent binding on the dispatch path. We
-  // surface the lock with an explicit toggle so flipping override-on requires
-  // a deliberate gesture; the picker stays read-only while locked.
-  const [unlocked, setUnlocked] = useState<boolean>(
-    Boolean(cfg.llm_provider_unlocked),
-  );
-  const [showOverrideConfirm, setShowOverrideConfirm] = useState(false);
   const [teamLead, setTeamLead] = useState(cfg.team_lead_slug ?? "");
   const [maxConcurrent, setMaxConcurrent] = useState(
     cfg.max_concurrent_agents ? String(cfg.max_concurrent_agents) : "",
@@ -122,7 +112,6 @@ function GeneralSection({ cfg, save }: SectionProps) {
   const onSave = async () => {
     const patch: ConfigUpdate = {
       llm_provider: provider as ConfigUpdate["llm_provider"],
-      llm_provider_unlocked: unlocked,
       default_format: format,
       blueprint,
       email,
@@ -133,12 +122,6 @@ function GeneralSection({ cfg, save }: SectionProps) {
       patch.max_concurrent_agents = parseInt(maxConcurrent, 10);
     if (timeout) patch.default_timeout = parseInt(timeout, 10);
     await save(patch);
-    // After a successful save, re-lock the override toggle locally so the
-    // user has to opt in again on the next change. The wire value persists
-    // (the broker stored whatever we sent) but the in-form draft resets to
-    // the safe state — same pattern as a one-shot "Apply to all" button.
-    setUnlocked(false);
-    setShowOverrideConfirm(false);
   };
 
   return (
@@ -148,7 +131,7 @@ function GeneralSection({ cfg, save }: SectionProps) {
         Core runtime settings. These map to CLI flags and config file entries.
       </p>
 
-      <div style={styles.groupTitle}>Default runtime for agents</div>
+      <div style={styles.groupTitle}>Default runtime for new agents</div>
       <p
         style={{
           fontSize: 12,
@@ -157,21 +140,17 @@ function GeneralSection({ cfg, save }: SectionProps) {
           lineHeight: 1.5,
         }}
       >
-        The runtime new agents inherit when created and the fallback for any
-        agent without a per-agent pick. To bring an OpenClaw or Hermes agent
-        into the team, use the Integrations app — those gateways are not
-        runtimes you assign here.
+        Picked for new agents at creation time. Existing agents keep whatever
+        runtime they already have — change those one at a time from each
+        agent's profile (Runtime section). To import OpenClaw or Hermes
+        agents into the team, use the Integrations app — those gateways are
+        not runtimes you assign here.
       </p>
       <Field label="Runtime" hint="--provider">
         <select
-          style={{
-            ...styles.input,
-            opacity: unlocked ? 1 : 0.7,
-            cursor: unlocked ? "pointer" : "not-allowed",
-          }}
+          style={styles.input}
           value={provider}
           onChange={(e) => setProvider(e.target.value as LLMRuntimeKind | "")}
-          disabled={!unlocked}
         >
           {cloudKinds.length > 0 && (
             <optgroup label="Cloud">
@@ -193,77 +172,6 @@ function GeneralSection({ cfg, save }: SectionProps) {
           )}
         </select>
       </Field>
-      <div className={`op-lock-card${unlocked ? " is-unlocked" : ""}`}>
-        <div className="op-lock-head">
-          <div className="op-lock-title">
-            <span className="op-lock-icon" aria-hidden="true">
-              <Lock width={14} height={14} />
-            </span>
-            <span className="op-lock-title-text">
-              {unlocked
-                ? "Unlocked — saving will override every agent's runtime"
-                : "Locked: default-for-new-agents only"}
-            </span>
-          </div>
-          <span
-            className={`op-status ${unlocked ? "is-warn" : "is-off"}`}
-            aria-hidden="true"
-          >
-            <span className={`op-led ${unlocked ? "is-warn" : "is-off"}`} />
-            {unlocked ? "OVERRIDE ARMED" : "SAFE"}
-          </span>
-        </div>
-        <p className="op-lock-body">
-          {unlocked
-            ? "While unlocked, this runtime will replace every agent's per-agent pick at dispatch time until you re-lock it. Per-agent picks are saved but ignored."
-            : "Changing this runtime only affects new agents. Existing agents keep their per-agent picks. Unlock to override every current agent."}
-        </p>
-        <label className="op-lock-toggle">
-          <input
-            type="checkbox"
-            checked={unlocked}
-            onChange={(e) => {
-              if (e.target.checked) {
-                setShowOverrideConfirm(true);
-              } else {
-                setUnlocked(false);
-                setShowOverrideConfirm(false);
-              }
-            }}
-          />
-          Unlock to override all current agents
-        </label>
-        {showOverrideConfirm && !unlocked && (
-          <div className="op-lock-confirm" role="alertdialog">
-            <div className="op-lock-confirm-text">
-              This will route every agent through{" "}
-              <strong>
-                {PROVIDER_LABELS[provider as LLMRuntimeKind] ?? provider}
-              </strong>{" "}
-              on their next turn. Confirm to unlock.
-            </div>
-            <div className="op-lock-confirm-actions">
-              <button
-                type="button"
-                className="btn btn-ghost btn-sm"
-                onClick={() => setShowOverrideConfirm(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="btn btn-primary btn-sm"
-                onClick={() => {
-                  setUnlocked(true);
-                  setShowOverrideConfirm(false);
-                }}
-              >
-                Unlock
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
       <div style={{ ...styles.groupTitle, marginTop: 24 }}>Agents</div>
       <Field label="Team Lead" hint="Default agent that leads operations">
         <input

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -26,6 +26,7 @@ import {
 } from "../ui/ShredWarning";
 import { showNotice } from "../ui/Toast";
 import { WipeModal } from "../ui/WipeModal";
+import { useOfficeMembers } from "../../hooks/useMembers";
 import { NexConnectPanel } from "./NexConnectPanel";
 import { ImageGenSection } from "./SettingsApp.imageGen";
 import { Field, KeyField, SaveButton } from "./settings/components";
@@ -81,6 +82,51 @@ const CLOUD_KINDS: ReadonlySet<LLMRuntimeKind> = new Set([
   "codex",
   "opencode",
 ]);
+
+// TeamLeadPicker reads the office roster so the human picks from real
+// agents rather than typing a slug. The saved value persists as a slug on
+// the wire (cfg.team_lead_slug) — the picker round-trips through the slug
+// even when the agent's display name later changes, so renaming an agent
+// doesn't break the Team Lead binding. Falls back to a free-text input
+// while the roster is still loading or empty, so the field is never a
+// dead end on a brand-new install.
+function TeamLeadPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (slug: string) => void;
+}) {
+  const { data: members = [], isLoading } = useOfficeMembers();
+  if (isLoading || members.length === 0) {
+    return (
+      <input
+        style={styles.input}
+        placeholder="e.g. ceo"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  const knownSlug = members.some((m) => m.slug === value);
+  return (
+    <select
+      style={styles.input}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">— pick an agent —</option>
+      {members.map((m) => (
+        <option key={m.slug} value={m.slug}>
+          {m.name ? `${m.name} (@${m.slug})` : `@${m.slug}`}
+        </option>
+      ))}
+      {value && !knownSlug && (
+        <option value={value}>@{value} (not in roster)</option>
+      )}
+    </select>
+  );
+}
 
 function GeneralSection({ cfg, save }: SectionProps) {
   const [provider, setProvider] = useState<LLMRuntimeKind | "">(
@@ -173,13 +219,8 @@ function GeneralSection({ cfg, save }: SectionProps) {
         </select>
       </Field>
       <div style={{ ...styles.groupTitle, marginTop: 24 }}>Agents</div>
-      <Field label="Team Lead" hint="Default agent that leads operations">
-        <input
-          style={styles.input}
-          placeholder="e.g. ceo"
-          value={teamLead}
-          onChange={(e) => setTeamLead(e.target.value)}
-        />
+      <Field label="Team Lead" hint="Agent that leads operations">
+        <TeamLeadPicker value={teamLead} onChange={setTeamLead} />
       </Field>
       <Field label="Max Concurrent" hint="Parallel agent limit">
         <input

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Refresh, WarningTriangle } from "iconoir-react";
+import { Lock, Refresh, WarningTriangle } from "iconoir-react";
 
 import {
   type ConfigSnapshot,
   type ConfigUpdate,
   getConfig,
   getLocalProvidersStatus,
+  type LLMRuntimeKind,
   type LocalProviderStatus,
   resetWorkspace,
   shredWorkspace,
@@ -67,8 +68,34 @@ function useShredAction() {
   };
 }
 
+const PROVIDER_LABELS: Record<LLMRuntimeKind, string> = {
+  "claude-code": "Claude Code",
+  codex: "Codex",
+  opencode: "Opencode",
+  "mlx-lm": "MLX-LM (Apple Silicon)",
+  ollama: "Ollama",
+  exo: "Exo",
+};
+const CLOUD_KINDS: ReadonlySet<LLMRuntimeKind> = new Set([
+  "claude-code",
+  "codex",
+  "opencode",
+]);
+
 function GeneralSection({ cfg, save }: SectionProps) {
-  const [provider, setProvider] = useState(cfg.llm_provider ?? "ollama");
+  const [provider, setProvider] = useState<LLMRuntimeKind | "">(
+    (cfg.llm_provider as LLMRuntimeKind | undefined) ?? "claude-code",
+  );
+  // unlocked mirrors Config.LLMProviderUnlocked on the wire. False (default) =
+  // friction-gated: the global runtime is the default for new agents and the
+  // fallback when an agent has no per-agent binding. True = the global
+  // runtime overrides every per-agent binding on the dispatch path. We
+  // surface the lock with an explicit toggle so flipping override-on requires
+  // a deliberate gesture; the picker stays read-only while locked.
+  const [unlocked, setUnlocked] = useState<boolean>(
+    Boolean(cfg.llm_provider_unlocked),
+  );
+  const [showOverrideConfirm, setShowOverrideConfirm] = useState(false);
   const [teamLead, setTeamLead] = useState(cfg.team_lead_slug ?? "");
   const [maxConcurrent, setMaxConcurrent] = useState(
     cfg.max_concurrent_agents ? String(cfg.max_concurrent_agents) : "",
@@ -81,9 +108,21 @@ function GeneralSection({ cfg, save }: SectionProps) {
   const [email, setEmail] = useState(cfg.email ?? "");
   const [devUrl, setDevUrl] = useState(cfg.dev_url ?? "");
 
+  const llmKinds: LLMRuntimeKind[] = (cfg.llm_provider_kinds ?? [
+    "claude-code",
+    "codex",
+    "opencode",
+    "mlx-lm",
+    "ollama",
+    "exo",
+  ]) as LLMRuntimeKind[];
+  const cloudKinds = llmKinds.filter((k) => CLOUD_KINDS.has(k));
+  const localKinds = llmKinds.filter((k) => !CLOUD_KINDS.has(k));
+
   const onSave = async () => {
     const patch: ConfigUpdate = {
       llm_provider: provider as ConfigUpdate["llm_provider"],
+      llm_provider_unlocked: unlocked,
       default_format: format,
       blueprint,
       email,
@@ -94,6 +133,12 @@ function GeneralSection({ cfg, save }: SectionProps) {
       patch.max_concurrent_agents = parseInt(maxConcurrent, 10);
     if (timeout) patch.default_timeout = parseInt(timeout, 10);
     await save(patch);
+    // After a successful save, re-lock the override toggle locally so the
+    // user has to opt in again on the next change. The wire value persists
+    // (the broker stored whatever we sent) but the in-form draft resets to
+    // the safe state — same pattern as a one-shot "Apply to all" button.
+    setUnlocked(false);
+    setShowOverrideConfirm(false);
   };
 
   return (
@@ -103,27 +148,163 @@ function GeneralSection({ cfg, save }: SectionProps) {
         Core runtime settings. These map to CLI flags and config file entries.
       </p>
 
-      <div style={styles.groupTitle}>Runtime</div>
-      <Field label="LLM Provider" hint="--provider">
+      <div style={styles.groupTitle}>Default runtime for agents</div>
+      <p
+        style={{
+          fontSize: 12,
+          color: "var(--text-tertiary)",
+          margin: "0 0 12px 0",
+          lineHeight: 1.5,
+        }}
+      >
+        The runtime new agents inherit when created and the fallback for any
+        agent without a per-agent pick. To bring an OpenClaw or Hermes agent
+        into the team, use the Integrations app — those gateways are not
+        runtimes you assign here.
+      </p>
+      <Field label="Runtime" hint="--provider">
         <select
-          style={styles.input}
+          style={{
+            ...styles.input,
+            opacity: unlocked ? 1 : 0.7,
+            cursor: unlocked ? "pointer" : "not-allowed",
+          }}
           value={provider}
-          onChange={(e) => setProvider(e.target.value as typeof provider)}
+          onChange={(e) => setProvider(e.target.value as LLMRuntimeKind | "")}
+          disabled={!unlocked}
         >
-          <optgroup label="Cloud">
-            <option value="claude-code">Claude Code</option>
-            <option value="codex">Codex</option>
-            <option value="opencode">Opencode</option>
-          </optgroup>
-          <optgroup label="Local">
-            <option value="mlx-lm">MLX-LM (Apple Silicon)</option>
-            <option value="ollama">Ollama</option>
-            <option value="exo">Exo</option>
-            <option value="hermes-agent">Hermes Agent</option>
-            <option value="openclaw-http">OpenClaw Gateway</option>
-          </optgroup>
+          {cloudKinds.length > 0 && (
+            <optgroup label="Cloud">
+              {cloudKinds.map((kind) => (
+                <option key={kind} value={kind}>
+                  {PROVIDER_LABELS[kind] ?? kind}
+                </option>
+              ))}
+            </optgroup>
+          )}
+          {localKinds.length > 0 && (
+            <optgroup label="Local">
+              {localKinds.map((kind) => (
+                <option key={kind} value={kind}>
+                  {PROVIDER_LABELS[kind] ?? kind}
+                </option>
+              ))}
+            </optgroup>
+          )}
         </select>
       </Field>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 10,
+          background: "var(--bg-muted, rgba(0,0,0,0.03))",
+          border: "1px solid var(--border)",
+          borderRadius: 6,
+          padding: "10px 12px",
+          marginBottom: 12,
+        }}
+      >
+        <Lock
+          width={16}
+          height={16}
+          style={{
+            marginTop: 2,
+            color: unlocked
+              ? "var(--danger-500, #c33)"
+              : "var(--text-tertiary)",
+            flexShrink: 0,
+          }}
+        />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: "var(--text)",
+              marginBottom: 4,
+            }}
+          >
+            {unlocked
+              ? "Unlocked — saving will override every agent's runtime"
+              : "Locked: default-for-new-agents only"}
+          </div>
+          <div
+            style={{
+              fontSize: 11,
+              color: "var(--text-tertiary)",
+              lineHeight: 1.5,
+              marginBottom: 8,
+            }}
+          >
+            {unlocked
+              ? "While unlocked, this runtime will replace every agent's per-agent pick at dispatch time until you re-lock it. Per-agent picks in the AgentProfilePanel are saved but ignored."
+              : "Changing this runtime only affects new agents. Existing agents keep their per-agent picks. Unlock to override every current agent."}
+          </div>
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 6,
+              fontSize: 12,
+              cursor: "pointer",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={unlocked}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  setShowOverrideConfirm(true);
+                } else {
+                  setUnlocked(false);
+                  setShowOverrideConfirm(false);
+                }
+              }}
+            />
+            Unlock to override all current agents
+          </label>
+          {showOverrideConfirm && !unlocked && (
+            <div
+              style={{
+                marginTop: 8,
+                padding: 8,
+                background: "var(--bg-card)",
+                border: "1px solid var(--danger-500, #c33)",
+                borderRadius: 4,
+                fontSize: 12,
+              }}
+            >
+              <div style={{ marginBottom: 6 }}>
+                This will route every agent through{" "}
+                <strong>
+                  {PROVIDER_LABELS[provider as LLMRuntimeKind] ?? provider}
+                </strong>{" "}
+                on their next turn. Confirm to unlock.
+              </div>
+              <div style={{ display: "flex", gap: 6 }}>
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm"
+                  onClick={() => setShowOverrideConfirm(false)}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-primary btn-sm"
+                  onClick={() => {
+                    setUnlocked(true);
+                    setShowOverrideConfirm(false);
+                  }}
+                >
+                  Unlock
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
       <div style={{ ...styles.groupTitle, marginTop: 24 }}>Agents</div>
       <Field label="Team Lead" hint="Default agent that leads operations">
         <input
@@ -215,6 +396,11 @@ interface LocalProviderMeta {
   blurb: string;
 }
 
+// LOCAL_PROVIDERS lists directly-dispatched local LLM runtimes only. The
+// Hermes Agent and OpenClaw Gateway entries that used to live here were
+// gateway-controlled — they belong in the Integrations app, not the
+// runtime picker, because their job is to import existing agents into the
+// team rather than to back a WUPHF-created agent's turns.
 const LOCAL_PROVIDERS: LocalProviderMeta[] = [
   {
     kind: "mlx-lm",
@@ -233,18 +419,6 @@ const LOCAL_PROVIDERS: LocalProviderMeta[] = [
     label: "Exo",
     blurb:
       "Distributes inference across multiple devices. Useful when you want to pool a Mac Studio + a laptop.",
-  },
-  {
-    kind: "hermes-agent",
-    label: "Hermes Agent",
-    blurb:
-      "Runs WUPHF members through a local Hermes gateway via its OpenAI-compatible API server.",
-  },
-  {
-    kind: "openclaw-http",
-    label: "OpenClaw Gateway",
-    blurb:
-      "Runs WUPHF members through OpenClaw Gateway's OpenAI-compatible Chat Completions endpoint.",
   },
 ];
 
@@ -805,24 +979,38 @@ function IntegrationsSection({ cfg, save }: SectionProps) {
   const [actionProvider, setActionProvider] = useState<string>(
     cfg.action_provider ?? "auto",
   );
-  const [gatewayUrl, setGatewayUrl] = useState(cfg.openclaw_gateway_url ?? "");
-  const [openclawToken, setOpenclawToken] = useState("");
 
   const onSave = async () => {
     const patch: ConfigUpdate = {
       action_provider: actionProvider as ConfigUpdate["action_provider"],
     };
-    if (gatewayUrl) patch.openclaw_gateway_url = gatewayUrl;
-    if (openclawToken) patch.openclaw_token = openclawToken;
     await save(patch);
-    setOpenclawToken("");
   };
 
+  // Gateway-style integrations (OpenClaw, Hermes, Telegram) now live in the
+  // dedicated Integrations app. We keep Action Provider + Workspace here
+  // because they're install-wide config knobs, not gateways — they configure
+  // routing for an existing action surface rather than importing agents.
   return (
     <div>
       <h2 style={styles.sectionTitle}>Integrations</h2>
       <p style={styles.sectionDesc}>
-        External service connections and action providers.
+        Install-wide integration knobs. Connect OpenClaw, Hermes, or Telegram
+        from the{" "}
+        <button
+          type="button"
+          className="btn btn-link"
+          style={{ padding: 0, height: "auto", fontSize: "inherit" }}
+          onClick={() =>
+            void router.navigate({
+              to: "/apps/$appId",
+              params: { appId: "integrations" },
+            })
+          }
+        >
+          Integrations app
+        </button>
+        .
       </p>
 
       <Field label="Action Provider" hint="External action routing">
@@ -836,30 +1024,6 @@ function IntegrationsSection({ cfg, save }: SectionProps) {
           <option value="composio">Composio</option>
         </select>
       </Field>
-
-      <div style={{ marginTop: 20 }}>
-        <div style={styles.groupTitle}>OpenClaw</div>
-        <Field label="Gateway URL" hint="WebSocket endpoint">
-          <input
-            style={{
-              ...styles.input,
-              fontFamily: "var(--font-mono)",
-              fontSize: 12,
-            }}
-            placeholder="ws://127.0.0.1:18789"
-            value={gatewayUrl}
-            onChange={(e) => setGatewayUrl(e.target.value)}
-          />
-        </Field>
-        <Field label="Token" hint="Gateway auth token">
-          <KeyField
-            hasValue={Boolean(cfg.openclaw_token_set)}
-            placeholder="oc_..."
-            value={openclawToken}
-            onChange={setOpenclawToken}
-          />
-        </Field>
-      </div>
 
       <div style={{ marginTop: 20 }}>
         <div style={styles.groupTitle}>Workspace</div>

--- a/web/src/components/apps/integrations/CardShell.tsx
+++ b/web/src/components/apps/integrations/CardShell.tsx
@@ -1,6 +1,13 @@
-// Shared visual primitive for every integration card. Card-level files
-// (OpenClawCard, HermesCard, TelegramCard, ...) compose this — they own
-// per-card state and submit logic; CardShell owns the chrome.
+// CardShell is the visual primitive every integration card composes. The
+// shape is a three-column grid: a "channel strip" rail with the icon, the
+// title + body, and a top-aligned status cell. Card-level files own state
+// and submit logic — CardShell owns chrome and layout.
+//
+// Status semantics map to operator.css's LED + status classes:
+//   connected  → green LED · CONNECTED
+//   available  → blue LED  · AVAILABLE
+//   warning    → amber LED · ATTENTION
+//   unconfigured → grey LED · NOT CONFIGURED
 
 export type CardStatus = "connected" | "available" | "unconfigured" | "warning";
 
@@ -12,18 +19,12 @@ interface CardShellProps {
   body: React.ReactNode;
 }
 
-function statusColor(status: CardStatus): string {
-  switch (status) {
-    case "connected":
-      return "#16a34a";
-    case "available":
-      return "#3b82f6";
-    case "warning":
-      return "#d97706";
-    default:
-      return "var(--text-tertiary)";
-  }
-}
+const STATUS_TONE: Record<CardStatus, "on" | "warn" | "off" | "info"> = {
+  connected: "on",
+  available: "info",
+  warning: "warn",
+  unconfigured: "off",
+};
 
 export function CardShell({
   icon,
@@ -32,53 +33,24 @@ export function CardShell({
   statusLabel,
   body,
 }: CardShellProps) {
+  const tone = STATUS_TONE[status];
   return (
-    <section
-      style={{
-        border: "1px solid var(--border)",
-        borderRadius: 8,
-        padding: 16,
-        marginBottom: 16,
-        background: "var(--bg-card)",
-      }}
-    >
-      <header
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
-          marginBottom: 12,
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <span style={{ fontSize: 22 }}>{icon}</span>
-          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{title}</h3>
+    <article className="op-card">
+      <div className="op-card-rail" aria-hidden="true">
+        {icon}
+      </div>
+      <div className="op-card-body">
+        <div className="op-card-title-row">
+          <h4 className="op-card-title">{title}</h4>
         </div>
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: 6,
-            fontSize: 11,
-            color: statusColor(status),
-            fontWeight: 600,
-            textTransform: "uppercase",
-            letterSpacing: 0.4,
-          }}
-        >
-          <span
-            style={{
-              width: 8,
-              height: 8,
-              borderRadius: "50%",
-              background: statusColor(status),
-              display: "inline-block",
-            }}
-          />
+        {body}
+      </div>
+      <div className="op-card-status-cell">
+        <span className={`op-status is-${tone}`}>
+          <span className={`op-led is-${tone}`} />
           {statusLabel}
         </span>
-      </header>
-      <div>{body}</div>
-    </section>
+      </div>
+    </article>
   );
 }

--- a/web/src/components/apps/integrations/CardShell.tsx
+++ b/web/src/components/apps/integrations/CardShell.tsx
@@ -1,30 +1,136 @@
-// CardShell is the visual primitive every integration card composes. The
-// shape is a three-column grid: a "channel strip" rail with the icon, the
-// title + body, and a top-aligned status cell. Card-level files own state
-// and submit logic — CardShell owns chrome and layout.
+import { NavArrowLeft, NavArrowRight } from "iconoir-react";
+import type { ReactElement, ReactNode } from "react";
+
+import type { IntegrationStatus, IntegrationStatusTone } from "./types";
+
+// CardShell is the chrome primitive used by both list rows and detail
+// headers. Two exports:
+//
+//   - IntegrationListRow: clickable row showing logo + title + summary +
+//     status. Used in the default list view of the Integrations app.
+//
+//   - IntegrationDetailHeader: back button + logo + title + status, sits
+//     above the descriptor's render() body in the detail view.
 //
 // Status semantics map to operator.css's LED + status classes:
-//   connected  → green LED · CONNECTED
-//   available  → blue LED  · AVAILABLE
-//   warning    → amber LED · ATTENTION
+//   connected   → green LED · CONNECTED
+//   available   → blue LED  · AVAILABLE
+//   warning     → amber LED · ATTENTION
 //   unconfigured → grey LED · NOT CONFIGURED
 
-export type CardStatus = "connected" | "available" | "unconfigured" | "warning";
+const TONE_CLASS: Record<IntegrationStatusTone, "on" | "warn" | "off" | "info"> =
+  {
+    connected: "on",
+    available: "info",
+    warning: "warn",
+    unconfigured: "off",
+  };
+
+function StatusPill({ status }: { status: IntegrationStatus }) {
+  const tone = TONE_CLASS[status.tone];
+  return (
+    <span className={`op-status is-${tone}`}>
+      <span className={`op-led is-${tone}`} />
+      {status.label}
+    </span>
+  );
+}
+
+interface IntegrationListRowProps {
+  logo: ReactElement;
+  title: string;
+  summary: string;
+  status: IntegrationStatus;
+  onOpen: () => void;
+}
+
+export function IntegrationListRow({
+  logo,
+  title,
+  summary,
+  status,
+  onOpen,
+}: IntegrationListRowProps) {
+  return (
+    <button
+      type="button"
+      className="op-list-row"
+      onClick={onOpen}
+      aria-label={`Open ${title} integration settings`}
+    >
+      <div className="op-list-row-logo" aria-hidden="true">
+        {logo}
+      </div>
+      <div className="op-list-row-body">
+        <div className="op-list-row-title">{title}</div>
+        <div className="op-list-row-summary">{summary}</div>
+      </div>
+      <div className="op-list-row-status">
+        <StatusPill status={status} />
+      </div>
+      <NavArrowRight
+        className="op-list-row-chevron"
+        width={18}
+        height={18}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}
+
+interface IntegrationDetailHeaderProps {
+  logo: ReactElement;
+  title: string;
+  summary: string;
+  status: IntegrationStatus;
+  onBack: () => void;
+}
+
+export function IntegrationDetailHeader({
+  logo,
+  title,
+  summary,
+  status,
+  onBack,
+}: IntegrationDetailHeaderProps) {
+  return (
+    <header className="op-detail-header">
+      <button
+        type="button"
+        className="op-detail-back"
+        onClick={onBack}
+        aria-label="Back to integrations list"
+      >
+        <NavArrowLeft width={16} height={16} aria-hidden="true" />
+        <span>All integrations</span>
+      </button>
+      <div className="op-detail-id">
+        <div className="op-detail-id-logo" aria-hidden="true">
+          {logo}
+        </div>
+        <div className="op-detail-id-text">
+          <h2 className="op-detail-title">{title}</h2>
+          <p className="op-detail-summary">{summary}</p>
+        </div>
+        <div className="op-detail-status">
+          <StatusPill status={status} />
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// Legacy export kept for any caller that still composes the inline-card
+// shape. New code uses IntegrationListRow + IntegrationDetailHeader.
+export type CardStatus = IntegrationStatusTone;
 
 interface CardShellProps {
-  icon: React.ReactNode;
+  icon: ReactNode;
   title: string;
   status: CardStatus;
   statusLabel: string;
-  body: React.ReactNode;
+  body: ReactNode;
 }
-
-const STATUS_TONE: Record<CardStatus, "on" | "warn" | "off" | "info"> = {
-  connected: "on",
-  available: "info",
-  warning: "warn",
-  unconfigured: "off",
-};
 
 export function CardShell({
   icon,
@@ -33,24 +139,20 @@ export function CardShell({
   statusLabel,
   body,
 }: CardShellProps) {
-  const tone = STATUS_TONE[status];
   return (
-    <article className="op-card">
+    <section className="op-card">
       <div className="op-card-rail" aria-hidden="true">
         {icon}
       </div>
       <div className="op-card-body">
         <div className="op-card-title-row">
-          <h4 className="op-card-title">{title}</h4>
+          <h3 className="op-card-title">{title}</h3>
         </div>
         {body}
       </div>
       <div className="op-card-status-cell">
-        <span className={`op-status is-${tone}`}>
-          <span className={`op-led is-${tone}`} />
-          {statusLabel}
-        </span>
+        <StatusPill status={{ tone: status, label: statusLabel }} />
       </div>
-    </article>
+    </section>
   );
 }

--- a/web/src/components/apps/integrations/CardShell.tsx
+++ b/web/src/components/apps/integrations/CardShell.tsx
@@ -1,0 +1,84 @@
+// Shared visual primitive for every integration card. Card-level files
+// (OpenClawCard, HermesCard, TelegramCard, ...) compose this — they own
+// per-card state and submit logic; CardShell owns the chrome.
+
+export type CardStatus = "connected" | "available" | "unconfigured" | "warning";
+
+interface CardShellProps {
+  icon: React.ReactNode;
+  title: string;
+  status: CardStatus;
+  statusLabel: string;
+  body: React.ReactNode;
+}
+
+function statusColor(status: CardStatus): string {
+  switch (status) {
+    case "connected":
+      return "#16a34a";
+    case "available":
+      return "#3b82f6";
+    case "warning":
+      return "#d97706";
+    default:
+      return "var(--text-tertiary)";
+  }
+}
+
+export function CardShell({
+  icon,
+  title,
+  status,
+  statusLabel,
+  body,
+}: CardShellProps) {
+  return (
+    <section
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 16,
+        background: "var(--bg-card)",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 12,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <span style={{ fontSize: 22 }}>{icon}</span>
+          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>{title}</h3>
+        </div>
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            fontSize: 11,
+            color: statusColor(status),
+            fontWeight: 600,
+            textTransform: "uppercase",
+            letterSpacing: 0.4,
+          }}
+        >
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: "50%",
+              background: statusColor(status),
+              display: "inline-block",
+            }}
+          />
+          {statusLabel}
+        </span>
+      </header>
+      <div>{body}</div>
+    </section>
+  );
+}

--- a/web/src/components/apps/integrations/HermesCard.tsx
+++ b/web/src/components/apps/integrations/HermesCard.tsx
@@ -1,67 +1,67 @@
 import { OpenNewWindow } from "iconoir-react";
 
 import type { LocalProviderStatus } from "../../../api/client";
-import { CardShell, type CardStatus } from "./CardShell";
+import type { IntegrationStatus } from "./types";
 
 // HermesCard reads the local-runtime probe to display connectivity. There's
 // no token to paste (Hermes auth lives in the gateway's own config); the
 // card's job is to surface whether the API server is reachable and to
 // point the user at install docs when it isn't.
-export function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
-  const hermes = statuses.find((s) => s.kind === "hermes-agent");
-  let status: CardStatus = "available";
-  let statusLabel = "Not detected";
-  if (hermes?.binary_installed && hermes.reachable) {
-    status = "connected";
-    statusLabel = "Reachable";
-  } else if (hermes?.binary_installed) {
-    status = "warning";
-    statusLabel = "Installed but unreachable";
-  }
 
+export function hermesStatus(
+  statuses: LocalProviderStatus[],
+): IntegrationStatus {
+  const hermes = statuses.find((s) => s.kind === "hermes-agent");
+  if (hermes?.binary_installed && hermes.reachable) {
+    return { tone: "connected", label: "Reachable" };
+  }
+  if (hermes?.binary_installed) {
+    return { tone: "warning", label: "Installed but unreachable" };
+  }
+  return { tone: "available", label: "Not detected" };
+}
+
+export function HermesDetail({
+  statuses,
+}: {
+  statuses: LocalProviderStatus[];
+}) {
+  const hermes = statuses.find((s) => s.kind === "hermes-agent");
   return (
-    <CardShell
-      icon={<span aria-hidden="true">🪽</span>}
-      title="Hermes"
-      status={status}
-      statusLabel={statusLabel}
-      body={
-        <div>
-          <p className="op-card-blurb" style={{ marginBottom: 8 }}>
-            Connect to a local Hermes gateway's OpenAI-compatible API server on{" "}
-            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
-              {hermes?.endpoint ?? "http://127.0.0.1:8642/v1"}
-            </code>
-            . When Hermes is running, imported Hermes-controlled agents route
-            their turns through this gateway.
-          </p>
-          {hermes && !hermes.binary_installed && (
-            <p className="op-runtime-note">
-              Install Hermes locally (see{" "}
-              <a
-                href="https://hermesagent.com"
-                target="_blank"
-                rel="noreferrer"
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: 4,
-                }}
-              >
-                hermesagent.com <OpenNewWindow width={11} height={11} />
-              </a>
-              ) and start its API server. This card auto-detects when the
-              endpoint becomes reachable.
-            </p>
-          )}
-          {hermes?.binary_installed && !hermes.reachable && (
-            <p className="op-runtime-note is-warn">
-              Hermes binary detected but the API server isn't responding. Start
-              it from a terminal and recheck.
-            </p>
-          )}
-        </div>
-      }
-    />
+    <div>
+      <p className="op-card-blurb" style={{ marginBottom: 8 }}>
+        Connect to a local Hermes gateway's OpenAI-compatible API server on{" "}
+        <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+          {hermes?.endpoint ?? "http://127.0.0.1:8642/v1"}
+        </code>
+        . When Hermes is running, imported Hermes-controlled agents route their
+        turns through this gateway.
+      </p>
+      {hermes && !hermes.binary_installed && (
+        <p className="op-runtime-note">
+          Install Hermes locally (see{" "}
+          <a
+            href="https://hermesagent.com"
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+            }}
+          >
+            hermesagent.com <OpenNewWindow width={11} height={11} />
+          </a>
+          ) and start its API server. This card auto-detects when the endpoint
+          becomes reachable.
+        </p>
+      )}
+      {hermes?.binary_installed && !hermes.reachable && (
+        <p className="op-runtime-note is-warn">
+          Hermes binary detected but the API server isn't responding. Start it
+          from a terminal and recheck.
+        </p>
+      )}
+    </div>
   );
 }

--- a/web/src/components/apps/integrations/HermesCard.tsx
+++ b/web/src/components/apps/integrations/HermesCard.tsx
@@ -1,0 +1,75 @@
+import { OpenNewWindow } from "iconoir-react";
+
+import type { LocalProviderStatus } from "../../../api/client";
+import { CardShell, type CardStatus } from "./CardShell";
+
+// HermesCard reads the local-runtime probe to display connectivity. There's
+// no token to paste (Hermes auth lives in the gateway's own config); the
+// card's job is to surface whether the API server is reachable and to
+// point the user at install docs when it isn't.
+export function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
+  const hermes = statuses.find((s) => s.kind === "hermes-agent");
+  let status: CardStatus = "available";
+  let statusLabel = "Not detected";
+  if (hermes?.binary_installed && hermes.reachable) {
+    status = "connected";
+    statusLabel = "Reachable";
+  } else if (hermes?.binary_installed) {
+    status = "warning";
+    statusLabel = "Installed but unreachable";
+  }
+
+  return (
+    <CardShell
+      icon={<span aria-hidden="true">🪽</span>}
+      title="Hermes"
+      status={status}
+      statusLabel={statusLabel}
+      body={
+        <div>
+          <p
+            style={{
+              margin: "0 0 10px 0",
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            Connect to a local Hermes gateway's OpenAI-compatible API server on{" "}
+            <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
+              {hermes?.endpoint ?? "http://127.0.0.1:8642/v1"}
+            </code>
+            . When Hermes is running, imported Hermes-controlled agents route
+            their turns through this gateway.
+          </p>
+          {hermes && !hermes.binary_installed && (
+            <p
+              style={{ margin: 0, fontSize: 12, color: "var(--text-tertiary)" }}
+            >
+              Install Hermes locally (see{" "}
+              <a
+                href="https://hermesagent.com"
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                hermesagent.com <OpenNewWindow width={11} height={11} />
+              </a>
+              ) and start its API server. This card auto-detects when the
+              endpoint becomes reachable.
+            </p>
+          )}
+          {hermes?.binary_installed && !hermes.reachable && (
+            <p style={{ margin: 0, fontSize: 12, color: "#d97706" }}>
+              Hermes binary detected but the API server isn't responding. Start
+              it from a terminal and recheck.
+            </p>
+          )}
+        </div>
+      }
+    />
+  );
+}

--- a/web/src/components/apps/integrations/HermesCard.tsx
+++ b/web/src/components/apps/integrations/HermesCard.tsx
@@ -27,13 +27,7 @@ export function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
       statusLabel={statusLabel}
       body={
         <div>
-          <p
-            style={{
-              margin: "0 0 10px 0",
-              fontSize: 13,
-              color: "var(--text-secondary)",
-            }}
-          >
+          <p className="op-card-blurb" style={{ marginBottom: 8 }}>
             Connect to a local Hermes gateway's OpenAI-compatible API server on{" "}
             <code style={{ fontFamily: "var(--font-mono)", fontSize: 12 }}>
               {hermes?.endpoint ?? "http://127.0.0.1:8642/v1"}
@@ -42,9 +36,7 @@ export function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
             their turns through this gateway.
           </p>
           {hermes && !hermes.binary_installed && (
-            <p
-              style={{ margin: 0, fontSize: 12, color: "var(--text-tertiary)" }}
-            >
+            <p className="op-runtime-note">
               Install Hermes locally (see{" "}
               <a
                 href="https://hermesagent.com"
@@ -63,7 +55,7 @@ export function HermesCard({ statuses }: { statuses: LocalProviderStatus[] }) {
             </p>
           )}
           {hermes?.binary_installed && !hermes.reachable && (
-            <p style={{ margin: 0, fontSize: 12, color: "#d97706" }}>
+            <p className="op-runtime-note is-warn">
               Hermes binary detected but the API server isn't responding. Start
               it from a terminal and recheck.
             </p>

--- a/web/src/components/apps/integrations/IntegrationLogos.tsx
+++ b/web/src/components/apps/integrations/IntegrationLogos.tsx
@@ -1,0 +1,143 @@
+import type { ReactElement } from "react";
+
+// Faithful brand glyphs for each integration. Stored as inline SVG so they
+// theme cleanly with our CSS variables and stay crisp at every viewport.
+//
+// Sourcing notes
+// - Telegram: the official paper-plane mark, brand color #229ED9, traced
+//   from the public brand assets at telegram.org/brand.
+// - OpenClaw: a stylized claw glyph approximating the OpenClaw project
+//   identity. The project does not publish a brand-asset license, so we
+//   draw a faithful representation rather than redistributing their
+//   wordmark — it reads as "OpenClaw" while staying inside our own art.
+// - Hermes: a winged-helmet mark referencing Nous Research's Hermes
+//   identity. Same rationale as OpenClaw — a representational glyph
+//   rather than a copy of their wordmark.
+
+const SIZE = 28;
+
+export function TelegramLogo(): ReactElement {
+  return (
+    <svg
+      width={SIZE}
+      height={SIZE}
+      viewBox="0 0 240 240"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <defs>
+        <linearGradient id="telegram-bg" x1="120" y1="0" x2="120" y2="240">
+          <stop offset="0" stopColor="#2AABEE" />
+          <stop offset="1" stopColor="#229ED9" />
+        </linearGradient>
+      </defs>
+      <circle cx="120" cy="120" r="120" fill="url(#telegram-bg)" />
+      <path
+        fill="#fff"
+        d="M54 117.7l130.6-50.4c6.1-2.2 11.4 1.5 9.4 10.7l-22.2 104.5c-1.7 7.4-6.1 9.2-12.4 5.7L123.3 161l-17.6 17c-2 1.9-3.6 3.6-7.5 3.6l2.7-38 69.2-62.5c3-2.7-.7-4.2-4.7-1.5l-85.6 53.9-36.9-11.5c-8-2.5-8.2-8 1.6-11.9z"
+      />
+    </svg>
+  );
+}
+
+export function OpenClawLogo(): ReactElement {
+  return (
+    <svg
+      width={SIZE}
+      height={SIZE}
+      viewBox="0 0 64 64"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <rect width="64" height="64" rx="14" fill="#0B0B12" />
+      <g
+        fill="none"
+        stroke="#F2C94C"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M14 42c4-12 9-18 16-20" />
+        <path d="M22 46c4-14 11-22 20-24" />
+        <path d="M30 50c4-16 13-25 22-26" />
+        <path d="M14 42c-2 3-2 6 1 8" />
+        <path d="M22 46c-2 3-2 6 1 8" />
+        <path d="M30 50c-2 3-2 6 1 8" />
+      </g>
+      <circle cx="50" cy="18" r="2.4" fill="#F2C94C" />
+    </svg>
+  );
+}
+
+export function HermesLogo(): ReactElement {
+  return (
+    <svg
+      width={SIZE}
+      height={SIZE}
+      viewBox="0 0 64 64"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <rect width="64" height="64" rx="14" fill="#111827" />
+      {/* Helmet dome */}
+      <path
+        d="M18 36c0-9 6-16 14-16s14 7 14 16v2H18z"
+        fill="#E5E7EB"
+      />
+      {/* Visor band */}
+      <rect x="18" y="34" width="28" height="4" fill="#9CA3AF" />
+      {/* Crest */}
+      <path
+        d="M32 14c-1 2-1 4 0 6 1-2 1-4 0-6z"
+        fill="#F59E0B"
+      />
+      <path
+        d="M30 18c-2 2-3 5-2 9 2-2 3-5 2-9z"
+        fill="#F59E0B"
+      />
+      {/* Left wing */}
+      <path
+        d="M14 32c4-2 8-2 12 0-3 3-7 4-12 4z"
+        fill="#F59E0B"
+      />
+      <path
+        d="M16 36c3-1 6 0 8 2-2 1-5 1-8-0z"
+        fill="#FBBF24"
+      />
+      {/* Right wing */}
+      <path
+        d="M50 32c-4-2-8-2-12 0 3 3 7 4 12 4z"
+        fill="#F59E0B"
+      />
+      <path
+        d="M48 36c-3-1-6 0-8 2 2 1 5 1 8-0z"
+        fill="#FBBF24"
+      />
+      {/* Base chin guard */}
+      <rect x="22" y="38" width="20" height="6" rx="2" fill="#9CA3AF" />
+    </svg>
+  );
+}
+
+// Generic glyph used as a fallback when an integration has no branded mark.
+// Same dimensions as the branded marks so list rows stay aligned.
+export function GenericIntegrationLogo(): ReactElement {
+  return (
+    <svg
+      width={SIZE}
+      height={SIZE}
+      viewBox="0 0 64 64"
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      <rect width="64" height="64" rx="14" fill="var(--bg-warm)" />
+      <path
+        d="M22 26h20v4l-6 6 6 6v4H22v-4l6-6-6-6z"
+        fill="none"
+        stroke="var(--text-secondary)"
+        strokeWidth="2.5"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/apps/integrations/OpenClawCard.tsx
+++ b/web/src/components/apps/integrations/OpenClawCard.tsx
@@ -57,60 +57,37 @@ export function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
       statusLabel={connected ? "Connected" : "Not configured"}
       body={
         <div>
-          <p
-            style={{
-              margin: "0 0 12px 0",
-              fontSize: 13,
-              color: "var(--text-secondary)",
-            }}
-          >
+          <p className="op-card-blurb">
             Bridge OpenClaw-controlled agents into the team. Provide your
             gateway's WebSocket URL and an auth token; new OpenClaw agents can
             then be onboarded from the gateway's session list.
           </p>
           <label
-            style={{
-              display: "block",
-              fontSize: 11,
-              fontWeight: 600,
-              marginBottom: 4,
-              color: "var(--text-secondary)",
-              textTransform: "uppercase",
-              letterSpacing: 0.4,
-            }}
+            className="op-eyebrow op-field-label"
+            htmlFor="op-openclaw-url"
           >
             Gateway URL
           </label>
           <input
-            className="input"
+            id="op-openclaw-url"
+            className="input op-field-input"
             type="text"
             placeholder="ws://127.0.0.1:18789"
             value={gatewayUrl}
             onChange={(e) => setGatewayUrl(e.target.value)}
-            style={{
-              width: "100%",
-              marginBottom: 10,
-              fontFamily: "var(--font-mono)",
-            }}
+            style={{ fontFamily: "var(--font-mono)", marginBottom: 10 }}
           />
           <label
-            style={{
-              display: "block",
-              fontSize: 11,
-              fontWeight: 600,
-              marginBottom: 4,
-              color: "var(--text-secondary)",
-              textTransform: "uppercase",
-              letterSpacing: 0.4,
-            }}
+            className="op-eyebrow op-field-label"
+            htmlFor="op-openclaw-token"
           >
             Token{" "}
             {tokenSet && !token ? (
               <span
                 style={{
                   fontWeight: 400,
-                  textTransform: "none",
                   letterSpacing: 0,
+                  textTransform: "none",
                   color: "var(--text-tertiary)",
                 }}
               >
@@ -119,22 +96,22 @@ export function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
             ) : null}
           </label>
           <input
-            className="input"
+            id="op-openclaw-token"
+            className="input op-field-input"
             type={revealToken ? "text" : "password"}
             placeholder={tokenSet ? "●●●●●●●●" : "oc_..."}
             value={token}
             onChange={(e) => setToken(e.target.value)}
-            style={{ width: "100%", marginBottom: 6 }}
+            style={{ marginBottom: 6 }}
           />
           <label
             style={{
               display: "inline-flex",
               alignItems: "center",
-              gap: 4,
-              fontSize: 11,
+              gap: 6,
+              fontSize: "var(--text-xs)",
               color: "var(--text-tertiary)",
               cursor: "pointer",
-              marginBottom: 14,
             }}
           >
             <input
@@ -144,7 +121,7 @@ export function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
             />
             Show token
           </label>
-          <div style={{ display: "flex", gap: 6 }}>
+          <div className="op-card-actions">
             <button
               type="button"
               className="btn btn-primary btn-sm"

--- a/web/src/components/apps/integrations/OpenClawCard.tsx
+++ b/web/src/components/apps/integrations/OpenClawCard.tsx
@@ -7,13 +7,25 @@ import {
   updateConfig,
 } from "../../../api/client";
 import { showNotice } from "../../ui/Toast";
-import { CardShell } from "./CardShell";
+import type { IntegrationStatus } from "./types";
 
-// OpenClawCard owns the gateway-URL + token form. Connection status is
-// derived from the /config snapshot: an OpenClaw is "Connected" when both
-// the URL and the token are saved; either-or stays "Not configured" so the
-// status badge never lies about a half-set state.
-export function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
+// OpenClawCard renders the detail body for the OpenClaw integration. The
+// list row chrome (logo + title + status) lives in IntegrationsApp; this
+// component owns the form, mutation, and per-field state.
+//
+// Connection model: an OpenClaw is "Connected" when both the gateway URL
+// and the auth token are saved. Half-set states stay "Not configured" so
+// the status badge never lies about partial config.
+
+export function openClawStatus(cfg: ConfigSnapshot): IntegrationStatus {
+  const connected =
+    Boolean(cfg.openclaw_token_set) && Boolean(cfg.openclaw_gateway_url);
+  return connected
+    ? { tone: "connected", label: "Connected" }
+    : { tone: "unconfigured", label: "Not configured" };
+}
+
+export function OpenClawDetail({ cfg }: { cfg: ConfigSnapshot }) {
   const queryClient = useQueryClient();
   const [gatewayUrl, setGatewayUrl] = useState(cfg.openclaw_gateway_url ?? "");
   const [token, setToken] = useState("");
@@ -50,93 +62,79 @@ export function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
       gatewayUrl === (cfg.openclaw_gateway_url ?? ""));
 
   return (
-    <CardShell
-      icon={<span aria-hidden="true">🦾</span>}
-      title="OpenClaw"
-      status={connected ? "connected" : "unconfigured"}
-      statusLabel={connected ? "Connected" : "Not configured"}
-      body={
-        <div>
-          <p className="op-card-blurb">
-            Bridge OpenClaw-controlled agents into the team. Provide your
-            gateway's WebSocket URL and an auth token; new OpenClaw agents can
-            then be onboarded from the gateway's session list.
-          </p>
-          <label
-            className="op-eyebrow op-field-label"
-            htmlFor="op-openclaw-url"
-          >
-            Gateway URL
-          </label>
-          <input
-            id="op-openclaw-url"
-            className="input op-field-input"
-            type="text"
-            placeholder="ws://127.0.0.1:18789"
-            value={gatewayUrl}
-            onChange={(e) => setGatewayUrl(e.target.value)}
-            style={{ fontFamily: "var(--font-mono)", marginBottom: 10 }}
-          />
-          <label
-            className="op-eyebrow op-field-label"
-            htmlFor="op-openclaw-token"
-          >
-            Token{" "}
-            {tokenSet && !token ? (
-              <span
-                style={{
-                  fontWeight: 400,
-                  letterSpacing: 0,
-                  textTransform: "none",
-                  color: "var(--text-tertiary)",
-                }}
-              >
-                (saved · paste to rotate)
-              </span>
-            ) : null}
-          </label>
-          <input
-            id="op-openclaw-token"
-            className="input op-field-input"
-            type={revealToken ? "text" : "password"}
-            placeholder={tokenSet ? "●●●●●●●●" : "oc_..."}
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            style={{ marginBottom: 6 }}
-          />
-          <label
+    <div>
+      <p className="op-card-blurb">
+        Bridge OpenClaw-controlled agents into the team. Provide your gateway's
+        WebSocket URL and an auth token; new OpenClaw agents can then be
+        onboarded from the gateway's session list.
+      </p>
+      <label className="op-eyebrow op-field-label" htmlFor="op-openclaw-url">
+        Gateway URL
+      </label>
+      <input
+        id="op-openclaw-url"
+        className="input op-field-input"
+        type="text"
+        placeholder="ws://127.0.0.1:18789"
+        value={gatewayUrl}
+        onChange={(e) => setGatewayUrl(e.target.value)}
+        style={{ fontFamily: "var(--font-mono)", marginBottom: 10 }}
+      />
+      <label className="op-eyebrow op-field-label" htmlFor="op-openclaw-token">
+        Token{" "}
+        {tokenSet && !token ? (
+          <span
             style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 6,
-              fontSize: "var(--text-xs)",
+              fontWeight: 400,
+              letterSpacing: 0,
+              textTransform: "none",
               color: "var(--text-tertiary)",
-              cursor: "pointer",
             }}
           >
-            <input
-              type="checkbox"
-              checked={revealToken}
-              onChange={(e) => setRevealToken(e.target.checked)}
-            />
-            Show token
-          </label>
-          <div className="op-card-actions">
-            <button
-              type="button"
-              className="btn btn-primary btn-sm"
-              disabled={disableSubmit}
-              onClick={() => mutation.mutate()}
-            >
-              {mutation.isPending
-                ? "Saving..."
-                : connected
-                  ? "Update connection"
-                  : "Connect"}
-            </button>
-          </div>
-        </div>
-      }
-    />
+            (saved · paste to rotate)
+          </span>
+        ) : null}
+      </label>
+      <input
+        id="op-openclaw-token"
+        className="input op-field-input"
+        type={revealToken ? "text" : "password"}
+        placeholder={tokenSet ? "●●●●●●●●" : "oc_..."}
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        style={{ marginBottom: 6 }}
+      />
+      <label
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          fontSize: "var(--text-xs)",
+          color: "var(--text-tertiary)",
+          cursor: "pointer",
+        }}
+      >
+        <input
+          type="checkbox"
+          checked={revealToken}
+          onChange={(e) => setRevealToken(e.target.checked)}
+        />
+        Show token
+      </label>
+      <div className="op-card-actions">
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          disabled={disableSubmit}
+          onClick={() => mutation.mutate()}
+        >
+          {mutation.isPending
+            ? "Saving..."
+            : connected
+              ? "Update connection"
+              : "Connect"}
+        </button>
+      </div>
+    </div>
   );
 }

--- a/web/src/components/apps/integrations/OpenClawCard.tsx
+++ b/web/src/components/apps/integrations/OpenClawCard.tsx
@@ -1,0 +1,165 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import {
+  type ConfigSnapshot,
+  type ConfigUpdate,
+  updateConfig,
+} from "../../../api/client";
+import { showNotice } from "../../ui/Toast";
+import { CardShell } from "./CardShell";
+
+// OpenClawCard owns the gateway-URL + token form. Connection status is
+// derived from the /config snapshot: an OpenClaw is "Connected" when both
+// the URL and the token are saved; either-or stays "Not configured" so the
+// status badge never lies about a half-set state.
+export function OpenClawCard({ cfg }: { cfg: ConfigSnapshot }) {
+  const queryClient = useQueryClient();
+  const [gatewayUrl, setGatewayUrl] = useState(cfg.openclaw_gateway_url ?? "");
+  const [token, setToken] = useState("");
+  const [revealToken, setRevealToken] = useState(false);
+  const tokenSet = Boolean(cfg.openclaw_token_set);
+  const urlSet = Boolean(cfg.openclaw_gateway_url);
+  const connected = tokenSet && urlSet;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const patch: ConfigUpdate = {};
+      if (gatewayUrl.trim()) patch.openclaw_gateway_url = gatewayUrl.trim();
+      if (token.trim()) patch.openclaw_token = token.trim();
+      await updateConfig(patch);
+    },
+    onSuccess: () => {
+      showNotice("OpenClaw connection saved.", "success");
+      setToken("");
+      void queryClient.invalidateQueries({ queryKey: ["config"] });
+    },
+    onError: (err) => {
+      showNotice(
+        err instanceof Error ? err.message : "Failed to save OpenClaw",
+        "error",
+      );
+    },
+  });
+
+  const disableSubmit =
+    mutation.isPending ||
+    !(gatewayUrl.trim() || token.trim()) ||
+    (connected &&
+      !token.trim() &&
+      gatewayUrl === (cfg.openclaw_gateway_url ?? ""));
+
+  return (
+    <CardShell
+      icon={<span aria-hidden="true">🦾</span>}
+      title="OpenClaw"
+      status={connected ? "connected" : "unconfigured"}
+      statusLabel={connected ? "Connected" : "Not configured"}
+      body={
+        <div>
+          <p
+            style={{
+              margin: "0 0 12px 0",
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            Bridge OpenClaw-controlled agents into the team. Provide your
+            gateway's WebSocket URL and an auth token; new OpenClaw agents can
+            then be onboarded from the gateway's session list.
+          </p>
+          <label
+            style={{
+              display: "block",
+              fontSize: 11,
+              fontWeight: 600,
+              marginBottom: 4,
+              color: "var(--text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+            }}
+          >
+            Gateway URL
+          </label>
+          <input
+            className="input"
+            type="text"
+            placeholder="ws://127.0.0.1:18789"
+            value={gatewayUrl}
+            onChange={(e) => setGatewayUrl(e.target.value)}
+            style={{
+              width: "100%",
+              marginBottom: 10,
+              fontFamily: "var(--font-mono)",
+            }}
+          />
+          <label
+            style={{
+              display: "block",
+              fontSize: 11,
+              fontWeight: 600,
+              marginBottom: 4,
+              color: "var(--text-secondary)",
+              textTransform: "uppercase",
+              letterSpacing: 0.4,
+            }}
+          >
+            Token{" "}
+            {tokenSet && !token ? (
+              <span
+                style={{
+                  fontWeight: 400,
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  color: "var(--text-tertiary)",
+                }}
+              >
+                (saved · paste to rotate)
+              </span>
+            ) : null}
+          </label>
+          <input
+            className="input"
+            type={revealToken ? "text" : "password"}
+            placeholder={tokenSet ? "●●●●●●●●" : "oc_..."}
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            style={{ width: "100%", marginBottom: 6 }}
+          />
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontSize: 11,
+              color: "var(--text-tertiary)",
+              cursor: "pointer",
+              marginBottom: 14,
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={revealToken}
+              onChange={(e) => setRevealToken(e.target.checked)}
+            />
+            Show token
+          </label>
+          <div style={{ display: "flex", gap: 6 }}>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              disabled={disableSubmit}
+              onClick={() => mutation.mutate()}
+            >
+              {mutation.isPending
+                ? "Saving..."
+                : connected
+                  ? "Update connection"
+                  : "Connect"}
+            </button>
+          </div>
+        </div>
+      }
+    />
+  );
+}

--- a/web/src/components/apps/integrations/TelegramCard.tsx
+++ b/web/src/components/apps/integrations/TelegramCard.tsx
@@ -1,37 +1,36 @@
 import type { ConfigSnapshot } from "../../../api/client";
 import { useAppStore } from "../../../stores/app";
-import { CardShell } from "./CardShell";
+import type { IntegrationStatus } from "./types";
 
 // TelegramCard wraps the existing /connect telegram modal so the
 // Integrations app is the single discoverable entry point. The slash
 // command continues to work — they call the same openConnectWizard
 // store action, so users have parallel UI + command-line paths.
-export function TelegramCard({ cfg }: { cfg: ConfigSnapshot }) {
+
+export function telegramStatus(cfg: ConfigSnapshot): IntegrationStatus {
+  return cfg.telegram_token_set
+    ? { tone: "connected", label: "Bot connected" }
+    : { tone: "unconfigured", label: "Not configured" };
+}
+
+export function TelegramDetail({ cfg }: { cfg: ConfigSnapshot }) {
   const openConnectWizard = useAppStore((s) => s.openConnectWizard);
   const tokenSet = Boolean(cfg.telegram_token_set);
   return (
-    <CardShell
-      icon={<span aria-hidden="true">✈️</span>}
-      title="Telegram"
-      status={tokenSet ? "connected" : "unconfigured"}
-      statusLabel={tokenSet ? "Bot connected" : "Not configured"}
-      body={
-        <div>
-          <p className="op-card-blurb">
-            Bring a Telegram chat into the office as a channel. Paste a bot
-            token, pick the chat, and replies route through the bot.
-          </p>
-          <div className="op-card-actions">
-            <button
-              type="button"
-              className="btn btn-primary btn-sm"
-              onClick={() => openConnectWizard("telegram")}
-            >
-              {tokenSet ? "Connect another chat" : "Connect Telegram"}
-            </button>
-          </div>
-        </div>
-      }
-    />
+    <div>
+      <p className="op-card-blurb">
+        Bring a Telegram chat into the office as a channel. Paste a bot token,
+        pick the chat, and replies route through the bot.
+      </p>
+      <div className="op-card-actions">
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={() => openConnectWizard("telegram")}
+        >
+          {tokenSet ? "Connect another chat" : "Connect Telegram"}
+        </button>
+      </div>
+    </div>
   );
 }

--- a/web/src/components/apps/integrations/TelegramCard.tsx
+++ b/web/src/components/apps/integrations/TelegramCard.tsx
@@ -17,23 +17,19 @@ export function TelegramCard({ cfg }: { cfg: ConfigSnapshot }) {
       statusLabel={tokenSet ? "Bot connected" : "Not configured"}
       body={
         <div>
-          <p
-            style={{
-              margin: "0 0 12px 0",
-              fontSize: 13,
-              color: "var(--text-secondary)",
-            }}
-          >
+          <p className="op-card-blurb">
             Bring a Telegram chat into the office as a channel. Paste a bot
             token, pick the chat, and replies route through the bot.
           </p>
-          <button
-            type="button"
-            className="btn btn-primary btn-sm"
-            onClick={() => openConnectWizard("telegram")}
-          >
-            {tokenSet ? "Connect another chat" : "Connect Telegram"}
-          </button>
+          <div className="op-card-actions">
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={() => openConnectWizard("telegram")}
+            >
+              {tokenSet ? "Connect another chat" : "Connect Telegram"}
+            </button>
+          </div>
         </div>
       }
     />

--- a/web/src/components/apps/integrations/TelegramCard.tsx
+++ b/web/src/components/apps/integrations/TelegramCard.tsx
@@ -1,0 +1,41 @@
+import type { ConfigSnapshot } from "../../../api/client";
+import { useAppStore } from "../../../stores/app";
+import { CardShell } from "./CardShell";
+
+// TelegramCard wraps the existing /connect telegram modal so the
+// Integrations app is the single discoverable entry point. The slash
+// command continues to work — they call the same openConnectWizard
+// store action, so users have parallel UI + command-line paths.
+export function TelegramCard({ cfg }: { cfg: ConfigSnapshot }) {
+  const openConnectWizard = useAppStore((s) => s.openConnectWizard);
+  const tokenSet = Boolean(cfg.telegram_token_set);
+  return (
+    <CardShell
+      icon={<span aria-hidden="true">✈️</span>}
+      title="Telegram"
+      status={tokenSet ? "connected" : "unconfigured"}
+      statusLabel={tokenSet ? "Bot connected" : "Not configured"}
+      body={
+        <div>
+          <p
+            style={{
+              margin: "0 0 12px 0",
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            Bring a Telegram chat into the office as a channel. Paste a bot
+            token, pick the chat, and replies route through the bot.
+          </p>
+          <button
+            type="button"
+            className="btn btn-primary btn-sm"
+            onClick={() => openConnectWizard("telegram")}
+          >
+            {tokenSet ? "Connect another chat" : "Connect Telegram"}
+          </button>
+        </div>
+      }
+    />
+  );
+}

--- a/web/src/components/apps/integrations/registry.test.tsx
+++ b/web/src/components/apps/integrations/registry.test.tsx
@@ -42,7 +42,7 @@ describe("integrations/registry", () => {
     // the contract the IntegrationsApp relies on to suppress cards on
     // builds where the Go layer can't service them.
     const ctx = {
-      cfg: { gateway_kinds: [] as never[] },
+      cfg: { gateway_kinds: [] as string[] },
       localStatuses: [],
     };
     for (const d of INTEGRATIONS) {
@@ -61,8 +61,12 @@ describe("integrations/registry", () => {
     // contract lets us read connection state without mounting the body.
     const ctx = {
       cfg: {
-        gateway_kinds: ["openclaw", "openclaw-http", "hermes-agent"],
-      } as never,
+        gateway_kinds: [
+          "openclaw",
+          "openclaw-http",
+          "hermes-agent",
+        ] as string[],
+      },
       localStatuses: [],
     };
     for (const d of INTEGRATIONS) {

--- a/web/src/components/apps/integrations/registry.test.tsx
+++ b/web/src/components/apps/integrations/registry.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { INTEGRATIONS } from "./registry";
+import { INTEGRATION_CATEGORIES } from "./types";
+
+describe("integrations/registry", () => {
+  it("uses unique ids", () => {
+    const ids = new Set<string>();
+    for (const d of INTEGRATIONS) {
+      expect(ids.has(d.id), `duplicate id: ${d.id}`).toBe(false);
+      ids.add(d.id);
+    }
+  });
+
+  it("only references declared categories", () => {
+    const known = new Set(INTEGRATION_CATEGORIES.map((c) => c.id));
+    for (const d of INTEGRATIONS) {
+      expect(
+        known.has(d.category),
+        `${d.id} -> unknown category ${d.category}`,
+      ).toBe(true);
+    }
+  });
+
+  it("populates External Agents and Channels", () => {
+    const byCat = new Map<string, number>();
+    for (const d of INTEGRATIONS) {
+      byCat.set(d.category, (byCat.get(d.category) ?? 0) + 1);
+    }
+    // The redesign requires at least one integration per declared
+    // category — an empty category would render an orphaned heading.
+    for (const cat of INTEGRATION_CATEGORIES) {
+      expect(
+        (byCat.get(cat.id) ?? 0) > 0,
+        `category ${cat.id} has no integrations`,
+      ).toBe(true);
+    }
+  });
+
+  it("hides each integration when its build gate is off", () => {
+    // Every descriptor must respect a gateway_kinds = [] context. This is
+    // the contract the IntegrationsApp relies on to suppress cards on
+    // builds where the Go layer can't service them.
+    const ctx = {
+      cfg: { gateway_kinds: [] as never[] },
+      localStatuses: [],
+    };
+    for (const d of INTEGRATIONS) {
+      // The Channels category is always available (no build gate). External
+      // Agents must be available iff their gateway is registered.
+      if (d.category === "external-agents") {
+        // biome-ignore lint/suspicious/noExplicitAny: ctx is a structural sample
+        expect(d.isAvailable(ctx as any)).toBe(false);
+      }
+    }
+  });
+});

--- a/web/src/components/apps/integrations/registry.test.tsx
+++ b/web/src/components/apps/integrations/registry.test.tsx
@@ -54,4 +54,26 @@ describe("integrations/registry", () => {
       }
     }
   });
+
+  it("provides a logo, summary, and status for every descriptor", () => {
+    // The list view depends on all three. A missing logo would render an
+    // empty rail; a missing summary collapses the row; status() pure-fn
+    // contract lets us read connection state without mounting the body.
+    const ctx = {
+      cfg: {
+        gateway_kinds: ["openclaw", "openclaw-http", "hermes-agent"],
+      } as never,
+      localStatuses: [],
+    };
+    for (const d of INTEGRATIONS) {
+      expect(typeof d.logo, `${d.id} missing logo()`).toBe("function");
+      expect(d.summary.length, `${d.id} summary empty`).toBeGreaterThan(20);
+      // biome-ignore lint/suspicious/noExplicitAny: ctx is a structural sample
+      const s = d.status(ctx as any);
+      expect(["connected", "available", "warning", "unconfigured"]).toContain(
+        s.tone,
+      );
+      expect(s.label.length, `${d.id} status label empty`).toBeGreaterThan(0);
+    }
+  });
 });

--- a/web/src/components/apps/integrations/registry.tsx
+++ b/web/src/components/apps/integrations/registry.tsx
@@ -1,0 +1,49 @@
+import { HermesCard } from "./HermesCard";
+import { OpenClawCard } from "./OpenClawCard";
+import { TelegramCard } from "./TelegramCard";
+import type { IntegrationContext, IntegrationDescriptor } from "./types";
+
+// INTEGRATIONS is the single source of truth for what the Integrations app
+// renders. Adding a new integration is a four-line change here plus a new
+// card file — no IntegrationsApp edits needed. The descriptor's category
+// places the card in the correct section; isAvailable hides the card on
+// builds where the backend can't actually service it.
+//
+// Ordering note: descriptors render in array order within a category. Put
+// the most common / well-trodden integration first; rare or
+// experimentally-supported ones after.
+export const INTEGRATIONS: readonly IntegrationDescriptor[] = [
+  // ── External Agents ──────────────────────────────────────────────
+  {
+    id: "openclaw",
+    category: "external-agents",
+    title: "OpenClaw",
+    isAvailable: ({ cfg }: IntegrationContext) => {
+      const kinds = cfg.gateway_kinds ?? ["openclaw"];
+      return kinds.includes("openclaw") || kinds.includes("openclaw-http");
+    },
+    render: ({ cfg }) => <OpenClawCard cfg={cfg} />,
+  },
+  {
+    id: "hermes",
+    category: "external-agents",
+    title: "Hermes",
+    isAvailable: ({ cfg }: IntegrationContext) => {
+      const kinds = cfg.gateway_kinds ?? ["hermes-agent"];
+      return kinds.includes("hermes-agent");
+    },
+    render: ({ localStatuses }) => <HermesCard statuses={localStatuses} />,
+  },
+
+  // ── Channels ─────────────────────────────────────────────────────
+  {
+    id: "telegram",
+    category: "channels",
+    title: "Telegram",
+    // Telegram is always available — the modal handles the
+    // server-not-reachable case at submit time, and there's no compile
+    // flag that strips Telegram support today.
+    isAvailable: () => true,
+    render: ({ cfg }) => <TelegramCard cfg={cfg} />,
+  },
+] as const;

--- a/web/src/components/apps/integrations/registry.tsx
+++ b/web/src/components/apps/integrations/registry.tsx
@@ -1,38 +1,50 @@
-import { HermesCard } from "./HermesCard";
-import { OpenClawCard } from "./OpenClawCard";
-import { TelegramCard } from "./TelegramCard";
+import { HermesDetail, hermesStatus } from "./HermesCard";
+import {
+  HermesLogo,
+  OpenClawLogo,
+  TelegramLogo,
+} from "./IntegrationLogos";
+import { OpenClawDetail, openClawStatus } from "./OpenClawCard";
+import { TelegramDetail, telegramStatus } from "./TelegramCard";
 import type { IntegrationContext, IntegrationDescriptor } from "./types";
 
 // INTEGRATIONS is the single source of truth for what the Integrations app
-// renders. Adding a new integration is a four-line change here plus a new
-// card file — no IntegrationsApp edits needed. The descriptor's category
-// places the card in the correct section; isAvailable hides the card on
-// builds where the backend can't actually service it.
+// renders. Adding a new integration is a single descriptor entry plus
+// optional logo + detail-component additions. The IntegrationsApp itself
+// has no per-integration knowledge.
 //
-// Ordering note: descriptors render in array order within a category. Put
-// the most common / well-trodden integration first; rare or
-// experimentally-supported ones after.
+// Ordering: descriptors render in array order within a category. Put the
+// most common / well-trodden integration first; rare or experimentally-
+// supported ones after.
 export const INTEGRATIONS: readonly IntegrationDescriptor[] = [
   // ── External Agents ──────────────────────────────────────────────
   {
     id: "openclaw",
     category: "external-agents",
     title: "OpenClaw",
+    summary:
+      "Bridge OpenClaw-controlled agent sessions into the office over a WebSocket gateway.",
+    logo: OpenClawLogo,
     isAvailable: ({ cfg }: IntegrationContext) => {
       const kinds = cfg.gateway_kinds ?? ["openclaw"];
       return kinds.includes("openclaw") || kinds.includes("openclaw-http");
     },
-    render: ({ cfg }) => <OpenClawCard cfg={cfg} />,
+    status: ({ cfg }) => openClawStatus(cfg),
+    render: ({ cfg }) => <OpenClawDetail cfg={cfg} />,
   },
   {
     id: "hermes",
     category: "external-agents",
     title: "Hermes",
+    summary:
+      "Route imported Hermes agents through a local Hermes gateway's OpenAI-compatible server.",
+    logo: HermesLogo,
     isAvailable: ({ cfg }: IntegrationContext) => {
       const kinds = cfg.gateway_kinds ?? ["hermes-agent"];
       return kinds.includes("hermes-agent");
     },
-    render: ({ localStatuses }) => <HermesCard statuses={localStatuses} />,
+    status: ({ localStatuses }) => hermesStatus(localStatuses),
+    render: ({ localStatuses }) => <HermesDetail statuses={localStatuses} />,
   },
 
   // ── Channels ─────────────────────────────────────────────────────
@@ -40,10 +52,14 @@ export const INTEGRATIONS: readonly IntegrationDescriptor[] = [
     id: "telegram",
     category: "channels",
     title: "Telegram",
+    summary:
+      "Bring a Telegram chat into the office as a channel; replies route through a bot you control.",
+    logo: TelegramLogo,
     // Telegram is always available — the modal handles the
     // server-not-reachable case at submit time, and there's no compile
     // flag that strips Telegram support today.
     isAvailable: () => true,
-    render: ({ cfg }) => <TelegramCard cfg={cfg} />,
+    status: ({ cfg }) => telegramStatus(cfg),
+    render: ({ cfg }) => <TelegramDetail cfg={cfg} />,
   },
 ] as const;

--- a/web/src/components/apps/integrations/types.ts
+++ b/web/src/components/apps/integrations/types.ts
@@ -1,0 +1,66 @@
+import type { ConfigSnapshot, LocalProviderStatus } from "../../../api/client";
+
+// IntegrationCategory groups cards by the role they play in the team. The
+// app renders each category as a labelled section. Add a new category only
+// when an integration genuinely doesn't fit any of the existing ones — most
+// new integrations should land in an existing bucket so users always know
+// where to look.
+//
+//   - external-agents: Gateways that import existing agents into the team
+//     (OpenClaw, Hermes). The agent's runtime is gateway-managed; WUPHF
+//     speaks to the gateway's transport rather than dispatching directly.
+//
+//   - channels: Inbound messaging streams that become channels in the
+//     office (Telegram today; Slack / Discord / WhatsApp can plug in
+//     under this category later).
+export type IntegrationCategory = "external-agents" | "channels";
+
+export interface IntegrationCategoryMeta {
+  id: IntegrationCategory;
+  title: string;
+  description: string;
+}
+
+export const INTEGRATION_CATEGORIES: readonly IntegrationCategoryMeta[] = [
+  {
+    id: "external-agents",
+    title: "External Agents",
+    description:
+      "Gateways that import agents from another system into the team. The imported agent's runtime is managed by the gateway, not WUPHF.",
+  },
+  {
+    id: "channels",
+    title: "Channels",
+    description:
+      "Inbound messaging streams that surface as channels in the office.",
+  },
+] as const;
+
+// Per-integration runtime context. The registry hands each render() call
+// the current /config snapshot and any local-runtime probes so cards don't
+// re-implement data fetching. Add new fields here when a category needs
+// fresh inputs (e.g. an OAuth-status query) rather than letting individual
+// cards call hooks ad-hoc.
+export interface IntegrationContext {
+  cfg: ConfigSnapshot;
+  localStatuses: LocalProviderStatus[];
+}
+
+// IntegrationDescriptor is the registry entry shape. Keep it data-shaped
+// (no hooks, no React state) — the only React-y field is the render
+// function. This makes the registry safe to enumerate, snapshot, and test
+// without mounting the app.
+export interface IntegrationDescriptor {
+  id: string;
+  category: IntegrationCategory;
+  title: string;
+  // isAvailable reports whether the build/Go layer supports this
+  // integration at all. False entries are filtered out before any cards
+  // render so we don't promise a Connect button the backend can't
+  // honor. Use it for compile-time gates (`gateway_kinds` membership for
+  // gateways, future build-tag checks for compose-only integrations).
+  isAvailable: (ctx: IntegrationContext) => boolean;
+  // render returns the card body. The IntegrationsApp wraps it in the
+  // shared CardShell so card files only worry about their own state.
+  render: (ctx: IntegrationContext) => React.ReactNode;
+}

--- a/web/src/components/apps/integrations/types.ts
+++ b/web/src/components/apps/integrations/types.ts
@@ -1,4 +1,9 @@
-import type { ConfigSnapshot, LocalProviderStatus } from "../../../api/client";
+import type { ReactElement, ReactNode } from "react";
+
+import type {
+  ConfigSnapshot,
+  LocalProviderStatus,
+} from "../../../api/client";
 
 // IntegrationCategory groups cards by the role they play in the team. The
 // app renders each category as a labelled section. Add a new category only
@@ -46,21 +51,49 @@ export interface IntegrationContext {
   localStatuses: LocalProviderStatus[];
 }
 
+// IntegrationStatus is the connectivity verdict the list view + detail
+// header both render. tone drives the LED + uppercase status pill; label
+// is the short uppercase string ("CONNECTED", "NOT CONFIGURED").
+export type IntegrationStatusTone =
+  | "connected"
+  | "available"
+  | "unconfigured"
+  | "warning";
+
+export interface IntegrationStatus {
+  tone: IntegrationStatusTone;
+  label: string;
+}
+
 // IntegrationDescriptor is the registry entry shape. Keep it data-shaped
-// (no hooks, no React state) — the only React-y field is the render
-// function. This makes the registry safe to enumerate, snapshot, and test
-// without mounting the app.
+// (no hooks, no React state) — the only React-y fields are the logo
+// component and the render function. This makes the registry safe to
+// enumerate, snapshot, and test without mounting the app.
+//
+// The split between list and detail rendering:
+//   - List view (default) renders {logo, title, summary, status}.
+//   - Detail view renders {logo, title, status, render(ctx)}. The render
+//     fn returns only the form body — back button + header chrome live
+//     in the detail layout, not in each card.
 export interface IntegrationDescriptor {
   id: string;
   category: IntegrationCategory;
   title: string;
+  // summary is the one-liner shown under the title in the list view. Aim
+  // for ≤ 80 chars so a row never wraps to two lines.
+  summary: string;
+  // logo returns the branded glyph rendered at 28px in both the list row
+  // and the detail header. Use IntegrationLogos.tsx exports when possible.
+  logo: () => ReactElement;
   // isAvailable reports whether the build/Go layer supports this
-  // integration at all. False entries are filtered out before any cards
-  // render so we don't promise a Connect button the backend can't
-  // honor. Use it for compile-time gates (`gateway_kinds` membership for
-  // gateways, future build-tag checks for compose-only integrations).
+  // integration at all. False entries are filtered out before any rows
+  // render so we don't promise a Connect button the backend can't honor.
   isAvailable: (ctx: IntegrationContext) => boolean;
-  // render returns the card body. The IntegrationsApp wraps it in the
-  // shared CardShell so card files only worry about their own state.
-  render: (ctx: IntegrationContext) => React.ReactNode;
+  // status returns the connectivity verdict from the current /config
+  // snapshot + probes. Used by both list and detail. Must be pure — no
+  // hooks, no side effects.
+  status: (ctx: IntegrationContext) => IntegrationStatus;
+  // render returns the detail-view body (form fields + action buttons).
+  // The IntegrationsApp wraps it in the back-button chrome.
+  render: (ctx: IntegrationContext) => ReactNode;
 }

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -587,34 +587,38 @@ describe("PrePickScreen", () => {
       );
     });
 
-    it("strips control characters from the endpoint URL before posting", async () => {
+    it("does not conflate the OAI-compat endpoint with OpenClaw config", async () => {
+      // Locks in the redesign: filling the Custom endpoint section must
+      // write only to provider_endpoints, never to openclaw_token /
+      // openclaw_gateway_url. OpenClaw is a gateway managed through the
+      // Integrations app; persisting an unrelated OAI-compat URL as the
+      // OpenClaw gateway was the exact "OpenClaw treated as a provider"
+      // bug this redesign closes.
       mockPrereqs({});
       const onComplete = vi.fn();
       render(<PrePickScreen onComplete={onComplete} />);
       await screen.findByTestId("pre-pick-oai-url");
 
-      // Inject a control char in the URL (after valid prefix so it passes URL validation)
-      // Use a URL that is valid but contains a control char we expect to be stripped.
-      // NOTE: URL constructor strips control chars itself, so we verify the sanitizer
-      // is invoked by checking the posted value is clean.
       fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
         target: { value: "https://example.com/v1" },
       });
       fireEvent.change(screen.getByTestId("pre-pick-oai-key"), {
-        target: { value: "tok-\x01secret" },
+        target: { value: "tok-secret" },
       });
 
       const submitBtn = await screen.findByTestId("pre-pick-form-submit");
       fireEvent.click(submitBtn);
 
       await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-      // The API key must have control chars stripped
-      expect(postMock).toHaveBeenCalledWith(
-        "/config",
-        expect.objectContaining({
-          openclaw_token: "tok-secret",
-        }),
-      );
+      const calledPayload = postMock.mock.calls[0]?.[1] as Record<
+        string,
+        unknown
+      >;
+      expect(calledPayload.openclaw_token).toBeUndefined();
+      expect(calledPayload.openclaw_gateway_url).toBeUndefined();
+      expect(calledPayload.provider_endpoints).toMatchObject({
+        "openai-compatible": { base_url: "https://example.com/v1" },
+      });
     });
   });
 

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -438,10 +438,11 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
       <div className="pre-pick-body">
         <div className="pre-pick-hero">
           <div className="pre-pick-eyebrow">WUPHF</div>
-          <h1 className="pre-pick-headline">Pick a runtime.</h1>
+          <h1 className="pre-pick-headline">Pick a default runtime.</h1>
           <p className="pre-pick-subhead">
-            Your office needs an AI runtime. Pick one of the three below, or use
-            an API key, a local model, or a custom endpoint.
+            This is the runtime new agents will inherit when they're created.
+            You can change it later in Settings, and every agent can be moved
+            to a different runtime one at a time from its profile.
           </p>
         </div>
 

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -220,8 +220,6 @@ type ConfigPayload = {
   openai_api_key?: string;
   gemini_api_key?: string;
   provider_endpoints?: Record<string, { base_url: string }>;
-  openclaw_token?: string;
-  openclaw_gateway_url?: string;
 };
 
 /**
@@ -246,13 +244,17 @@ function buildConfigPayload(
     payload.llm_provider = localProvider;
     payload.llm_provider_priority = [localProvider];
   } else if (oaiCompatFilled(oaiUrl)) {
+    // Custom OAI-compatible endpoint goes into provider_endpoints. We do
+    // NOT write to openclaw_* here — that conflated OpenClaw (a gateway
+    // for importing existing agents) with generic OpenAI-compatible HTTP
+    // runtimes. OpenClaw is configured through the Integrations app, not
+    // through this onboarding step. The oaiKey field is intentionally
+    // unused on this path; users wanting to pair an API key with the
+    // endpoint should paste it in the OpenAI API key row above.
+    void oaiKey;
     payload.provider_endpoints = {
       "openai-compatible": { base_url: sanitizeConfigString(oaiUrl) },
     };
-    if (oaiKey.trim()) {
-      payload.openclaw_token = sanitizeConfigString(oaiKey);
-      payload.openclaw_gateway_url = sanitizeConfigString(oaiUrl);
-    }
   }
 
   for (const f of API_KEY_FIELDS) {
@@ -494,8 +496,9 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
         <div className="pre-pick-section" data-testid="pre-pick-oai-section">
           <p className="pre-pick-section-heading">Custom endpoint</p>
           <p className="pre-pick-section-hint">
-            Any server that speaks the OpenAI REST protocol (OpenClaw, LiteLLM,
-            vLLM, etc.).
+            Any server that speaks the OpenAI REST protocol (LiteLLM, vLLM,
+            llama.cpp server, etc.). For OpenClaw or Hermes, use the
+            Integrations app after onboarding.
           </p>
           <OpenAICompatibleInput
             endpointUrl={oaiUrl}

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -232,7 +232,13 @@ function buildConfigPayload(
   provider: string,
   localProvider: string,
   oaiUrl: string,
-  oaiKey: string,
+  // _oaiKey is intentionally unused on the current write path: the OAI-
+  // compatible endpoint section writes only to provider_endpoints, never
+  // to openclaw_* (gateway config) or to an Anthropic/OpenAI key row.
+  // Kept in the signature so the call site can stay 1:1 with form
+  // state — renaming the parameter to _oaiKey marks the intent for
+  // TypeScript-aware linters without forcing a 4-argument call shape.
+  _oaiKey: string,
   apiKeys: Record<string, string>,
 ): ConfigPayload {
   const payload: ConfigPayload = { memory_backend: "markdown" };
@@ -248,10 +254,9 @@ function buildConfigPayload(
     // NOT write to openclaw_* here — that conflated OpenClaw (a gateway
     // for importing existing agents) with generic OpenAI-compatible HTTP
     // runtimes. OpenClaw is configured through the Integrations app, not
-    // through this onboarding step. The oaiKey field is intentionally
+    // through this onboarding step. The _oaiKey parameter is intentionally
     // unused on this path; users wanting to pair an API key with the
     // endpoint should paste it in the OpenAI API key row above.
-    void oaiKey;
     payload.provider_endpoints = {
       "openai-compatible": { base_url: sanitizeConfigString(oaiUrl) },
     };
@@ -441,8 +446,10 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
           <h1 className="pre-pick-headline">Pick a default runtime.</h1>
           <p className="pre-pick-subhead">
             This is the runtime new agents will inherit when they're created.
-            You can change it later in Settings, and every agent can be moved
-            to a different runtime one at a time from its profile.
+            You can change it later in Settings, and most agents can be moved to
+            a different runtime one at a time from their profile. Agents
+            imported through a gateway (OpenClaw, Hermes) are managed from the
+            Integrations app instead.
           </p>
         </div>
 

--- a/web/src/components/onboarding/runtimeConstants.ts
+++ b/web/src/components/onboarding/runtimeConstants.ts
@@ -39,20 +39,18 @@ export type ApiKeyFieldDef = (typeof API_KEY_FIELDS)[number];
 // LOCAL_PROVIDER_LABELS is shared between LocalProviderPicker and the
 // PrePickScreen submit logic. Kept here to avoid three-way drift if a
 // runtime is renamed or added.
+//
+// Gateway-style runtimes (Hermes Agent, OpenClaw Gateway) used to live here
+// alongside the directly-dispatchable local LLMs. They were removed because
+// they are gateways for importing existing agents into the team, not LLM
+// runtimes for backing WUPHF-created agents. Surfacing them as runtime tiles
+// confused users about whether picking "OpenClaw" meant "host my agents on
+// OpenClaw" or "import OpenClaw agents into the team." The Integrations app
+// (Settings → Integrations) is now the single place gateways are configured.
 export const LOCAL_PROVIDER_LABELS = [
   { kind: "mlx-lm" as const, label: "MLX-LM", blurb: "macOS / Apple Silicon" },
   { kind: "ollama" as const, label: "Ollama", blurb: "macOS / Linux" },
   { kind: "exo" as const, label: "Exo", blurb: "Multi-device pool" },
-  {
-    kind: "hermes-agent" as const,
-    label: "Hermes Agent",
-    blurb: "Agent gateway",
-  },
-  {
-    kind: "openclaw-http" as const,
-    label: "OpenClaw Gateway",
-    blurb: "Agent gateway",
-  },
 ] as const;
 
 export type LocalProviderMeta = (typeof LOCAL_PROVIDER_LABELS)[number];

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -21,7 +21,7 @@ export function appTitle(app: string): string {
 export const ONBOARDING_COPY = {
   step1_headline: "AI employees with a shared brain",
   step1_subhead:
-    "A collaborative office where AI agents like Claude Code, Codex, and OpenClaw learn your work playbooks, build personalized skills, and execute, 24x7.\nEach agent is backed by its own knowledge graph.",
+    "A collaborative office where AI agents like Claude Code, Codex, and Opencode learn your work playbooks, build personalized skills, and execute, 24x7.\nEach agent is backed by its own knowledge graph.",
   step1_cta: "Continue",
   step2_headline: "Name your office",
   step2_subhead: "This becomes the workspace your agents call home.",

--- a/web/src/lib/modelCatalog.ts
+++ b/web/src/lib/modelCatalog.ts
@@ -12,24 +12,66 @@ import type { LLMRuntimeKind, LocalProviderStatus } from "../api/client";
 // Local runtimes return an empty list here — their model dropdown is
 // populated dynamically from the /status/local-providers probe (see
 // modelOptionsForKind below).
+//
+// Sourcing (verified 2026-05-29):
+//   - claude-code → Anthropic model overview
+//     https://platform.claude.com/docs/en/docs/about-claude/models
+//   - codex → OpenAI models index (developers.openai.com)
+//     https://developers.openai.com/api/docs/models/all
+//   - opencode mixes Anthropic + OpenAI via Models.dev, so the catalog
+//     surfaces the most common headline ids from each.
+//
+// Each list is ordered current-first so the dropdown's first non-default
+// option is the recommended pick. Aliases (claude-opus-4-7, claude-sonnet-4-6,
+// claude-haiku-4-5) are preferred over dated snapshots because they reduce
+// surprise migrations when Anthropic pins a new dated ID under the same
+// alias.
 const CLOUD_MODELS: Record<
   Exclude<LLMRuntimeKind, "mlx-lm" | "ollama" | "exo">,
   string[]
 > = {
   "claude-code": [
-    "claude-opus-4-7",
+    // Current / recommended
+    "claude-opus-4-8",
     "claude-sonnet-4-6",
-    "claude-haiku-4-5-20251001",
+    "claude-haiku-4-5",
+    // Legacy but still available
+    "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-5",
+    "claude-opus-4-5",
+    "claude-opus-4-1",
   ],
-  codex: ["gpt-5.1", "gpt-5", "gpt-4o", "gpt-4o-mini", "o3", "o4-mini"],
-  opencode: [
-    "claude-opus-4-7",
-    "claude-sonnet-4-6",
-    "gpt-5.1",
+  codex: [
+    // Current / recommended
+    "gpt-5.5",
+    "gpt-5.5-pro",
+    "gpt-5.4",
+    "gpt-5.4-pro",
+    "gpt-5.4-mini",
+    "gpt-5.4-nano",
+    // Codex-specialised agentic coding model
+    "gpt-5.3-codex",
+    // Legacy but still available via API
+    "gpt-5.2",
     "gpt-5",
-    "claude-sonnet-4-5",
+    "gpt-5-mini",
+    "gpt-5-nano",
+    "o3",
+    "o3-pro",
+  ],
+  opencode: [
+    // Anthropic top picks
+    "claude-opus-4-8",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+    // OpenAI top picks
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.3-codex",
+    // Common older fallbacks
+    "claude-opus-4-7",
+    "gpt-5",
   ],
 };
 

--- a/web/src/lib/modelCatalog.ts
+++ b/web/src/lib/modelCatalog.ts
@@ -1,0 +1,105 @@
+import type { LLMRuntimeKind, LocalProviderStatus } from "../api/client";
+
+// MODEL_CATALOG is a curated suggestion list per LLM runtime. We let users
+// pick from these in the AgentProfilePanel + AgentWizard dropdowns instead
+// of free-typing a model identifier — typos in model ids are a real failure
+// mode (codex/claude refuse the request, the agent appears silent).
+//
+// Cloud runtimes ship a fixed list of well-known ids. They drift as new
+// model families launch, but the "Custom…" escape hatch in the picker
+// keeps power users unblocked while we update the catalog.
+//
+// Local runtimes return an empty list here — their model dropdown is
+// populated dynamically from the /status/local-providers probe (see
+// modelOptionsForKind below).
+const CLOUD_MODELS: Record<
+  Exclude<LLMRuntimeKind, "mlx-lm" | "ollama" | "exo">,
+  string[]
+> = {
+  "claude-code": [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-6",
+    "claude-sonnet-4-5",
+  ],
+  codex: ["gpt-5.1", "gpt-5", "gpt-4o", "gpt-4o-mini", "o3", "o4-mini"],
+  opencode: [
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "gpt-5.1",
+    "gpt-5",
+    "claude-sonnet-4-5",
+  ],
+};
+
+// Empty model entry maps to "use the runtime's default" (broker leaves
+// ProviderBinding.Model unset and each runner picks its own default).
+export const INHERIT_MODEL_VALUE = "";
+
+// Sentinel used by the picker to fall back to a text input when none of
+// the curated suggestions fit. Component code reads selectedValue ===
+// CUSTOM_MODEL_VALUE and renders the free-text input.
+export const CUSTOM_MODEL_VALUE = "__custom__";
+
+export interface ModelOption {
+  value: string;
+  label: string;
+}
+
+// modelOptionsForKind returns the dropdown options for a given runtime
+// kind. The list always begins with the "Use runtime default" entry; the
+// "Custom…" entry is appended at the end so power users can pick a model
+// the catalog doesn't know about yet.
+//
+// `localStatuses` lets the picker show real installed models for local
+// runtimes (mlx-lm / ollama / exo). When undefined, local runtimes fall
+// back to just {default, custom}.
+export function modelOptionsForKind(
+  kind: LLMRuntimeKind | "",
+  localStatuses?: LocalProviderStatus[],
+): ModelOption[] {
+  const options: ModelOption[] = [
+    { value: INHERIT_MODEL_VALUE, label: "Use runtime default" },
+  ];
+  if (kind === "" ) {
+    return options;
+  }
+  if (kind === "mlx-lm" || kind === "ollama" || kind === "exo") {
+    const status = localStatuses?.find((s) => s.kind === kind);
+    const loaded = status?.loaded_model?.trim();
+    const configured = status?.model?.trim();
+    const seen = new Set<string>();
+    for (const candidate of [loaded, configured]) {
+      if (candidate && !seen.has(candidate)) {
+        options.push({ value: candidate, label: candidate });
+        seen.add(candidate);
+      }
+    }
+  } else if (kind in CLOUD_MODELS) {
+    for (const model of CLOUD_MODELS[
+      kind as keyof typeof CLOUD_MODELS
+    ]) {
+      options.push({ value: model, label: model });
+    }
+  }
+  options.push({ value: CUSTOM_MODEL_VALUE, label: "Custom…" });
+  return options;
+}
+
+// isCatalogModel reports whether modelValue is one of the curated entries
+// for the given runtime kind. Used to decide whether the picker should
+// open in "select" mode (catalog match) or "custom text" mode (the saved
+// value isn't in the catalog, so the user typed it).
+export function isCatalogModel(
+  kind: LLMRuntimeKind | "",
+  modelValue: string,
+  localStatuses?: LocalProviderStatus[],
+): boolean {
+  if (modelValue === "") return true;
+  const options = modelOptionsForKind(kind, localStatuses);
+  return options.some(
+    (o) =>
+      o.value !== CUSTOM_MODEL_VALUE && o.value === modelValue,
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -19,6 +19,7 @@ import "./styles/console.css";
 import "./styles/pixel-skill-card.css";
 import "./styles/lifecycle.css";
 import "./styles/onboarding.css";
+import "./styles/operator.css";
 
 // Attach the root route's component at startup. Defining the component
 // inside `lib/router.ts` would create a circular import: RootRoute reads

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -109,6 +109,11 @@ const SettingsApp = lazy(() =>
     default: m.SettingsApp,
   })),
 );
+const IntegrationsApp = lazy(() =>
+  import("../components/apps/IntegrationsApp").then((m) => ({
+    default: m.IntegrationsApp,
+  })),
+);
 const SkillsApp = lazy(() =>
   import("../components/apps/SkillsApp").then((m) => ({
     default: m.SkillsApp,
@@ -330,6 +335,7 @@ const APP_PANELS = {
   activity: ArtifactsApp,
   receipts: ReceiptsApp,
   "health-check": HealthCheckApp,
+  integrations: IntegrationsApp,
   settings: SettingsApp,
   console: ConsoleApp,
 } satisfies Record<AppPanelId, ComponentType>;

--- a/web/src/routes/routeRegistry.ts
+++ b/web/src/routes/routeRegistry.ts
@@ -4,6 +4,7 @@ export const APP_PANEL_IDS = [
   "console",
   "graph",
   "health-check",
+  "integrations",
   "policies",
   "receipts",
   "requests",
@@ -57,6 +58,7 @@ export const APP_LABELS: Record<AppPanelId | FirstClassAppId, string> = {
   console: "Console",
   graph: "Graph",
   "health-check": "Access & Health",
+  integrations: "Integrations",
   policies: "Policies",
   receipts: "Receipts",
   requests: "Requests",
@@ -84,6 +86,7 @@ const SIDEBAR_TOOL_EMOJIS: Partial<
   skills: "⚡",
   receipts: "🧾",
   "health-check": "📶",
+  integrations: "🔌",
   settings: "⚙",
 };
 
@@ -123,6 +126,7 @@ export const SIDEBAR_TOOLS: readonly SidebarTool[] = [
   { id: "skills", kind: "app-panel" },
   { id: "receipts", kind: "app-panel" },
   { id: "health-check", kind: "app-panel" },
+  { id: "integrations", kind: "app-panel" },
   { id: "settings", kind: "app-panel" },
 ].map((entry) => ({
   ...entry,

--- a/web/src/styles/operator.css
+++ b/web/src/styles/operator.css
@@ -33,6 +33,7 @@
 
 .op-led {
   --led-color: var(--text-tertiary);
+
   display: inline-block;
   width: 8px;
   height: 8px;
@@ -57,9 +58,9 @@
 }
 
 .op-led.is-on {
-  animation: opLedPulse 2.8s ease-in-out infinite;
+  animation: op-led-pulse 2.8s ease-in-out infinite;
 }
-@keyframes opLedPulse {
+@keyframes op-led-pulse {
   0%,
   100% {
     box-shadow:
@@ -458,12 +459,17 @@
   cursor: pointer;
   font: inherit;
   color: inherit;
-  transition: border-color 140ms ease, box-shadow 140ms ease,
-    transform 140ms ease, background 140ms ease;
+  transition:
+    border-color 140ms ease,
+    box-shadow 140ms ease,
+    transform 140ms ease,
+    background 140ms ease;
 }
 .op-list-row:hover {
   border-color: var(--border-strong);
-  box-shadow: 0 1px 0 var(--border-light), 0 8px 18px -10px rgba(0, 0, 0, 0.10);
+  box-shadow:
+    0 1px 0 var(--border-light),
+    0 8px 18px -10px rgba(0, 0, 0, 0.1);
   transform: translateY(-1px);
 }
 .op-list-row:hover .op-list-row-chevron {
@@ -509,7 +515,9 @@
 }
 .op-list-row-chevron {
   color: var(--text-tertiary);
-  transition: transform 140ms ease, color 140ms ease;
+  transition:
+    transform 140ms ease,
+    color 140ms ease;
   flex-shrink: 0;
 }
 
@@ -533,7 +541,9 @@
   color: var(--text-tertiary);
   cursor: pointer;
   align-self: flex-start;
-  transition: color 140ms ease, transform 140ms ease;
+  transition:
+    color 140ms ease,
+    transform 140ms ease;
 }
 .op-detail-back:hover {
   color: var(--text);

--- a/web/src/styles/operator.css
+++ b/web/src/styles/operator.css
@@ -1,0 +1,437 @@
+/* operator.css — shared visual language for runtime / provider / gateway
+ * surfaces. The aesthetic: an operator's instrument panel for the AI team.
+ * Precision typography, status-LED color semantics, monospace eyebrow
+ * labels, a single accent stripe per card so each surface feels
+ * deliberately placed rather than dropped into a generic grid.
+ *
+ * Covered surfaces:
+ *   - Settings → Default runtime card (.op-lock-card)
+ *   - Integrations app category sections + cards (.op-category, .op-card)
+ *   - AgentProfilePanel runtime section (.op-runtime, .op-row)
+ *   - AgentWizard provider + model fields (inherit .op-eyebrow + chrome)
+ *
+ * Keep this file restricted to the operator-console pattern; do not
+ * bloat it with per-surface one-offs — push those back to the component.
+ */
+
+/* ───────────────────────── Eyebrow / monospace labels */
+
+.op-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.op-eyebrow-strong {
+  color: var(--text-secondary);
+}
+
+/* ───────────────────────── Status LED + label */
+
+.op-led {
+  --led-color: var(--text-tertiary);
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--led-color);
+  box-shadow:
+    0 0 0 2px color-mix(in srgb, var(--led-color) 18%, transparent),
+    0 0 6px color-mix(in srgb, var(--led-color) 35%, transparent);
+  flex-shrink: 0;
+}
+.op-led.is-on {
+  --led-color: var(--success-400);
+}
+.op-led.is-warn {
+  --led-color: var(--warning-400);
+}
+.op-led.is-off {
+  --led-color: var(--text-tertiary);
+}
+.op-led.is-info {
+  --led-color: #3b82f6;
+}
+
+.op-led.is-on {
+  animation: opLedPulse 2.8s ease-in-out infinite;
+}
+@keyframes opLedPulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--led-color) 18%, transparent),
+      0 0 6px color-mix(in srgb, var(--led-color) 35%, transparent);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px color-mix(in srgb, var(--led-color) 26%, transparent),
+      0 0 10px color-mix(in srgb, var(--led-color) 55%, transparent);
+  }
+}
+
+.op-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.op-status.is-on {
+  color: var(--success-400);
+}
+.op-status.is-warn {
+  color: var(--warning-400);
+}
+.op-status.is-off {
+  color: var(--text-tertiary);
+}
+.op-status.is-info {
+  color: #3b82f6;
+}
+
+/* ───────────────────────── Lock card (Settings master switch) */
+
+.op-lock-card {
+  position: relative;
+  margin-bottom: 16px;
+  padding: 14px 16px 14px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  transition:
+    border-color 180ms ease,
+    background 180ms ease;
+}
+.op-lock-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 3px;
+  background: var(--text-tertiary);
+  transition: background 180ms ease;
+}
+.op-lock-card.is-unlocked {
+  background: var(--warning-100);
+  border-color: var(--warning-200);
+}
+.op-lock-card.is-unlocked::before {
+  background: var(--warning-400);
+}
+
+.op-lock-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.op-lock-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--text-tertiary) 12%, transparent);
+  color: var(--text-secondary);
+  transition:
+    transform 280ms cubic-bezier(0.34, 1.56, 0.64, 1),
+    background 200ms ease,
+    color 200ms ease;
+}
+.op-lock-card.is-unlocked .op-lock-icon {
+  background: color-mix(in srgb, var(--warning-400) 18%, transparent);
+  color: var(--warning-500);
+  transform: rotate(-14deg);
+}
+
+.op-lock-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+.op-lock-title-text {
+  font-size: var(--text-base);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.op-lock-body {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0 0 10px 0;
+}
+
+.op-lock-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--text-sm);
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+.op-lock-toggle input {
+  appearance: none;
+  width: 32px;
+  height: 18px;
+  border-radius: var(--radius-full);
+  background: var(--neutral-200);
+  position: relative;
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+.op-lock-toggle input::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: white;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+  transition: transform 180ms ease;
+}
+.op-lock-toggle input:checked {
+  background: var(--warning-400);
+}
+.op-lock-toggle input:checked::after {
+  transform: translateX(14px);
+}
+
+.op-lock-confirm {
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--warning-300);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+.op-lock-confirm-text strong {
+  color: var(--warning-500);
+}
+.op-lock-confirm-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+/* ───────────────────────── Integrations: category section */
+
+.op-category {
+  margin-bottom: 28px;
+}
+.op-category-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 8px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.op-category-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text);
+  margin: 0;
+}
+.op-category-title::before {
+  content: "";
+  display: inline-block;
+  width: 14px;
+  height: 1px;
+  background: var(--text);
+}
+.op-category-blurb {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  line-height: 1.5;
+  margin: 0;
+  text-align: right;
+  max-width: 60%;
+}
+
+/* ───────────────────────── Integrations: card */
+
+.op-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  gap: 16px;
+  padding: 16px 18px;
+  margin-bottom: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease,
+    transform 160ms ease;
+}
+.op-card:hover {
+  border-color: var(--border-strong);
+  box-shadow:
+    0 1px 0 var(--border-light),
+    0 6px 18px -8px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+.op-card-rail {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 28px;
+  line-height: 1;
+}
+.op-card-rail::after {
+  content: "";
+  position: absolute;
+  right: -8px;
+  top: 50%;
+  width: 1px;
+  height: 24px;
+  background: var(--border);
+  transform: translateY(-50%);
+}
+.op-card-body {
+  min-width: 0;
+}
+.op-card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.op-card-title {
+  margin: 0;
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--text);
+}
+.op-card-blurb {
+  margin: 0 0 12px 0;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+.op-card-status-cell {
+  align-self: start;
+  padding-top: 4px;
+}
+
+.op-field-label {
+  display: block;
+  margin-bottom: 4px;
+}
+.op-field-input {
+  width: 100%;
+}
+.op-card-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+/* ───────────────────────── Runtime section (AgentProfilePanel) */
+
+.op-runtime {
+  /* Inherits the agent-profile-section padding from agents.css; we only
+   * style the inner content so the section header keeps its existing
+   * typographic role. */
+}
+.op-runtime-grid {
+  display: grid;
+  grid-template-columns: 76px 1fr;
+  row-gap: 8px;
+  column-gap: 12px;
+  align-items: center;
+}
+.op-runtime-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+.op-runtime-value {
+  min-width: 0;
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+.op-runtime-value select,
+.op-runtime-value input {
+  width: 100%;
+}
+
+.op-runtime-managed {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+  border-radius: var(--radius-full);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-warm);
+}
+
+.op-runtime-note {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-left: 2px solid var(--border-strong);
+  background: var(--bg-subtle);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+.op-runtime-note.is-warn {
+  border-left-color: var(--warning-400);
+  background: var(--warning-100);
+}
+
+.op-runtime-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+/* ───────────────────────── Hints under form fields */
+
+.op-hint {
+  display: block;
+  margin-top: 6px;
+  font-size: var(--text-xs);
+  color: var(--text-tertiary);
+  line-height: 1.45;
+}

--- a/web/src/styles/operator.css
+++ b/web/src/styles/operator.css
@@ -435,3 +435,161 @@
   color: var(--text-tertiary);
   line-height: 1.45;
 }
+
+/* ───────────────────────── Integrations list rows */
+
+.op-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.op-list-row {
+  display: grid;
+  grid-template-columns: 44px 1fr auto 18px;
+  align-items: center;
+  gap: 14px;
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition: border-color 140ms ease, box-shadow 140ms ease,
+    transform 140ms ease, background 140ms ease;
+}
+.op-list-row:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 1px 0 var(--border-light), 0 8px 18px -10px rgba(0, 0, 0, 0.10);
+  transform: translateY(-1px);
+}
+.op-list-row:hover .op-list-row-chevron {
+  transform: translateX(2px);
+  color: var(--text);
+}
+.op-list-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.op-list-row-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+.op-list-row-body {
+  min-width: 0;
+}
+.op-list-row-title {
+  font-size: var(--text-md);
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.2;
+}
+.op-list-row-summary {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  line-height: 1.4;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.op-list-row-status {
+  flex-shrink: 0;
+}
+.op-list-row-chevron {
+  color: var(--text-tertiary);
+  transition: transform 140ms ease, color 140ms ease;
+  flex-shrink: 0;
+}
+
+/* ───────────────────────── Integrations detail header */
+
+.op-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.op-detail-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  font: inherit;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  cursor: pointer;
+  align-self: flex-start;
+  transition: color 140ms ease, transform 140ms ease;
+}
+.op-detail-back:hover {
+  color: var(--text);
+}
+.op-detail-back:hover svg {
+  transform: translateX(-2px);
+}
+.op-detail-back svg {
+  transition: transform 140ms ease;
+}
+
+.op-detail-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--border);
+}
+.op-detail-id {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 16px;
+}
+.op-detail-id-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-md);
+  background: var(--bg-warm);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+.op-detail-id-text {
+  min-width: 0;
+}
+.op-detail-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.2px;
+  color: var(--text);
+}
+.op-detail-summary {
+  margin: 4px 0 0 0;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+.op-detail-status {
+  align-self: flex-start;
+  padding-top: 4px;
+}
+
+.op-detail-body {
+  padding: 4px 2px 0 2px;
+}


### PR DESCRIPTION
## Summary
- Per-agent runtime picker in **AgentProfilePanel** (provider + model, with Reset/Save) and **AgentWizard** (Inherit / specific runtime + optional model), backed by the existing per-agent ProviderBinding broker write path.
- Global runtime in **Settings** becomes a friction-gated override: locked by default (default-for-new-agents only); explicit Unlock + confirm flips it to override-all-agents-on-dispatch. After save it re-locks locally so flipping override again requires a deliberate gesture.
- New **Integrations app** at `/apps/integrations` with cards for **OpenClaw**, **Hermes**, and **Telegram**. OpenClaw gateway URL + token move here from Settings. Telegram wraps the existing connect modal.
- Backend split between *runtimes* and *gateways*: `provider.Entry.Capabilities.GatewayOnly` keeps `openclaw-http` / `hermes-agent` out of the global picker but still routable for imported agents. New `provider.LLMProviderKinds` / `GatewayKinds` / `IsGatewayKind` helpers; `config.LLMProviderUnlocked` field; `DefaultStreamFnResolver` honors the lock.
- CEO template generator (`/office-members/generate`) now suggests `provider` + `model` so the wizard pre-populates the picker; gateway kinds are scrubbed from suggestions because the wizard never creates gateway-bound agents.
- Onboarding picker (Step 5 + constants) drops Hermes Agent and OpenClaw Gateway tiles; the only Local LLMs surfaced are mlx-lm, ollama, exo.

## Why this shape

The Settings global LLMProvider was both a default for new agents and an implicit override that silently leaked over per-agent picks. That conflation was the source of the bug the user surfaced: changing the global silently clobbered every agent. The lock makes "override all" a deliberate gesture instead of a side effect of editing a setting.

OpenClaw and Hermes were rendered as runtimes alongside Claude Code / Codex. They aren't runtimes — they are gateways for importing existing agents. Pulling them into a separate Integrations app and out of the runtime pickers fixes the "is this a runtime or a gateway?" confusion the user called out.

Per-agent runtime selection was already supported in the broker (`SetMemberProvider`, `MemberProviderKind`, persisted on `officeMember.Provider`) but had no UI. The new AgentProfilePanel section uses the existing `POST /office-members {action:"update", provider:{kind, model}}` write path with three render modes: gateway-bound agents see a "Managed by &lt;Gateway&gt;" pill instead of the picker; the picker goes read-only when the global lock is unlocked; otherwise it's editable.

## Wire-shape additions
`/config` GET response gains:
```json
{
  "llm_provider_unlocked": false,
  "llm_provider_kinds": ["claude-code", "codex", "opencode", "mlx-lm", "ollama", "exo"],
  "gateway_kinds": ["hermes-agent", "openclaw-http"]
}
```
POST accepts `llm_provider_unlocked: bool`.

## Test plan
- [x] `go test ./internal/provider/... ./internal/config/... ./internal/team/ -race` — green
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean (pre-existing complexity warning only)
- [x] Targeted web vitest: `web/src/components/agents,apps,onboarding,integrations,api` (203 pass)
- [x] `bun run build` — green
- [x] New backend tests cover: GatewayOnly registration, LLMProviderKinds/GatewayKinds split, IsGatewayKind classification, `/config` exposes lock + split, lock round-trips on POST.
- [x] Existing tests still pass: `TestHandleConfig_ProviderEndpointsAllowsOpenclawHTTPRuntime` (gateway runtimes remain configurable via `provider_endpoints` thanks to switching that validator from `IsLLMProviderKindAllowed` to `provider.Lookup`).
- [ ] Manual: open Settings → Default runtime; confirm picker is locked; flip unlock + confirm; save; reopen — confirm re-lock + the override is persisted on the wire.
- [ ] Manual: open an agent profile; confirm RuntimeSection picker; change runtime + model; save; reopen — confirm persistence.
- [ ] Manual: navigate to /apps/integrations; configure OpenClaw URL + token; confirm GET reflects connection state.
- [ ] Manual: from Composer run `/connect telegram` from within Integrations; confirm wizard opens.
- [ ] Manual: confirm AgentWizard Manual mode shows Runtime + Model and Inherit default option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




## Summary by CodeRabbit

* **New Features**
  * Added Integrations app for managing external services (OpenClaw, Hermes Agent, Telegram).
  * Added per-agent runtime and model configuration with editable picker.
  * Added global runtime override with unlock mechanism in Settings.
  * Message content now converts emoji to shortcodes.

* **Changes**
  * Gateway-managed runtimes (Hermes, OpenClaw) separated from direct runtime selection.
  * Settings simplified: Local LLMs now shows only directly-dispatchable runtimes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshots

![01-settings-default-runtime](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/01-settings-default-runtime.png)

![02-integrations-list](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/02-integrations-list.png)

![03-integrations-detail-openclaw](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/03-integrations-detail-openclaw.png)

![04-agent-runtime-editable](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/04-agent-runtime-editable.png)

![05-agent-runtime-gateway-managed](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/05-agent-runtime-gateway-managed.png)

![06-agent-wizard-runtime-model](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/06-agent-wizard-runtime-model.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrations app to manage gateway integrations (OpenClaw, Hermes) and connect channels (Telegram)
  * Per-agent runtime & model selection with managed (read-only) vs editable views
  * Emoji normalization in posted messages (common emoji → shortcodes)

* **UI/UX Improvements**
  * Split runtime lists into direct runtimes vs gateway kinds across Config, Settings, and onboarding
  * Removed gateway tiles from local runtime pickers; gateway setup moved to Integrations
  * New operator styles and refined integrations visuals; onboarding copy tweak (named example agent)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Screenshots

![01-settings-default-runtime](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/01-settings-default-runtime.png)

![02-integrations-list](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/02-integrations-list.png)

![03-integrations-detail-openclaw](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/03-integrations-detail-openclaw.png)

![04-agent-runtime-editable](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/04-agent-runtime-editable.png)

![05-agent-runtime-gateway-managed](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/05-agent-runtime-gateway-managed.png)

![06-agent-wizard-runtime-model](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1001/06-agent-wizard-runtime-model.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrations app to manage gateway integrations (OpenClaw, Hermes) and connect channels (Telegram)
  * Per-agent runtime & model selection with managed (read-only) vs editable views
  * Emoji normalization in posted messages (common emoji → shortcodes)

* **UI/UX Improvements**
  * Split runtime lists into direct runtimes vs gateway kinds across Config and Settings
  * Removed gateway tiles from local runtime pickers/onboarding; gateway setup moved to Integrations
  * New operator styles and refined integrations visuals

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->