### PR TITLE
fix(onboarding): restore full blueprint catalog + stop CEO LLM in Phase 2

### DIFF
--- a/internal/operations/loader.go
+++ b/internal/operations/loader.go
@@ -74,6 +74,8 @@ func normalizeBlueprint(templateID string, blueprint Blueprint) Blueprint {
 	blueprint.ReviewerPaths = normalizeReviewerPaths(blueprint.ReviewerPaths)
 	blueprint.Outcome = strings.TrimSpace(blueprint.Outcome)
 	blueprint.Category = strings.TrimSpace(strings.ToLower(blueprint.Category))
+	blueprint.Icon = strings.TrimSpace(blueprint.Icon)
+	blueprint.DisplayName = strings.TrimSpace(blueprint.DisplayName)
 	blueprint.FirstTasks = normalizeFirstTasks(blueprint.FirstTasks)
 	blueprint.Skills = normalizeBlueprintSkills(blueprint.Skills)
 	blueprint.Requirements = normalizeBlueprintRequirements(blueprint.Requirements)

--- a/internal/operations/types.go
+++ b/internal/operations/types.go
@@ -25,8 +25,17 @@ type Blueprint struct {
 	// scaffold, first tasks, and provider requirements for a pack
 	// before committing. Optional — older blueprints without these
 	// fields still load and degrade gracefully in the UI.
-	Outcome               string                  `json:"outcome,omitempty" yaml:"outcome,omitempty"`
-	Category              string                  `json:"category,omitempty" yaml:"category,omitempty"`
+	Outcome  string `json:"outcome,omitempty" yaml:"outcome,omitempty"`
+	Category string `json:"category,omitempty" yaml:"category,omitempty"`
+	// Icon is a single emoji or glyph used by the onboarding blueprint
+	// picker so each pack reads as a recognizable card rather than a
+	// bare label. Optional — the UI falls back to a generic icon when
+	// unset, so legacy blueprints still render.
+	Icon string `json:"icon,omitempty" yaml:"icon,omitempty"`
+	// DisplayName is a short, scannable label for the picker (for
+	// example "Bookkeeping" rather than "Bookkeeping and Invoicing
+	// Service"). Optional — the picker falls back to Name when unset.
+	DisplayName           string                  `json:"display_name,omitempty" yaml:"display_name,omitempty"`
 	FirstTasks            []BlueprintFirstTask    `json:"first_tasks,omitempty" yaml:"first_tasks,omitempty"`
 	Skills                []BlueprintSkill        `json:"skills,omitempty" yaml:"skills,omitempty"`
 	Requirements          []BlueprintRequirement  `json:"requirements,omitempty" yaml:"requirements,omitempty"`

--- a/internal/team/broker_onboarding_phase2.go
+++ b/internal/team/broker_onboarding_phase2.go
@@ -583,14 +583,9 @@ func ceoDeterministicMessages(phase string, s *onboarding.State) []ceoMessagePay
 			Content:      "Pick a starter template, or start from scratch:",
 			SuggestionID: "blueprint-pick",
 			SuggestionPayload: mustMarshalRaw(map[string]interface{}{
-				"field": "blueprint_id",
-				"label": "Pick a starter template, or start from scratch:",
-				"options": []map[string]interface{}{
-					{"id": "bookkeeping-invoicing-service", "label": "Bookkeeping"},
-					{"id": "niche-crm", "label": "Niche CRM"},
-					{"id": "youtube-factory", "label": "YouTube Factory"},
-					{"id": "", "label": "Start from scratch"},
-				},
+				"field":   "blueprint_id",
+				"label":   "Pick a starter template, or start from scratch:",
+				"options": blueprintChipOptions(),
 			}),
 		})
 		return out
@@ -669,6 +664,60 @@ func ceoDeterministicMessages(phase string, s *onboarding.State) []ceoMessagePay
 		// draft/approve/kickoff and unknown phases return nil — no Phase 2 wiring.
 		return nil
 	}
