### PR TITLE
feat(themes): twilight identity for nex-dark

### DIFF
--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -69,3 +69,117 @@ html[data-theme="nex-dark"] .sidebar-header {
 html[data-theme="nex-dark"] .message:hover {
   background: #191a1b;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Dark-theme contrast fixes
+   The base stylesheets target light surfaces. Anywhere a rule
+   hardcodes a light bg + dark text (or vice versa) needs an
+   override here so the dark theme stays readable.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── @mention pill — light tan + dark orange reads as a stain on dark bg ── */
+html[data-theme="nex-dark"] {
+  --mention-bg: rgba(255, 182, 71, 0.16);
+  --mention-fg: #ffb647;
+  --syntax-number: #f7deab;
+  --syntax-bool: #f0a8c8;
+}
+
+/* ── Task status badges — light pastel chips don't survive on dark surface ── */
+html[data-theme="nex-dark"] .task-detail-status-badge.status-done {
+  background: rgba(47, 170, 100, 0.14);
+  color: #54c984;
+  border-color: rgba(47, 170, 100, 0.3);
+}
+html[data-theme="nex-dark"] .task-detail-status-badge.status-blocked {
+  background: rgba(255, 182, 71, 0.14);
+  color: #ffb647;
+  border-color: rgba(255, 182, 71, 0.3);
+}
+
+/* ── Insight badges — white text on bright accent washes out; tint the bg
+       darker so the white-on-color stays legible ── */
+html[data-theme="nex-dark"] .insight-badge-low {
+  color: var(--text);
+  background: var(--bg-warm);
+}
+
+/* ── Notebook surface — base tokens assume cream-paper light mode.
+       Re-map to a dark parchment palette so the wiki notebook reads. ── */
+html[data-theme="nex-dark"] .notebook-surface {
+  --nb-paper: #161718;
+  --nb-paper-dark: #111213;
+  --nb-rule: rgba(255, 255, 255, 0.03);
+  --nb-surface: #1a1b1c;
+  --nb-text: #e9eaeb;
+  --nb-text-muted: #aeb1b2;
+  --nb-text-tertiary: #7d8082;
+  --nb-border: #2a2d2f;
+  --nb-border-light: #1e2022;
+  --nb-ink-blue: #88a4c2;
+  --nb-stamp-red: #d6443c;
+  --nb-amber: #ffb647;
+  --nb-amber-bg: rgba(255, 182, 71, 0.1);
+  --nb-amber-hover: #f0a541;
+  --nb-green-approve: #54c984;
+  --nb-green-bg: rgba(84, 201, 132, 0.1);
+
+  /* Kill the cream paper grain — both layers read as scanlines on dark. */
+  background-image: none !important;
+  background-color: var(--nb-paper);
+}
+
+/* Notebook status pills — were hardcoded dark grays/ambers/burgundies that
+   only contrasted against cream paper. Re-tint for the dark surface. */
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-item .nb-status-draft {
+  color: var(--text-secondary);
+}
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-item .nb-status-review {
+  color: #ffb647;
+}
+html[data-theme="nex-dark"]
+  .notebook-surface
+  .nb-shelf-item
+  .nb-status-changes {
+  color: #ff7e6e;
+}
+
+/* Notebook shelf cards — hardcoded white background flips to dark card. */
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-card {
+  background: var(--nb-paper-dark);
+  outline-color: rgba(255, 255, 255, 0.08);
+  color: var(--nb-text);
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.4),
+    0 1px 2px rgba(0, 0, 0, 0.3);
+}
+html[data-theme="nex-dark"] .notebook-surface .nb-shelf-card:hover {
+  background: #1f2021;
+  outline-color: rgba(255, 255, 255, 0.18);
+}
+html[data-theme="nex-dark"]
+  .notebook-surface
+  .nb-shelf-card
+  .nb-shelf-card-meta {
+  color: var(--text-tertiary);
+}
+
+/* Notebook review cards — were bright yellow sticky-notes (#eef679 / #f5fb95).
+   On dark surface the yellow burns; switch to dark amber chip. */
+html[data-theme="nex-dark"] .notebook-surface .nb-review-card {
+  background: rgba(255, 182, 71, 0.1);
+  outline-color: rgba(255, 255, 255, 0.1);
+  color: var(--nb-text);
+}
+html[data-theme="nex-dark"] .notebook-surface .nb-review-card:hover {
+  background: rgba(255, 182, 71, 0.18);
+  outline-color: rgba(255, 182, 71, 0.4);
+}
+
+/* Scrollbar thumb hover — base uses rgba(0,0,0,0.4) which disappears on dark */
+html[data-theme="nex-dark"] .notebook-surface::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.25);
+}
+
+/* ── Wiki text muted/rule fallbacks now resolve to theme tokens via
+       :root in wiki.css; nothing extra needed here. ── */

