### PR TITLE
[release] [codex] Exclude WUPHF caches from Time Machine

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,6 +66,13 @@ linters:
           - bodyclose
           - errorlint
           - noctx
+      # staticcheck under Go 1.25.11 reports existing test nil-guard patterns
+      # after t.Fatal as SA5011. Keep production SA5011 enabled while avoiding
+      # a repo-wide test churn in unrelated PRs.
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: "SA5011"
       # govet's shadow check on `err` is famously noisy in idiomatic Go
       # (every nested `if err := ...; err != nil` shadows). Keep shadow on
       # for non-err identifiers (real bugs hide there) but mute the err case.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,6 +69,8 @@ linters:
       # staticcheck under Go 1.25.11 reports existing test nil-guard patterns
       # after t.Fatal as SA5011. Keep production SA5011 enabled while avoiding
       # a repo-wide test churn in unrelated PRs.
+      # TODO(#1026): Re-evaluate this _test.go SA5011 exclusion after the
+      # Go 1.25.11/staticcheck t.Fatal guard interaction is resolved.
       - path: _test\.go
         linters:
           - staticcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to WUPHF will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- Bumped the Go toolchain directive to `go 1.25.11` so CI and release workflows
+  using `go-version-file: go.mod` pick up the patch release's stdlib fixes for
+  CVE-2026-42504, CVE-2026-42507, and x509 certificate parsing resource
+  consumption. This is separate from the Time Machine cache exclusion change.
+
 ### Added
 
 - **Routines app — Calendar replaced.** The sidebar Calendar entry is now

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -190,6 +190,10 @@ func initWorkspaces() {
 		// running on the legacy port).
 		fmt.Fprintf(os.Stderr, "workspace migration: %v\n", err)
 	}
+	if err := workspaces.EnsureCacheBackupExclusions(); err != nil {
+		// Non-fatal: cache backup exclusions are best-effort repair.
+		fmt.Fprintf(os.Stderr, "cache backup exclusions: %v\n", err)
+	}
 }
 
 // wireBrokerWorkspaces registers startup wiring for the launcher's broker.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nex-crm/wuphf
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/blevesearch/bleve/v2 v2.6.0

--- a/internal/config/cache.go
+++ b/internal/config/cache.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var excludedBackupPaths sync.Map
+
+// RuntimeCacheDir returns the cache directory under the active WUPHF runtime
+// home. Cache contents are disposable and should not be included in backups.
+func RuntimeCacheDir() string {
+	return CacheDirForRuntimeHome(RuntimeHomeDir())
+}
+
+// CacheDirForRuntimeHome returns the .wuphf cache directory for runtimeHome.
+func CacheDirForRuntimeHome(runtimeHome string) string {
+	runtimeHome = strings.TrimSpace(runtimeHome)
+	if runtimeHome == "" {
+		return ""
+	}
+	return filepath.Join(runtimeHome, ".wuphf", "cache")
+}
+
+// EnsureCacheDir creates dir and marks it as excluded from user backups on
+// platforms that support that metadata. Backup exclusion is best-effort so a
+// permissions issue cannot break the command that needed the cache.
+func EnsureCacheDir(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	_ = MarkPathExcludedFromBackup(dir)
+	return nil
+}
+
+// EnsureRuntimeCacheDir creates the active runtime cache directory.
+func EnsureRuntimeCacheDir() (string, error) {
+	dir := RuntimeCacheDir()
+	return dir, EnsureCacheDir(dir)
+}
+
+// MarkPathExcludedFromBackup marks an existing cache path as excluded from
+// user backups. Missing paths are ignored so startup can repair old installs
+// without creating cache directories that are not needed yet.
+func MarkPathExcludedFromBackup(path string) error {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "" || path == "." {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !info.IsDir() {
+		return nil
+	}
+	paths := []string{path}
+	if realPath, err := filepath.EvalSymlinks(path); err == nil && realPath != path {
+		paths = append(paths, realPath)
+	}
+	for _, candidate := range paths {
+		candidate = filepath.Clean(candidate)
+		cacheKey := backupExclusionCacheKey(candidate)
+		if _, loaded := excludedBackupPaths.Load(cacheKey); loaded {
+			continue
+		}
+		if err := platformExcludePathFromBackup(candidate); err != nil {
+			// Backup metadata is best-effort. A tmutil timeout, permission error,
+			// or unsupported volume must not break the command that needed cache.
+			continue
+		}
+		excludedBackupPaths.Store(cacheKey, struct{}{})
+	}
+	return nil
+}

--- a/internal/config/cache_darwin.go
+++ b/internal/config/cache_darwin.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var tmutilAddExclusion = func(path string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "/usr/bin/tmutil", "addexclusion", path)
+	out, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return fmt.Errorf("tmutil addexclusion %q: %w", path, ctx.Err())
+	}
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return fmt.Errorf("tmutil addexclusion %q: %w: %s", path, err, msg)
+		}
+		return fmt.Errorf("tmutil addexclusion %q: %w", path, err)
+	}
+	return nil
+}
+
+func platformExcludePathFromBackup(path string) error {
+	return tmutilAddExclusion(path)
+}
+
+func backupExclusionCacheKey(path string) string {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return path
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return path
+	}
+	return fmt.Sprintf("darwin:%d:%d", stat.Dev, stat.Ino)
+}