+}
+
+// blueprintChipOptions builds the chip-row options surfaced at PhaseBlueprint.
+// It loads every operations blueprint on disk so the picker shows the full
+// catalog with icon, label, and description rather than a hardcoded
+// three-pack subset. The "Start from scratch" sentinel is always appended
+// last so the user has a single empty-office option.
+//
+// Best-effort: if blueprint discovery fails (missing templates dir in a
+// stripped build, malformed YAML) we fall back to a minimal scratch-only
+// menu rather than blocking phase advancement. This mirrors the loader's
+// stripped-build fallback elsewhere in the codebase.
+func blueprintChipOptions() []map[string]interface{} {
+	const fallbackCount = 1
+	const scratchDescription = "Empty office, your call. Start from a blank slate."
+
+	bps, err := operations.ListBlueprints(onboarding.ResolveTemplatesRepoRoot(""))
+	if err != nil {
+		log.Printf("onboarding: list blueprints for chip row: %v", err)
+		return []map[string]interface{}{{
+			"id":          "",
+			"label":       "Start from scratch",
+			"icon":        "✨",
+			"description": scratchDescription,
+		}}
+	}
+
+	options := make([]map[string]interface{}, 0, len(bps)+fallbackCount)
+	for _, bp := range bps {
+		label := bp.DisplayName
+		if label == "" {
+			label = bp.Name
+		}
+		if label == "" {
+			label = bp.ID
+		}
+		description := bp.Outcome
+		if description == "" {
+			description = bp.Description
+		}
+		options = append(options, map[string]interface{}{
+			"id":          bp.ID,
+			"label":       label,
+			"icon":        bp.Icon,
+			"description": description,
+		})
+	}
+	options = append(options, map[string]interface{}{
+		"id":          "",
+		"label":       "Start from scratch",
+		"icon":        "✨",
+		"description": scratchDescription,
+	})
+	return options
 }
 
 func teamTrimItems(s *onboarding.State) []map[string]interface{} {

--- a/internal/team/broker_onboarding_scan_test.go
+++ b/internal/team/broker_onboarding_scan_test.go
@@ -119,6 +119,60 @@ func TestCeoDeterministicMessages_BlueprintNoAckWhenNoUrl(t *testing.T) {
 	}
 }
 
