### PR TITLE
fix(themes): readable text in nex-dark and noir-gold

### DIFF
--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -69,3 +69,117 @@ html[data-theme="nex-dark"] .sidebar-header {
 html[data-theme="nex-dark"] .message:hover {
   background: #191a1b;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Dark-theme contrast fixes
+   The base stylesheets target light surfaces. Anywhere a rule
+   hardcodes a light bg + dark text (or vice versa) needs an
+   override here so the dark theme stays readable.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── @mention pill — light tan + dark orange reads as a stain on dark bg ── */
+html[data-theme="nex-dark"] {
+  --mention-bg: rgba(255, 182, 71, 0.16);
+  --mention-fg: #ffb647;
+  --syntax-number: #f7deab;
+  --syntax-bool: #f0a8c8;
+}
+
+/* ── Task status badges — light pastel chips don't survive on dark surface ── */
+html[data-theme="nex-dark"] .task-detail-status-badge.status-done {
+  background: rgba(47, 170, 100, 0.14);
+  color: #54c984;
+  border-color: rgba(47, 170, 100, 0.3);
+}
+html[data-theme="nex-dark"] .task-detail-status-badge.status-blocked {
+  background: rgba(255, 182, 71, 0.14);
+  color: #ffb647;
+  border-color: rgba(255, 182, 71, 0.3);
+}
+
+/* ── Insight badges — white text on bright accent washes out; tint the bg
+       darker so the white-on-color stays legible ── */
+html[data-theme="nex-dark"] .insight-badge-low {
+  color: var(--text);
+  background: var(--bg-warm);
+}
+
+/* ── Notebook surface — base tokens assume cream-paper light mode.
+       Re-map to a dark parchment palette so the wiki notebook reads. ── */
+html[data-theme="nex-dark"] .notebook-surface {
+  --nb-paper: #161718;
+  --nb-paper-dark: #111213;
+  --nb-rule: rgba(255, 255, 255, 0.03);
+  --nb-surface: #1a1b1c;
+  --nb-text: #e9eaeb;
+  --nb-text-muted: #aeb1b2;
+  --nb-text-tertiary: #7d8082;
+  --nb-border: #2a2d2f;
+  --nb-border-light: #1e2022;
+  --nb-ink-blue: #88a4c2;
+  --nb-stamp-red: #d6443c;
+  --nb-amber: #ffb647;
+  --nb-amber-bg: rgba(255, 182, 71, 0.1);
+  --nb-amber-hover: #f0a541;
+  --nb-green-approve: #54c984;
+  --nb-green-bg: rgba(84, 201, 132, 0.1);
+
+  /* Kill the cream paper grain — both layers read as scanlines on dark. */
+  background-image: none !important;
+  background-color: var(--nb-paper);
+}
+
+/* Notebook status pills — were hardcoded dark grays/ambers/burgundies that
+   only contrasted against cream paper. Re-tint for the dark surface. */
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-item .nb-status-draft {
+  color: var(--text-secondary);
+}
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-item .nb-status-review {
+  color: #ffb647;
+}
+html[data-theme="nex-dark"]
+  .notebook-surface
+  .nb-shelf-item
+  .nb-status-changes {
+  color: #ff7e6e;
+}
+
+/* Notebook shelf cards — hardcoded white background flips to dark card. */
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-card {
+  background: var(--nb-paper-dark);
+  outline-color: rgba(255, 255, 255, 0.08);
+  color: var(--nb-text);
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.4),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+}
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-card:hover {
+  background: #1f2021;
+  outline-color: rgba(255, 255, 255, 0.18);
+}
+html[data-theme="nex-dark"]
+  .notebook-surface
+  .nb-shelf-card
+  .nb-shelf-card-meta {
+  color: var(--text-tertiary);
+}
+
+/* Notebook review cards — were bright yellow sticky-notes (#eef679 / #f5fb95).
+   On dark surface the yellow burns; switch to dark amber chip. */
+html[data-theme="nex-dark"] .notebook-surface .nb-review-card {
+  background: rgba(255, 182, 71, 0.1);
+  outline-color: rgba(255, 255, 255, 0.1);
+  color: var(--nb-text);
+}
+html[data-theme="nex-dark"] .notebook-surface .nb-review-card:hover {
+  background: rgba(255, 182, 71, 0.18);
+  outline-color: rgba(255, 182, 71, 0.4);
+}
+
+/* Scrollbar thumb hover — base uses rgba(0,0,0,0.4) which disappears on dark */
+html[data-theme="nex-dark"] .notebook-surface::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+/* ── Wiki text muted/rule fallbacks now resolve to theme tokens via
+       :root in wiki.css; nothing extra needed here. ── */

--- a/web/public/themes/noir-gold.css
+++ b/web/public/themes/noir-gold.css
@@ -692,3 +692,70 @@ html[data-theme="noir-gold"] .sidebar .sidebar-agent-activity {
   color: var(--gold-300);
   opacity: 1;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Noir-gold contrast fixes
+   Source CSS that hardcodes pastel light bgs with dark text fails
+   on deep noir. Override per-rule with gold-tinted equivalents.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── @mention pill + json syntax — original tan/orange already tracks
+       the gold ramp closely; tighten to gold tokens so the pill looks
+       designed-in rather than washed out. ── */
+html[data-theme="noir-gold"] {
+  --mention-bg: rgba(201, 162, 39, 0.14);
+  --mention-fg: var(--gold-200);
+  --syntax-number: var(--gold-300);
+  --syntax-bool: #f0a8c8;
+}
+
+/* ── Task status badges ── */
+html[data-theme="noir-gold"] .task-detail-status-badge.status-done {
+  background: rgba(47, 170, 100, 0.14);
+  color: var(--success-300);
+  border-color: rgba(47, 170, 100, 0.3);
+}
+html[data-theme="noir-gold"] .task-detail-status-badge.status-in_progress,
+html[data-theme="noir-gold"] .task-detail-status-badge.status-review {
+  background: var(--accent-bg);
+  color: var(--gold-200);
+  border-color: rgba(201, 162, 39, 0.3);
+}
+html[data-theme="noir-gold"] .task-detail-status-badge.status-blocked {
+  background: rgba(240, 177, 74, 0.14);
+  color: var(--warning-300);
+  border-color: rgba(240, 177, 74, 0.3);
+}
+
+/* ── Insight badges — accent stays gold; white text on bright gold
+       washes out. Switch the medium tier to dark text on gold. ── */
+html[data-theme="noir-gold"] .insight-badge-medium {
+  color: var(--gold-950);
+  background: var(--accent);
+}
+html[data-theme="noir-gold"] .insight-badge-low {
+  color: var(--text);
+  background: var(--bg-warm);
+}
+
+/* ── Scrollbar thumb hover — base uses rgba(0,0,0,0.4) which disappears ── */
+html[data-theme="noir-gold"] .notebook-surface::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(245, 233, 200, 0.25);
+}
+
+/* ── Notebook status pills — re-tint for parchment surface ── */
+html[data-theme="noir-gold"] .notebook-surface .nb-shelf-item .nb-status-draft {
+  color: var(--text-secondary);
+}
+html[data-theme="noir-gold"]
+  .notebook-surface
+  .nb-shelf-item
+  .nb-status-review {
+  color: var(--gold-300);
+}
+html[data-theme="noir-gold"]
+  .notebook-surface
+  .nb-shelf-item
+  .nb-status-changes {
+  color: var(--red);
+}

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2135,9 +2135,9 @@ html[data-theme="nex"]
   border: 1px solid var(--border);
 }
 .task-detail-status-badge.status-done {
-  background: #e7f9ed;
-  color: #0b6b2a;
-  border-color: #c6eed2;
+  background: var(--success-100, #e7f9ed);
+  color: var(--success-500, #0b6b2a);
+  border-color: var(--success-200, #c6eed2);
 }
 .task-detail-status-badge.status-in_progress,
 .task-detail-status-badge.status-review {
@@ -2146,9 +2146,9 @@ html[data-theme="nex"]
   border-color: var(--accent-bg);
 }
 .task-detail-status-badge.status-blocked {
-  background: #fff4d6;
-  color: #7a5500;
-  border-color: #f2d98a;
+  background: var(--warning-100, #fff4d6);
+  color: var(--warning-500, #7a5500);
+  border-color: var(--warning-200, #f2d98a);
 }
 .task-detail-status-badge.status-canceled,
 .task-detail-status-badge.status-cancelled {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -432,8 +432,8 @@
 /* ─── @mention ─── */
 .mention {
   display: inline-block;
-  background: #fdf1e2;
-  color: #d4700e;
+  background: var(--mention-bg, var(--warning-100, #fdf1e2));
+  color: var(--mention-fg, var(--warning-500, #d4700e));
   padding: 0 5px;
   border-radius: 3px;
   font-weight: 600;
@@ -947,10 +947,10 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   white-space: pre-wrap;
 }
 .sv-num {
-  color: #b08800;
+  color: var(--syntax-number, #b08800);
 }
 .sv-bool {
-  color: #c25a8b;
+  color: var(--syntax-bool, #c25a8b);
   font-weight: 600;
 }
 .sv-null {

--- a/web/src/styles/rich-artifacts.css
+++ b/web/src/styles/rich-artifacts.css
@@ -14,7 +14,7 @@
 .rich-artifact-frame-modal {
   height: 100%;
   min-height: 0;
-  background: #fff;
+  background: var(--bg-card, #fff);
 }
 
 .rich-artifact-meta {
@@ -40,9 +40,10 @@
   grid-template-rows: auto minmax(0, 1fr);
   gap: 12px;
   padding: 14px;
-  border: 1px solid rgba(20, 24, 31, 0.18);
+  border: 1px solid var(--border, rgba(20, 24, 31, 0.18));
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.98);
+  background: var(--bg-card, rgba(255, 255, 255, 0.98));
+  color: var(--text);
   box-shadow: 0 28px 80px rgba(20, 24, 31, 0.22);
 }
 
@@ -74,10 +75,10 @@
   justify-content: center;
   min-height: 32px;
   padding: 0 12px;
-  border: 1px solid rgba(31, 41, 55, 0.18);
+  border: 1px solid var(--border, rgba(31, 41, 55, 0.18));
   border-radius: 6px;
-  background: #fff;
-  color: #172033;
+  background: var(--bg-card, #fff);
+  color: var(--text, #172033);
   font: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -86,7 +87,7 @@
 .rich-artifact-modal-actions button:hover,
 .rich-artifact-modal-actions a:hover,
 .nb-visual-artifact-actions button:hover {
-  background: #f5f7fa;
+  background: var(--bg-warm, #f5f7fa);
 }
 
 .rich-artifact-modal-actions button:disabled {
@@ -150,9 +151,9 @@
   gap: 16px;
   align-items: center;
   padding: 12px;
-  border: 1px solid rgba(48, 60, 84, 0.14);
+  border: 1px solid var(--border, rgba(48, 60, 84, 0.14));
   border-radius: 8px;
-  background: #fff;
+  background: var(--bg-card, #fff);
 }
 
 .nb-visual-artifact-card h3 {

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -19,6 +19,12 @@
   --wk-text: var(--text);
   --wk-text-muted: var(--text-secondary);
   --wk-text-tertiary: var(--text-tertiary);
+  /* Body/rule aliases for wk-team-learnings + playbook synthesis. Defined
+     here (not just as fallbacks) so dark themes get readable colors. */
+  --wk-body: var(--text);
+  --wk-body-muted: var(--text-secondary);
+  --wk-rule: var(--border);
+  --wk-rule-soft: var(--border-light);
   --wk-border: var(--border);
   --wk-border-light: var(--border-light);
   --wk-border-strong: var(--border-dark);
@@ -2326,12 +2332,12 @@
   cursor: progress;
 }
 .wk-playbook-synthesis[data-state="success"] .wk-playbook-synthesis__button {
-  color: #2a7d2a;
-  border-color: #2a7d2a;
+  color: var(--green);
+  border-color: var(--green);
 }
 .wk-playbook-synthesis[data-state="error"] .wk-playbook-synthesis__button {
-  color: #c94a4a;
-  border-color: #c94a4a;
+  color: var(--red);
+  border-color: var(--red);
 }
 
 .wk-team-learnings {
@@ -2391,7 +2397,7 @@
   background: rgba(0, 0, 0, 0.025);
 }
 .wk-team-learning__trusted {
-  color: #2a7d2a;
+  color: var(--green);
 }
 .wk-team-learning__key {
   min-width: 0;


### PR DESCRIPTION
## Summary

Dark theme and noir-gold had several surfaces where text was unreadable or near-unreadable. Audit found two classes of failure:

1. **Source CSS hardcoded light-mode colors** — e.g. `color: #2a7d2a` on a callout, `background: #fff` on a modal frame — with no `dark:` variant or token indirection, so they rendered the same regardless of theme.
2. **Wiki referenced undefined CSS variables** — `var(--wk-body, #111)` / `var(--wk-rule, rgba(0,0,0,0.18))` etc. were referenced 28 times but never defined, so they always fell back to the light-mode hex literal. Black text on dark bg in `wk-team-learnings` etc.

## What changed

**Source-level (theme-agnostic):**

- `wiki.css` — define `--wk-body`, `--wk-body-muted`, `--wk-rule`, `--wk-rule-soft` at `:root` so they resolve to the active theme's `--text` / `--text-secondary` / `--border` / `--border-light`. Replace hardcoded `#2a7d2a`/`#c94a4a` semantic colors on playbook synthesis + trusted-learning with `var(--green)` / `var(--red)`.
- `messages.css` — `.mention`, `.sv-num`, `.sv-bool` go through new `--mention-bg`/`--mention-fg`/`--syntax-number`/`--syntax-bool` tokens (originals preserved as fallbacks so light theme is untouched).
- `layout.css` — `.task-detail-status-badge.status-done`/`.status-blocked` use `--success-*`/`--warning-*` ramp tokens.
- `rich-artifacts.css` — modal frame, modal shell, action buttons, visual-artifact card switch hardcoded `#fff`/`#172033`/`#f5f7fa` to tokens with hex fallbacks.

**Per-theme overrides (`nex-dark.css` + `noir-gold.css`):**

- Define dark token values for the new `--mention-*`/`--syntax-*` aliases.
- Per-rule overrides for the task status badges so the chip text/bg stay legible on dark.
- Re-map the entire `.notebook-surface` palette (paper → dark, ink → light) on `nex-dark`. Noir-gold already had this; light themes untouched.
- Notebook status pills, shelf cards, review sticky-notes, and scrollbar thumb hover all get per-theme overrides.

## Verification

- `bunx tsc --noEmit` clean
- `bunx biome check` clean except 2 intentional `!important` warnings on `notebook-surface` `background-image: none` (matches the existing pattern in noir-gold for the same reason — overriding the cream-paper grain).
- Light theme (`nex`) visually verified unchanged (Playwright screenshot).
- Dark theme (`nex-dark`) + noir-gold visually verified: mention pills, status badges, notebook surface, and wiki team-learnings now readable.

## Test plan

- [ ] Boot `bun run dev` in `web/`, flip through the three themes via the sidebar swatch picker.
- [ ] Verify a chat message with `@ceo` mention renders a legible pill in all three themes.
- [ ] Open the wiki, scroll to a page with a `Team Learnings` section; text should be readable in dark + noir.
- [ ] Open a task with `status: done` or `status: blocked` — badge should be legible.
- [ ] Open the notebook surface (Wiki app); verify paper, shelf cards, and review sticky-notes are legible on `nex-dark`.

## Follow-up

A second draft PR is stacked on this one: `feat/twilight-dark-theme` gives `nex-dark` an actual visual point of view (twilight palette + body gradient + brand-violet accents in place of generic amber). That PR depends on this one being merged first; this PR is the defensive contrast layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-nex-light](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1007/01-nex-light.png)

![02-nex-dark](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1007/02-nex-dark.png)

![03-noir-gold](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1007/03-noir-gold.png)