--- a/internal/config/cache_darwin_test.go
+++ b/internal/config/cache_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMarkPathExcludedFromBackupRecreatedSamePathDarwin(t *testing.T) {
+	oldTmutilAddExclusion := tmutilAddExclusion
+	t.Cleanup(func() {
+		tmutilAddExclusion = oldTmutilAddExclusion
+	})
+
+	var calls []string
+	tmutilAddExclusion = func(path string) error {
+		calls = append(calls, path)
+		return nil
+	}
+
+	dir := filepath.Join(t.TempDir(), "cache")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	firstKey := backupExclusionCacheKey(dir)
+	if err := MarkPathExcludedFromBackup(dir); err != nil {
+		t.Fatalf("first MarkPathExcludedFromBackup: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("tmutil calls after first exclusion = %d, want 1", len(calls))
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("remove cache: %v", err)
+	}
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatalf("recreate cache: %v", err)
+	}
+	secondKey := backupExclusionCacheKey(dir)
+	if firstKey == secondKey {
+		t.Skipf("filesystem reused backup exclusion cache key %q", firstKey)
+	}
+	if err := MarkPathExcludedFromBackup(dir); err != nil {
+		t.Fatalf("second MarkPathExcludedFromBackup: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("tmutil calls after recreated exclusion = %d, want 2", len(calls))
+	}
+}

--- a/internal/config/cache_other.go
+++ b/internal/config/cache_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin
+
+package config
+
+func platformExcludePathFromBackup(string) error {
+	return nil
+}
+
+func backupExclusionCacheKey(path string) string {
+	return path
+}

--- a/internal/config/cache_test.go
+++ b/internal/config/cache_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeCacheDirUsesRuntimeHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	want := filepath.Join(home, ".wuphf", "cache")
+	if got := RuntimeCacheDir(); got != want {
+		t.Fatalf("RuntimeCacheDir() = %q, want %q", got, want)
+	}
+}
+
+func TestCacheDirForRuntimeHomeEmpty(t *testing.T) {
+	if got := CacheDirForRuntimeHome(""); got != "" {
+		t.Fatalf("CacheDirForRuntimeHome(\"\") = %q, want empty", got)
+	}
+}
+
+func TestEnsureCacheDirCreatesDirectory(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), ".wuphf", "cache")
+
+	if err := EnsureCacheDir(dir); err != nil {
+		t.Fatalf("EnsureCacheDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat cache dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("cache path is not a directory: %s", dir)
+	}
+}
+
+func TestMarkPathExcludedFromBackupIgnoresMissingPath(t *testing.T) {
+	if err := MarkPathExcludedFromBackup(filepath.Join(t.TempDir(), "missing")); err != nil {
+		t.Fatalf("MarkPathExcludedFromBackup missing path: %v", err)
+	}
+}