+// TestBlueprintChipOptions_LoadsFullCatalog locks in the regression that the
+// onboarding blueprint picker has to surface every blueprint shipped under
+// templates/operations, each with its icon and description, plus the
+// "Start from scratch" sentinel last. The old PhaseBlueprint emit used a
+// hardcoded three-entry slice and dropped the rest of the catalog from the
+// UI; this test fails if anyone falls back to that shape.
+func TestBlueprintChipOptions_LoadsFullCatalog(t *testing.T) {
+	opts := blueprintChipOptions()
+	if len(opts) < 4 {
+		t.Fatalf("expected catalog + scratch (>=4 options); got %d", len(opts))
+	}
+
+	last := opts[len(opts)-1]
+	if last["id"] != "" {
+		t.Errorf("scratch sentinel must come last with id=\"\"; got %v", last["id"])
+	}
+	if got, _ := last["label"].(string); got != "Start from scratch" {
+		t.Errorf("scratch label = %q, want %q", got, "Start from scratch")
+	}
+
+	bookkeeping := findOptionByID(opts, "bookkeeping-invoicing-service")
+	if bookkeeping == nil {
+		t.Fatal("expected bookkeeping-invoicing-service in options")
+	}
+	if got, _ := bookkeeping["icon"].(string); got == "" {
+		t.Errorf("bookkeeping option must carry an icon; got empty")
+	}
+	if got, _ := bookkeeping["description"].(string); got == "" {
+		t.Errorf("bookkeeping option must carry a description; got empty")
+	}
+
+	// Every catalog entry must have id, label, icon, description.
+	for _, opt := range opts[:len(opts)-1] {
+		if id, _ := opt["id"].(string); id == "" {
+			t.Errorf("catalog entry has empty id: %v", opt)
+		}
+		if label, _ := opt["label"].(string); label == "" {
+			t.Errorf("catalog entry has empty label: %v", opt)
+		}
+		if desc, _ := opt["description"].(string); desc == "" {
+			t.Errorf("catalog entry has empty description: %v", opt)
+		}
+	}
+}
+
+func findOptionByID(opts []map[string]interface{}, id string) map[string]interface{} {
+	for _, opt := range opts {
+		if got, _ := opt["id"].(string); got == id {
+			return opt
+		}
+	}
+	return nil
+}
+
 func TestLegalPhaseTransitions_PhaseScanToPhaseWebsite(t *testing.T) {
 	// Recovery: PhaseScan → PhaseWebsite must be legal so the user can
 	// retry with a different URL after a scan failure. (#934)

--- a/internal/team/broker_onboarding_scan_test.go
+++ b/internal/team/broker_onboarding_scan_test.go
@@ -158,6 +158,9 @@ func TestBlueprintChipOptions_LoadsFullCatalog(t *testing.T) {
 		if label, _ := opt["label"].(string); label == "" {
 			t.Errorf("catalog entry has empty label: %v", opt)
 		}
+		if icon, _ := opt["icon"].(string); icon == "" {
+			t.Errorf("catalog entry has empty icon: %v", opt)
+		}
 		if desc, _ := opt["description"].(string); desc == "" {
 			t.Errorf("catalog entry has empty description: %v", opt)
 		}

--- a/internal/team/notifier_delivery.go
+++ b/internal/team/notifier_delivery.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/onboarding"
 )
 
 // Notification debounce cooldowns. Prevents agent-to-agent feedback
@@ -44,6 +46,18 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	// change would silently turn the demo seed into an LLM-burning
 	// broadcast. One filter, one place.
 	if msg.Kind == "demo_seed" {
+		return
+	}
+	// Phase 2 onboarding is fully deterministic — the broker emits CEO
+	// cards from ceoDeterministicMessages and the user replies via the
+	// structured-card POST handlers. The CEO agent must NOT fire an LLM
+	// run in response, or the user sees a spurious "CEO is typing…"
+	// stream and the deterministic flow stalls behind a Claude turn that
+	// has nothing to add. (Spec: docs/specs/onboarding-into-office.md
+	// "zero LLM tokens in Phase 2".) Gate on (CEO DM channel + onboarding
+	// phase is deterministic) so other channels and the post-onboarding
+	// CEO DM keep their normal headless behaviour.
+	if isDeterministicPhase2CEODM(msg.Channel) {
 		return
 	}
 	immediate, delayed := l.notificationTargetsForMessage(msg)
@@ -275,4 +289,52 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 		return
 	}
 	l.paneDispatch().Enqueue(target.Slug, target.PaneTarget, notification)
+}
+
+// isDeterministicPhase2CEODM reports whether a message landed in the
+// CEO DM during an onboarding phase where the broker drives the
+// conversation via deterministic templates and no LLM should fire.
+//
+// In production the CEO DM lands at the canonical pair-sorted slug
+// ("ceo__human"), not the reserved CEOOnboardingDMSlug constant — that
+// constant is for the state record only. So we match on "DM whose
+// target agent is CEO" instead of a literal slug comparison.
+//
+// Phase 2 covers greet → bridge (everything before the user opts into
+// the first issue). draft/approve/kickoff and complete are NOT gated —
+// those are the LLM-backed phases where the CEO agent is supposed to
+// drive the chat.
+//
+// Errors loading the state file fall through to "not gated" so a
+// missing or corrupt onboarded.json never silences a real post-
+// onboarding CEO turn.
+func isDeterministicPhase2CEODM(channel string) bool {
+	ch := normalizeChannelSlug(channel)
+	if ch == "" {
+		return false
+	}
+	target := DMTargetAgent(ch)
+	if target != "ceo" && ch != onboarding.CEOOnboardingDMSlug {
+		return false
+	}
+	s, err := onboarding.Load()
+	if err != nil || s == nil {
+		return false
+	}
+	// Already onboarded → CEO LLM is fully active again.
+	if s.Onboarded() {
+		return false
+	}
+	switch s.Phase {
+	case onboarding.PhaseGreet,
+		onboarding.PhaseIdentity,
+		onboarding.PhaseWebsite,
+		onboarding.PhaseScan,
+		onboarding.PhaseBlueprint,
+		onboarding.PhaseTeam,
+		onboarding.PhaseSeed,
+		onboarding.PhaseBridge:
+		return true
+	}
+	return false
 }

