### PR TITLE
feat(messages): inline typing indicator + Claude-style ThinkingLoader with The Office verbs

### DIFF
--- a/web/e2e/screenshots/typing-loader.mjs
+++ b/web/e2e/screenshots/typing-loader.mjs
@@ -1,0 +1,221 @@
+// Capture the inline typing indicator (Claude-style ThinkingLoader with The
+// Office verbs) rendered at the foot of the message feed, across all three
+// themes, plus the multi-agent stacked-avatar variant.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh typing-loader <pr-number>
+
+import {
+  DEFAULT_BASE,
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+} from "./lib.mjs";
+import process from "node:process";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const CONFIG = {
+  llm_provider: "claude-code",
+  llm_provider_configured: true,
+  memory_backend: "markdown",
+  team_lead_slug: "ceo",
+};
+
+const MESSAGES = [
+  {
+    id: "msg-1",
+    from: "you",
+    channel: "general",
+    content: "@dwight what is the status of the Scranton numbers?",
+    timestamp: "2026-05-29T12:00:00Z",
+  },
+  {
+    id: "msg-2",
+    from: "dwight",
+    channel: "general",
+    content:
+      "Pulling them now. Fact: the Scranton branch is the most efficient branch.",
+    timestamp: "2026-05-29T12:00:30Z",
+  },
+];
+
+// One active agent → single bubble; two → stacked avatars. `status: "active"`
+// is what TypingIndicator keys on.
+function memberPayload(members) {
+  return { members, meta: { humanHasPosted: true } };
+}
+
+const SINGLE = memberPayload([
+  {
+    slug: "dwight",
+    name: "Dwight",
+    role: "Sales",
+    provider: "claude-code",
+    built_in: true,
+    online: true,
+    status: "active",
+  },
+]);
+
+const MULTI = memberPayload([
+  {
+    slug: "dwight",
+    name: "Dwight",
+    role: "Sales",
+    provider: "claude-code",
+    built_in: true,
+    online: true,
+    status: "active",
+  },
+  {
+    slug: "jim",
+    name: "Jim",
+    role: "Sales",
+    provider: "claude-code",
+    built_in: true,
+    online: true,
+    status: "active",
+  },
+]);
+
+const json = (body) => ({
+  contentType: "application/json",
+  body: JSON.stringify(body),
+});
+
+async function mountFeed(context, members) {
+  await installCommonMocks(context, {
+    extra: async (ctx) => {
+      await ctx.route("**/api/config", (r) => r.fulfill(json(CONFIG)));
+      await ctx.route("**/api/office-members", (r) => r.fulfill(json(members)));
+      // Channel members empty → the indicator falls back to all active office
+      // members, which keeps this fixture independent of /members membership.
+      await ctx.route("**/api/members*", (r) =>
+        r.fulfill(json({ members: [] })),
+      );
+      await ctx.route("**/api/channels", (r) =>
+        r.fulfill(
+          json({
+            channels: [
+              { slug: "general", name: "General", description: "Shared" },
+            ],
+          }),
+        ),
+      );
+      await ctx.route("**/api/messages*", (r) =>
+        r.fulfill(json({ messages: MESSAGES })),
+      );
+      await ctx.route("**/api/workspaces/list", (r) =>
+        r.fulfill(json({ workspaces: [] })),
+      );
+      await ctx.route("**/api/requests*", (r) =>
+        r.fulfill(json({ requests: [] })),
+      );
+      await ctx.route("**/api/review/list*", (r) =>
+        r.fulfill(json({ reviews: [] })),
+      );
+      await ctx.route("**/api/tasks/inbox", (r) =>
+        r.fulfill(
+          json({
+            rows: [],
+            counts: {
+              decisionRequired: 0,
+              running: 0,
+              blocked: 0,
+              mergedToday: 0,
+            },
+            refreshedAt: "2026-05-29T12:00:00Z",
+          }),
+        ),
+      );
+      await ctx.route("**/api/tasks?*", (r) => r.fulfill(json({ tasks: [] })));
+      await ctx.route("**/api/usage", (r) =>
+        r.fulfill(
+          json({
+            total: {
+              input_tokens: 0,
+              output_tokens: 0,
+              cache_read_tokens: 0,
+              cache_creation_tokens: 0,
+              total_tokens: 0,
+              cost_usd: 0,
+              requests: 0,
+            },
+          }),
+        ),
+      );
+      await ctx.route("**/api/commands", (r) => r.fulfill(json([])));
+      await ctx.route("**/api/upgrade-check", (r) =>
+        r.fulfill(
+          json({
+            current: "0.83.5",
+            latest: "0.83.5",
+            upgrade_available: false,
+            is_dev_build: false,
+          }),
+        ),
+      );
+    },
+  });
+}
+
+const { browser, context, page, errors } = await launchBrowser({
+  viewport: { width: 1280, height: 850 },
+});
+
+async function capture(members, theme, name) {
+  // Park on a blank page first so the previous capture's React Query
+  // refetch timers are torn down before we swap routes — otherwise an
+  // in-flight poll hits an unrouted endpoint and logs a transient 502.
+  await page.goto("about:blank", { waitUntil: "load" });
+  await mountFeed(context, members);
+  await page.goto(`${DEFAULT_BASE}/#/channels/general`, { waitUntil: "load" });
+  await page.waitForSelector(".status-bar", { timeout: 15_000 });
+  await flipStore(page);
+  // Drive the real setTheme action (not setState) so data-theme is written and
+  // RootRoute's effect swaps in the matching /themes/<id>.css.
+  await page.evaluate(async (t) => {
+    const m = await import("/src/stores/app.ts");
+    m.useAppStore.getState().setTheme(t);
+  }, theme);
+  await page.waitForSelector(`html[data-theme="${theme}"]`, {
+    timeout: 10_000,
+  });
+  try {
+    await page.waitForSelector(".typing-message", { timeout: 10_000 });
+  } catch (err) {
+    console.error(await page.locator("body").innerText());
+    throw err;
+  }
+  // Let the phrase cycle land on a real Office verb (initial mount may show
+  // the first tick) and the dots settle into their wave.
+  await page.waitForTimeout(900);
+  const header = await page
+    .locator(".typing-message .message-author")
+    .innerText();
+  console.log(`[${name}] typing header → ${header}`);
+  await shotElement(page, ".conversation-chat", OUT, name);
+}
+
+await capture(MULTI, "noir-gold", "01-typing-multi-noir");
+await capture(SINGLE, "nex", "02-typing-feed-light");
+await capture(SINGLE, "nex-dark", "03-typing-feed-dark");
+
+// Transient resource blips (502s from poll requests racing a route swap
+// during capture) are a harness artifact, not a product error. Real page
+// errors (pageerror, uncaught) still fail the run.
+const realErrors = errors.filter((e) => !e.includes("Failed to load resource"));
+if (realErrors.length > 0) {
+  console.error(realErrors.join("\n"));
+  await browser.close();
+  process.exit(1);
+}
+
+console.log(`captured 3 screenshots to ${OUT}`);
+await browser.close();

