### PR TITLE
[release] feat(chat): improve issue chat surface and dedupe redundant cards

### DIFF
--- a/internal/team/broker_issue_comment_card_test.go
+++ b/internal/team/broker_issue_comment_card_test.go
@@ -1,0 +1,548 @@
+package team
+
+// Coverage for the Issue chat-surface fixes that landed together:
+//
+//  1. Creating an Issue (task_type=issue) emits exactly one chat card
+//     of kind=issue_created and zero issue_lifecycle cards. Pre-fix,
+//     the legacy-derived LifecycleState read off the task at create
+//     time leaked into the apply call, which bypassed the prev=="" guard
+//     and emitted a redundant "<legacy> → drafting" lifecycle card on
+//     top of the proper issue_created card.
+//
+//  2. POST /tasks/{id}/comment broadcasts an instructional brief in
+//     Content (telling the woken agent to reply via team_task comment
+//     and NOT change lifecycle state) instead of the raw comment body.
+//     The comment text itself flows through the structured Payload so
+//     the FE IssueCommentCard can render it, but the agent loop reads
+//     Content. Without the brief, woken agents historically interpreted
+//     the comment text as a chat directive and started executing the
+//     work, even on un-approved Issues.
+//
+//  3. Issue chat cards (created / lifecycle / comment) carry ReplyTo =
+//     task.ThreadID so they fold into the originating thread instead
+//     of seeding new top-level messages that visually float above
+//     subsequent chat replies.
+//
+//  4. Multi-step lifecycle transitions on a single user action (e.g.
+//     Drafting→Approved→Running on Approve & Start) coalesce so the
+//     channel only shows ONE card representing the final state.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCreateIssueEmitsOnlyOneCardKind(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	body, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Ship the Inbox needs-action filter",
+		"details":    "Add a new default tab in the Decision Inbox.",
+		"created_by": "ceo",
+		"owner":      "builder",
+		"channel":    "general",
+		"task_type":  "issue",
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("task post failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("unexpected status %d: %s", resp.StatusCode, raw)
+	}
+	var result struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode task response: %v", err)
+	}
+	taskID := strings.TrimSpace(result.Task.ID)
+	if taskID == "" {
+		t.Fatalf("missing task id in response")
+	}
+
+	var (
+		createdCards   int
+		lifecycleCards int
+	)
+	b.mu.Lock()
+	for _, msg := range b.messages {
+		if msg.SourceTaskID != taskID {
+			continue
+		}
+		switch msg.Kind {
+		case "issue_created":
+			createdCards++
+		case "issue_lifecycle":
+			lifecycleCards++
+		}
+	}
+	b.mu.Unlock()
+
+	if createdCards != 1 {
+		t.Fatalf("expected exactly one issue_created card, got %d", createdCards)
+	}
+	if lifecycleCards != 0 {
+		t.Fatalf("expected zero issue_lifecycle cards at create time, got %d", lifecycleCards)
+	}
+}
+
+func TestPostIssueCommentBroadcastsInstructionalBrief(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	// Create the parent Issue first so the comment endpoint resolves.
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Pick a Postgres major version",
+		"details":    "Need to align with platform before staging cutover.",
+		"created_by": "ceo",
+		"owner":      "builder",
+		"channel":    "general",
+		"task_type":  "issue",
+	})
+	createReq, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+b.Token())
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+	if createResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(createResp.Body)
+		createResp.Body.Close()
+		t.Fatalf("unexpected create status %d: %s", createResp.StatusCode, raw)
+	}
+	var createResult struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&createResult); err != nil {
+		createResp.Body.Close()
+		t.Fatalf("decode create response: %v", err)
+	}
+	createResp.Body.Close()
+	taskID := strings.TrimSpace(createResult.Task.ID)
+
+	commentText := "Should we go with PG16 or wait for 17 GA?"
+	commentBody, _ := json.Marshal(map[string]string{"body": commentText})
+	commentReq, _ := http.NewRequest(
+		http.MethodPost,
+		base+"/tasks/"+taskID+"/comment",
+		bytes.NewReader(commentBody),
+	)
+	commentReq.Header.Set("Authorization", "Bearer "+b.Token())
+	commentReq.Header.Set("Content-Type", "application/json")
+	commentResp, err := http.DefaultClient.Do(commentReq)
+	if err != nil {
+		t.Fatalf("post comment: %v", err)
+	}
+	defer commentResp.Body.Close()
+	if commentResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(commentResp.Body)
+		t.Fatalf("unexpected comment status %d: %s", commentResp.StatusCode, raw)
+	}
+
+	var commentMsg *channelMessage
+	b.mu.Lock()
+	for i := range b.messages {
+		msg := &b.messages[i]
+		if msg.SourceTaskID == taskID && msg.Kind == "issue_comment" {
+			commentMsg = msg
+			break
+		}
+	}
+	b.mu.Unlock()
+
+	if commentMsg == nil {
+		t.Fatalf("expected an issue_comment chat message for task %s", taskID)
+	}
+
+	// The broadcast must come from "system" so the FE can route it
+	// through the IssueCommentCard rather than rendering as a human
+	// chat bubble.
+	if commentMsg.From != "system" {
+		t.Fatalf("expected From=system on issue_comment broadcast, got %q", commentMsg.From)
+	}
+
+	// Content is the agent-facing brief. It MUST tell the agent to
+	// reply via team_task action=comment and MUST forbid changing
+	// the Issue's lifecycle state. It MUST NOT inline the full
+	// comment body (that's what tripped agents into executing
+	// pre-fix — the body looked like a chat directive).
+	content := commentMsg.Content
+	if !strings.Contains(content, "team_task action=comment") {
+		t.Fatalf("expected Content to instruct team_task action=comment, got %q", content)
+	}
+	if !strings.Contains(content, "Do NOT change") {
+		t.Fatalf("expected Content to forbid lifecycle change, got %q", content)
+	}
+	if strings.Contains(content, commentText) {
+		t.Fatalf("expected Content to omit raw comment body, got %q", content)
+	}
+
+	// The structured payload carries the body for the FE card.
+	if len(commentMsg.Payload) == 0 {
+		t.Fatalf("expected non-empty Payload on issue_comment broadcast")
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(commentMsg.Payload, &payload); err != nil {
+		t.Fatalf("decode Payload: %v", err)
+	}
+	if payload["task_id"] != taskID {
+		t.Fatalf("payload.task_id mismatch: got %q want %q", payload["task_id"], taskID)
+	}
+	if payload["excerpt"] != commentText {
+		t.Fatalf("payload.excerpt mismatch: got %q want %q", payload["excerpt"], commentText)
+	}
+	if payload["lifecycle_state"] == "" {
+		t.Fatalf("expected payload.lifecycle_state to be populated, got empty")
+	}
+
+	// CEO must be in the tagged list so an untagged comment still
+	// wakes the channel leader. Owner should also be tagged.
+	taggedSet := map[string]bool{}
+	for _, slug := range commentMsg.Tagged {
+		taggedSet[slug] = true
+	}
+	if !taggedSet["ceo"] {
+		t.Fatalf("expected ceo to be tagged, got %v", commentMsg.Tagged)
+	}
+	if !taggedSet["builder"] {
+		t.Fatalf("expected owner (builder) to be tagged, got %v", commentMsg.Tagged)
+	}
+}
+
+// TestIssueCardsReplyInOriginatingThread verifies that the three Issue
+// chat cards (created / lifecycle / comment) all set ReplyTo to the
+// originating thread id stored on the task. Pre-fix, cards seeded
+// their own top-level chat slot, which left subsequent chat replies
+// appearing visually below them as if the card were "newer".
+func TestIssueCardsReplyInOriginatingThread(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	const threadRoot = "msg-thread-root-1"
+
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Wire ReplyTo on Issue cards",
+		"details":    "Cards should fold into the originating thread.",
+		"created_by": "ceo",
+		"owner":      "builder",
+		"channel":    "general",
+		"task_type":  "issue",
+		"thread_id":  threadRoot,
+	})
+	createReq, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+b.Token())
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if createResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(createResp.Body)
+		createResp.Body.Close()
+		t.Fatalf("unexpected create status %d: %s", createResp.StatusCode, raw)
+	}
+	var createResult struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&createResult); err != nil {
+		createResp.Body.Close()
+		t.Fatalf("decode create: %v", err)
+	}
+	createResp.Body.Close()
+	taskID := strings.TrimSpace(createResult.Task.ID)
+
+	// Comment to emit an issue_comment card.
+	commentBody, _ := json.Marshal(map[string]string{"body": "Quick question on scope."})
+	commentReq, _ := http.NewRequest(
+		http.MethodPost,
+		base+"/tasks/"+taskID+"/comment",
+		bytes.NewReader(commentBody),
+	)
+	commentReq.Header.Set("Authorization", "Bearer "+b.Token())
+	commentReq.Header.Set("Content-Type", "application/json")
+	commentResp, err := http.DefaultClient.Do(commentReq)
+	if err != nil {
+		t.Fatalf("comment: %v", err)
+	}
+	commentResp.Body.Close()
+
+	// Force a lifecycle transition (Drafting → Review) to emit an
+	// issue_lifecycle card. transitionLifecycleLocked is the public
+	// chokepoint and only requires the lock to be held by the caller.
+	b.mu.Lock()
+	_, lerr := b.transitionLifecycleLocked(taskID, LifecycleStateReview, "test-trigger")
+	b.mu.Unlock()
+	if lerr != nil {
+		t.Fatalf("lifecycle transition: %v", lerr)
+	}
+
+	wantKinds := map[string]bool{
+		"issue_created":   false,
+		"issue_comment":   false,
+		"issue_lifecycle": false,
+	}
+	b.mu.Lock()
+	for _, msg := range b.messages {
+		if strings.TrimSpace(msg.SourceTaskID) != taskID {
+			continue
+		}
+		if _, ok := wantKinds[msg.Kind]; !ok {
+			continue
+		}
+		if msg.ReplyTo != threadRoot {
+			b.mu.Unlock()
+			t.Fatalf(
+				"kind=%s ReplyTo mismatch: got %q want %q",
+				msg.Kind, msg.ReplyTo, threadRoot,
+			)
+		}
+		wantKinds[msg.Kind] = true
+	}
+	b.mu.Unlock()
+	for kind, seen := range wantKinds {
+		if !seen {
+			t.Fatalf("expected to see a %s card for task %s, missing", kind, taskID)
+		}
+	}
+}
+
+// TestLifecycleCardsCoalesceWithinShortWindow verifies that two
+// lifecycle transitions firing within the coalesce window leave only
+// the most recent card in the channel. Mirrors the user-visible burst
+// of Drafting→Approved→Running on a single Approve & Start click.
+func TestLifecycleCardsCoalesceWithinShortWindow(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Coalesce lifecycle bursts",
+		"details":    "Drive two transitions to verify dedup.",
+		"created_by": "ceo",
+		"owner":      "builder",
+		"channel":    "general",
+		"task_type":  "issue",
+	})
+	createReq, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", "Bearer "+b.Token())
+	createReq.Header.Set("Content-Type", "application/json")
+	createResp, err := http.DefaultClient.Do(createReq)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if createResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(createResp.Body)
+		createResp.Body.Close()
+		t.Fatalf("unexpected create status %d: %s", createResp.StatusCode, raw)
+	}
+	var createResult struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.NewDecoder(createResp.Body).Decode(&createResult); err != nil {
+		createResp.Body.Close()
+		t.Fatalf("decode create: %v", err)
+	}
+	createResp.Body.Close()
+	taskID := strings.TrimSpace(createResult.Task.ID)
+
+	// Two transitions back-to-back. Both will emit lifecycle cards.
+	// Coalesce should leave only one card (the most recent kind).
+	b.mu.Lock()
+	if _, err := b.transitionLifecycleLocked(taskID, LifecycleStateApproved, "approve"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("transition to approved: %v", err)
+	}
+	if _, err := b.transitionLifecycleLocked(taskID, LifecycleStateRunning, "start"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("transition to running: %v", err)
+	}
+	b.mu.Unlock()
+
+	var (
+		lifecycleCards []channelMessage
+	)
+	b.mu.Lock()
+	for _, msg := range b.messages {
+		if strings.TrimSpace(msg.SourceTaskID) != taskID {
+			continue
+		}
+		if msg.Kind != "issue_lifecycle" {
+			continue
+		}
+		lifecycleCards = append(lifecycleCards, msg)
+	}
+	b.mu.Unlock()
+
+	if len(lifecycleCards) != 1 {
+		t.Fatalf(
+			"expected exactly 1 issue_lifecycle card after coalesce, got %d (%v)",
+			len(lifecycleCards), lifecycleCards,
+		)
+	}
+	// The surviving card must represent the LATEST transition.
+	var payload map[string]string
+	if err := json.Unmarshal(lifecycleCards[0].Payload, &payload); err != nil {
+		t.Fatalf("decode lifecycle payload: %v", err)
+	}
+	if payload["to_state"] != string(LifecycleStateRunning) {
+		t.Fatalf("expected to_state=running on surviving card, got %q", payload["to_state"])
+	}
+}
+
+// TestLifecycleCardsDoNotCoalesceAcrossTasks ensures the dedup window
+// is per-task — a transition on task A must not drop a recent card
+// for an unrelated task B in the same channel.
+func TestLifecycleCardsDoNotCoalesceAcrossTasks(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	mkTask := func(title string) string {
+		body, _ := json.Marshal(map[string]any{
+			"action":     "create",
+			"title":      title,
+			"details":    "n/a",
+			"created_by": "ceo",
+			"owner":      "builder",
+			"channel":    "general",
+			"task_type":  "issue",
+		})
+		req, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("create %q: %v", title, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected create status %d: %s", resp.StatusCode, raw)
+		}
+		var result struct {
+			Task teamTask `json:"task"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode %q: %v", title, err)
+		}
+		return strings.TrimSpace(result.Task.ID)
+	}
+
+	taskA := mkTask("Task A")
+	taskB := mkTask("Task B")
+
+	b.mu.Lock()
+	if _, err := b.transitionLifecycleLocked(taskA, LifecycleStateApproved, "approve"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("A→approved: %v", err)
+	}
+	if _, err := b.transitionLifecycleLocked(taskB, LifecycleStateApproved, "approve"); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("B→approved: %v", err)
+	}
+	b.mu.Unlock()
+
+	countA := 0
+	countB := 0
+	b.mu.Lock()
+	for _, msg := range b.messages {
+		if msg.Kind != "issue_lifecycle" {
+			continue
+		}
+		switch strings.TrimSpace(msg.SourceTaskID) {
+		case taskA:
+			countA++
+		case taskB:
+			countB++
+		}
+	}
+	b.mu.Unlock()
+
+	if countA != 1 || countB != 1 {
+		t.Fatalf(
+			"expected one lifecycle card per task (A=%d, B=%d)",
+			countA, countB,
+		)
+	}
+}
+
+// TestCoalesceWindowDoesNotRemoveOlderCards verifies that cards older
+// than the coalesce window stay put. Without this, a freshly emitted
+// transition would silently swallow a card from minutes earlier and
+// destroy chat history.
+func TestCoalesceWindowDoesNotRemoveOlderCards(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Inject a synthetic "old" card directly via appendMessageLocked
+	// so we control its timestamp.
+	oldTimestamp := time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339)
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:           fmt.Sprintf("msg-%d", b.counter),
+		From:         "system",
+		Channel:      "general",
+		Kind:         "issue_lifecycle",
+		Title:        "Old card",
+		Content:      "Old lifecycle event",
+		Timestamp:    oldTimestamp,
+		SourceTaskID: "task-old",
+	})
+
+	removed := b.coalesceRecentLifecycleCardLocked("task-old", 10*time.Second)
+	if removed != 0 {
+		t.Fatalf("expected coalesce to skip cards older than the window, removed=%d", removed)
+	}
+}

--- a/internal/team/broker_issue_comment_card_test.go
+++ b/internal/team/broker_issue_comment_card_test.go
@@ -168,18 +168,22 @@ func TestPostIssueCommentBroadcastsInstructionalBrief(t *testing.T) {
 		t.Fatalf("unexpected comment status %d: %s", commentResp.StatusCode, raw)
 	}
 
-	var commentMsg *channelMessage
+	var (
+		commentMsg channelMessage
+		found      bool
+	)
 	b.mu.Lock()
 	for i := range b.messages {
 		msg := &b.messages[i]
 		if msg.SourceTaskID == taskID && msg.Kind == "issue_comment" {
-			commentMsg = msg
+			commentMsg = *msg
+			found = true
 			break
 		}
 	}
 	b.mu.Unlock()
 
-	if commentMsg == nil {
+	if !found {
 		t.Fatalf("expected an issue_comment chat message for task %s", taskID)
 	}
 

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -473,6 +473,12 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			// this restore, the block silently disappears when the
 			// human clicks Approve & Start.
 			depBlocked := b.tasks[len(b.tasks)-1].blocked
+			// Blank the legacy-derived LifecycleState before applying
+			// Drafting so the prev=="" guard in applyLifecycleStateLocked
+			// suppresses the (otherwise) redundant issue_lifecycle chat
+			// card on Issue creation — postIssueCreatedCardLocked below
+			// is the one card we want for the create event.
+			b.tasks[len(b.tasks)-1].LifecycleState = ""
 			_ = b.applyLifecycleStateLocked(&b.tasks[len(b.tasks)-1], LifecycleStateDrafting)
 			if depBlocked {
 				b.tasks[len(b.tasks)-1].blocked = true

--- a/internal/team/broker_tasks_notifications.go
+++ b/internal/team/broker_tasks_notifications.go
@@ -353,14 +353,20 @@ func (b *Broker) postIssueCreatedCardLocked(actor string, task *teamTask) {
 	}
 	b.counter++
 	b.appendMessageLocked(channelMessage{
-		ID:           fmt.Sprintf("msg-%d", b.counter),
-		From:         "system",
-		Channel:      taskChannel,
-		Kind:         "issue_created",
-		Title:        title,
-		Content:      fmt.Sprintf("Issue created: %s — %s", task.ID, title),
-		Tagged:       dedupeReassignTags([]string{"ceo", strings.TrimSpace(task.Owner), actor}),
-		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   taskChannel,
+		Kind:      "issue_created",
+		Title:     title,
+		Content:   fmt.Sprintf("Issue created: %s — %s", task.ID, title),
+		Tagged:    dedupeReassignTags([]string{"ceo", strings.TrimSpace(task.Owner), actor}),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		// ReplyTo folds the card into the originating chat thread so
+		// subsequent messages in that thread appear after the card
+		// rather than the card visually floating "above" newer chat
+		// activity in its own top-level slot. task.ThreadID is set at
+		// create time from the agent's MCP call.
+		ReplyTo:      strings.TrimSpace(task.ThreadID),
 		SourceTaskID: task.ID,
 		Payload:      raw,
 	})
@@ -379,6 +385,16 @@ func (b *Broker) postIssueCreatedCardLocked(actor string, task *teamTask) {
 // "no one is listening" comment. Tag dedupe + ordering follows the
 // existing dedupeReassignTags helper.
 //
+// Content shape (load-bearing): the broker emits an instructional brief
+// the woken agent reads — "reply via team_task action=comment, do NOT
+// change lifecycle state" — INSTEAD of the raw comment body. Without
+// this hint, agents historically interpreted the comment text as a
+// chat directive and started executing work on un-approved Issues
+// rather than answering the comment thread. The full body still lives
+// on the packet feedback log (AppendPacketFeedbackLocked, called by
+// the handler before this) and in the structured Payload below so the
+// FE card can show the excerpt.
+//
 // Must be called while b.mu is held for write.
 func (b *Broker) postIssueCommentBroadcastLocked(actor string, task *teamTask, body string) {
 	if task == nil {
@@ -396,12 +412,14 @@ func (b *Broker) postIssueCommentBroadcastLocked(actor string, task *teamTask, b
 	if title == "" {
 		title = task.ID
 	}
+	owner := strings.TrimSpace(task.Owner)
+	lifecycleState := string(task.LifecycleState)
 
 	// Build the tagged list. Always include CEO + the Issue owner so
 	// they see clarifications even when no one @-mentioned them. Add
 	// any @slug parsed from the body so multi-agent threads work.
 	tagged := []string{"ceo"}
-	if owner := strings.TrimSpace(task.Owner); owner != "" {
+	if owner != "" {
 		tagged = append(tagged, owner)
 	}
 	tagged = append(tagged, parseAtMentions(body)...)
@@ -412,17 +430,57 @@ func (b *Broker) postIssueCommentBroadcastLocked(actor string, task *teamTask, b
 		excerpt = strings.TrimSpace(excerpt[:500]) + "…"
 	}
 
+	payload := map[string]string{
+		"task_id":         task.ID,
+		"title":           title,
+		"owner":           owner,
+		"channel":         taskChannel,
+		"lifecycle_state": lifecycleState,
+		"author":          actor,
+		"excerpt":         excerpt,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	// Instructional brief the woken agent reads. Tells them WHERE to
+	// reply (the Issue's comment thread, not chat) and explicitly
+	// forbids lifecycle changes from this signal alone. The actual
+	// comment text is structured under Payload + on the packet, so
+	// the agent can fetch it deliberately when ready to reply.
+	stateHint := ""
+	if lifecycleState != "" {
+		stateHint = fmt.Sprintf(" (state: %s)", lifecycleState)
+	}
+	authorLabel := actor
+	if authorLabel == "" {
+		authorLabel = "Someone"
+	}
+	content := fmt.Sprintf(
+		"@%s commented on Issue %s%s — %s.\n"+
+			"Reply via team_task action=comment on this Issue. "+
+			"Do NOT change its lifecycle state from this comment alone.",
+		authorLabel,
+		task.ID,
+		stateHint,
+		title,
+	)
+
 	b.counter++
 	b.appendMessageLocked(channelMessage{
-		ID:           fmt.Sprintf("msg-%d", b.counter),
-		From:         actor,
-		Channel:      taskChannel,
-		Kind:         "issue_comment",
-		Title:        title,
-		Content:      fmt.Sprintf("Comment on %s — %s\n\n%s", task.ID, title, excerpt),
-		Tagged:       tagged,
-		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   taskChannel,
+		Kind:      "issue_comment",
+		Title:     title,
+		Content:   content,
+		Tagged:    tagged,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		// Fold into the Issue's originating thread (see postIssueCreatedCardLocked).
+		ReplyTo:      strings.TrimSpace(task.ThreadID),
 		SourceTaskID: task.ID,
+		Payload:      raw,
 	})
 }
 
@@ -525,19 +583,67 @@ func (b *Broker) postIssueLifecycleCardLocked(task *teamTask, from, to Lifecycle
 	tagged = dedupeReassignTags(tagged)
 
 	human := issueLifecycleHumanLine(transition, task.ID, title, owner)
+
+	// Coalesce: if a recent (<10s) issue_lifecycle card for the SAME
+	// task is still in the message log, drop it before appending the
+	// new card. This collapses multi-step flows that a user perceives
+	// as ONE action (e.g. Approve & Start fires Drafting→Approved
+	// AND Approved→Running back-to-back). Without this, the channel
+	// shows two lifecycle cards for one click. The 10s window is
+	// conservative — typical multi-step flows complete in under 1s.
+	b.coalesceRecentLifecycleCardLocked(task.ID, 10*time.Second)
+
 	b.counter++
 	b.appendMessageLocked(channelMessage{
-		ID:           fmt.Sprintf("msg-%d", b.counter),
-		From:         "system",
-		Channel:      taskChannel,
-		Kind:         "issue_lifecycle",
-		Title:        title,
-		Content:      human,
-		Tagged:       tagged,
-		Timestamp:    time.Now().UTC().Format(time.RFC3339),
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   taskChannel,
+		Kind:      "issue_lifecycle",
+		Title:     title,
+		Content:   human,
+		Tagged:    tagged,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		// Fold into the Issue's originating thread (see postIssueCreatedCardLocked).
+		ReplyTo:      strings.TrimSpace(task.ThreadID),
 		SourceTaskID: task.ID,
 		Payload:      raw,
 	})
+}
+
+// coalesceRecentLifecycleCardLocked removes any issue_lifecycle card
+// for taskID emitted within the last `window`. Used to collapse a
+// burst of lifecycle transitions (e.g. Drafting→Approved→Running on
+// a single Approve & Start click) into the most recent card, so the
+// channel does not stack redundant cards for what a user reads as one
+// action.
+//
+// Walks newest-first and stops at the first message older than the
+// window. Returns the number of cards removed.
+//
+// Caller must hold b.mu for write.
+func (b *Broker) coalesceRecentLifecycleCardLocked(taskID string, window time.Duration) int {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" || len(b.messages) == 0 {
+		return 0
+	}
+	cutoff := time.Now().UTC().Add(-window)
+	removed := 0
+	for i := len(b.messages) - 1; i >= 0; i-- {
+		msg := b.messages[i]
+		ts, err := time.Parse(time.RFC3339, msg.Timestamp)
+		if err == nil && ts.Before(cutoff) {
+			break
+		}
+		if msg.Kind != "issue_lifecycle" {
+			continue
+		}
+		if strings.TrimSpace(msg.SourceTaskID) != taskID {
+			continue
+		}
+		b.messages = append(b.messages[:i], b.messages[i+1:]...)
+		removed++
+	}
+	return removed
 }
 
 // issueLifecycleHumanLine renders the plain-text fallback that shows in

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -28,6 +28,10 @@ import {
   useArtifactSkeletonTrigger,
 } from "./ArtifactSkeleton";
 import {
+  IssueCommentCard,
+  parseIssueCommentPayload,
+} from "./cards/IssueCommentCard";
+import {
   IssueCreatedCard,
   parseIssueCreatedPayload,
 } from "./cards/IssueCreatedCard";
@@ -186,6 +190,16 @@ export function MessageBubble({
   if (message.kind === "issue_created") {
     const payload = parseIssueCreatedPayload(message.payload);
     return <IssueCreatedCard payload={payload} />;
+  }
+
+  // PR-style Issue comment card. Broker emits one per
+  // POST /tasks/{id}/comment with a brief instructional content the
+  // agent loop wakes on; the card body shows the actual comment as a
+  // distinct chat surface so the human's question on the Issue does
+  // not look like a free-form chat ask.
+  if (message.kind === "issue_comment") {
+    const payload = parseIssueCommentPayload(message.payload);
+    return <IssueCommentCard payload={payload} />;
   }
 
   // Lifecycle transition cards (Drafting→Running, →Done, etc). Broker

--- a/web/src/components/messages/cards/IssueCommentCard.tsx
+++ b/web/src/components/messages/cards/IssueCommentCard.tsx
@@ -1,0 +1,107 @@
+/**
+ * IssueCommentCard — chat card emitted when a human (or agent) leaves a
+ * PR-style comment on an Issue via POST /tasks/{id}/comment.
+ *
+ * The broker posts a system-authored message (Kind="issue_comment") into
+ * the channel where the Issue lives. Without a dedicated card, that
+ * message rendered as a plain markdown chat bubble — which made the
+ * comment text look like a direct chat ask, prompting the woken agent
+ * to act on it rather than reply to the thread on the Issue.
+ *
+ * This card surfaces the comment as a clear "this happened on Issue X"
+ * affordance with a Read & Reply CTA that routes to the Issue detail
+ * view (where the activity feed is the canonical reply thread).
+ *
+ * Security: payload fields are plain text only. The broker-side
+ * sanitizer is authoritative; this component is defense-in-depth.
+ */
+
+import { router } from "../../../lib/router";
+
+export interface IssueCommentPayload {
+  task_id?: string;
+  title?: string;
+  owner?: string;
+  channel?: string;
+  lifecycle_state?: string;
+  author?: string;
+  excerpt?: string;
+}
+
+function isStringField(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+export function parseIssueCommentPayload(raw: unknown): IssueCommentPayload {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  const r = raw as Record<string, unknown>;
+  const out: IssueCommentPayload = {};
+  if (isStringField(r.task_id)) out.task_id = r.task_id;
+  if (isStringField(r.title)) out.title = r.title;
+  if (isStringField(r.owner)) out.owner = r.owner;
+  if (isStringField(r.channel)) out.channel = r.channel;
+  if (isStringField(r.lifecycle_state))
+    out.lifecycle_state = r.lifecycle_state;
+  if (isStringField(r.author)) out.author = r.author;
+  if (isStringField(r.excerpt)) out.excerpt = r.excerpt;
+  return out;
+}
+
+export interface IssueCommentCardProps {
+  payload: IssueCommentPayload;
+}
+
+export function IssueCommentCard({ payload }: IssueCommentCardProps) {
+  const taskId = payload.task_id ?? "";
+  const title = payload.title ?? "(untitled issue)";
+  const author = payload.author ?? "Human";
+  const excerpt = payload.excerpt ?? "";
+  const state = payload.lifecycle_state;
+  const isDrafting = state === "drafting";
+
+  function openIssue() {
+    if (!taskId) return;
+    void router.navigate({
+      to: "/issues/$issueId",
+      params: { issueId: taskId },
+    });
+  }
+
+  const eyebrow = isDrafting
+    ? `Comment on Drafting issue · @${author}`
+    : `Comment on issue · @${author}`;
+
+  return (
+    <button
+      type="button"
+      className="issue-comment-card"
+      onClick={openIssue}
+      data-testid="issue-comment-card"
+      data-task-id={taskId}
+      data-lifecycle-state={state ?? ""}
+      aria-label={`Open issue ${taskId}: ${title}`}
+      disabled={!taskId}
+    >
+      <span className="issue-comment-card-icon" aria-hidden="true">
+        💬
+      </span>
+      <span className="issue-comment-card-body">
+        <span className="issue-comment-card-eyebrow">
+          {eyebrow}
+          {taskId ? (
+            <span className="issue-comment-card-id"> · {taskId}</span>
+          ) : null}
+        </span>
+        <span className="issue-comment-card-title">{title}</span>
+        {excerpt ? (
+          <span className="issue-comment-card-excerpt">{excerpt}</span>
+        ) : null}
+      </span>
+      <span className="issue-comment-card-cta" aria-hidden="true">
+        Read & Reply →
+      </span>
+    </button>
+  );
+}

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -1950,6 +1950,93 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   outline-color: var(--amber-600, #d97706);
 }
 
+/* ─── Issue comment card ──────────────────────────────────────────────
+   System-authored card emitted on POST /tasks/{id}/comment. Same
+   banner pattern as IssueCreatedCard so the comment is visually
+   distinct from a free-form chat bubble. */
+.issue-comment-card {
+  margin: 8px 0;
+  padding: 10px 14px;
+  width: 100%;
+  background: color-mix(in srgb, var(--accent, #2563eb) 4%, var(--bg-card));
+  border: 1px solid
+    color-mix(in srgb, var(--accent, #2563eb) 30%, var(--border));
+  border-radius: var(--radius-md, 8px);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease;
+}
+.issue-comment-card:hover:not([disabled]) {
+  background: color-mix(in srgb, var(--accent, #2563eb) 10%, var(--bg-card));
+  border-color: var(--accent, #2563eb);
+}
+.issue-comment-card:focus-visible {
+  outline: 2px solid var(--accent, #2563eb);
+  outline-offset: 2px;
+}
+.issue-comment-card[disabled] {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.issue-comment-card-icon {
+  font-size: 18px;
+  line-height: 1.2;
+  padding-top: 1px;
+}
+.issue-comment-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
+}
+.issue-comment-card-eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent, #2563eb);
+}
+.issue-comment-card-id {
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: none;
+  letter-spacing: 0;
+}
+.issue-comment-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.issue-comment-card-excerpt {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.issue-comment-card-cta {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent, #2563eb);
+  white-space: nowrap;
+  align-self: flex-start;
+  padding-top: 2px;
+}
+
 /* ─── Issue lifecycle transition card ───────────────────────────────── */
 .issue-lifecycle-card {
   margin: 8px 0;


### PR DESCRIPTION
## Summary

A bundle of fixes to the Issue chat surface so human comments don't get mistaken for chat directives, cards don't pile on top of each other for one logical action, and cards live inside the thread they originated from.

**Reported symptoms (compiled across messages):**
- "I put a comment on the issue that ended up putting the comment directly in chat and then led to prompting the agent to respond already without issue being approved. The issue comment was also not responded to, instead work already started with that comment in chat."
- "Cards can be redundant. For example, there is one for lifecycle change and one when an issue is created, both pointing to the same thing. We could suppress the former in this case. We should check for such redundancies."
- "Cards above newer messages happens because they are not inside the message thread."

## Changes

### 1. `IssueCommentCard` (new) + agent brief
- `web/src/components/messages/cards/IssueCommentCard.tsx` — banner card with author + Issue title + excerpt + `Read & Reply →` CTA routing to `/issues/$issueId`.
- `web/src/styles/messages.css` — `.issue-comment-card` styles mirroring the existing `.issue-created-card` pattern.
- `web/src/components/messages/MessageBubble.tsx` — route `kind="issue_comment"` through the new card.
- `internal/team/broker_tasks_notifications.go` — `postIssueCommentBroadcastLocked` now:
  - Sets `From="system"` (was: author slug)
  - Emits `Content` as an instructional brief: `"@<author> commented on Issue X (state: <state>) — <title>. Reply via team_task action=comment on this Issue. Do NOT change its lifecycle state from this comment alone."`
  - **Omits the raw comment body from Content.** Body flows through structured `Payload.excerpt` for the FE card and stays on the packet feedback log.

### 2. Suppress redundant `issue_lifecycle` card on Issue create
- `internal/team/broker_tasks_mutation_service.go` — blank `task.LifecycleState` before the create-time `applyLifecycleStateLocked(...Drafting)` so the `prev==""` guard fires. The proper `issue_created` card still emits via `postIssueCreatedCardLocked` immediately after.

### 3. Fold Issue cards into the originating chat thread
- `internal/team/broker_tasks_notifications.go` — all three Issue card emitters (`postIssueCreatedCardLocked` / `postIssueLifecycleCardLocked` / `postIssueCommentBroadcastLocked`) now set `ReplyTo = task.ThreadID`. The task's `ThreadID` is already populated at create time from the agent's MCP call.
- Effect: cards fold into the chat thread that triggered them, so subsequent chat replies appear inline with the card instead of in a different visual slot.

### 4. Coalesce multi-step lifecycle bursts
- `internal/team/broker_tasks_notifications.go` — new `coalesceRecentLifecycleCardLocked` removes any prior `issue_lifecycle` card for the same task emitted within the last 10s before appending a new one.
- Effect: Drafting→Approved→Running on a single Approve & Start click now shows ONE card representing the final state instead of two.
- Per-task scoped — bursts on different tasks do not interfere.

## Tests
`internal/team/broker_issue_comment_card_test.go` (new) covers:
- `TestCreateIssueEmitsOnlyOneCardKind` — create Issue → exactly 1 `issue_created`, 0 `issue_lifecycle`
- `TestPostIssueCommentBroadcastsInstructionalBrief` — comment → `From=system`, `Content` contains `team_task action=comment` + `Do NOT change`, omits raw body; `Payload` carries `task_id` + `excerpt` + `lifecycle_state`; `Tagged` includes `ceo` + owner
- `TestIssueCardsReplyInOriginatingThread` — all three card kinds carry `ReplyTo = task.ThreadID`
- `TestLifecycleCardsCoalesceWithinShortWindow` — two back-to-back transitions on one task → exactly 1 surviving card representing the latest state
- `TestLifecycleCardsDoNotCoalesceAcrossTasks` — bursts on different tasks each leave 1 card
- `TestCoalesceWindowDoesNotRemoveOlderCards` — cards older than 10s are untouched

## Test plan
- [x] `go test ./internal/team/` — all green (full suite)
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: rebuild + restart broker, comment on a Drafting Issue, confirm card renders + agent replies via comment thread (no lifecycle change)
- [ ] Manual: Approve & Start an Issue, confirm only ONE lifecycle card appears
- [ ] Manual: confirm Issue cards appear inside the originating chat thread

## Out of scope (deferred to follow-ups)
- **Cross-kind dedup**: e.g. when `action=reject` fires both `task_rejected` (plain message with rejection reason) and `issue_lifecycle` (structured card → rejected). The right fix is to add a structured `task_rejected` card and then drop the lifecycle card for that transition — a larger UI surface change than this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System "issue comment" cards now appear with an instructional brief, author, truncated excerpt, lifecycle hint, tagged recipients (includes leadership, owner, and parsed mentions), and a quick link into the issue; cards are tied to the originating thread.

* **Style**
  * New styles for the issue comment card (layout, hover/focus, excerpt clamping, CTA).

* **Bug Fixes**
  * New issues no longer emit redundant lifecycle cards on creation. Lifecycle transition cards coalesce within a short window (per-task, does not cross tasks, preserves older cards).

* **Tests**
  * Added broker-level tests covering comment cards, threading, recipient tagging, and lifecycle coalescing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->