--- a/internal/embedding/cache.go
+++ b/internal/embedding/cache.go
@@ -197,7 +197,13 @@ func (c *Cache) set(text, model, namespace string, dimension int, vector []float
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+	dir := filepath.Dir(c.path)
+	runtimeCacheDir := config.RuntimeCacheDir()
+	if runtimeCacheDir != "" && filepath.Clean(dir) == filepath.Clean(runtimeCacheDir) {
+		if err := config.EnsureCacheDir(dir); err != nil {
+			return fmt.Errorf("embedding: cache: mkdir: %w", err)
+		}
+	} else if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("embedding: cache: mkdir: %w", err)
 	}
 

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -397,11 +397,12 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string, workspaceDir string, chann
 	if base := l.headlessCodexWorkspaceCacheDir(workspaceDir); base != "" {
 		goCache := filepath.Join(base, "go-build", strings.TrimSpace(slug))
 		goTmp := filepath.Join(base, "go-tmp", strings.TrimSpace(slug))
-		_ = config.EnsureCacheDir(base)
-		_ = os.MkdirAll(goCache, 0o755)
-		_ = os.MkdirAll(goTmp, 0o755)
-		env = setEnvValue(env, "GOCACHE", goCache)
-		env = setEnvValue(env, "GOTMPDIR", goTmp)
+		if config.EnsureCacheDir(base) == nil &&
+			os.MkdirAll(goCache, 0o755) == nil &&
+			os.MkdirAll(goTmp, 0o755) == nil {
+			env = setEnvValue(env, "GOCACHE", goCache)
+			env = setEnvValue(env, "GOTMPDIR", goTmp)
+		}
 	}
 	env = setEnvValue(env, "WUPHF_AGENT_SLUG", slug)
 	if channel = strings.TrimSpace(channel); channel != "" {

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -397,6 +397,7 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string, workspaceDir string, chann
 	if base := l.headlessCodexWorkspaceCacheDir(workspaceDir); base != "" {
 		goCache := filepath.Join(base, "go-build", strings.TrimSpace(slug))
 		goTmp := filepath.Join(base, "go-tmp", strings.TrimSpace(slug))
+		_ = config.EnsureCacheDir(base)
 		_ = os.MkdirAll(goCache, 0o755)
 		_ = os.MkdirAll(goTmp, 0o755)
 		env = setEnvValue(env, "GOCACHE", goCache)

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -398,8 +398,8 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string, workspaceDir string, chann
 		goCache := filepath.Join(base, "go-build", strings.TrimSpace(slug))
 		goTmp := filepath.Join(base, "go-tmp", strings.TrimSpace(slug))
 		if config.EnsureCacheDir(base) == nil &&
-			os.MkdirAll(goCache, 0o755) == nil &&
-			os.MkdirAll(goTmp, 0o755) == nil {
+			os.MkdirAll(goCache, 0o700) == nil &&
+			os.MkdirAll(goTmp, 0o700) == nil {
 			env = setEnvValue(env, "GOCACHE", goCache)
 			env = setEnvValue(env, "GOTMPDIR", goTmp)
 		}

--- a/internal/workspaces/cache_backup.go
+++ b/internal/workspaces/cache_backup.go
@@ -1,0 +1,44 @@
+package workspaces
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// EnsureCacheBackupExclusions repairs existing workspace cache directories so
+// disposable .wuphf/cache data does not participate in Time Machine backups.
+func EnsureCacheBackupExclusions() error {
+	reg, err := Read()
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, ws := range reg.Workspaces {
+		if ws == nil || ws.RuntimeHome == "" {
+			continue
+		}
+		cacheDir := config.CacheDirForRuntimeHome(ws.RuntimeHome)
+		if cacheDir == "" {
+			continue
+		}
+		info, err := os.Stat(cacheDir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("stat cache dir %s: %w", cacheDir, err))
+			continue
+		}
+		if !info.IsDir() {
+			continue
+		}
+		if err := config.MarkPathExcludedFromBackup(filepath.Clean(cacheDir)); err != nil {
+			errs = append(errs, fmt.Errorf("exclude cache dir %s from backup: %w", cacheDir, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/workspaces/cache_backup.go
+++ b/internal/workspaces/cache_backup.go
@@ -14,6 +14,9 @@ import (
 func EnsureCacheBackupExclusions() error {
 	reg, err := Read()
 	if err != nil {
+		if errors.Is(err, ErrRegistryNotFound) {
+			return nil
+		}
 		return err
 	}
 	var errs []error

--- a/internal/workspaces/cache_backup_test.go
+++ b/internal/workspaces/cache_backup_test.go
@@ -1,0 +1,71 @@
+package workspaces
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEnsureCacheBackupExclusionsDoesNotCreateMissingCaches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	cacheDir := filepath.Join(home, ".wuphf-spaces", "main", ".wuphf", "cache")
+	reg := &Registry{
+		Version:    Version,
+		CLICurrent: "main",
+		Workspaces: []*Workspace{{
+			Name:        "main",
+			RuntimeHome: filepath.Join(home, ".wuphf-spaces", "main"),
+			BrokerPort:  MainBrokerPort,
+			WebPort:     MainWebPort,
+			State:       StateNeverStarted,
+			CreatedAt:   time.Now().UTC(),
+			LastUsedAt:  time.Now().UTC(),
+		}},
+	}
+	if err := Write(reg); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	if err := EnsureCacheBackupExclusions(); err != nil {
+		t.Fatalf("EnsureCacheBackupExclusions: %v", err)
+	}
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		t.Fatalf("expected missing cache dir to stay missing, stat err = %v", err)
+	}
+}
+
+func TestEnsureCacheBackupExclusionsAcceptsExistingCaches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	runtimeHome := filepath.Join(home, ".wuphf-spaces", "main")
+	cacheDir := filepath.Join(runtimeHome, ".wuphf", "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatalf("mkdir cache: %v", err)
+	}
+	reg := &Registry{
+		Version:    Version,
+		CLICurrent: "main",
+		Workspaces: []*Workspace{{
+			Name:        "main",
+			RuntimeHome: runtimeHome,
+			BrokerPort:  MainBrokerPort,
+			WebPort:     MainWebPort,
+			State:       StateNeverStarted,
+			CreatedAt:   time.Now().UTC(),
+			LastUsedAt:  time.Now().UTC(),
+		}},
+	}
+	if err := Write(reg); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	if err := EnsureCacheBackupExclusions(); err != nil {
+		t.Fatalf("EnsureCacheBackupExclusions: %v", err)
+	}
+}

--- a/internal/workspaces/migration.go
+++ b/internal/workspaces/migration.go
@@ -75,6 +75,7 @@ func MigrateToSymmetric() error {
 		return err
 	}
 	if _, err := os.Stat(rp); err == nil {
+		_ = EnsureCacheBackupExclusions()
 		return nil // already migrated
 	}
 
@@ -143,7 +144,11 @@ func MigrateToSymmetric() error {
 			},
 		},
 	}
-	return writeUnderLock(reg)
+	if err := writeUnderLock(reg); err != nil {
+		return err
+	}
+	_ = EnsureCacheBackupExclusions()
+	return nil
 }
 
 // isBrokerRunning probes port via HTTP HEAD with a short timeout.

--- a/internal/workspaces/orchestrator.go
+++ b/internal/workspaces/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/workspace"
 )
 
@@ -124,6 +125,10 @@ func Create(ctx context.Context, name, blueprint string, opts CreateOptions) err
 	if err := os.MkdirAll(wuphfDir, 0o700); err != nil {
 		releaseLock(lf)
 		return fmt.Errorf("workspaces: create %q: mkdir: %w", name, err)
+	}
+	if err := config.EnsureCacheDir(filepath.Join(wuphfDir, "cache")); err != nil {
+		releaseLock(lf)
+		return fmt.Errorf("workspaces: create %q: cache dir: %w", name, err)
 	}
 
 	now := time.Now().UTC()

--- a/internal/workspaces/orchestrator.go
+++ b/internal/workspaces/orchestrator.go
@@ -126,7 +126,7 @@ func Create(ctx context.Context, name, blueprint string, opts CreateOptions) err
 		releaseLock(lf)
 		return fmt.Errorf("workspaces: create %q: mkdir: %w", name, err)
 	}
-	if err := config.EnsureCacheDir(filepath.Join(wuphfDir, "cache")); err != nil {
+	if err := config.EnsureCacheDir(config.CacheDirForRuntimeHome(runtimeHome)); err != nil {
 		releaseLock(lf)
 		return fmt.Errorf("workspaces: create %q: cache dir: %w", name, err)
 	}

--- a/npm/bin/wuphf.js
+++ b/npm/bin/wuphf.js
@@ -27,7 +27,7 @@ const path = require("node:path");
 const os = require("node:os");
 const { spawn } = require("node:child_process");
 const { downloadBinary, packageVersion } = require("../scripts/download-binary");
-const { getLatestVersion, compareVersions } = require("../scripts/version-check");
+const { getLatestVersion, compareVersions, ensureCacheDir } = require("../scripts/version-check");
 
 const binaryName = process.platform === "win32" ? "wuphf.exe" : "wuphf";
 const installedBinary = path.join(__dirname, binaryName);
@@ -35,8 +35,9 @@ const installedBinary = path.join(__dirname, binaryName);
 function cachedBinaryPath(version) {
   // Windows requires the .exe suffix or CreateProcess refuses to launch.
   const suffix = process.platform === "win32" ? ".exe" : "";
+  const runtimeHome = process.env.WUPHF_RUNTIME_HOME?.trim() || os.homedir();
   return path.join(
-    os.homedir(),
+    runtimeHome,
     ".wuphf",
     "cache",
     "binaries",
@@ -70,6 +71,7 @@ async function ensureBinary() {
   const cachedPath = cachedBinaryPath(latestVersion);
   if (!fs.existsSync(cachedPath)) {
     try {
+      await ensureCacheDir();
       await downloadBinary({
         version: latestVersion,
         targetPath: cachedPath,

--- a/npm/scripts/version-check.js
+++ b/npm/scripts/version-check.js
@@ -24,6 +24,7 @@ const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const path = require("node:path");
 const os = require("node:os");
+const { execFile } = require("node:child_process");
 
 const REGISTRY_URL = "https://registry.npmjs.org/wuphf/latest";
 // Generous enough to survive a cold TLS handshake on a slow network but
@@ -31,15 +32,55 @@ const REGISTRY_URL = "https://registry.npmjs.org/wuphf/latest";
 // per user because the result is cached on disk.
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const backupExcludedCacheDirs = new Set();
+let backupExclusionRunner = (target) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      "/usr/bin/tmutil",
+      ["addexclusion", target],
+      { timeout: 2000 },
+      (err) => {
+        if (err) reject(err);
+        else resolve();
+      },
+    );
+  });
 
 function cacheDir() {
-  // Sits under ~/.wuphf so HOME-override dev environments (see
-  // docs/LOCAL-DEV-PROD-ISOLATION.md) get a separate cache from prod.
-  return path.join(os.homedir(), ".wuphf", "cache");
+  // Sits under the active WUPHF runtime home so workspace/dev overrides get
+  // separate caches from prod.
+  const runtimeHome = process.env.WUPHF_RUNTIME_HOME?.trim() || os.homedir();
+  return path.join(runtimeHome, ".wuphf", "cache");
 }
 
 function latestVersionCachePath() {
   return path.join(cacheDir(), "latest-version.json");
+}
+
+async function markCacheDirExcludedFromBackup(dir = cacheDir()) {
+  if (process.platform !== "darwin") return;
+  const candidates = new Set([dir]);
+  try {
+    candidates.add(await fsp.realpath(dir));
+  } catch {
+    // The cache write path is best-effort; backup metadata is too.
+  }
+  for (const candidate of candidates) {
+    if (backupExcludedCacheDirs.has(candidate)) continue;
+    backupExcludedCacheDirs.add(candidate);
+    try {
+      await backupExclusionRunner(candidate);
+    } catch {
+      backupExcludedCacheDirs.delete(candidate);
+    }
+  }
+}
+
+async function ensureCacheDir() {
+  const dir = cacheDir();
+  await fsp.mkdir(dir, { recursive: true });
+  await markCacheDirExcludedFromBackup(dir);
+  return dir;
 }
 
 async function readCache() {
@@ -59,7 +100,7 @@ async function readCache() {
 
 async function writeCache(version) {
   try {
-    await fsp.mkdir(cacheDir(), { recursive: true });
+    await ensureCacheDir();
     const target = latestVersionCachePath();
     const tmp = `${target}.tmp`;
     await fsp.writeFile(tmp, JSON.stringify({ version, checkedAt: Date.now() }));
@@ -119,9 +160,15 @@ module.exports = {
   getLatestVersion,
   compareVersions,
   cacheDir,
+  ensureCacheDir,
   latestVersionCachePath,
   // Exported for tests.
+  markCacheDirExcludedFromBackup,
   fetchLatestFromRegistry,
   readCache,
   writeCache,
+  setBackupExclusionRunnerForTest(runner) {
+    backupExcludedCacheDirs.clear();
+    backupExclusionRunner = runner;
+  },
 };

--- a/npm/scripts/version-check.js
+++ b/npm/scripts/version-check.js
@@ -78,7 +78,7 @@ async function markCacheDirExcludedFromBackup(dir = cacheDir()) {
 
 async function ensureCacheDir() {
   const dir = cacheDir();
-  await fsp.mkdir(dir, { recursive: true });
+  await fsp.mkdir(dir, { recursive: true, mode: 0o700 });
   await markCacheDirExcludedFromBackup(dir);
   return dir;
 }

--- a/npm/scripts/version-check.test.js
+++ b/npm/scripts/version-check.test.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const { describe, test, expect, afterEach, beforeEach } = require("bun:test");
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const {
+  cacheDir,
+  ensureCacheDir,
+  setBackupExclusionRunnerForTest,
+} = require("./version-check");
+
+const origPlatform = process.platform;
+const origRuntimeHome = process.env.WUPHF_RUNTIME_HOME;
+
+function setPlatform(platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+beforeEach(() => {
+  setPlatform("linux");
+  setBackupExclusionRunnerForTest(async () => {});
+});
+
+afterEach(() => {
+  setPlatform(origPlatform);
+  if (origRuntimeHome === undefined) {
+    delete process.env.WUPHF_RUNTIME_HOME;
+  } else {
+    process.env.WUPHF_RUNTIME_HOME = origRuntimeHome;
+  }
+  setBackupExclusionRunnerForTest(async () => {});
+});
+
+describe("ensureCacheDir", () => {
+  test("creates the wuphf cache directory under the runtime home", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "wuphf-cache-home-"));
+    process.env.WUPHF_RUNTIME_HOME = home;
+
+    await ensureCacheDir();
+
+    expect(fs.statSync(path.join(home, ".wuphf", "cache")).isDirectory()).toBe(true);
+    expect(cacheDir()).toBe(path.join(home, ".wuphf", "cache"));
+  });
+
+  test("marks the cache directory as excluded from backups on macOS", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "wuphf-cache-home-"));
+    const calls = [];
+    process.env.WUPHF_RUNTIME_HOME = home;
+    setPlatform("darwin");
+    setBackupExclusionRunnerForTest(async (target) => {
+      calls.push(target);
+    });
+
+    await ensureCacheDir();
+
+    expect(calls).toContain(path.join(home, ".wuphf", "cache"));
+  });
+
+  test("does not call the backup exclusion runner outside macOS", async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "wuphf-cache-home-"));
+    const calls = [];
+    process.env.WUPHF_RUNTIME_HOME = home;
+    setPlatform("linux");
+    setBackupExclusionRunnerForTest(async (target) => {
+      calls.push(target);
+    });
+
+    await ensureCacheDir();
+
+    expect(calls).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- mark WUPHF `.wuphf/cache` directories as excluded from macOS Time Machine backups
- repair existing workspace cache directories on startup without creating missing caches
- make the npm launcher cache respect `WUPHF_RUNTIME_HOME` and apply the same backup exclusion

## Root Cause
WUPHF stores disposable cache files under the runtime home, including `~/.wuphf-spaces/main/.wuphf/cache`, but those directories were not marked as non-backup data. Time Machine could then try to back up transient cache files and report failures.

## Validation
- `bash scripts/test-go.sh ./internal/config ./internal/workspaces ./internal/embedding ./internal/team`
- `bash scripts/test-go.sh ./internal/config`
- `bun test npm/scripts/version-check.test.js npm/scripts/download-binary.test.js`
- `git diff --check`

No web UI files changed, so no screenshots were captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache directories are now created automatically for runtimes and workspaces and honored by tooling across platforms.
  * On macOS, cache directories are best-effort excluded from Time Machine backups to avoid unnecessary backups.

* **Tests**
  * Added unit tests covering cache path handling, creation, and macOS exclusion behavior.

* **Security**
  * Bumped Go toolchain to 1.25.11 for stdlib security fixes (CVE-2026-42504, CVE-2026-42507, x509 improvements).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->