--- a/web/e2e/screenshots/typing-loader.mjs
+++ b/web/e2e/screenshots/typing-loader.mjs
@@ -89,7 +89,7 @@ const json = (body) => ({
   body: JSON.stringify(body),
 });
 
-async function mountFeed(context, members) {
+async function mountFeed(members) {
   await installCommonMocks(context, {
     extra: async (ctx) => {
       await ctx.route("**/api/config", (r) => r.fulfill(json(CONFIG)));
@@ -174,7 +174,7 @@ async function capture(members, theme, name) {
   // refetch timers are torn down before we swap routes — otherwise an
   // in-flight poll hits an unrouted endpoint and logs a transient 502.
   await page.goto("about:blank", { waitUntil: "load" });
-  await mountFeed(context, members);
+  await mountFeed(members);
   await page.goto(`${DEFAULT_BASE}/#/channels/general`, { waitUntil: "load" });
   await page.waitForSelector(".status-bar", { timeout: 15_000 });
   await flipStore(page);
@@ -203,19 +203,32 @@ async function capture(members, theme, name) {
   await shotElement(page, ".conversation-chat", OUT, name);
 }
 
-await capture(MULTI, "noir-gold", "01-typing-multi-noir");
-await capture(SINGLE, "nex", "02-typing-feed-light");
-await capture(SINGLE, "nex-dark", "03-typing-feed-dark");
+// Track failure via a flag rather than process.exit() inside the try —
+// process.exit does not run finally, which would leak the browser. The
+// finally always closes it; we exit after.
+let failed = false;
+try {
+  await capture(MULTI, "noir-gold", "01-typing-multi-noir");
+  await capture(SINGLE, "nex", "02-typing-feed-light");
+  await capture(SINGLE, "nex-dark", "03-typing-feed-dark");
 
-// Transient resource blips (502s from poll requests racing a route swap
-// during capture) are a harness artifact, not a product error. Real page
-// errors (pageerror, uncaught) still fail the run.
-const realErrors = errors.filter((e) => !e.includes("Failed to load resource"));
-if (realErrors.length > 0) {
-  console.error(realErrors.join("\n"));
+  // Transient resource blips (502s from poll requests racing a route swap
+  // during capture) are a harness artifact, not a product error. Real page
+  // errors (pageerror, uncaught) still fail the run.
+  const realErrors = errors.filter(
+    (e) => !e.includes("Failed to load resource"),
+  );
+  if (realErrors.length > 0) {
+    console.error(realErrors.join("\n"));
+    failed = true;
+  } else {
+    console.log(`captured 3 screenshots to ${OUT}`);
+  }
+} catch (err) {
+  console.error(err);
+  failed = true;
+} finally {
   await browser.close();
-  process.exit(1);
 }
 
-console.log(`captured 3 screenshots to ${OUT}`);
-await browser.close();
+if (failed) process.exit(1);

--- a/web/src/components/messages/DMView.tsx
+++ b/web/src/components/messages/DMView.tsx
@@ -86,17 +86,24 @@ export function DMView({ agentSlug, channelSlug }: DMViewProps) {
               {messages.map((msg) => (
                 <MessageBubble key={msg.id} message={msg} />
               ))}
-            </div>
-          ) : lastMessage ? (
-            <div className="dm-chat-preview">
-              <MessageBubble message={lastMessage} />
+              {/* Inline at the foot of the scroll — the spot the agent's
+                  reply will land, so the loader is replaced in place. */}
+              <TypingIndicator />
             </div>
           ) : (
-            <div className="dm-chat-preview dm-chat-preview-empty">
-              No messages yet — start the conversation below.
-            </div>
+            <>
+              {lastMessage ? (
+                <div className="dm-chat-preview">
+                  <MessageBubble message={lastMessage} />
+                </div>
+              ) : (
+                <div className="dm-chat-preview dm-chat-preview-empty">
+                  No messages yet — start the conversation below.
+                </div>
+              )}
+              <TypingIndicator />
+            </>
           )}
-          <TypingIndicator />
           <InterviewBar />
           <Composer />
         </div>

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -5,7 +5,9 @@ import { useMessages } from "../../hooks/useMessages";
 import { formatDateLabel } from "../../lib/format";
 import { useChannelSlug } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
+import { ThinkingLoader } from "../ui/ThinkingLoader";
 import { MessageBubble } from "./MessageBubble";
+import { TypingIndicator } from "./TypingIndicator";
 
 function dateDayKey(ts: string): string {
   const d = new Date(ts);
@@ -70,8 +72,8 @@ export function MessageFeed() {
 
   if (isLoading && messages.length === 0) {
     return (
-      <div className="messages">
-        <span className="messages-loading-label">Loading messages...</span>
+      <div className="messages messages-loading">
+        <ThinkingLoader variant="block" label="Loading messages…" />
       </div>
     );
   }
@@ -99,6 +101,7 @@ export function MessageFeed() {
             Michael would be proud. Probably.
           </span>
         </div>
+        <TypingIndicator />
       </div>
     );
   }
@@ -253,6 +256,7 @@ export function MessageFeed() {
           </div>
         );
       })}
+      <TypingIndicator />
     </div>
   );
 }

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef } from "react";
 import type { Message } from "../../api/client";
 import { useMessages } from "../../hooks/useMessages";
 import { formatDateLabel } from "../../lib/format";
+import { OFFICE_LOADING_PHRASES } from "../../lib/officeLoadingPhrases";
 import { useChannelSlug } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
 import { ThinkingLoader } from "../ui/ThinkingLoader";
@@ -73,7 +74,11 @@ export function MessageFeed() {
   if (isLoading && messages.length === 0) {
     return (
       <div className="messages messages-loading">
-        <ThinkingLoader variant="block" label="Loading messages…" />
+        <ThinkingLoader
+          variant="block"
+          label="Loading messages…"
+          phrases={OFFICE_LOADING_PHRASES}
+        />
       </div>
     );
   }

--- a/web/src/components/messages/TypingIndicator.test.tsx
+++ b/web/src/components/messages/TypingIndicator.test.tsx
@@ -50,7 +50,13 @@ describe("<TypingIndicator>", () => {
 
     render(<TypingIndicator />);
 
-    expect(screen.getByText("CEO is typing...")).toBeInTheDocument();
+    // The bubble shows the author heading + an italic verb, and carries an
+    // accessible "is typing" label for screen readers.
+    expect(screen.getByText("CEO")).toBeInTheDocument();
+    expect(screen.getByText("is typing")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /CEO is typing/ }),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/PM/)).not.toBeInTheDocument();
   });
 