--- a/internal/team/notifier_delivery_onboarding_test.go
+++ b/internal/team/notifier_delivery_onboarding_test.go
@@ -1,0 +1,63 @@
+package team
+
+import (
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/onboarding"
+)
+
+// TestIsDeterministicPhase2CEODM_GatesCEODMDuringPhase2 locks in the
+// regression that an LLM agent must not fire while the deterministic
+// Phase 2 onboarding conversation is driving the CEO DM. Prior to the
+// gate, deliverMessageNotification enqueued a Claude turn for every
+// human reply to a ceo_form_field / ceo_chip_row / ceo_team_trim card,
+// which produced a sticky "CEO is typing…" indicator and stalled the
+// scripted flow behind a hallucinated LLM response.
+func TestIsDeterministicPhase2CEODM_GatesCEODMDuringPhase2(t *testing.T) {
+	cases := []struct {
+		name    string
+		channel string
+		phase   string
+		onboard bool
+		want    bool
+	}{
+		{"CEO DM mid-phase-blueprint", "ceo__human", onboarding.PhaseBlueprint, false, true},
+		{"CEO DM mid-phase-team", "ceo__human", onboarding.PhaseTeam, false, true},
+		{"CEO DM mid-phase-greet", "human__ceo", onboarding.PhaseGreet, false, true},
+		{"reserved CEO DM slug", onboarding.CEOOnboardingDMSlug, onboarding.PhaseBlueprint, false, true},
+		{"CEO DM after onboarding complete", "ceo__human", onboarding.PhaseComplete, true, false},
+		{"CEO DM in LLM-backed draft phase", "ceo__human", onboarding.PhaseDraft, false, false},
+		{"non-CEO DM during Phase 2", "engineer__human", onboarding.PhaseTeam, false, false},
+		{"non-DM channel during Phase 2", "general", onboarding.PhaseTeam, false, false},
+		{"empty channel during Phase 2", "", onboarding.PhaseTeam, false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			// Belt-and-suspenders: clear WUPHF_RUNTIME_HOME so RuntimeHomeDir
+			// resolves to the temp HOME and the test stays sealed from any
+			// stale local broker state on the dev machine.
+			t.Setenv("WUPHF_RUNTIME_HOME", "")
+
+			s, err := onboarding.Load()
+			if err != nil {
+				t.Fatalf("onboarding.Load: %v", err)
+			}
+			s.Phase = tc.phase
+			if tc.onboard {
+				s.CompletedAt = "2026-05-28T00:00:00Z"
+			}
+			if err := onboarding.Save(s); err != nil {
+				t.Fatalf("onboarding.Save: %v", err)
+			}
+
+			got := isDeterministicPhase2CEODM(tc.channel)
+			if got != tc.want {
+				t.Fatalf("isDeterministicPhase2CEODM(%q) with phase=%q onboarded=%v = %v, want %v",
+					tc.channel, tc.phase, tc.onboard, got, tc.want)
+			}
+		})
+	}
+}

--- a/templates/operations/bookkeeping-invoicing-service/blueprint.yaml
+++ b/templates/operations/bookkeeping-invoicing-service/blueprint.yaml
@@ -1,5 +1,7 @@
 id: bookkeeping-invoicing-service
 name: Bookkeeping and Invoicing Service
