### PR TITLE
feat(themes): twilight identity for nex-dark

### DIFF
--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -19,22 +19,26 @@ html[data-theme="nex-dark"] {
   --overlay-white: rgba(255, 255, 255, 0.12);
   --overlay-white-strong: rgba(255, 255, 255, 0.32);
 
-  /* ── Semantic aliases ── */
-  --bg: #111213;
-  --bg-warm: #191a1b;
-  --bg-subtle: #0d0e0f;
-  --bg-card: #151617;
-  --text: #e9eaeb;
-  --text-secondary: #aeb1b2;
-  --text-tertiary: #686c6e;
-  --text-disabled: #434647;
+  /* ── Twilight palette ──
+     The light theme is purple-on-white; "nex-dark" is the same brand at
+     night, not a neutral dark mode. Every surface picks up a faint violet
+     temperature, and text warms toward cream so it pairs with the
+     aubergine ground instead of fighting it. */
+  --bg: #121017;
+  --bg-warm: #1c1825;
+  --bg-subtle: #0d0c14;
+  --bg-card: #16131e;
+  --text: #ece8ef;
+  --text-secondary: #b2adbb;
+  --text-tertiary: #75707d;
+  --text-disabled: #46424d;
 
   /* accent stays the same purple/tertiary */
 
-  --border: #1e2022;
-  --border-light: #171819;
-  --border-dark: #2a2d2f;
-  --border-strong: #434647;
+  --border: #221d2c;
+  --border-light: #1a1623;
+  --border-dark: #2e2839;
+  --border-strong: #45404d;
 
   /* ── Sidebar – keep purple but use a deeper shade ── */
   --nex-sidebar: #4a1f70;
@@ -44,15 +48,24 @@ html[data-theme="nex-dark"] {
   --nex-sidebar-text-active: #ffffff;
 }
 
-/* ── Override hard-coded message text color (not a CSS variable in nex.css) ── */
-html[data-theme="nex-dark"] .message-text {
-  color: #c8cacc;
+/* ── Twilight atmosphere on body — a slow vertical fade from aubergine
+   to ink so the surface reads as a lit room rather than a flat panel.
+   The gradient is fixed so it does not tile when the chat scrolls. ── */
+html[data-theme="nex-dark"] body {
+  background-color: var(--bg);
+  background-image: linear-gradient(180deg, #1a1228 0%, #0e0f14 100%);
+  background-attachment: fixed;
 }
 
-/* ── Composer inner border slightly lighter for dark bg ── */
+/* ── Override hard-coded message text color (not a CSS variable in nex.css) ── */
+html[data-theme="nex-dark"] .message-text {
+  color: #d2cdda;
+}
+
+/* ── Composer inner — match the violet-warmed card tone ── */
 html[data-theme="nex-dark"] .composer-inner {
-  background: #191a1b;
-  border-color: #2a2d2f;
+  background: var(--bg-warm);
+  border-color: var(--border-dark);
 }
 
 /* ── Sidebar bottom matches deeper dark ── */
@@ -77,11 +90,13 @@ html[data-theme="nex-dark"] .message:hover {
    override here so the dark theme stays readable.
    ═══════════════════════════════════════════════════════════════ */
 
-/* ── @mention pill — light tan + dark orange reads as a stain on dark bg ── */
+/* ── @mention + json-syntax accents track the brand purple, not amber.
+   At night the same violet that owns the sidebar should own the inline
+   accents too — otherwise the dark theme reads as a stranger. ── */
 html[data-theme="nex-dark"] {
-  --mention-bg: rgba(255, 182, 71, 0.16);
-  --mention-fg: #ffb647;
-  --syntax-number: #f7deab;
+  --mention-bg: rgba(196, 176, 255, 0.14);
+  --mention-fg: #c4b0ff;
+  --syntax-number: #c4b0ff;
   --syntax-bool: #f0a8c8;
 }
 
@@ -92,9 +107,9 @@ html[data-theme="nex-dark"] .task-detail-status-badge.status-done {
   border-color: rgba(47, 170, 100, 0.3);
 }
 html[data-theme="nex-dark"] .task-detail-status-badge.status-blocked {
-  background: rgba(255, 182, 71, 0.14);
-  color: #ffb647;
-  border-color: rgba(255, 182, 71, 0.3);
+  background: rgba(196, 176, 255, 0.14);
+  color: #c4b0ff;
+  border-color: rgba(196, 176, 255, 0.3);
 }
 
 /* ── Insight badges — white text on bright accent washes out; tint the bg

--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -30,7 +30,8 @@ html[data-theme="nex-dark"] {
   --bg-card: #16131e;
   --text: #ece8ef;
   --text-secondary: #b2adbb;
-  --text-tertiary: #75707d;
+  /* #75707d failed WCAG AA (3.62:1) on --bg-warm; bumped to 5.22:1. */
+  --text-tertiary: #928d9c;
   --text-disabled: #46424d;
 
   /* accent stays the same purple/tertiary */
@@ -39,6 +40,11 @@ html[data-theme="nex-dark"] {
   --border-light: #1a1623;
   --border-dark: #2e2839;
   --border-strong: #45404d;
+
+  /* Body gradient stops — tokenized so the twilight palette can be
+     tuned in one place. */
+  --bg-gradient-top: #1a1228;
+  --bg-gradient-bottom: #0e0f14;
 
   /* ── Sidebar – keep purple but use a deeper shade ── */
   --nex-sidebar: #4a1f70;
@@ -53,7 +59,11 @@ html[data-theme="nex-dark"] {
    The gradient is fixed so it does not tile when the chat scrolls. ── */
 html[data-theme="nex-dark"] body {
   background-color: var(--bg);
-  background-image: linear-gradient(180deg, #1a1228 0%, #0e0f14 100%);
+  background-image: linear-gradient(
+    180deg,
+    var(--bg-gradient-top) 0%,
+    var(--bg-gradient-bottom) 100%
+  );
   background-attachment: fixed;
 }
 


### PR DESCRIPTION
## Summary

After [#1007](https://github.com/nex-crm/wuphf/pull/1007) (the defensive contrast pass), `nex-dark` reads correctly but has no point of view — the file's own header described it as "a token re-skin of the light theme." Light `nex` is purple-on-white; noir-gold is aged manuscript + gold; `nex-dark` was "lights off" with nothing of its own.

This PR gives `nex-dark` an actual visual identity — **twilight** — the same brand at night rather than a neutral dark mode.

> Note: opened fresh because the original draft (#1008) was auto-closed when its base branch was deleted after #1007 merged. Same head branch, same commit content, retargeted to `main`.

## What changed

Three atmosphere moves, all in `web/public/themes/nex-dark.css`. No new structure, no other files touched.

1. **Palette retoned with violet temperature.** `--bg`, `--bg-card`, `--bg-warm`, `--bg-subtle`, `--border*` all shift from neutral gray toward aubergine (e.g. `#151617` → `#16131e`). `--text` warms from `#e9eaeb` to `#ece8ef` so it pairs with the violet ground instead of fighting it. Every surface picks up the brand temperature.
2. **Body gradient.** `linear-gradient(180deg, #1a1228 0%, #0e0f14 100%)` on `body` with `background-attachment: fixed`. The surface reads as a lit room, not a flat panel. The sidebar purple block visually flows down into the body instead of being pasted onto neutral dark.
3. **Brand-violet inline accents.** `--mention-bg`/`--mention-fg`, `--syntax-number`, and the `.status-blocked` badge switch from the amber the contrast pass picked for legibility (`#ffb647`) to brand violet (`#c4b0ff`). The same purple that owns the sidebar now owns inline accents too.

## Why this is its own PR

#1007 is defensive — it fixes objectively unreadable text. This PR is a taste call about whether `nex-dark` should have its own identity. Splitting let reviewers land the contrast fix without blocking on the design discussion.

## Verification

- `bunx tsc --noEmit` clean
- Light theme (`nex`) and noir-gold visually unchanged (Playwright screenshot diff is on `nex-dark` only)
- `nex-dark` visually verified at `:7910`: sidebar purple flows into the gradient ground, mention pill `@ceo` renders violet on dark, status-blocked badge tracks the brand

## Test plan

- [ ] `bun run dev` in `web/`; switch to nex-dark via the sidebar swatch picker
- [ ] Verify body has a subtle aubergine→ink gradient (more obvious at the top edge near the channel header)
- [ ] Verify a chat message with `@ceo` mention shows a violet pill (not amber)
- [ ] Verify a task with `status: blocked` shows a violet badge
- [ ] Switch to `nex` (light) and confirm nothing changed
- [ ] Switch to `noir-gold` and confirm nothing changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-nex-light](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1009/01-nex-light.png)

![02-nex-dark](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1009/02-nex-dark.png)

![03-noir-gold](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1009/03-noir-gold.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the dark theme to a new "Twilight" purple/violet palette for improved visual consistency and mood.
  * Replaced amber/yellow accents with violet/cream tones across mentions, code accents, and status indicators.
  * Introduced tokenized body gradient stops and a refined fixed-position background gradient for enhanced depth, hierarchy, and readability in dark mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->