@@ -71,7 +77,10 @@ describe("<TypingIndicator>", () => {
 
     render(<TypingIndicator />);
 
-    expect(screen.getByText("PM is typing...")).toBeInTheDocument();
+    expect(screen.getByText("PM")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", { name: /PM is typing/ }),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/CEO/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/messages/TypingIndicator.tsx
+++ b/web/src/components/messages/TypingIndicator.tsx
@@ -1,6 +1,15 @@
 import { useChannelMembers, useOfficeMembers } from "../../hooks/useMembers";
 import { useCurrentRoute } from "../../routes/useCurrentRoute";
+import { PixelAvatar } from "../ui/PixelAvatar";
+import { ThinkingLoader } from "../ui/ThinkingLoader";
 
+/**
+ * TypingIndicator renders as an incoming message bubble pinned to the bottom
+ * of the feed — the exact spot the next message will land, à la Claude. When
+ * the real message arrives it replaces this placeholder in place, so the
+ * conversation reads as one continuous stream instead of a footer caption
+ * blinking on and off below the composer.
+ */
 export function TypingIndicator() {
   const route = useCurrentRoute();
   const currentChannel =
@@ -21,21 +30,39 @@ export function TypingIndicator() {
   if (active.length === 0) return null;
 
   const names = active.map((m) => m.name || m.slug);
-  const label =
+  const heading =
     names.length === 1
-      ? `${names[0]} is typing...`
+      ? names[0]
       : names.length <= 3
-        ? `${names.join(", ")} are typing...`
-        : `${names.length} agents are typing...`;
+        ? names.join(", ")
+        : `${names.length} agents`;
+  const verb = names.length === 1 ? "is typing" : "are typing";
+  const label = `${heading} ${verb}…`;
+
+  // Up to three stacked avatars echo who is composing; the bubble itself
+  // carries the live loader so the focus stays on the incoming message.
+  const avatarSlugs = active.slice(0, 3).map((m) => m.slug);
 
   return (
-    <div className="typing-indicator" style={{ padding: "0 20px 8px" }}>
-      <div className="typing-dots">
-        <span className="typing-dot" />
-        <span className="typing-dot" />
-        <span className="typing-dot" />
+    <div className="message typing-message" data-testid="typing-indicator">
+      <div className="message-avatar typing-message-avatar">
+        {avatarSlugs.map((slug, i) => (
+          <span
+            key={slug}
+            className="typing-avatar-stack-item"
+            style={{ zIndex: avatarSlugs.length - i }}
+          >
+            <PixelAvatar slug={slug} size={24} />
+          </span>
+        ))}
       </div>
-      <span>{label}</span>
+      <div className="message-content">
+        <div className="message-header">
+          <span className="message-author">{heading}</span>
+          <span className="typing-verb">{verb}</span>
+        </div>
+        <ThinkingLoader label={label} />
+      </div>
     </div>
   );
 }

--- a/web/src/components/messages/TypingIndicator.tsx
+++ b/web/src/components/messages/TypingIndicator.tsx
@@ -1,4 +1,5 @@
 import { useChannelMembers, useOfficeMembers } from "../../hooks/useMembers";
+import { OFFICE_LOADING_PHRASES } from "../../lib/officeLoadingPhrases";
 import { useCurrentRoute } from "../../routes/useCurrentRoute";
 import { PixelAvatar } from "../ui/PixelAvatar";
 import { ThinkingLoader } from "../ui/ThinkingLoader";
@@ -61,7 +62,7 @@ export function TypingIndicator() {
           <span className="message-author">{heading}</span>
           <span className="typing-verb">{verb}</span>
         </div>
-        <ThinkingLoader label={label} />
+        <ThinkingLoader label={label} phrases={OFFICE_LOADING_PHRASES} />
       </div>
     </div>
   );

--- a/web/src/components/ui/ThinkingLoader.stories.tsx
+++ b/web/src/components/ui/ThinkingLoader.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { OFFICE_LOADING_PHRASES } from "../../lib/officeLoadingPhrases";
 import { ThinkingLoader } from "./ThinkingLoader";
 
 const meta: Meta<typeof ThinkingLoader> = {
@@ -30,8 +31,32 @@ export const InlineNoLabel: Story = {
   args: { variant: "inline" },
 };
 
+/** Cycling The Office gerunds inside the typing bubble, à la the Claude Code spinner. */
+export const InlineOfficePhrases: Story = {
+  args: {
+    variant: "inline",
+    label: "Dwight is typing…",
+    phrases: OFFICE_LOADING_PHRASES,
+  },
+};
+
 export const Block: Story = {
   args: { variant: "block", label: "Loading messages…" },
+  decorators: [
+    (Story) => (
+      <div style={{ height: 160, display: "flex" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const BlockOfficePhrases: Story = {
+  args: {
+    variant: "block",
+    label: "Loading messages…",
+    phrases: OFFICE_LOADING_PHRASES,
+  },
   decorators: [
     (Story) => (
       <div style={{ height: 160, display: "flex" }}>

--- a/web/src/components/ui/ThinkingLoader.stories.tsx
+++ b/web/src/components/ui/ThinkingLoader.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ThinkingLoader } from "./ThinkingLoader";
+
+const meta: Meta<typeof ThinkingLoader> = {
+  title: "Design System/Atoms/ThinkingLoader",
+  component: ThinkingLoader,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Claude-style 'a response is materializing here' loader. The inline " +
+          "variant is a soft incoming-bubble pill with wave dots and a " +
+          "traveling sheen; the block variant is a centered shimmer label for " +
+          "whole-surface loading. Both adapt to theme via color-mix and respect " +
+          "prefers-reduced-motion.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ThinkingLoader>;
+
+export const Inline: Story = {
+  args: { variant: "inline", label: "CEO is typing…" },
+};
+
+export const InlineNoLabel: Story = {
+  args: { variant: "inline" },
+};
+
+export const Block: Story = {
+  args: { variant: "block", label: "Loading messages…" },
+  decorators: [
+    (Story) => (
+      <div style={{ height: 160, display: "flex" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/web/src/components/ui/ThinkingLoader.tsx
+++ b/web/src/components/ui/ThinkingLoader.tsx
@@ -1,3 +1,7 @@
+import { useCyclingPhrase } from "../../hooks/useCyclingPhrase";
+
+const NO_PHRASES: readonly string[] = [];
+
 /**
  * ThinkingLoader — a Claude-style "a response is materializing here" loader.
  *
@@ -8,6 +12,11 @@
  *  - `block`: a centered shimmer label for whole-surface loading states
  *    (e.g. the message feed's first fetch).
  *
+ * Pass `phrases` to rotate a cycling word à la the Claude Code spinner — we use
+ * a The Office–themed set (see officeLoadingPhrases). The cycling text is
+ * decorative and aria-hidden; the stable `label` carries the accessible name so
+ * screen readers are not spammed on every tick.
+ *
  * Motion is theme-adaptive (color-mix off --text/--accent) and fully disabled
  * under prefers-reduced-motion via CSS.
  */
@@ -15,22 +24,44 @@ interface ThinkingLoaderProps {
   variant?: "inline" | "block";
   /** Accessible description announced to screen readers (e.g. "CEO is typing"). */
   label?: string;
+  /** Rotating decorative phrases (e.g. OFFICE_LOADING_PHRASES). */
+  phrases?: readonly string[];
   className?: string;
 }
 
 export function ThinkingLoader({
   variant = "inline",
   label,
+  phrases,
   className,
 }: ThinkingLoaderProps) {
+  const list = phrases ?? NO_PHRASES;
+  const phrase = useCyclingPhrase(list, 2400, list.length > 0);
+  const hasPhrase = list.length > 0 && phrase.length > 0;
+
   if (variant === "block") {
     return (
       <div
         className={`thinking-loader thinking-loader-block${className ? ` ${className}` : ""}`}
         role="status"
         aria-live="polite"
+        aria-label={label}
       >
-        <span className="thinking-shimmer-text">{label ?? "Loading…"}</span>
+        {hasPhrase ? (
+          <span
+            key={phrase}
+            className="thinking-shimmer-text thinking-shimmer-text-cycle"
+            aria-hidden="true"
+          >
+            {phrase}
+            <span className="thinking-ellipsis" aria-hidden="true">
+              …
+            </span>
+          </span>
+        ) : (
+          <span className="thinking-shimmer-text">{label ?? "Loading…"}</span>
+        )}
+        {label ? <span className="sr-only">{label}</span> : null}
       </div>
     );
   }
@@ -43,9 +74,17 @@ export function ThinkingLoader({
       aria-label={label}
     >
       <span className="thinking-bubble" aria-hidden="true">
-        <span className="thinking-dot" />
-        <span className="thinking-dot" />
-        <span className="thinking-dot" />
+        <span className="thinking-dots">
+          <span className="thinking-dot" />
+          <span className="thinking-dot" />
+          <span className="thinking-dot" />
+        </span>
+        {hasPhrase ? (
+          <span key={phrase} className="thinking-bubble-phrase">
+            {phrase}
+            <span className="thinking-ellipsis">…</span>
+          </span>
+        ) : null}
       </span>
       {label ? <span className="sr-only">{label}</span> : null}
     </div>

--- a/web/src/components/ui/ThinkingLoader.tsx
+++ b/web/src/components/ui/ThinkingLoader.tsx
@@ -1,0 +1,53 @@
+/**
+ * ThinkingLoader — a Claude-style "a response is materializing here" loader.
+ *
+ * Two variants:
+ *  - `inline` (default): three wave dots tucked inside a soft incoming-bubble
+ *    pill with a traveling sheen. Used by TypingIndicator so the loader sits
+ *    exactly where the next message bubble will render.
+ *  - `block`: a centered shimmer label for whole-surface loading states
+ *    (e.g. the message feed's first fetch).
+ *
+ * Motion is theme-adaptive (color-mix off --text/--accent) and fully disabled
+ * under prefers-reduced-motion via CSS.
+ */
+interface ThinkingLoaderProps {
+  variant?: "inline" | "block";
+  /** Accessible description announced to screen readers (e.g. "CEO is typing"). */
+  label?: string;
+  className?: string;
+}
+
+export function ThinkingLoader({
+  variant = "inline",
+  label,
+  className,
+}: ThinkingLoaderProps) {
+  if (variant === "block") {
+    return (
+      <div
+        className={`thinking-loader thinking-loader-block${className ? ` ${className}` : ""}`}
+        role="status"
+        aria-live="polite"
+      >
+        <span className="thinking-shimmer-text">{label ?? "Loading…"}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`thinking-loader thinking-loader-inline${className ? ` ${className}` : ""}`}
+      role="status"
+      aria-live="polite"
+      aria-label={label}
+    >
+      <span className="thinking-bubble" aria-hidden="true">
+        <span className="thinking-dot" />
+        <span className="thinking-dot" />
+        <span className="thinking-dot" />
+      </span>
+      {label ? <span className="sr-only">{label}</span> : null}
+    </div>
+  );
+}

--- a/web/src/components/ui/ThinkingLoader.tsx
+++ b/web/src/components/ui/ThinkingLoader.tsx
@@ -36,6 +36,11 @@ export function ThinkingLoader({
   className,
 }: ThinkingLoaderProps) {
   const list = phrases ?? NO_PHRASES;
+  // The visible content is decorative (aria-hidden / cycling), so the
+  // role="status" live region needs a stable accessible name of its own —
+  // otherwise it is announced unnamed. Fall back to "Loading…" when no
+  // caller label is supplied.
+  const statusLabel = label ?? "Loading…";
   const phrase = useCyclingPhrase(list, 2400, list.length > 0);
   const hasPhrase = list.length > 0 && phrase.length > 0;
 
@@ -45,7 +50,7 @@ export function ThinkingLoader({
         className={`thinking-loader thinking-loader-block${className ? ` ${className}` : ""}`}
         role="status"
         aria-live="polite"
-        aria-label={label}
+        aria-label={statusLabel}
       >
         {hasPhrase ? (
           <span
@@ -59,9 +64,11 @@ export function ThinkingLoader({
             </span>
           </span>
         ) : (
-          <span className="thinking-shimmer-text">{label ?? "Loading…"}</span>
+          <span className="thinking-shimmer-text" aria-hidden="true">
+            {statusLabel}
+          </span>
         )}
-        {label ? <span className="sr-only">{label}</span> : null}
+        <span className="sr-only">{statusLabel}</span>
       </div>
     );
   }
@@ -71,7 +78,7 @@ export function ThinkingLoader({
       className={`thinking-loader thinking-loader-inline${className ? ` ${className}` : ""}`}
       role="status"
       aria-live="polite"
-      aria-label={label}
+      aria-label={statusLabel}
     >
       <span className="thinking-bubble" aria-hidden="true">
         <span className="thinking-dots">
@@ -86,7 +93,7 @@ export function ThinkingLoader({
           </span>
         ) : null}
       </span>
-      {label ? <span className="sr-only">{label}</span> : null}
+      <span className="sr-only">{statusLabel}</span>
     </div>
   );
 }

--- a/web/src/hooks/useCyclingPhrase.ts
+++ b/web/src/hooks/useCyclingPhrase.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+
+import { randomOfficePhraseIndex } from "../lib/officeLoadingPhrases";
+
+/**
+ * Cycles through `phrases` on a fixed interval, returning the current entry.
+ * Pass a module-level constant array so its identity is stable across renders.
+ * Returns "" when there is nothing to show.
+ *
+ * The starting index is randomised so two loaders on screen do not march in
+ * lock step; the rotation order itself stays deterministic.
+ */
+export function useCyclingPhrase(
+  phrases: readonly string[],
+  intervalMs = 2400,
+  enabled = true,
+): string {
+  const [index, setIndex] = useState(() =>
+    phrases.length ? randomOfficePhraseIndex() % phrases.length : 0,
+  );
+  // Keep the timer reading the latest length without re-arming on every tick.
+  const lengthRef = useRef(phrases.length);
+  lengthRef.current = phrases.length;
+
+  useEffect(() => {
+    if (!enabled || phrases.length <= 1) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % Math.max(1, lengthRef.current));
+    }, intervalMs);
+    return () => clearInterval(id);
+  }, [enabled, phrases.length, intervalMs]);
+
+  if (!phrases.length) return "";
+  return phrases[index % phrases.length];
+}

--- a/web/src/hooks/useCyclingPhrase.ts
+++ b/web/src/hooks/useCyclingPhrase.ts
@@ -1,7 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 
-import { randomOfficePhraseIndex } from "../lib/officeLoadingPhrases";
-
 /**
  * Cycles through `phrases` on a fixed interval, returning the current entry.
  * Pass a module-level constant array so its identity is stable across renders.
@@ -16,7 +14,7 @@ export function useCyclingPhrase(
   enabled = true,
 ): string {
   const [index, setIndex] = useState(() =>
-    phrases.length ? randomOfficePhraseIndex() % phrases.length : 0,
+    phrases.length ? Math.floor(Math.random() * phrases.length) : 0,
   );
   // Keep the timer reading the latest length without re-arming on every tick.
   const lengthRef = useRef(phrases.length);

--- a/web/src/lib/officeLoadingPhrases.ts
+++ b/web/src/lib/officeLoadingPhrases.ts
@@ -1,0 +1,38 @@
+/**
+ * The Office–themed loading verbs, in the spirit of the Claude Code spinner's
+ * rotating gerunds ("Cogitating…", "Percolating…"). Kept short so they fit a
+ * typing bubble, and on-brand with the WUPHF voice (honest, funny, The Office).
+ *
+ * Microcopy follows the house style: no contractions, no em-dashes. They cycle
+ * decoratively, so they are aria-hidden behind a stable status label.
+ */
+export const OFFICE_LOADING_PHRASES = [
+  "Schruting",
+  "Beet farming",
+  "Booking the conference room",
+  "Parkouring",
+  "Negotiating",
+  "Calculating threat level midnight",
+  "Reticulating the Dundies",
+  "Folding paper",
+  "Convening the Finer Things Club",
+  "Declaring bankruptcy",
+  "Practicing improv",
+  "Managing the Scranton branch",
+  "Brewing pretzel-day mustard",
+  "Cc-ing the whole office",
+  "Setting the stapler in gelatin",
+  "Bears, beets, Battlestar",
+  "Channeling Prison Mike",
+  "Doodling on the whiteboard",
+  "Rehearsing the Dunder Mifflin jingle",
+  "Asking what she said",
+] as const;
+
+/**
+ * Pick a starting phrase. Randomised only so two bubbles on screen do not lock
+ * step; the cycle itself is deterministic.
+ */
+export function randomOfficePhraseIndex(): number {
+  return Math.floor(Math.random() * OFFICE_LOADING_PHRASES.length);
+}

--- a/web/src/lib/officeLoadingPhrases.ts
+++ b/web/src/lib/officeLoadingPhrases.ts
@@ -28,11 +28,3 @@ export const OFFICE_LOADING_PHRASES = [
   "Rehearsing the Dunder Mifflin jingle",
   "Asking what she said",
 ] as const;
-
-/**
- * Pick a starting phrase. Randomised only so two bubbles on screen do not lock
- * step; the cycle itself is deterministic.
- */
-export function randomOfficePhraseIndex(): number {
-  return Math.floor(Math.random() * OFFICE_LOADING_PHRASES.length);
-}

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -23,7 +23,6 @@ import { Composer } from "../components/messages/Composer";
 import { DMView } from "../components/messages/DMView";
 import { InterviewBar } from "../components/messages/InterviewBar";
 import { MessageFeed } from "../components/messages/MessageFeed";
-import { TypingIndicator } from "../components/messages/TypingIndicator";
 import { OnboardingChat } from "../components/onboarding/OnboardingChat";
 import { PrePickScreen } from "../components/onboarding/PrePickScreen";
 import { ConfirmHost } from "../components/ui/ConfirmDialog";
@@ -357,7 +356,6 @@ function ConversationView() {
     <div className="conversation-shell">
       <div className="conversation-chat">
         <MessageFeed />
-        <TypingIndicator />
         <InterviewBar />
         <Composer />
       </div>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -340,6 +340,15 @@ body {
     background-position: -50% 0;
   }
 }
+@keyframes thinking-ellipsis-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
 .animate-fade {
   animation: fadeIn 0.3s ease-out;
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -309,14 +309,35 @@ body {
     transform: rotate(360deg);
   }
 }
-@keyframes typing-bounce {
+/* ThinkingLoader — wave dots, traveling sheen, and shimmer text.
+   Used by the inline TypingIndicator bubble and the feed loading state. */
+@keyframes thinking-wave {
   0%,
-  80%,
+  60%,
   100% {
-    transform: scale(0);
+    transform: translateY(0) scale(1);
+    opacity: 0.35;
   }
-  40% {
-    transform: scale(1);
+  30% {
+    transform: translateY(-4px) scale(1.18);
+    opacity: 1;
+  }
+}
+@keyframes thinking-sheen {
+  0% {
+    transform: translateX(-100%);
+  }
+  60%,
+  100% {
+    transform: translateX(100%);
+  }
+}
+@keyframes thinking-text-shimmer {
+  0% {
+    background-position: 150% 0;
+  }
+  100% {
+    background-position: -50% 0;
   }
 }
 .animate-fade {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -651,11 +651,17 @@
 .thinking-loader-inline {
   display: inline-flex;
 }
+.thinking-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+}
 .thinking-bubble {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   /* Incoming-bubble silhouette: the top-left corner is pinched so it
      reads as anchored to the avatar above, like a real reply bubble. */
   padding: 11px 15px;
@@ -691,6 +697,50 @@
   animation-delay: 0.32s;
 }
 
+/* Cycling The Office phrase inside the bubble — a shimmering gerund in the
+   spirit of the Claude Code spinner. Re-keyed on every phrase so it fades in
+   fresh; the shimmer sweep runs continuously over the text. */
+.thinking-bubble-phrase {
+  position: relative;
+  font-size: var(--text-sm, 13px);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  background: linear-gradient(
+    100deg,
+    var(--text-tertiary) 20%,
+    var(--text-secondary) 45%,
+    var(--text) 50%,
+    var(--text-secondary) 55%,
+    var(--text-tertiary) 80%
+  );
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation:
+    thinking-phrase-in 0.32s ease-out,
+    thinking-text-shimmer 2.2s linear infinite;
+}
+.thinking-ellipsis {
+  /* Animated trailing dots so a static gerund still feels alive. */
+  -webkit-background-clip: initial;
+  background-clip: initial;
+  color: var(--text-tertiary);
+  animation: thinking-ellipsis-pulse 1.4s steps(1, end) infinite;
+}
+
+@keyframes thinking-phrase-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* Block variant — whole-surface loading (feed first fetch). A single
    line of shimmer text centered in the empty space. */
 .thinking-loader-block {
@@ -715,18 +765,30 @@
   color: transparent;
   animation: thinking-text-shimmer 1.8s linear infinite;
 }
+.thinking-shimmer-text-cycle {
+  animation:
+    thinking-phrase-in 0.32s ease-out,
+    thinking-text-shimmer 1.8s linear infinite;
+}
 
 @media (prefers-reduced-motion: reduce) {
   .thinking-bubble::after,
   .thinking-dot,
-  .thinking-shimmer-text {
+  .thinking-ellipsis,
+  .thinking-bubble-phrase,
+  .thinking-shimmer-text,
+  .thinking-shimmer-text-cycle {
     animation: none;
   }
-  .thinking-shimmer-text {
+  .thinking-shimmer-text,
+  .thinking-bubble-phrase {
     background: none;
     -webkit-background-clip: border-box;
     background-clip: border-box;
-    color: var(--text-tertiary);
+    color: var(--text-secondary);
+  }
+  .thinking-ellipsis {
+    opacity: 0.6;
   }
   .thinking-dot {
     /* Hold dots at a legible mid-state instead of frozen mid-wave. */

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -645,8 +645,17 @@
    it while the dots ride a soft wave. Disabled under reduced motion.
    ───────────────────────────────────────────────────────────── */
 .thinking-loader {
-  --tl-dot: color-mix(in srgb, var(--text-secondary) 70%, var(--accent) 30%);
-  --tl-sheen: color-mix(in srgb, var(--text) 9%, transparent);
+  /* Fallbacks for browsers without color-mix (CSS Color 5): a solid
+     secondary-tinted dot and an invisible sheen. Both degrade cleanly. */
+  --tl-dot: var(--text-secondary);
+  --tl-sheen: transparent;
+}
+/* Theme-adaptive blend where supported — overrides the fallbacks above. */
+@supports (color: color-mix(in srgb, red, blue)) {
+  .thinking-loader {
+    --tl-dot: color-mix(in srgb, var(--text-secondary) 70%, var(--accent) 30%);
+    --tl-sheen: color-mix(in srgb, var(--text) 9%, transparent);
+  }
 }
 .thinking-loader-inline {
   display: inline-flex;
@@ -1758,7 +1767,8 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   padding: 10px 14px;
   width: 100%;
   background: color-mix(in srgb, var(--accent, #2563eb) 6%, var(--bg-card));
-  border: 1px solid color-mix(in srgb, var(--accent, #2563eb) 40%, var(--border));
+  border: 1px solid
+    color-mix(in srgb, var(--accent, #2563eb) 40%, var(--border));
   border-radius: var(--radius-md, 8px);
   display: flex;
   align-items: center;
@@ -1767,7 +1777,9 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   cursor: pointer;
   font: inherit;
   color: inherit;
-  transition: background 120ms ease, border-color 120ms ease;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
 }
 .issue-created-card:hover:not([disabled]) {
   background: color-mix(in srgb, var(--accent, #2563eb) 12%, var(--bg-card));
@@ -1832,7 +1844,11 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
 }
 .issue-created-card--awaiting-approval {
   background: color-mix(in srgb, var(--amber-600, #d97706) 8%, var(--bg-card));
-  border-color: color-mix(in srgb, var(--amber-600, #d97706) 60%, var(--border));
+  border-color: color-mix(
+    in srgb,
+    var(--amber-600, #d97706) 60%,
+    var(--border)
+  );
 }
 .issue-created-card--awaiting-approval:hover:not([disabled]) {
   background: color-mix(in srgb, var(--amber-600, #d97706) 14%, var(--bg-card));
@@ -1864,7 +1880,9 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   cursor: pointer;
   font: inherit;
   color: inherit;
-  transition: background 120ms ease, border-color 120ms ease;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
 }
 .issue-lifecycle-card:hover:not([disabled]) {
   filter: brightness(1.04);
@@ -1941,7 +1959,11 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   color: var(--success, #16a34a);
 }
 .issue-lifecycle-card--stop {
-  background: color-mix(in srgb, var(--text-tertiary, #6b7280) 8%, var(--bg-card));
+  background: color-mix(
+    in srgb,
+    var(--text-tertiary, #6b7280) 8%,
+    var(--bg-card)
+  );
   border-color: var(--border);
 }
 .issue-lifecycle-card--stop .issue-lifecycle-card-eyebrow {
@@ -1949,7 +1971,11 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
 }
 .issue-lifecycle-card--warn {
   background: color-mix(in srgb, var(--amber-600, #d97706) 8%, var(--bg-card));
-  border-color: color-mix(in srgb, var(--amber-600, #d97706) 50%, var(--border));
+  border-color: color-mix(
+    in srgb,
+    var(--amber-600, #d97706) 50%,
+    var(--border)
+  );
 }
 .issue-lifecycle-card--warn .issue-lifecycle-card-eyebrow,
 .issue-lifecycle-card--warn .issue-lifecycle-card-cta {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -581,31 +581,157 @@
   margin-bottom: 4px;
 }
 
-/* ─── Typing indicator ─── */
-.typing-indicator {
+/* ─── Typing indicator ───────────────────────────────────────────
+   Renders as an incoming message bubble pinned to the foot of the
+   feed — the exact spot the next message lands. Reuses the .message
+   grid (avatar + content) so it lines up pixel-for-pixel with real
+   bubbles and is swapped in place when the reply arrives.
+   ───────────────────────────────────────────────────────────── */
+.typing-message {
+  /* Slightly longer settle than a real message so the placeholder
+     eases in rather than snapping. */
+  animation: fadeIn 0.4s ease-out;
+}
+.typing-message .message-content {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 20px;
-  font-size: var(--text-sm);
+  flex-direction: column;
+  gap: 4px;
+}
+.typing-verb {
+  font-size: var(--text-xs, 11px);
+  font-style: italic;
   color: var(--text-tertiary);
+  letter-spacing: 0.01em;
 }
-.typing-dots {
-  display: flex;
-  gap: 3px;
+
+/* Stacked avatars when more than one agent is composing. */
+.typing-message-avatar {
+  background: transparent;
+  padding: 0;
+  position: relative;
+  overflow: visible;
 }
-.typing-dot {
-  width: 4px;
-  height: 4px;
+.typing-avatar-stack-item {
+  display: inline-flex;
+  width: 36px;
+  height: 36px;
+  padding: 6px;
+  box-sizing: border-box;
+  border-radius: 8px;
+  background: var(--bg-warm);
+}
+.typing-avatar-stack-item:not(:first-child) {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateX(calc(9px * var(--stack-offset, 0)));
+  box-shadow: -2px 0 0 var(--bg-card);
+}
+.typing-avatar-stack-item:nth-child(2) {
+  --stack-offset: 1;
+}
+.typing-avatar-stack-item:nth-child(3) {
+  --stack-offset: 2;
+}
+.typing-avatar-stack-item .pixel-avatar {
+  width: 100%;
+  height: 100%;
+}
+
+/* ─── ThinkingLoader — Claude-style "response materializing" loader ──
+   Theme-adaptive sheen and dot tint via color-mix so it reads on
+   light, dark, and noir without per-theme overrides. The pill is the
+   placeholder for the incoming bubble; a sweep of light travels across
+   it while the dots ride a soft wave. Disabled under reduced motion.
+   ───────────────────────────────────────────────────────────── */
+.thinking-loader {
+  --tl-dot: color-mix(in srgb, var(--text-secondary) 70%, var(--accent) 30%);
+  --tl-sheen: color-mix(in srgb, var(--text) 9%, transparent);
+}
+.thinking-loader-inline {
+  display: inline-flex;
+}
+.thinking-bubble {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  /* Incoming-bubble silhouette: the top-left corner is pinched so it
+     reads as anchored to the avatar above, like a real reply bubble. */
+  padding: 11px 15px;
+  border-radius: var(--radius-sm) var(--radius-lg) var(--radius-lg)
+    var(--radius-lg);
+  background: var(--bg-warm);
+  overflow: hidden;
+}
+.thinking-bubble::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    100deg,
+    transparent 25%,
+    var(--tl-sheen) 50%,
+    transparent 75%
+  );
+  transform: translateX(-100%);
+  animation: thinking-sheen 1.8s ease-in-out infinite;
+}
+.thinking-dot {
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
-  background: var(--text-tertiary);
-  animation: typing-bounce 1.4s ease-in-out infinite;
+  background: var(--tl-dot);
+  animation: thinking-wave 1.3s ease-in-out infinite;
 }
-.typing-dot:nth-child(2) {
+.thinking-dot:nth-child(2) {
   animation-delay: 0.16s;
 }
-.typing-dot:nth-child(3) {
+.thinking-dot:nth-child(3) {
   animation-delay: 0.32s;
+}
+
+/* Block variant — whole-surface loading (feed first fetch). A single
+   line of shimmer text centered in the empty space. */
+.thinking-loader-block {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+}
+.thinking-shimmer-text {
+  font-size: var(--text-sm, 13px);
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  background: linear-gradient(
+    100deg,
+    var(--text-tertiary) 30%,
+    var(--text) 50%,
+    var(--text-tertiary) 70%
+  );
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: thinking-text-shimmer 1.8s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .thinking-bubble::after,
+  .thinking-dot,
+  .thinking-shimmer-text {
+    animation: none;
+  }
+  .thinking-shimmer-text {
+    background: none;
+    -webkit-background-clip: border-box;
+    background-clip: border-box;
+    color: var(--text-tertiary);
+  }
+  .thinking-dot {
+    /* Hold dots at a legible mid-state instead of frozen mid-wave. */
+    opacity: 0.6;
+  }
 }
 
 /* ─── Interview bar (inline above composer, mirrors TUI) ─── */
@@ -1773,6 +1899,11 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
 }
 
 /* ─── Feed loading / empty states ─── */
+.messages.messages-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .messages-loading-label {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## What

Moves the \"agent is typing\" indicator off the composer footer and into the **foot of the message feed**, rendered as an incoming message bubble — the exact spot the reply lands, à la Claude. When the real message arrives it is swapped in place, so the conversation reads as one continuous stream instead of a caption blinking on and off below the composer.

Adds a reusable **Claude-style `ThinkingLoader`** and rotates **The Office–themed loading verbs** through it (our own set, no new dependency), in the spirit of the Claude Code spinner.

## Changes

**Inline placement**
- `MessageFeed` mounts the indicator inside `.messages` (populated **and** empty states).
- `DMView` mounts it at the foot of the expanded chat scroll; collapsed drawer keeps it under the preview.
- Removed the standalone footer `<TypingIndicator />` from `ConversationView`.
- `TypingIndicator` now renders on the `.message` grid: stacked avatars of the composing agent(s), author heading, italic verb, and the loader. Accessible status label preserved.

**`ThinkingLoader` (`components/ui/`)**
- `inline`: wave dots in a soft incoming-bubble pill with a traveling sheen.
- `block`: centered shimmer text for the feed's first-fetch loading state.
- Theme-adaptive via `color-mix` (Nex Light, Nex Dark, Noir Gold), fully disabled under `prefers-reduced-motion`.
- Retired the orphaned `typing-bounce` keyframe.

**The Office loading verbs**
- `officeLoadingPhrases.ts`: 20 short, on-brand gerunds (house style: no contractions, no em-dashes) — \"Schruting…\", \"Parkouring…\", \"Cc-ing the whole office…\", \"Rehearsing the Dunder Mifflin jingle…\".
- `useCyclingPhrase`: interval cycler with a randomised start index and stable rotation order; reads length via a ref so the timer does not re-arm per tick.
- Cycling text is decorative (aria-hidden, re-keyed for a fade-in) behind the stable status label, so screen readers are not spammed on every tick. Animated ellipsis keeps a static gerund alive.

**Storybook**
- `ThinkingLoader.stories.tsx` with `Inline`, `InlineNoLabel`, `InlineOfficePhrases`, `Block`, `BlockOfficePhrases`.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bunx biome check` clean
- [x] `bash scripts/test-web.sh web/src/components/messages/` + OnboardingChat — 172 pass
- [x] `bun run build` green
- [x] Visually verified the loader + Office phrases across all three themes (Storybook)
- [ ] Screenshots to follow on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-typing-multi-noir](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1010/01-typing-multi-noir.png)

![02-typing-feed-light](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1010/02-typing-feed-light.png)

![03-typing-feed-dark](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1010/03-typing-feed-dark.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned typing indicator as an incoming-message placeholder with stacked avatars; now appears in expanded chats, collapsed previews, after empty-channel content, and in feed renders.
  * Added ThinkingLoader (inline/block), a cycling-phrase hook, and office-themed loading phrases; Storybook stories added.

* **Style**
  * New loader animations and CSS for thinking/typing visuals with prefers-reduced-motion support.

* **Tests**
  * Updated tests to assert accessible typing semantics.

* **Chores**
  * E2E screenshot runner captures themed typing-indicator states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nex-crm/wuphf/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->