+display_name: Bookkeeping
+icon: "📊"
 kind: finance
 category: services
 outcome: "Books, invoices, and monthly close — with an audit trail."

--- a/templates/operations/local-business-ai-package/blueprint.yaml
+++ b/templates/operations/local-business-ai-package/blueprint.yaml
@@ -1,5 +1,7 @@
 id: local-business-ai-package
 name: Local Business AI Package
+display_name: Local Business AI
+icon: "🏪"
 kind: local_service
 category: services
 outcome: "Intake, booking, and follow-up for local-business clients."

--- a/templates/operations/multi-agent-workflow-consulting/blueprint.yaml
+++ b/templates/operations/multi-agent-workflow-consulting/blueprint.yaml
@@ -1,5 +1,7 @@
 id: multi-agent-workflow-consulting
 name: Multi-Agent Workflow Consulting
+display_name: Workflow Consulting
+icon: "💼"
 kind: consulting
 category: services
 outcome: "Client engagements that ship multi-agent workflows."

--- a/templates/operations/niche-crm/blueprint.yaml
+++ b/templates/operations/niche-crm/blueprint.yaml
@@ -1,5 +1,7 @@
 id: niche-crm
 name: Niche CRM
+display_name: Niche CRM
+icon: "🎯"
 kind: product_gtm
 category: product
 outcome: "Build and launch a focused CRM for a specific niche."

--- a/templates/operations/paid-discord-community/blueprint.yaml
+++ b/templates/operations/paid-discord-community/blueprint.yaml
@@ -1,5 +1,7 @@
 id: paid-discord-community
 name: Paid Discord Community
+display_name: Paid Discord
+icon: "💬"
 kind: community
 category: media
 outcome: "Onboarding, moderation, and engagement for a paid community."

--- a/templates/operations/youtube-factory/blueprint.yaml
+++ b/templates/operations/youtube-factory/blueprint.yaml
@@ -1,5 +1,7 @@
 id: youtube-factory
 name: YouTube Factory
+display_name: YouTube Factory
+icon: "📹"
 kind: media_business
 category: media
 outcome: "Script, film, publish, and analyze a recurring YouTube channel."

--- a/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
+++ b/web/src/components/messages/InterviewBar.ceoKinds.test.tsx
@@ -276,6 +276,68 @@ describe("CeoChipRow", () => {
     );
     expect(document.querySelector("img")).not.toBeInTheDocument();
   });
