### PR TITLE
[release] fix(routines): exclude one-shot watchdog jobs from the Routines list

### DIFF
--- a/web/e2e/screenshots/routines-filter.mjs
+++ b/web/e2e/screenshots/routines-filter.mjs
@@ -1,0 +1,180 @@
+// Capture the Routines list before/after the one-shot-watchdog filter fix.
+//
+// The broker enqueues one-shot task_follow_up / request_follow_up / recheck
+// jobs on every task-lifecycle transition. They ride the wire with
+// interval_minutes: 0, and the old classifier treated `typeof 0 === "number"`
+// as a cadence, so they flooded the Routines list. This spec seeds a realistic
+// /scheduler payload (2 real routines + 1 system cron + 4 one-shot watchdogs)
+// and shoots the Routines surface.
+//
+// Run order is controlled by the wrapper / driver, which sets the code state
+// (fixed vs reverted) and passes WUPHF_SHOT_LABEL so the before/after PNGs
+// land side by side in one orphan branch:
+//
+//   WUPHF_SHOT_LABEL=01-before  (classifier reverted to origin/main)
+//   WUPHF_SHOT_LABEL=02-after   (classifier fixed)
+
+import process from "node:process";
+
+import {
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+} from "./lib.mjs";
+
+const BASE = process.env.BASE_URL ?? "http://localhost:5273";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh / driver");
+  process.exit(2);
+}
+const LABEL = process.env.WUPHF_SHOT_LABEL ?? "routines";
+
+// Anchor everything to a fixed clock so the seeded next_run / due_at values
+// are stable across runs (no Date.now() drift between before and after).
+const NOW = Date.parse("2026-06-01T08:00:00Z");
+const inMin = (m) => new Date(NOW + m * 60_000).toISOString();
+const inHrs = (h) => new Date(NOW + h * 3_600_000).toISOString();
+
+// Two genuine recurring routines — these SHOULD always appear.
+const RECURRING = [
+  {
+    slug: "rita-standup-digest",
+    label: "Morning standup digest",
+    kind: "agent",
+    target_type: "agent",
+    target_id: "rita",
+    interval_minutes: 1440,
+    enabled: true,
+    next_run: inHrs(25),
+    last_run: inHrs(-23),
+    last_run_status: "ok",
+  },
+  {
+    slug: "workflow:weekly-pipeline-report",
+    label: "Weekly pipeline report",
+    kind: "workflow",
+    target_type: "workflow",
+    schedule_expr: "0 9 * * 1",
+    interval_minutes: 0,
+    enabled: true,
+    next_run: inHrs(73),
+    last_run: inHrs(-95),
+    last_run_status: "ok",
+  },
+];
+
+// One broker-managed system cron — hidden behind the "Show system" toggle in
+// both before and after (its visibility is governed by system_managed, not by
+// the bug).
+const SYSTEM = [
+  {
+    slug: "nex-insights",
+    label: "Nex insights",
+    kind: "cron",
+    interval_minutes: 30,
+    enabled: true,
+    system_managed: true,
+    next_run: inMin(30),
+    last_run: inMin(-30),
+    last_run_status: "ok",
+  },
+];
+
+// Four one-shot watchdog jobs the broker auto-enqueues per task transition.
+// interval_minutes: 0, no cron, not system-managed — pure plumbing. These are
+// the rows that cluttered the list before the fix.
+const WATCHDOGS = [
+  {
+    slug: "task_follow_up:general:task-101",
+    label: "Follow up on Draft the Q3 launch brief",
+    kind: "task_follow_up",
+    target_type: "task",
+    target_id: "task-101",
+    interval_minutes: 0,
+    due_at: inMin(45),
+    next_run: inMin(45),
+    status: "scheduled",
+  },
+  {
+    slug: "recheck:general:task:task-102",
+    label: "Recheck task Reconcile the billing export",
+    kind: "recheck",
+    target_type: "task",
+    target_id: "task-102",
+    interval_minutes: 0,
+    due_at: inHrs(2),
+    next_run: inHrs(2),
+    status: "scheduled",
+  },
+  {
+    slug: "task_follow_up:general:task-103",
+    label: "Follow up on Sync the CRM contacts",
+    kind: "task_follow_up",
+    target_type: "task",
+    target_id: "task-103",
+    interval_minutes: 0,
+    due_at: inMin(90),
+    next_run: inMin(90),
+    status: "scheduled",
+  },
+  {
+    slug: "request_follow_up:general:req-7",
+    label: "Follow up on access request from Priya",
+    kind: "request_follow_up",
+    target_type: "request",
+    target_id: "req-7",
+    interval_minutes: 0,
+    due_at: inHrs(3),
+    next_run: inHrs(3),
+    status: "scheduled",
+  },
+];
+
+const JOBS = [...RECURRING, ...SYSTEM, ...WATCHDOGS];
+
+const { browser, context, page } = await launchBrowser();
+
+await installCommonMocks(context, {
+  extra: async (ctx) => {
+    // GET /api/scheduler (+ optional ?due_only). The single `*` matches the
+    // query string but not the /system-specs or /{slug}/runs subpaths.
+    await ctx.route("**/api/scheduler", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ jobs: JOBS }),
+      }),
+    );
+    await ctx.route("**/api/scheduler?*", (r) =>
+      r.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ jobs: JOBS }),
+      }),
+    );
+  },
+});
+
+// Boot the Shell, flip the store connected, then route to Routines. The app
+// uses hash routing, so deep-linking is a location.hash change after boot
+// (the connect path lands on the CEO chat first). The list view + hidden
+// system routines are the defaults for a fresh browser context (empty
+// localStorage) — exactly what a user lands on.
+await page.goto(`${BASE}/`, { waitUntil: "load" });
+await page.waitForSelector(".status-bar", { timeout: 15_000 });
+await flipStore(page);
+await page.waitForTimeout(500);
+await page.evaluate(() => {
+  window.location.hash = "#/routines";
+});
+await page.waitForSelector('[data-testid="routines-app"]', { timeout: 15_000 });
+await page.waitForSelector('[data-testid="routines-title"]', {
+  timeout: 10_000,
+});
+// Let the 15s-interval query settle and the list paint.
+await page.waitForTimeout(700);
+
+await shotElement(page, '[data-testid="routines-app"]', OUT, `${LABEL}-routines-list`);
+
+await browser.close();

