### PR TITLE
feat(inbox): add Needs action filter as default tab

### DIFF
--- a/web/e2e/screenshots/inbox-needs-action.mjs
+++ b/web/e2e/screenshots/inbox-needs-action.mjs
@@ -1,0 +1,171 @@
+// Capture the Inbox surface before vs. after the Needs action filter
+// becomes the default tab. Mocks /api/inbox/items with three pending
+// rows + two terminal/back-with-author rows (rejected task, review in
+// changes_requested) so the All vs. Needs action delta is visible.
+//
+// Run via:
+//   web/e2e/screenshots/publish.sh inbox-needs-action <pr-number>
+
+import process from "node:process";
+
+import {
+  DEFAULT_BASE,
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const NOW = new Date().toISOString();
+
+const INBOX_ITEMS = {
+  items: [
+    {
+      kind: "task",
+      taskId: "task-2741",
+      title: "Refactor agent-rail event pill state",
+      agentSlug: "mira",
+      createdAt: NOW,
+      isUnread: true,
+      task: {
+        taskId: "task-2741",
+        title: "Refactor agent-rail event pill state",
+        assignment: "Decide whether to ship the refactor",
+        state: "decision",
+        severityCounts: {
+          critical: 0,
+          major: 1,
+          minor: 0,
+          nitpick: 0,
+          skipped: 0,
+        },
+        lastChangedAt: NOW,
+        elapsed: "10m",
+        isUrgent: false,
+      },
+    },
+    {
+      kind: "request",
+      requestId: "req-1",
+      title: "Bump Postgres to 17?",
+      agentSlug: "ada",
+      channel: "general",
+      createdAt: NOW,
+      request: {
+        kind: "approval",
+        question: "Bump Postgres to 17 in staging?",
+        from: "ada",
+        blocking: true,
+      },
+    },
+    {
+      kind: "review",
+      reviewId: "rev-1",
+      title: "Promote draft to wiki",
+      agentSlug: "wren",
+      createdAt: NOW,
+      review: {
+        state: "pending",
+        reviewerSlug: "owner",
+        sourceSlug: "wren",
+        targetPath: "wiki/draft.md",
+      },
+    },
+    {
+      kind: "task",
+      taskId: "task-rejected",
+      title: "Reject ship of the refactor",
+      agentSlug: "mira",
+      createdAt: NOW,
+      task: {
+        taskId: "task-rejected",
+        title: "Reject ship of the refactor",
+        assignment: "Triage the rejection",
+        state: "rejected",
+        severityCounts: {
+          critical: 0,
+          major: 0,
+          minor: 0,
+          nitpick: 0,
+          skipped: 0,
+        },
+        lastChangedAt: NOW,
+        elapsed: "1h",
+        isUrgent: false,
+      },
+    },
+    {
+      kind: "review",
+      reviewId: "rev-cr",
+      title: "Wiki promotion bounced back",
+      agentSlug: "wren",
+      createdAt: NOW,
+      review: {
+        state: "changes_requested",
+        reviewerSlug: "owner",
+        sourceSlug: "wren",
+        targetPath: "wiki/draft.md",
+      },
+    },
+  ],
+  counts: {
+    decisionRequired: 0,
+    running: 0,
+    blocked: 0,
+    approvedToday: 0,
+    unread: 1,
+  },
+  refreshedAt: NOW,
+};
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1280, height: 800 },
+});
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    await ctx.route("**/api/inbox/items*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(INBOX_ITEMS),
+      }),
+    );
+    await ctx.route("**/api/requests*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ requests: [] }),
+      }),
+    );
+    await ctx.route("**/api/reviews*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ reviews: [] }),
+      }),
+    );
+  },
+});
+
+await page.goto(`${DEFAULT_BASE}/inbox`, { waitUntil: "load" });
+await page.waitForSelector(".status-bar", { timeout: 15_000 });
+await flipStore(page);
+await page.waitForSelector(".inbox-filter-bar", { timeout: 10_000 });
+await page.waitForTimeout(400);
+
+// 1. Default tab — Needs action is selected, terminal/back-with-author
+// rows are hidden, three actionable rows remain.
+await shotElement(page, ".inbox-shell", OUT, "01-needs-action-default");
+
+// 2. Click All to reveal the full actionable list including rejected
+// + changes_requested rows.
+await page.locator('[data-testid="inbox-filter-all"]').click();
+await page.waitForTimeout(200);
+await shotElement(page, ".inbox-shell", OUT, "02-all-shows-everything");
+
+console.log(`captured 2 screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/components/lifecycle/DecisionInbox.test.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.test.tsx
@@ -160,6 +160,59 @@ describe("<DecisionInbox> (mail-style)", () => {
     expect(rows[1]).toHaveAttribute("data-unread", "false");
   });
 
+  it("defaults to the Needs action filter and excludes rejected + changes_requested rows", () => {
+    const rejectedTask: InboxItem = {
+      ...MIRA_TASK,
+      taskId: "task-rejected",
+      title: "Reject ship of the refactor",
+      task: { ...MIRA_TASK.task, taskId: "task-rejected", state: "rejected" },
+    };
+    const changesRequestedReview: InboxItem = {
+      ...WREN_REVIEW,
+      reviewId: "rev-cr",
+      title: "Wiki promotion bounced back",
+      review: { ...WREN_REVIEW.review, state: "changes_requested" },
+    };
+    render(
+      wrap(
+        <DecisionInbox
+          initialItems={[
+            MIRA_TASK,
+            ADA_REQUEST,
+            WREN_REVIEW,
+            rejectedTask,
+            changesRequestedReview,
+          ]}
+        />,
+      ),
+    );
+    // Needs action filter is selected by default and excludes both
+    // rejected tasks (terminal) and changes_requested reviews (back
+    // with the submitter).
+    expect(screen.getByTestId("inbox-filter-needs-action")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.queryByText(/Reject ship of the refactor/i)).toBeNull();
+    expect(screen.queryByText(/Wiki promotion bounced back/i)).toBeNull();
+    // The three actionable + still-pending rows remain visible.
+    expect(
+      screen.getAllByText(/Refactor agent-rail event pill state/i).length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Bump Postgres to 17/i).length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText(/Promote draft to wiki/i)).toBeInTheDocument();
+    // The All chip surfaces the terminal rows when clicked.
+    fireEvent.click(screen.getByTestId("inbox-filter-all"));
+    expect(
+      screen.getByText(/Reject ship of the refactor/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Wiki promotion bounced back/i),
+    ).toBeInTheDocument();
+  });
+
   it("Unread filter chip narrows the list to unread items only", () => {
     const unreadItem: InboxItem = { ...MIRA_TASK, isUnread: true };
     const readItem: InboxItem = {

--- a/web/src/components/lifecycle/DecisionInbox.tsx
+++ b/web/src/components/lifecycle/DecisionInbox.tsx
@@ -57,6 +57,7 @@ interface DecisionInboxProps {
 }
 
 type InboxFilter =
+  | "needs-action"
   | "all"
   | "unread"
   | "decisions"
@@ -65,6 +66,7 @@ type InboxFilter =
   | "rejected";
 
 const FILTER_ORDER: readonly InboxFilter[] = [
+  "needs-action",
   "all",
   "unread",
   "decisions",
@@ -74,6 +76,7 @@ const FILTER_ORDER: readonly InboxFilter[] = [
 ];
 
 const FILTER_LABEL: Record<InboxFilter, string> = {
+  "needs-action": "Needs action",
   all: "All",
   unread: "Unread",
   decisions: "Decisions",
@@ -155,10 +158,52 @@ function isInboxItemActionable(item: InboxItem): boolean {
   }
 }
 
+// "Needs action" is a strict subset of "actionable": items where the human
+// is the immediate blocker right now.
+//
+//   - Requests: every actionable request is awaiting the human's answer.
+//   - Reviews: pending / in-review only. changes_requested means the ball
+//     is back with the submitter, so it's actionable but not on the human.
+//   - Tasks: decision / review / changes_requested. rejected is a terminal
+//     state — the human already said no, so it's actionable for triage
+//     but doesn't need action.
+const NEEDS_ACTION_TASK_STATES = new Set([
+  "decision",
+  "review",
+  "changes_requested",
+]);
+
+function isReviewNeedsAction(item: InboxItem & { kind: "review" }): boolean {
+  const state = (item.review.state ?? "").toLowerCase();
+  return state === "pending" || state === "in-review" || state === "in_review";
+}
+
+function isTaskNeedsAction(item: InboxItem & { kind: "task" }): boolean {
+  const state = (item.task?.state ?? "").toLowerCase();
+  return NEEDS_ACTION_TASK_STATES.has(state);
+}
+
+function isInboxItemNeedsAction(item: InboxItem): boolean {
+  switch (item.kind) {
+    case "task":
+      return isTaskNeedsAction(item);
+    case "request":
+      return isRequestActionable(item);
+    case "review":
+      return isReviewNeedsAction(item);
+    default: {
+      const _exhaustive: never = item;
+      void _exhaustive;
+      return false;
+    }
+  }
+}
+
 function itemMatchesFilter(item: InboxItem, filter: InboxFilter): boolean {
   // The actionability invariant is pre-filtered upstream of this call —
   // every item reaching here is already known to need a human decision.
   if (filter === "all") return true;
+  if (filter === "needs-action") return isInboxItemNeedsAction(item);
   if (filter === "unread") return item.isUnread === true;
   if (filter === "requests") return item.kind === "request";
   if (filter === "reviews") return item.kind === "review";
@@ -195,7 +240,7 @@ export function DecisionInbox({
 }: DecisionInboxProps) {
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [showLoadingText, setShowLoadingText] = useState(false);
-  const [filter, setFilter] = useState<InboxFilter>("all");
+  const [filter, setFilter] = useState<InboxFilter>("needs-action");
 
   const seed: UnifiedInboxResponse | undefined = initialItems
     ? {
@@ -249,6 +294,7 @@ export function DecisionInbox({
   );
   const filterCounts = useMemo(() => {
     const counts: Record<InboxFilter, number> = {
+      "needs-action": 0,
       all: allItems.length,
       unread: 0,
       decisions: 0,


### PR DESCRIPTION
## Summary

The Inbox previously defaulted to **All**, which mixed every actionable item without distinguishing what was waiting on the human right now from what was just lingering (rejected tasks, reviews bounced back to the author). Operators read this as "everything is mixed".

This adds a **Needs action** tab at position 0 and makes it the default. It is a strict subset of the existing actionability filter:

- **Requests**: every blocking request (already 1:1 with awaiting human).
- **Reviews**: `pending` / `in-review` only — `changes_requested` means the submitter holds the ball, so it's actionable but not on the human.
- **Tasks**: `decision` / `review` / `changes_requested` — `rejected` is a terminal state that needs no action.

The existing **All** tab keeps its current semantics so terminal + back-with-author rows remain one click away.

Filter order is now: `[Needs action] [All] [Unread] [Decisions] [Requests] [Reviews] [Rejected]`.

## Test plan
- [x] `bash scripts/test-web.sh web/src/components/lifecycle/DecisionInbox.test.tsx` — 7 pass, 2 pre-existing skips
- [x] `bunx tsc --noEmit`
- [x] New test covers default tab, rejected/changes_requested exclusion, click-to-All reveal
- [ ] Manual: open the Inbox, confirm Needs action is the default and that flipping to All surfaces rejected / changes_requested rows
- [ ] Screenshots: see published `screenshots/pr-<n>` branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a "Needs action" Inbox filter that shows only items requiring immediate attention and is now the default view.
  * Filter counts updated to include the new "Needs action" bucket.

* **Tests**
  * Added unit tests validating default filter selection and visibility toggling between "Needs action" and "All".
  * Added an end-to-end screenshot script that captures the Inbox in the default "Needs action" state and after switching to "All".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->