+
+  it("renders rich card layout when options carry icon + description", () => {
+    const cardPayload: CeoChipRowPayload = {
+      field: "blueprint_id",
+      label: "Pick a starter template:",
+      options: [
+        {
+          id: "bookkeeping-invoicing-service",
+          label: "Bookkeeping",
+          icon: "📊",
+          description:
+            "Books, invoices, and monthly close — with an audit trail.",
+        },
+        {
+          id: "niche-crm",
+          label: "Niche CRM",
+          icon: "🎯",
+          description: "Build and launch a focused CRM for a specific niche.",
+        },
+        {
+          id: "",
+          label: "Start from scratch",
+          icon: "✨",
+          description: "Empty office, your call. Start from a blank slate.",
+        },
+      ],
+    };
+    render(
+      <CeoChipRow payload={cardPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    expect(screen.getByText("Bookkeeping")).toBeInTheDocument();
+    expect(screen.getByText("Niche CRM")).toBeInTheDocument();
+    expect(screen.getByText("Start from scratch")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Books, invoices, and monthly close — with an audit trail.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Build and launch a focused CRM for a specific niche."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("📊")).toBeInTheDocument();
+    expect(screen.getByText("🎯")).toBeInTheDocument();
+    expect(screen.getByText("✨")).toBeInTheDocument();
+  });
+
+  it("falls back to plain pill chips when no option ships icon or description", () => {
+    const pillPayload: CeoChipRowPayload = {
+      field: "bridge_choice",
+      label: "What's next?",
+      options: [
+        { id: "start_issue", label: "Start an issue" },
+        { id: "look_around", label: "Look around first" },
+      ],
+    };
+    const { container } = render(
+      <CeoChipRow payload={pillPayload} stage="pending" onSubmit={vi.fn()} />,
+    );
+    expect(container.querySelector(".ceo-chip-grid-options")).toBeNull();
+    expect(container.querySelector(".ceo-chip-card")).toBeNull();
+    expect(container.querySelector(".ceo-chip-row-options")).not.toBeNull();
+  });
 });
 
 // ── ceo_checklist ─────────────────────────────────────────────────────────

--- a/web/src/components/messages/cards/CeoChipRow.tsx
+++ b/web/src/components/messages/cards/CeoChipRow.tsx
@@ -14,7 +14,11 @@
 
 import { useRef, useState } from "react";
 
-import type { CardStage, CeoChipRowPayload } from "../../onboarding/types";
+import type {
+  CardStage,
+  CeoChipOption,
+  CeoChipRowPayload,
+} from "../../onboarding/types";
 
 interface CeoChipRowProps {
   payload: CeoChipRowPayload;
@@ -89,9 +93,17 @@ export function CeoChipRow({
     }
   };
 
+  // Card layout kicks in whenever any option ships an icon or description —
+  // that signals the row was meant as a richer picker (blueprint catalog)
+  // rather than a flat pill row (bridge_choice). Plain rows degrade to the
+  // original chip pill style so legacy chip_rows render unchanged.
+  const isCardLayout = payload.options.some(
+    (o) => (o.icon ?? "") !== "" || (o.description ?? "") !== "",
+  );
+
   return (
     <div
-      className="ceo-card ceo-card--chip-row"
+      className={`ceo-card ceo-card--chip-row${isCardLayout ? " ceo-card--chip-grid" : ""}`}
       data-testid="ceo-chip-row"
       role="group"
       aria-label={payload.label}
@@ -100,31 +112,93 @@ export function CeoChipRow({
         <div className="ceo-card-label">{payload.label}</div>
       ) : null}
       <div
-        className="ceo-chip-row-options"
+        className={
+          isCardLayout ? "ceo-chip-grid-options" : "ceo-chip-row-options"
+        }
         role="listbox"
         aria-label={payload.label}
       >
         {payload.options.map((opt, idx) => (
-          <button
+          <ChipOptionButton
             key={opt.id}
-            id={`ceo-chip-${payload.field}-${opt.id}`}
-            ref={idx === 0 ? firstChipRef : undefined}
-            type="button"
-            role="option"
-            aria-selected={selected === opt.id}
-            className={`ceo-chip${selected === opt.id ? " ceo-chip--selected" : ""}`}
-            disabled={stage === "submitting"}
-            onClick={() => handleSelect(opt.id)}
+            opt={opt}
+            field={payload.field}
+            isCardLayout={isCardLayout}
+            selected={selected === opt.id}
+            isSubmitting={stage === "submitting"}
+            firstChipRef={idx === 0 ? firstChipRef : undefined}
+            onSelect={handleSelect}
             onKeyDown={(e) => handleKeyDown(e, opt.id, idx)}
-          >
-            {stage === "submitting" && selected === opt.id ? (
-              <span className="ceo-card-spinner" aria-hidden="true" />
-            ) : null}
-            {/* Render as text — never innerHTML */}
-            {opt.label}
-          </button>
+          />
         ))}
       </div>
     </div>
+  );
+}
+
+interface ChipOptionButtonProps {
+  opt: CeoChipOption;
+  field: string;
+  isCardLayout: boolean;
+  selected: boolean;
+  isSubmitting: boolean;
+  firstChipRef?: React.RefObject<HTMLButtonElement | null>;
+  onSelect: (id: string) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+}
+
+function ChipOptionButton({
+  opt,
+  field,
+  isCardLayout,
+  selected,
+  isSubmitting,
+  firstChipRef,
+  onSelect,
+  onKeyDown,
+}: ChipOptionButtonProps) {
+  const hasDescription = (opt.description ?? "") !== "";
+  const hasIcon = (opt.icon ?? "") !== "";
+  const className = isCardLayout
+    ? `ceo-chip-card${selected ? " ceo-chip-card--selected" : ""}`
+    : `ceo-chip${selected ? " ceo-chip--selected" : ""}`;
+  const descId = `ceo-chip-${field}-${opt.id}-desc`;
+  return (
+    <button
+      id={`ceo-chip-${field}-${opt.id}`}
+      ref={firstChipRef}
+      type="button"
+      role="option"
+      aria-selected={selected}
+      aria-describedby={hasDescription ? descId : undefined}
+      className={className}
+      disabled={isSubmitting}
+      onClick={() => onSelect(opt.id)}
+      onKeyDown={onKeyDown}
+    >
+      {isSubmitting && selected ? (
+        <span className="ceo-card-spinner" aria-hidden="true" />
+      ) : null}
+      {isCardLayout ? (
+        <>
+          {hasIcon ? (
+            <span className="ceo-chip-card-icon" aria-hidden="true">
+              {opt.icon}
+            </span>
+          ) : null}
+          <span className="ceo-chip-card-body">
+            <span className="ceo-chip-card-label">{opt.label}</span>
+            {hasDescription ? (
+              <span className="ceo-chip-card-description" id={descId}>
+                {opt.description}
+              </span>
+            ) : null}
+          </span>
+        </>
+      ) : (
+        /* Render as text — never innerHTML */
+        opt.label
+      )}
+    </button>
   );
 }

--- a/web/src/components/onboarding/types.ts
+++ b/web/src/components/onboarding/types.ts
@@ -101,6 +101,18 @@ export interface CeoFormFieldPayload {
 export interface CeoChipOption {
   id: string;
   label: string;
+  /**
+   * Single emoji or short glyph rendered alongside the label. Optional —
+   * the chip falls back to a plain pill when unset, so legacy chip rows
+   * keep working.
+   */
+  icon?: string;
+  /**
+   * One-line plain-text description shown under the label when present.
+   * Used by the onboarding blueprint picker so each pack reads as a card
+   * with its own purpose instead of an unlabeled pill.
+   */
+  description?: string;
 }
 
 export interface CeoChipRowPayload {

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2424,6 +2424,85 @@
   cursor: not-allowed;
 }
 
+/* ─── Chip-row card variant (blueprint picker) ──────────────────────────
+ * Used when chip options ship an icon or description (e.g. the blueprint
+ * catalog). Renders each option as a clickable card with icon, title, and
+ * one-line description so the user picks based on what each pack actually
+ * does instead of a bare pill label. Plain chip rows still render as pills.
+ */
+
+.ceo-chip-grid-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 10px;
+}
+
+.ceo-chip-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md, 8px);
+  background: var(--bg-card);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 120ms ease,
+    background 120ms ease,
+    transform 120ms ease;
+}
+
+.ceo-chip-card:hover:not(:disabled) {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.ceo-chip-card--selected,
+.ceo-chip-card:focus-visible {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  outline: none;
+}
+
+.ceo-chip-card:focus-visible {
+  box-shadow: 0 0 0 var(--focus-ring-width) var(--accent);
+}
+
+.ceo-chip-card:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ceo-chip-card-icon {
+  flex-shrink: 0;
+  font-size: 22px;
+  line-height: 1;
+  width: 28px;
+  text-align: center;
+}
+
+.ceo-chip-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.ceo-chip-card-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.ceo-chip-card-description {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+
 /* ─── Checklist ────────────────────────────────────────────────────────── */
 
 .ceo-checklist-items {

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2501,6 +2501,14 @@
   font-size: 12px;
   color: var(--text-secondary);
   line-height: 1.35;
+  /* Curated descriptions are one-liners today, but clamp to 2 lines as a
+   * layout safeguard so a future blueprint with a longer outcome line
+   * cannot push the card grid out of alignment. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 /* ─── Checklist ────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Two related onboarding-into-office regressions, fixed together:

1. **Blueprint catalog truncated to 3 pills.** The CEO chat blueprint step surfaced only Bookkeeping / Niche CRM / YouTube Factory as bare pills — three of the six packs shipped under `templates/operations/`, with no description, no icon. Restore the full catalog by loading every blueprint via `operations.ListBlueprints` and emitting each option with its icon and outcome line. The chip row auto-detects the richer shape and renders cards (icon + label + one-line description), falling back to plain pills for legacy rows like `bridge_choice`.

2. **CEO LLM fires in Phase 2 and stalls the deterministic flow.** Phase 2 is supposed to be zero-LLM — the broker emits CEO cards, the user replies via the structured-card POST handlers. In practice `deliverMessageNotification` enqueued a Claude turn for every human reply in the CEO DM, producing a sticky "CEO is typing…" stream that stalled onboarding behind a hallucinated LLM response. Gate the dispatch on (CEO DM + onboarding phase ∈ greet…bridge) so the LLM stays off until draft / approve / kickoff (or onboarding completes), at which point the CEO agent is fully active again.

## Backend

- `operations.Blueprint`: optional `Icon` and `DisplayName` for the picker; loader normalizes both.
- `broker_onboarding_phase2` `PhaseBlueprint`: chip row now sourced from `blueprintChipOptions()`, which lists every operations blueprint and appends the "Start from scratch" sentinel last. Graceful fallback to scratch-only when the templates dir is missing.
- `notifier_delivery`: new `isDeterministicPhase2CEODM(channel)` helper returns true only when the message lands in a DM whose target is the CEO **and** onboarding is still in a deterministic Phase 2 phase. Errors loading state fall through to "not gated" so a missing or corrupt `onboarded.json` never silences a real post-onboarding turn.
- `templates/operations/*/blueprint.yaml`: each pack now ships its own `icon` and `display_name`, so future packs are self-describing.

## Frontend

- `CeoChipOption`: optional `icon` and `description` (server-side sanitized via the existing `sanitizeCEOPayload` recursive walk).
- `CeoChipRow`: detects card vs pill shape via per-option presence of icon or description, renders a 2-column grid of cards with body and `aria-describedby` for the description.
- `onboarding.css`: `.ceo-chip-card*` styles built from existing design tokens (`--accent`, `--bg-card`, `--text-secondary`, `--radius-md`), so all three themes render correctly.

## Tests

- `TestBlueprintChipOptions_LoadsFullCatalog` locks in the regression that every catalog entry surfaces with id, label, icon, and description, with scratch last.
- `TestIsDeterministicPhase2CEODM_GatesCEODMDuringPhase2` covers nine cases: four Phase 2 phases must gate (including the reserved slug), draft / complete must NOT gate, non-CEO DM / non-DM / empty channel must NOT gate.
- Two new `CeoChipRow` vitest cases: the card layout renders icons and descriptions, plain pill rows still render via the original chip row.

## Test plan

- [x] `go test ./internal/team/... ./internal/onboarding/... ./internal/operations/...` — all green
- [x] `bash scripts/test-web.sh` — 1690 pass / 2 skipped (was 1688, +2 new)
- [x] `bunx tsc --noEmit` — clean for changed files
- [x] `bunx biome check --write` — clean
- [x] `go vet ./...` + `go build ./...` — clean
- [x] Live-verified on a fresh runtime home (port 7921): blueprint picker shows all six packs as cards; selecting one advances cleanly through the team trim without the spurious LLM stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-blueprint-catalog-cards](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1006/01-blueprint-catalog-cards.png)

![02-bridge-pill-fallback](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1006/02-bridge-pill-fallback.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template picker now supports richer card-style options with icons, display names, and one-line descriptions.
* **Bug Fixes**
  * CEO direct-message notifications are suppressed during the deterministic Phase 2 onboarding flow.
* **Tests**
  * Added tests validating blueprint catalog loading and the Phase 2 notification gating behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1006?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->