--- a/web/src/components/apps/RoutinesApp.test.tsx
+++ b/web/src/components/apps/RoutinesApp.test.tsx
@@ -34,6 +34,20 @@ const { MOCK_JOBS, MOCK_RUNS } = vi.hoisted(() => {
         last_run: new Date(now - 26 * 60 * 60_000).toISOString(),
         last_run_status: "failed",
       },
+      // One-shot watchdog job the broker enqueues per task transition. It
+      // arrives with interval_minutes: 0 (no omitempty on the wire), no cron,
+      // and is not system-managed — so it must never render as a routine.
+      {
+        slug: "task_follow_up:general:task-42",
+        label: "Follow up on Ship the launch post",
+        kind: "task_follow_up",
+        target_type: "task",
+        target_id: "task-42",
+        interval_minutes: 0,
+        due_at: new Date(now + 30 * 60_000).toISOString(),
+        next_run: new Date(now + 30 * 60_000).toISOString(),
+        status: "scheduled",
+      },
     ] as SchedulerJob[],
     MOCK_RUNS: [
       {
@@ -148,6 +162,31 @@ describe("RoutinesApp", () => {
     // System routine (nex-insights) is hidden behind the opt-in toggle.
     expect(
       screen.queryByTestId("routine-row-nex-insights"),
+    ).not.toBeInTheDocument();
+    // One-shot follow-up watchdog jobs are internal plumbing, not routines —
+    // they must never render here, even though they ship interval_minutes: 0.
+    expect(
+      screen.queryByTestId("routine-row-task_follow_up:general:task-42"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("never surfaces one-shot watchdog jobs, even with system routines shown", async () => {
+    render(wrap(<RoutinesApp />));
+    const toggle = await screen.findByTestId("routines-show-system-toggle");
+    const checkbox = toggle.querySelector(
+      "input[type=checkbox]",
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+    // System routine becomes visible…
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("routine-row-nex-insights"),
+      ).toBeInTheDocument(),
+    );
+    // …but the one-shot follow-up is filtered out entirely: it is neither
+    // system-managed nor recurring, so "Show system" must not reveal it.
+    expect(
+      screen.queryByTestId("routine-row-task_follow_up:general:task-42"),
     ).not.toBeInTheDocument();
   });
 

--- a/web/src/components/apps/schedulerJobClassification.test.ts
+++ b/web/src/components/apps/schedulerJobClassification.test.ts
@@ -3,28 +3,78 @@ import { describe, expect, it } from "vitest";
 import type { SchedulerJob } from "../../api/client";
 import { isCadenceSchedulerJob } from "./schedulerJobClassification";
 
+// Mirror the broker wire shape: schedulerJob serializes IntervalMinutes
+// WITHOUT omitempty, so EVERY job arrives with interval_minutes present —
+// one-shot watchdogs included (IntervalMinutes: 0 → "interval_minutes": 0).
+// The fixture defaults to 0 on purpose so these tests catch the
+// `typeof interval_minutes === "number"` regression that let one-shot
+// follow-ups leak into the Routines list.
 function job(overrides: Partial<SchedulerJob>): SchedulerJob {
   return {
     slug: "job",
     label: "Job",
     enabled: true,
+    interval_minutes: 0,
     ...overrides,
   };
 }
 
 describe("isCadenceSchedulerJob", () => {
-  it("classifies system, interval, and non-empty cron jobs as cadence jobs", () => {
+  it("classifies system, interval, override, and non-empty cron jobs as cadence jobs", () => {
     expect(isCadenceSchedulerJob(job({ system_managed: true }))).toBe(true);
     expect(isCadenceSchedulerJob(job({ interval_minutes: 5 }))).toBe(true);
+    expect(isCadenceSchedulerJob(job({ interval_override: 30 }))).toBe(true);
     expect(isCadenceSchedulerJob(job({ schedule_expr: "0 9 * * MON" }))).toBe(
       true,
     );
+    expect(isCadenceSchedulerJob(job({ cron: "*/15 * * * *" }))).toBe(true);
   });
 
-  it("keeps one-shot and blank-cron jobs in the timeline", () => {
+  it("keeps one-shot, zero-interval, and blank-cron jobs out of routines", () => {
     expect(isCadenceSchedulerJob(job({ due_at: "2026-05-02T12:00:00Z" }))).toBe(
       false,
     );
+    // interval_minutes: 0 is the broker default for one-shots — it is NOT a
+    // cadence even though the field is present on the wire.
+    expect(isCadenceSchedulerJob(job({ interval_minutes: 0 }))).toBe(false);
     expect(isCadenceSchedulerJob(job({ schedule_expr: "   " }))).toBe(false);
+  });
+
+  // Regression: the broker enqueues one-shot watchdog jobs per task-lifecycle
+  // transition. On the wire they carry interval_minutes: 0, no cron, and are
+  // not system-managed. They are internal plumbing, not user routines, and
+  // must never appear on the Routines surface.
+  it("excludes one-shot lifecycle watchdog jobs (follow-up / recheck)", () => {
+    const watchdogs: Array<Partial<SchedulerJob>> = [
+      {
+        kind: "task_follow_up",
+        target_type: "task",
+        slug: "task_follow_up:general:t-1",
+      },
+      {
+        kind: "request_follow_up",
+        target_type: "request",
+        slug: "request_follow_up:general:r-1",
+      },
+      {
+        kind: "recheck",
+        target_type: "task",
+        slug: "recheck:general:task:t-1",
+      },
+    ];
+    for (const w of watchdogs) {
+      expect(
+        isCadenceSchedulerJob(
+          job({
+            ...w,
+            target_id: "t-1",
+            interval_minutes: 0,
+            due_at: "2026-05-02T12:00:00Z",
+            next_run: "2026-05-02T12:00:00Z",
+            status: "scheduled",
+          }),
+        ),
+      ).toBe(false);
+    }
   });
 });

--- a/web/src/components/apps/schedulerJobClassification.ts
+++ b/web/src/components/apps/schedulerJobClassification.ts
@@ -1,15 +1,43 @@
 import type { SchedulerJob } from "../../api/client";
 
+/**
+ * True when a scheduler job is a recurring *routine* — a broker-managed
+ * cron, an interval cadence, or a cron expression — as opposed to a
+ * transient one-shot job.
+ *
+ * The broker enqueues one-shot watchdog jobs (`task_follow_up`,
+ * `request_follow_up`, `recheck`) on every task-lifecycle transition. Those
+ * are internal plumbing, not routines, and must stay out of the Routines
+ * surface.
+ *
+ * Wire-shape trap: `schedulerJob.IntervalMinutes` is serialized WITHOUT
+ * `omitempty`, so every job — one-shot watchdogs included — arrives with
+ * `interval_minutes: 0`. A bare `typeof job.interval_minutes === "number"`
+ * check is therefore true for ALL jobs, which let one-shot follow-ups flood
+ * the Routines list. A cadence requires a *positive* interval.
+ */
 export function isCadenceSchedulerJob(job: SchedulerJob): boolean {
   return (
     job.system_managed === true ||
-    typeof job.interval_minutes === "number" ||
+    hasPositiveInterval(job) ||
     hasCronExpression(job)
   );
 }
 
-function hasCronExpression(job: SchedulerJob): boolean {
+function hasPositiveInterval(job: SchedulerJob): boolean {
+  // interval_override (human cadence override) wins over interval_minutes,
+  // mirroring routineModel.routineSchedule and the broker's nextRoutineRun.
   return (
-    typeof job.schedule_expr === "string" && job.schedule_expr.trim().length > 0
+    isPositiveNumber(job.interval_override) ||
+    isPositiveNumber(job.interval_minutes)
   );
+}
+
+function isPositiveNumber(value: number | undefined): boolean {
+  return typeof value === "number" && value > 0;
+}
+
+function hasCronExpression(job: SchedulerJob): boolean {
+  const expr = job.schedule_expr ?? job.cron;
+  return typeof expr === "string" && expr.trim().length > 0;
 }


### PR DESCRIPTION
## What

The **Routines** surface was flooded with one-off "Follow up on …" and "Recheck task …" rows that no one created. Those are one-shot watchdog jobs the broker auto-enqueues on every task-lifecycle transition (`task_follow_up`, `request_follow_up`, `recheck`) — internal plumbing, not routines. `RoutinesApp` already *intended* to exclude them (its comment: *"One-shot follow-ups … would just be noise"*), but the classifier let every one through.

## Root cause — a wire-shape trap

`schedulerJob.IntervalMinutes` (Go) is serialized **without `omitempty`**, so every job hits the wire as `"interval_minutes": 0`, watchdogs included. `isCadenceSchedulerJob` gated on:

```ts
typeof job.interval_minutes === "number"   // typeof 0 === "number" → true for ALL jobs
```

So the "is this recurring?" check passed for everything, and each per-task watchdog rendered as a routine. The unit test missed it because its fixture **omitted** `interval_minutes` (`typeof undefined` is falsy), so it never exercised the real wire shape.

## Fix

A routine now requires a **positive** interval, a cron expression, or `system_managed`:

```ts
job.system_managed === true || hasPositiveInterval(job) || hasCronExpression(job)
```

One-shot watchdogs (interval `0`, no cron, not system-managed) are excluded entirely — they never appear, even under *Show system*, because they are transient plumbing, not crons.

Verified safe to filter all interval-0/no-cron/non-system jobs: the `ScheduleBuilder` composer can only emit recurring frequencies (interval / hourly / daily / weekdays / weekly / monthly), so a human can never create a legitimate one-shot routine that this would hide.

## Test plan

- `schedulerJobClassification.test.ts` — fixture now defaults `interval_minutes: 0` (mirrors the wire, so it actually guards the regression) + explicit follow-up / recheck cases. **green**
- `RoutinesApp.test.tsx` — added a one-shot follow-up to the fixture; asserts it never renders as a row, even with *Show system* on. **7 passed** (was 5)
- `SystemSchedulesPanel.test.tsx` (other classifier consumer) — **14 passed**, no collateral
- `bunx tsc --noEmit` clean · `bunx biome check` clean

## Notes

- `SystemSchedulesPanel.tsx` carries the same latent `typeof interval_minutes === "number"` pattern but is **dead code** (nothing mounts it since `CalendarApp` was deleted). This fix covers it for free; worth deleting separately.

## Screenshots

Routines list seeded with 2 recurring routines + 1 system cron + 4 one-shot watchdog jobs.

**Before** — four "One-shot / Unassigned" follow-up & recheck rows clutter the list (count: 6):

![before](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1016/01-before-routines-list.png)

**After** — only the two real recurring routines remain (count: 2); watchdogs are filtered out:

![after](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1016/02-after-routines-list.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - One-shot system watchdog/maintenance jobs that previously appeared in the Routines list are now correctly filtered out and hidden from the UI.

* **Tests**
  - Expanded unit/regression tests and a new end-to-end screenshot spec to ensure these one-shot jobs remain excluded and the Routines view renders consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->