--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -19,22 +19,26 @@ html[data-theme="nex-dark"] {
   --overlay-white: rgba(255, 255, 255, 0.12);
   --overlay-white-strong: rgba(255, 255, 255, 0.32);
 
-  /* ── Semantic aliases ── */
-  --bg: #111213;
-  --bg-warm: #191a1b;
-  --bg-subtle: #0d0e0f;
-  --bg-card: #151617;
-  --text: #e9eaeb;
-  --text-secondary: #aeb1b2;
-  --text-tertiary: #686c6e;
-  --text-disabled: #434647;
+  /* ── Twilight palette ──
+     The light theme is purple-on-white; "nex-dark" is the same brand at
+     night, not a neutral dark mode. Every surface picks up a faint violet
+     temperature, and text warms toward cream so it pairs with the
+     aubergine ground instead of fighting it. */
+  --bg: #121017;
+  --bg-warm: #1c1825;
+  --bg-subtle: #0d0c14;
+  --bg-card: #16131e;
+  --text: #ece8ef;
+  --text-secondary: #b2adbb;
+  --text-tertiary: #75707d;
+  --text-disabled: #46424d;
 
   /* accent stays the same purple/tertiary */
 
-  --border: #1e2022;
-  --border-light: #171819;
-  --border-dark: #2a2d2f;
-  --border-strong: #434647;
+  --border: #221d2c;
+  --border-light: #1a1623;
+  --border-dark: #2e2839;
+  --border-strong: #45404d;
 
   /* ── Sidebar – keep purple but use a deeper shade ── */
   --nex-sidebar: #4a1f70;
@@ -44,15 +48,24 @@ html[data-theme="nex-dark"] {
   --nex-sidebar-text-active: #ffffff;
 }
 
-/* ── Override hard-coded message text color (not a CSS variable in nex.css) ── */
-html[data-theme="nex-dark"] .message-text {
-  color: #c8cacc;
+/* ── Twilight atmosphere on body — a slow vertical fade from aubergine
+   to ink so the surface reads as a lit room rather than a flat panel.
+   The gradient is fixed so it does not tile when the chat scrolls. ── */
+html[data-theme="nex-dark"] body {
+  background-color: var(--bg);
+  background-image: linear-gradient(180deg, #1a1228 0%, #0e0f14 100%);
+  background-attachment: fixed;
 }
 
-/* ── Composer inner border slightly lighter for dark bg ── */
+/* ── Override hard-coded message text color (not a CSS variable in nex.css) ── */
+html[data-theme="nex-dark"] .message-text {
+  color: #d2cdda;
+}
+
+/* ── Composer inner — match the violet-warmed card tone ── */
 html[data-theme="nex-dark"] .composer-inner {
-  background: #191a1b;
-  border-color: #2a2d2f;
+  background: var(--bg-warm);
+  border-color: var(--border-dark);
 }
 
 /* ── Sidebar bottom matches deeper dark ── */
@@ -77,11 +90,13 @@ html[data-theme="nex-dark"] .message:hover {
    override here so the dark theme stays readable.
    ═══════════════════════════════════════════════════════════════ */
 
-/* ── @mention pill — light tan + dark orange reads as a stain on dark bg ── */
+/* ── @mention + json-syntax accents track the brand purple, not amber.
+   At night the same violet that owns the sidebar should own the inline
+   accents too — otherwise the dark theme reads as a stranger. ── */
 html[data-theme="nex-dark"] {
-  --mention-bg: rgba(255, 182, 71, 0.16);
-  --mention-fg: #ffb647;
-  --syntax-number: #f7deab;
+  --mention-bg: rgba(196, 176, 255, 0.14);
+  --mention-fg: #c4b0ff;
+  --syntax-number: #c4b0ff;
   --syntax-bool: #f0a8c8;
 }
 
@@ -92,9 +107,9 @@ html[data-theme="nex-dark"] .task-detail-status-badge.status-done {
   border-color: rgba(47, 170, 100, 0.3);
 }
 html[data-theme="nex-dark"] .task-detail-status-badge.status-blocked {
-  background: rgba(255, 182, 71, 0.14);
-  color: #ffb647;
-  border-color: rgba(255, 182, 71, 0.3);
+  background: rgba(196, 176, 255, 0.14);
+  color: #c4b0ff;
+  border-color: rgba(196, 176, 255, 0.3);
 }
 
 /* ── Insight badges — white text on bright accent washes out; tint the bg

--- a/web/public/themes/noir-gold.css
+++ b/web/public/themes/noir-gold.css
@@ -692,3 +692,70 @@ html[data-theme="noir-gold"] .sidebar .sidebar-agent-activity {
   color: var(--gold-300);
   opacity: 1;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Noir-gold contrast fixes
+   Source CSS that hardcodes pastel light bgs with dark text fails
+   on deep noir. Override per-rule with gold-tinted equivalents.
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── @mention pill + json syntax — original tan/orange already tracks
+       the gold ramp closely; tighten to gold tokens so the pill looks
+       designed-in rather than washed out. ── */
+html[data-theme="noir-gold"] {
+  --mention-bg: rgba(201, 162, 39, 0.14);
+  --mention-fg: var(--gold-200);
+  --syntax-number: var(--gold-300);
+  --syntax-bool: #f0a8c8;
+}
+
+/* ── Task status badges ── */
+html[data-theme="noir-gold"] .task-detail-status-badge.status-done {
+  background: rgba(47, 170, 100, 0.14);
+  color: var(--success-300);
+  border-color: rgba(47, 170, 100, 0.3);
+}
+html[data-theme="noir-gold"] .task-detail-status-badge.status-in_progress,
+html[data-theme="noir-gold"] .task-detail-status-badge.status-review {
+  background: var(--accent-bg);
+  color: var(--gold-200);
+  border-color: rgba(201, 162, 39, 0.3);
+}
+html[data-theme="noir-gold"] .task-detail-status-badge.status-blocked {
+  background: rgba(240, 177, 74, 0.14);
+  color: var(--warning-300);
+  border-color: rgba(240, 177, 74, 0.3);
+}
+
+/* ── Insight badges — accent stays gold; white text on bright gold
+       washes out. Switch the medium tier to dark text on gold. ── */
+html[data-theme="noir-gold"] .insight-badge-medium {
+  color: var(--gold-950);
+  background: var(--accent);
+}
+html[data-theme="noir-gold"] .insight-badge-low {
+  color: var(--text);
+  background: var(--bg-warm);
+}
+
+/* ── Scrollbar thumb hover — base uses rgba(0,0,0,0.4) which disappears ── */
+html[data-theme="noir-gold"] .notebook-surface::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(245, 233, 200, 0.25);
+}
+
+/* ── Notebook status pills — re-tint for parchment surface ── */
+html[data-theme="noir-gold"] .notebook-surface .nb-shelf-item .nb-status-draft {
+  color: var(--text-secondary);
+}
+html[data-theme="noir-gold"]
+  .notebook-surface
+  .nb-shelf-item
+  .nb-status-review {
+  color: var(--gold-300);
+}
+html[data-theme="noir-gold"]
+  .notebook-surface
+  .nb-shelf-item
+  .nb-status-changes {
+  color: var(--red);
+}

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2135,9 +2135,9 @@ html[data-theme="nex"]
   border: 1px solid var(--border);
 }
 .task-detail-status-badge.status-done {
-  background: #e7f9ed;
-  color: #0b6b2a;
-  border-color: #c6eed2;
+  background: var(--success-100, #e7f9ed);
+  color: var(--success-500, #0b6b2a);
+  border-color: var(--success-200, #c6eed2);
 }
 .task-detail-status-badge.status-in_progress,
 .task-detail-status-badge.status-review {
@@ -2146,9 +2146,9 @@ html[data-theme="nex"]
   border-color: var(--accent-bg);
 }
 .task-detail-status-badge.status-blocked {
-  background: #fff4d6;
-  color: #7a5500;
-  border-color: #f2d98a;
+  background: var(--warning-100, #fff4d6);
+  color: var(--warning-500, #7a5500);
+  border-color: var(--warning-200, #f2d98a);
 }
 .task-detail-status-badge.status-canceled,
 .task-detail-status-badge.status-cancelled {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -432,8 +432,8 @@
 /* ─── @mention ─── */
 .mention {
   display: inline-block;
-  background: #fdf1e2;
-  color: #d4700e;
+  background: var(--mention-bg, var(--warning-100, #fdf1e2));
+  color: var(--mention-fg, var(--warning-500, #d4700e));
   padding: 0 5px;
   border-radius: 3px;
   font-weight: 600;
@@ -947,10 +947,10 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   white-space: pre-wrap;
 }
 .sv-num {
-  color: #b08800;
+  color: var(--syntax-number, #b08800);
 }
 .sv-bool {
-  color: #c25a8b;
+  color: var(--syntax-bool, #c25a8b);
   font-weight: 600;
 }
 .sv-null {

--- a/web/src/styles/rich-artifacts.css
+++ b/web/src/styles/rich-artifacts.css
@@ -14,7 +14,7 @@
 .rich-artifact-frame-modal {
   height: 100%;
   min-height: 0;
-  background: #fff;
+  background: var(--bg-card, #fff);
 }
 
 .rich-artifact-meta {
@@ -40,9 +40,10 @@
   grid-template-rows: auto minmax(0, 1fr);
   gap: 12px;
   padding: 14px;
-  border: 1px solid rgba(20, 24, 31, 0.18);
+  border: 1px solid var(--border, rgba(20, 24, 31, 0.18));
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.98);
+  background: var(--bg-card, rgba(255, 255, 255, 0.98));
+  color: var(--text);
   box-shadow: 0 28px 80px rgba(20, 24, 31, 0.22);
 }
 
@@ -74,10 +75,10 @@
   justify-content: center;
   min-height: 32px;
   padding: 0 12px;
-  border: 1px solid rgba(31, 41, 55, 0.18);
+  border: 1px solid var(--border, rgba(31, 41, 55, 0.18));
   border-radius: 6px;
-  background: #fff;
-  color: #172033;
+  background: var(--bg-card, #fff);
+  color: var(--text, #172033);
   font: inherit;
   text-decoration: none;
   cursor: pointer;
@@ -86,7 +87,7 @@
 .rich-artifact-modal-actions button:hover,
 .rich-artifact-modal-actions a:hover,
 .nb-visual-artifact-actions button:hover {
-  background: #f5f7fa;
+  background: var(--bg-warm, #f5f7fa);
 }
 
 .rich-artifact-modal-actions button:disabled {
@@ -150,9 +151,9 @@
   gap: 16px;
   align-items: center;
   padding: 12px;
-  border: 1px solid rgba(48, 60, 84, 0.14);
+  border: 1px solid var(--border, rgba(48, 60, 84, 0.14));
   border-radius: 8px;
-  background: #fff;
+  background: var(--bg-card, #fff);
 }
 
 .nb-visual-artifact-card h3 {

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -19,6 +19,12 @@
   --wk-text: var(--text);
   --wk-text-muted: var(--text-secondary);
   --wk-text-tertiary: var(--text-tertiary);
+  /* Body/rule aliases for wk-team-learnings + playbook synthesis. Defined
+     here (not just as fallbacks) so dark themes get readable colors. */
+  --wk-body: var(--text);
+  --wk-body-muted: var(--text-secondary);
+  --wk-rule: var(--border);
+  --wk-rule-soft: var(--border-light);
   --wk-border: var(--border);
   --wk-border-light: var(--border-light);
   --wk-border-strong: var(--border-dark);
@@ -2326,12 +2332,12 @@
   cursor: progress;
 }
 .wk-playbook-synthesis[data-state="success"] .wk-playbook-synthesis__button {
-  color: #2a7d2a;
-  border-color: #2a7d2a;
+  color: var(--green);
+  border-color: var(--green);
 }
 .wk-playbook-synthesis[data-state="error"] .wk-playbook-synthesis__button {
-  color: #c94a4a;
-  border-color: #c94a4a;
+  color: var(--red);
+  border-color: var(--red);
 }
 
 .wk-team-learnings {
@@ -2391,7 +2397,7 @@
   background: rgba(0, 0, 0, 0.025);
 }
 .wk-team-learning__trusted {
-  color: #2a7d2a;
+  color: var(--green);
 }
 .wk-team-learning__key {
   min-width: 0;


### PR DESCRIPTION
## Summary

After [#1007](https://github.com/nex-crm/wuphf/pull/1007) lands, `nex-dark` reads correctly but has no point of view — the file's own header describes it as "a token re-skin of the light theme." Light `nex` is purple-on-white; noir-gold is aged manuscript + gold; `nex-dark` was "lights off" with nothing of its own.

This PR gives `nex-dark` an actual visual identity — **twilight** — the same brand at night rather than a neutral dark mode.

## What changed

Three atmosphere moves, all in `web/public/themes/nex-dark.css`. No new structure, no other files touched.

1. **Palette retoned with violet temperature.** `--bg`, `--bg-card`, `--bg-warm`, `--bg-subtle`, `--border*` all shift from neutral gray toward aubergine (e.g. `#151617` → `#16131e`). `--text` warms from `#e9eaeb` to `#ece8ef` so it pairs with the violet ground instead of fighting it. Every surface picks up the brand temperature.
2. **Body gradient.** `linear-gradient(180deg, #1a1228 0%, #0e0f14 100%)` on `body` with `background-attachment: fixed`. The surface reads as a lit room, not a flat panel. The sidebar purple block visually flows down into the body instead of being pasted onto neutral dark.
3. **Brand-violet inline accents.** `--mention-bg`/`--mention-fg`, `--syntax-number`, and the `.status-blocked` badge switch from the amber the contrast pass picked for legibility (`#ffb647`) to brand violet (`#c4b0ff`). The same purple that owns the sidebar now owns inline accents too.

## Why this is its own PR

[#1007](https://github.com/nex-crm/wuphf/pull/1007) is defensive — it fixes objectively unreadable text. This PR is a taste call about whether `nex-dark` should have its own identity. Splitting lets reviewers land the contrast fix without blocking on the design discussion.

## Verification

- `bunx tsc --noEmit` clean
- `bunx biome check` clean (same 2 intentional `!important` warnings carried from #1007)
- Light theme (`nex`) and noir-gold visually unchanged (Playwright screenshot diff is on `nex-dark` only)
- `nex-dark` visually verified at `:7910`: sidebar purple flows into the gradient ground, mention pill `@ceo` renders violet on dark, status-blocked badge tracks the brand

## Test plan

- [ ] `bun run dev` in `web/`; switch to nex-dark via the sidebar swatch picker
- [ ] Verify body has a subtle aubergine→ink gradient (more obvious at the top edge near the channel header)
- [ ] Verify a chat message with `@ceo` mention shows a violet pill (not amber)
- [ ] Verify a task with `status: blocked` shows a violet badge
- [ ] Switch to `nex` (light) and confirm nothing changed
- [ ] Switch to `noir-gold` and confirm nothing changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-nex-light](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1008/01-nex-light.png)

![02-nex-dark](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1008/02-nex-dark.png)

![03-noir-gold](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1008/03-noir-gold.png)

