### PR TITLE
feat(onboarding): capture founder email via PostHog (env-gated)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,16 @@ jobs:
 
       - name: Build React frontend
         working-directory: web
+        # Vite inlines import.meta.env.VITE_* into the bundle at build time, so
+        # the PostHog project key is baked into every published binary HERE,
+        # once, for the whole release. When POSTHOG_PROJECT_KEY is unset (forks,
+        # source builds), the value is empty and onboarding analytics stay
+        # dormant (see web/src/lib/analytics.ts getConfig). The phc_ project key
+        # is write-only and safe to ship in client code; the host falls back to
+        # us.i.posthog.com when POSTHOG_HOST is not set.
+        env:
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_PROJECT_KEY }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ vars.POSTHOG_HOST }}
         run: |
           bun install --frozen-lockfile
           bun run build

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -1138,8 +1138,14 @@ func applyFormAnswer(s *State, field string, value interface{}) error {
 		s.FormAnswers.OwnerRole = sanitizeStr(value)
 	case "owner_email":
 		// Founder email captured on the welcome step. PII, stored locally; the
-		// remote keep-in-touch send is gated separately on the web side.
-		s.FormAnswers.OwnerEmail = sanitizeStr(value)
+		// remote keep-in-touch send is gated separately on the web side. Reject
+		// non-string payloads (as picked_agents / scan_complete do) so a
+		// malformed request cannot silently clear a previously stored address.
+		raw, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("owner_email must be a string")
+		}
+		s.FormAnswers.OwnerEmail = sanitizeStr(raw)
 	case "blueprint_id":
 		s.FormAnswers.BlueprintID = normalizeBlueprintAnswer(sanitizeStr(value))
 	case "picked_agents":

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -1136,6 +1136,10 @@ func applyFormAnswer(s *State, field string, value interface{}) error {
 		s.FormAnswers.OwnerName = sanitizeStr(value)
 	case "owner_role":
 		s.FormAnswers.OwnerRole = sanitizeStr(value)
+	case "owner_email":
+		// Founder email captured on the welcome step. PII, stored locally; the
+		// remote keep-in-touch send is gated separately on the web side.
+		s.FormAnswers.OwnerEmail = sanitizeStr(value)
 	case "blueprint_id":
 		s.FormAnswers.BlueprintID = normalizeBlueprintAnswer(sanitizeStr(value))
 	case "picked_agents":

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -125,6 +125,40 @@ func TestHandleAnswerPersistsOwnerEmail(t *testing.T) {
 	})
 }
 
+func TestHandleAnswerRejectsNonStringOwnerEmail(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		// Seed a valid email first.
+		seed := httptest.NewRequest(
+			http.MethodPost,
+			"/onboarding/answer",
+			bytes.NewReader([]byte(`{"field":"owner_email","value":"maya@nex.ai"}`)),
+		)
+		HandleAnswer(httptest.NewRecorder(), seed)
+
+		// A non-string payload must be rejected with 400, not coerced to "".
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/onboarding/answer",
+			bytes.NewReader([]byte(`{"field":"owner_email","value":123}`)),
+		)
+		w := httptest.NewRecorder()
+
+		HandleAnswer(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status: got %d, want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+		// The previously stored value must survive the rejected request.
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.FormAnswers.OwnerEmail != "maya@nex.ai" {
+			t.Fatalf("owner email was clobbered: got %q, want %q", s.FormAnswers.OwnerEmail, "maya@nex.ai")
+		}
+	})
+}
+
 func TestHandleAnswerRejectsEmptyTaskPrompt(t *testing.T) {
 	withTempHome(t, func(_ string) {
 		req := httptest.NewRequest(

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -101,6 +101,30 @@ func TestHandleAnswerPersistsTaskPrompt(t *testing.T) {
 	})
 }
 
+func TestHandleAnswerPersistsOwnerEmail(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		req := httptest.NewRequest(
+			http.MethodPost,
+			"/onboarding/answer",
+			bytes.NewReader([]byte(`{"field":"owner_email","value":"  maya@nex.ai  "}`)),
+		)
+		w := httptest.NewRecorder()
+
+		HandleAnswer(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want %d body=%s", w.Code, http.StatusOK, w.Body.String())
+		}
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.FormAnswers.OwnerEmail != "maya@nex.ai" {
+			t.Fatalf("owner email = %q, want %q", s.FormAnswers.OwnerEmail, "maya@nex.ai")
+		}
+	})
+}
+
 func TestHandleAnswerRejectsEmptyTaskPrompt(t *testing.T) {
 	withTempHome(t, func(_ string) {
 		req := httptest.NewRequest(

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -55,7 +55,7 @@ type FormAnswers struct {
 	WebsiteURL   string   `json:"website_url,omitempty"`
 	OwnerName    string   `json:"owner_name,omitempty"`
 	OwnerRole    string   `json:"owner_role,omitempty"`
-	OwnerEmail   string   `json:"owner_email,omitempty"` // captured in onboarding; PII, stored locally
+	OwnerEmail   string   `json:"owner_email,omitempty"`  // captured in onboarding; PII, stored locally
 	BlueprintID  string   `json:"blueprint_id,omitempty"` // empty = scratch path
 	PickedAgents []string `json:"picked_agents,omitempty"`
 	ScanComplete bool     `json:"scan_complete,omitempty"`

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -55,6 +55,7 @@ type FormAnswers struct {
 	WebsiteURL   string   `json:"website_url,omitempty"`
 	OwnerName    string   `json:"owner_name,omitempty"`
 	OwnerRole    string   `json:"owner_role,omitempty"`
+	OwnerEmail   string   `json:"owner_email,omitempty"` // captured in onboarding; PII, stored locally
 	BlueprintID  string   `json:"blueprint_id,omitempty"` // empty = scratch path
 	PickedAgents []string `json:"picked_agents,omitempty"`
 	ScanComplete bool     `json:"scan_complete,omitempty"`

--- a/web/src/components/onboarding/wizard/steps/StepFirstIssue.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepFirstIssue.tsx
@@ -13,12 +13,19 @@
  * The wizard's advance gate requires non-empty text, so the Finish button is
  * disabled while the field is blank. Copy from
  * ONBOARDING_WIZARD_COPY.first-issue.
+ *
+ * As the final step, this is also where the "keep me in touch" consent box
+ * lives. It is only shown when an email was captured on the welcome step, is
+ * checked by default, and gates whether that address is attached to the PostHog
+ * person at Finish (the email is still stored locally either way). See
+ * useOnboardingWizard + lib/analytics.
  */
 
 import { useCallback } from "react";
 
 import { PixelAvatar } from "../../../ui/PixelAvatar";
 import {
+  ONBOARDING_EMAIL_COPY,
   ONBOARDING_FIRST_ISSUE_EXAMPLE,
   ONBOARDING_WIZARD_COPY,
   type OnboardingWizardStepProps,
@@ -82,6 +89,23 @@ export function StepFirstIssue({
             Your team picks this up the moment you walk into the office.
           </p>
         </div>
+
+        {answers.email.trim() ? (
+          <label className="onboarding-keep-in-touch">
+            <input
+              type="checkbox"
+              className="onboarding-keep-in-touch-box"
+              checked={answers.keepInTouch}
+              onChange={(event) =>
+                setAnswers({ keepInTouch: event.target.checked })
+              }
+              data-testid="onboarding-keep-in-touch"
+            />
+            <span className="onboarding-keep-in-touch-copy">
+              {ONBOARDING_EMAIL_COPY.consent}
+            </span>
+          </label>
+        ) : null}
       </div>
 
       <div className="office-tour-slide-stage office-tour-slide-stage--first-issue">

--- a/web/src/components/onboarding/wizard/steps/StepMeet.test.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepMeet.test.tsx
@@ -20,10 +20,17 @@ import { StepMeet } from "./StepMeet";
 const recordOnboardingEmailViewed = vi.fn();
 const recordOnboardingEmailStarted = vi.fn();
 
-vi.mock("../../../../lib/analytics", () => ({
-  recordOnboardingEmailViewed: () => recordOnboardingEmailViewed(),
-  recordOnboardingEmailStarted: () => recordOnboardingEmailStarted(),
-}));
+// Partial mock: spy on the two record functions, but keep the real
+// isValidEmail (StepMeet uses it for the non-blocking invalid-email hint).
+vi.mock("../../../../lib/analytics", async (importActual) => {
+  const actual =
+    await importActual<typeof import("../../../../lib/analytics")>();
+  return {
+    ...actual,
+    recordOnboardingEmailViewed: () => recordOnboardingEmailViewed(),
+    recordOnboardingEmailStarted: () => recordOnboardingEmailStarted(),
+  };
+});
 
 function makeAnswers(
   overrides: Partial<OnboardingAnswers> = {},
@@ -44,11 +51,14 @@ function makeAnswers(
   };
 }
 
-function renderStep(setAnswers = vi.fn()) {
+function renderStep(
+  setAnswers = vi.fn(),
+  answers: Partial<OnboardingAnswers> = {},
+) {
   return render(
     <StepMeet
       active={true}
-      answers={makeAnswers()}
+      answers={makeAnswers(answers)}
       setAnswers={setAnswers}
       blueprints={[]}
     />,
@@ -93,5 +103,30 @@ describe("StepMeet email capture", () => {
       target: { value: "   " },
     });
     expect(recordOnboardingEmailStarted).not.toHaveBeenCalled();
+  });
+
+  it("shows the normal hint and no invalid state for an empty field", () => {
+    renderStep();
+    const input = screen.getByTestId("onboarding-owner-email");
+    expect(input.getAttribute("aria-invalid")).toBe("false");
+    expect(
+      screen.getByTestId("onboarding-owner-email-hint").className,
+    ).not.toContain("onboarding-meet-email-hint--invalid");
+  });
+
+  it("warns (without gating) when the email is non-empty but invalid", () => {
+    renderStep(vi.fn(), { email: "not-an-email" });
+    const input = screen.getByTestId("onboarding-owner-email");
+    const hint = screen.getByTestId("onboarding-owner-email-hint");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(hint.className).toContain("onboarding-meet-email-hint--invalid");
+    expect(hint.textContent).toMatch(/does not look like an email/i);
+  });
+
+  it("treats a valid email as not invalid", () => {
+    renderStep(vi.fn(), { email: "maya@nex.ai" });
+    expect(
+      screen.getByTestId("onboarding-owner-email").getAttribute("aria-invalid"),
+    ).toBe("false");
   });
 });

--- a/web/src/components/onboarding/wizard/steps/StepMeet.test.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepMeet.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * StepMeet tests — the welcome step doubles as the email-capture entry point.
+ *
+ * Pins the funnel wiring that is easy to break silently:
+ *   - the optional email field renders alongside the office name,
+ *   - an anonymous "view" ping fires once when the step mounts,
+ *   - an anonymous "start" ping fires once, on the first keystroke only,
+ *   - typing patches answers.email through setAnswers.
+ *
+ * The analytics module is mocked, so these assert the call contract, not any
+ * network behavior (that lives in lib/analytics.test.ts).
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OnboardingAnswers } from "../wizardSteps";
+import { StepMeet } from "./StepMeet";
+
+const recordOnboardingEmailViewed = vi.fn();
+const recordOnboardingEmailStarted = vi.fn();
+
+vi.mock("../../../../lib/analytics", () => ({
+  recordOnboardingEmailViewed: () => recordOnboardingEmailViewed(),
+  recordOnboardingEmailStarted: () => recordOnboardingEmailStarted(),
+}));
+
+function makeAnswers(
+  overrides: Partial<OnboardingAnswers> = {},
+): OnboardingAnswers {
+  return {
+    companyName: "",
+    ownerName: "",
+    ownerRole: "",
+    email: "",
+    keepInTouch: true,
+    blueprintId: "",
+    pickedAgents: [],
+    startFromScratch: false,
+    agentName: "",
+    agentInstructions: "",
+    firstIssue: "",
+    ...overrides,
+  };
+}
+
+function renderStep(setAnswers = vi.fn()) {
+  return render(
+    <StepMeet
+      active={true}
+      answers={makeAnswers()}
+      setAnswers={setAnswers}
+      blueprints={[]}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("StepMeet email capture", () => {
+  it("renders the optional email field next to the office name", () => {
+    renderStep();
+    expect(screen.getByTestId("onboarding-office-name")).toBeTruthy();
+    expect(screen.getByTestId("onboarding-owner-email")).toBeTruthy();
+  });
+
+  it("fires a single anonymous viewed event on mount", () => {
+    renderStep();
+    expect(recordOnboardingEmailViewed).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires the started event only on the first keystroke", () => {
+    const setAnswers = vi.fn();
+    renderStep(setAnswers);
+    const input = screen.getByTestId("onboarding-owner-email");
+
+    fireEvent.change(input, { target: { value: "m" } });
+    fireEvent.change(input, { target: { value: "ma" } });
+
+    expect(recordOnboardingEmailStarted).toHaveBeenCalledTimes(1);
+    expect(setAnswers).toHaveBeenLastCalledWith({ email: "ma" });
+  });
+
+  it("does not fire the started event for whitespace-only input", () => {
+    renderStep();
+    fireEvent.change(screen.getByTestId("onboarding-owner-email"), {
+      target: { value: "   " },
+    });
+    expect(recordOnboardingEmailStarted).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/onboarding/wizard/steps/StepMeet.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepMeet.tsx
@@ -5,11 +5,19 @@
  * visual is a mock office coming online, so the first thing the user sees is
  * their (mock) office coming to life.
  *
- * This is also where the office / company name is collected (the only input on
- * this step). The wizard hook persists it into Partial at finish so the broker
- * reads it back at complete time (the seed contract). Naming the office is not
- * gated: a user can advance without naming it, in which case the broker uses
- * its default. Example chips fill the field with one click to lower friction.
+ * This is also where the office / company name and an optional founder email
+ * are collected. The wizard hook persists the name into Partial at finish so
+ * the broker reads it back at complete time (the seed contract). Naming the
+ * office is not gated: a user can advance without naming it, in which case the
+ * broker uses its default. Example chips fill the field with one click to lower
+ * friction.
+ *
+ * The email is a "keep in touch" ask, never a wall: it does not gate advancing.
+ * As the welcome step, this is also where the anonymous capture funnel starts
+ * (a viewed event on mount, a started event on the first keystroke). The
+ * address itself is only attached to the PostHog person later, at finish, and
+ * only with consent (see useOnboardingWizard + lib/analytics). Both events are
+ * dormant unless a PostHog project key is configured.
  *
  * The stage visual is a rendered Remotion clip (web/public/media/onboarding/
  * meet-office.gif): a "wuphf · office" window where the founding team comes
@@ -21,9 +29,14 @@
  * ONBOARDING_WIZARD_COPY.meet (single source of truth).
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import {
+  recordOnboardingEmailStarted,
+  recordOnboardingEmailViewed,
+} from "../../../../lib/analytics";
+import {
+  ONBOARDING_EMAIL_COPY,
   ONBOARDING_WIZARD_COPY,
   type OnboardingWizardStepProps,
 } from "../wizardSteps";
@@ -45,6 +58,28 @@ export function StepMeet({
   const setOfficeName = useCallback(
     (value: string) => {
       setAnswers({ companyName: value });
+    },
+    [setAnswers],
+  );
+
+  // Fire the anonymous "saw the email step" event once, when the welcome step
+  // first mounts. The host remounts steps on change, so this runs exactly once
+  // per visit to this step. No PII: distinct id + source only.
+  useEffect(() => {
+    recordOnboardingEmailViewed();
+  }, []);
+
+  // The start event fires once, on the first non-empty keystroke in the email
+  // field. It signals intent (the user began typing) without sending the
+  // partial address. The ref keeps it to a single emit per visit.
+  const startedRef = useRef(false);
+  const setEmail = useCallback(
+    (value: string) => {
+      setAnswers({ email: value });
+      if (!startedRef.current && value.trim().length > 0) {
+        startedRef.current = true;
+        recordOnboardingEmailStarted();
+      }
     },
     [setAnswers],
   );
@@ -96,6 +131,29 @@ export function StepMeet({
           <p className="onboarding-meet-name-hint">
             You can rename it later. We will use a sensible default if you leave
             it blank.
+          </p>
+        </div>
+
+        <div className="onboarding-team-field onboarding-meet-email-field">
+          <label
+            className="onboarding-team-label"
+            htmlFor="onboarding-owner-email"
+          >
+            {ONBOARDING_EMAIL_COPY.label}
+          </label>
+          <input
+            id="onboarding-owner-email"
+            className="onboarding-team-input"
+            type="email"
+            value={answers.email}
+            placeholder={ONBOARDING_EMAIL_COPY.placeholder}
+            autoComplete="email"
+            inputMode="email"
+            onChange={(event) => setEmail(event.target.value)}
+            data-testid="onboarding-owner-email"
+          />
+          <p className="onboarding-meet-name-hint">
+            {ONBOARDING_EMAIL_COPY.hint}
           </p>
         </div>
       </div>

--- a/web/src/components/onboarding/wizard/steps/StepMeet.tsx
+++ b/web/src/components/onboarding/wizard/steps/StepMeet.tsx
@@ -32,6 +32,7 @@
 import { useCallback, useEffect, useRef } from "react";
 
 import {
+  isValidEmail,
   recordOnboardingEmailStarted,
   recordOnboardingEmailViewed,
 } from "../../../../lib/analytics";
@@ -83,6 +84,13 @@ export function StepMeet({
     },
     [setAnswers],
   );
+
+  // Non-blocking validity signal. The email is optional and never gates
+  // advancing, so an invalid entry is not an error that stops onboarding — it is
+  // simply dropped (run() only persists / sends a valid address). We surface a
+  // quiet warning so the drop is never silent, but we do not block Finish.
+  const emailInvalid =
+    answers.email.trim().length > 0 && !isValidEmail(answers.email);
 
   return (
     <div
@@ -149,11 +157,22 @@ export function StepMeet({
             placeholder={ONBOARDING_EMAIL_COPY.placeholder}
             autoComplete="email"
             inputMode="email"
+            aria-invalid={emailInvalid}
+            aria-describedby="onboarding-owner-email-hint"
             onChange={(event) => setEmail(event.target.value)}
             data-testid="onboarding-owner-email"
           />
-          <p className="onboarding-meet-name-hint">
-            {ONBOARDING_EMAIL_COPY.hint}
+          <p
+            id="onboarding-owner-email-hint"
+            className={`onboarding-meet-name-hint${
+              emailInvalid ? " onboarding-meet-email-hint--invalid" : ""
+            }`}
+            aria-live="polite"
+            data-testid="onboarding-owner-email-hint"
+          >
+            {emailInvalid
+              ? ONBOARDING_EMAIL_COPY.invalid
+              : ONBOARDING_EMAIL_COPY.hint}
           </p>
         </div>
       </div>

--- a/web/src/components/onboarding/wizard/useOnboardingWizard.ts
+++ b/web/src/components/onboarding/wizard/useOnboardingWizard.ts
@@ -38,6 +38,10 @@ import {
   postOnboardingAnswer,
   postOnboardingProgress,
 } from "../../../api/onboarding";
+import {
+  isValidEmail,
+  recordOnboardingEmailCaptured,
+} from "../../../lib/analytics";
 import { directChannelSlug, useAppStore } from "../../../stores/app";
 import type { BlueprintOption } from "./types";
 import { toBlueprintOption } from "./types";
@@ -67,6 +71,7 @@ async function persistOnboardingIdentity(
   companyName: string,
   ownerName: string,
   ownerRole: string,
+  email: string,
 ): Promise<void> {
   if (companyName) {
     await postOnboardingProgress("identity", { company_name: companyName });
@@ -74,6 +79,23 @@ async function persistOnboardingIdentity(
   }
   if (ownerName) await postOnboardingAnswer("owner_name", ownerName);
   if (ownerRole) await postOnboardingAnswer("owner_role", ownerRole);
+  // The email is persisted locally regardless of the keep-in-touch consent —
+  // consent only gates the remote send (handled in runFinish), not the local
+  // record of who the founder is. Only a well-formed address is stored.
+  if (email && isValidEmail(email))
+    await postOnboardingAnswer("owner_email", email);
+}
+
+/**
+ * Attach the welcome-step email to the PostHog person, but only when the user
+ * left the keep-in-touch box checked and the address is well-formed. This is
+ * the single PII egress point; it is dormant unless a PostHog project key is
+ * configured (see lib/analytics). Fire-and-forget, so it never blocks the office.
+ */
+function maybeRecordOnboardingEmail(email: string, keepInTouch: boolean): void {
+  if (keepInTouch && isValidEmail(email)) {
+    recordOnboardingEmailCaptured(email);
+  }
 }
 
 /** Initial answers. The first issue is prefilled with the RevOps example. */
@@ -82,6 +104,8 @@ function initialAnswers(): OnboardingAnswers {
     companyName: "",
     ownerName: "",
     ownerRole: "",
+    email: "",
+    keepInTouch: true,
     blueprintId: "",
     pickedAgents: [],
     startFromScratch: false,
@@ -217,12 +241,19 @@ export function useOnboardingWizard(
       const companyName = answers.companyName.trim();
       const ownerName = answers.ownerName.trim();
       const ownerRole = answers.ownerRole.trim();
+      const email = answers.email.trim();
       const firstIssue = answers.firstIssue.trim();
       const blueprintId = answers.blueprintId.trim();
 
       async function run(): Promise<void> {
         // 1. Persist identity so the office seed reads it back at complete time.
-        await persistOnboardingIdentity(companyName, ownerName, ownerRole);
+        //    The email rides along here as owner_email (stored locally always).
+        await persistOnboardingIdentity(
+          companyName,
+          ownerName,
+          ownerRole,
+          email,
+        );
 
         // 2. Seed the team + post the first CEO turn + flip onboarded=true.
         //    blueprint empty => scratch path; agents filters the roster.
@@ -242,6 +273,11 @@ export function useOnboardingWizard(
         if (result.ok !== true && result.already_completed !== true) {
           throw new Error("Onboarding did not complete");
         }
+
+        // 2b. With consent, register the welcome-step email with the collector.
+        //     Runs after complete has succeeded so a lead capture never blocks
+        //     landing in the office. See maybeRecordOnboardingEmail.
+        maybeRecordOnboardingEmail(email, answers.keepInTouch);
 
         // 3. Seed the CEO DM composer so the office opens with the issue ready
         //    to send (same pendingComposerDraft path the old tour finish used).
@@ -272,6 +308,8 @@ export function useOnboardingWizard(
       answers.companyName,
       answers.ownerName,
       answers.ownerRole,
+      answers.email,
+      answers.keepInTouch,
       answers.firstIssue,
       answers.blueprintId,
       answers.pickedAgents,

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -52,6 +52,11 @@ export const ONBOARDING_WIZARD_STEP_IDS: OnboardingWizardStepId[] = [
  *                   broker can read it back at complete time (seed contract).
  * - `ownerName`     optional founder name, persisted via /onboarding/answer.
  * - `ownerRole`     optional founder role, persisted via /onboarding/answer.
+ * - `email`         optional founder email captured on the welcome step.
+ *                   Persisted locally as owner_email; attached to the PostHog
+ *                   person at finish ONLY when `keepInTouch` is left checked.
+ * - `keepInTouch`   consent for the remote email send. Defaults to true; the
+ *                   email is still stored locally when it is unchecked.
  * - `blueprintId`   the picked starter roster id, or "" for the scratch path.
  * - `pickedAgents`  the agent slugs kept from the blueprint roster.
  * - `agentName`     the name briefed for the first agent (team step).
@@ -63,6 +68,8 @@ export interface OnboardingAnswers {
   companyName: string;
   ownerName: string;
   ownerRole: string;
+  email: string;
+  keepInTouch: boolean;
   blueprintId: string;
   pickedAgents: string[];
   /**
@@ -144,6 +151,24 @@ export const ONBOARDING_WIZARD_COPY: Record<
     body: "Write the first thing you want your office to handle. We prefilled a CRM cleanup so your team has real work the moment you walk in. Edit it, or write your own.",
   },
 };
+
+/**
+ * Email-capture copy. The email is optional and never gates advancing: it is a
+ * "keep in touch" ask, not a signup wall. The consent line is the verbatim
+ * promise we make about how the address is used, so it lives here as the single
+ * source of truth. WUPHF voice: no contractions, no em-dashes, Oxford comma.
+ */
+export const ONBOARDING_EMAIL_COPY = {
+  /** Field label on the welcome (meet) step. */
+  label: "Your email",
+  /** Placeholder for the email input. */
+  placeholder: "you@company.com",
+  /** Hint under the field. Sets the expectation before anyone types. */
+  hint: "Optional. We use it to keep you posted on WUPHF, and nothing else.",
+  /** Consent checkbox label on the final step. Checked by default. */
+  consent:
+    "Keep me posted on WUPHF. It is open source and built in the open, and we would love to learn what to build next. No spam, we promise.",
+} as const;
 
 /** UI chrome labels for the wizard host. WUPHF voice, no contractions. */
 export const ONBOARDING_WIZARD_LABELS = {

--- a/web/src/components/onboarding/wizard/wizardSteps.ts
+++ b/web/src/components/onboarding/wizard/wizardSteps.ts
@@ -165,6 +165,13 @@ export const ONBOARDING_EMAIL_COPY = {
   placeholder: "you@company.com",
   /** Hint under the field. Sets the expectation before anyone types. */
   hint: "Optional. We use it to keep you posted on WUPHF, and nothing else.",
+  /**
+   * Non-blocking warning shown under the field when the value is non-empty but
+   * not a valid address. The field never gates advancing, so this nudges rather
+   * than blocks: an invalid email is simply dropped, and this says so.
+   */
+  invalid:
+    "That does not look like an email. Leave it blank, or fix it to stay in touch.",
   /** Consent checkbox label on the final step. Checked by default. */
   consent:
     "Keep me posted on WUPHF. It is open source and built in the open, and we would love to learn what to build next. No spam, we promise.",

--- a/web/src/lib/analytics.test.ts
+++ b/web/src/lib/analytics.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isValidEmail,
+  recordOnboardingEmailCaptured,
+  recordOnboardingEmailStarted,
+  recordOnboardingEmailViewed,
+} from "./analytics";
+
+const KEY = "VITE_PUBLIC_POSTHOG_KEY";
+const HOST = "VITE_PUBLIC_POSTHOG_HOST";
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+  // Each test starts from a clean session so the visit id is freshly minted.
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+/** The parsed JSON body of the Nth fetch call. */
+function bodyOf(call: number): Record<string, unknown> {
+  const init = fetchMock.mock.calls[call]?.[1] as RequestInit | undefined;
+  return JSON.parse(init?.body as string) as Record<string, unknown>;
+}
+
+/** The `properties` object of the Nth captured event. */
+function propsOf(call: number): Record<string, unknown> {
+  return bodyOf(call).properties as Record<string, unknown>;
+}
+
+describe("isValidEmail", () => {
+  it.each([
+    ["maya@nex.ai", true],
+    ["  sam@dunder.co  ", true],
+    ["nope", false],
+    ["no@domain", false],
+    ["@no-local.com", false],
+    ["spaces in@email.com", false],
+    ["", false],
+  ])("%s -> %s", (input, expected) => {
+    expect(isValidEmail(input)).toBe(expected);
+  });
+});
+
+describe("dormant by default", () => {
+  it("does not call fetch when the PostHog key is unset", () => {
+    recordOnboardingEmailViewed();
+    recordOnboardingEmailStarted();
+    recordOnboardingEmailCaptured("maya@nex.ai");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("with a PostHog key configured", () => {
+  beforeEach(() => {
+    vi.stubEnv(KEY, "phc_test_key");
+  });
+
+  it("posts funnel events to the default host's /capture/ with no PII", () => {
+    recordOnboardingEmailViewed();
+    recordOnboardingEmailStarted();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://us.i.posthog.com/capture/",
+    );
+    expect(fetchMock.mock.calls[0][1]?.keepalive).toBe(true);
+
+    expect(bodyOf(0)).toMatchObject({
+      api_key: "phc_test_key",
+      event: "onboarding_email_viewed",
+    });
+    expect(bodyOf(1)).toMatchObject({ event: "onboarding_email_started" });
+    expect(propsOf(0)).toEqual({ source: "onboarding-welcome" });
+    expect(propsOf(0)).not.toHaveProperty("$set");
+    expect(JSON.stringify(bodyOf(0))).not.toContain("@");
+  });
+
+  it("attaches the email to the person via $set on capture", () => {
+    recordOnboardingEmailCaptured("  maya@nex.ai  ");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(bodyOf(0)).toMatchObject({ event: "onboarding_email_captured" });
+    expect(propsOf(0).$set).toEqual({ email: "maya@nex.ai" });
+  });
+
+  it("ignores a blank email", () => {
+    recordOnboardingEmailCaptured("   ");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses one distinct id across events in a session", () => {
+    recordOnboardingEmailViewed();
+    recordOnboardingEmailStarted();
+    recordOnboardingEmailCaptured("maya@nex.ai");
+
+    const ids = new Set([
+      bodyOf(0).distinct_id,
+      bodyOf(1).distinct_id,
+      bodyOf(2).distinct_id,
+    ]);
+    expect(ids.size).toBe(1);
+  });
+
+  it("swallows a fetch rejection without throwing", () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+    expect(() => recordOnboardingEmailCaptured("maya@nex.ai")).not.toThrow();
+  });
+});
+
+describe("host override", () => {
+  it("honors a custom host and trims a trailing slash", () => {
+    vi.stubEnv(KEY, "phc_test_key");
+    vi.stubEnv(HOST, "https://eu.i.posthog.com/");
+
+    recordOnboardingEmailViewed();
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://eu.i.posthog.com/capture/",
+    );
+  });
+});

--- a/web/src/lib/analytics.ts
+++ b/web/src/lib/analytics.ts
@@ -1,0 +1,164 @@
+/**
+ * analytics: PostHog-backed onboarding capture, no SDK.
+ *
+ * A thin capture client that posts a handful of explicit events straight to
+ * PostHog's ingestion endpoint with `fetch`. We deliberately do NOT pull in
+ * posthog-js: no autocapture, no pageview tracking, no PostHog cookies, no
+ * fingerprinting. Just three named events keyed to a random per-session id.
+ * That keeps the bundle flat and the privacy story honest for a local,
+ * self-hosted OSS app.
+ *
+ * Configuration (both build-time, Vite):
+ *   - VITE_PUBLIC_POSTHOG_KEY   the PROJECT api key (phc_…). This is write-only
+ *                               and safe to ship in client code by design; it
+ *                               cannot read data back. UNSET in this repo, so a
+ *                               stock build (and every fork) stays dormant.
+ *   - VITE_PUBLIC_POSTHOG_HOST  ingestion host, defaults to us.i.posthog.com.
+ *                               Set to eu.i.posthog.com or a reverse proxy as
+ *                               needed.
+ *
+ * Two rules keep this honest:
+ *
+ *   1. DORMANT BY DEFAULT. With no project key, every function here is a no-op,
+ *      so a default OSS build never phones home and forks never send their data
+ *      to our project.
+ *
+ *   2. CONSENT GATES THE EMAIL. The two funnel events (`recordOnboardingEmail-
+ *      Viewed` / `…Started`) carry only an anonymous per-session id and a
+ *      source tag, never an address. The email is attached to the PostHog
+ *      person (via `$set`) exactly once, at finish, and only when the caller
+ *      passes consent (see useOnboardingWizard). It is never logged.
+ *
+ * All calls are best-effort and fire-and-forget: failures are swallowed and
+ * never block onboarding.
+ */
+
+const VISIT_ID_KEY = "wuphf-analytics-visit-id";
+const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+
+/** Source tag attached to every onboarding event, for filtering in PostHog. */
+export const ONBOARDING_SOURCE = "onboarding-welcome";
+
+/** Loose RFC-ish email shape. Good enough to skip obvious junk before sending. */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** True when the string looks like an email address worth capturing. */
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email.trim());
+}
+
+interface PostHogConfig {
+  key: string;
+  host: string;
+}
+
+/**
+ * The resolved PostHog config, or null when no project key is set (dormant).
+ * Read on every call (not memoized at module load) so the dormant/active
+ * decision is always live and so tests can flip it with `vi.stubEnv`.
+ */
+function getConfig(): PostHogConfig | null {
+  const rawKey = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+  const key = typeof rawKey === "string" ? rawKey.trim() : "";
+  if (!key) return null;
+
+  const rawHost = import.meta.env.VITE_PUBLIC_POSTHOG_HOST;
+  const host = typeof rawHost === "string" ? rawHost.trim() : "";
+  return {
+    key,
+    host: (host || DEFAULT_POSTHOG_HOST).replace(/\/+$/, ""),
+  };
+}
+
+/**
+ * A short opaque id for the current browser session, used as the PostHog
+ * distinct_id so the funnel events group into one person. Anonymous: a random
+ * UUID, not derived from any user data, and held only in sessionStorage
+ * (cleared when the tab closes).
+ */
+function getVisitId(): string {
+  if (typeof window === "undefined" || typeof sessionStorage === "undefined") {
+    return uuid();
+  }
+  let id = sessionStorage.getItem(VISIT_ID_KEY);
+  if (!id) {
+    id = uuid();
+    sessionStorage.setItem(VISIT_ID_KEY, id);
+  }
+  return id;
+}
+
+function uuid(): string {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
+  // Fallback for very old browsers. Cryptographically weak, but this is only a
+  // funnel-grouping id, never a security token.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Send a single event to PostHog's /capture/ endpoint, fire-and-forget. When
+ * `set` is provided, its keys are written onto the PostHog person via `$set`
+ * (this is how an event both records a step and attaches the email). No-op when
+ * the channel is dormant. Network/HTTP errors are swallowed: analytics must
+ * never surface to, or block, the user who is onboarding.
+ */
+function capture(event: string, set?: Record<string, string>): void {
+  const cfg = getConfig();
+  if (!cfg || typeof fetch === "undefined") return;
+
+  const properties: Record<string, unknown> = { source: ONBOARDING_SOURCE };
+  if (set) properties.$set = set;
+
+  try {
+    void fetch(`${cfg.host}/capture/`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        api_key: cfg.key,
+        event,
+        distinct_id: getVisitId(),
+        properties,
+      }),
+      keepalive: true,
+    }).catch(() => {});
+  } catch {
+    /* swallow: a dropped analytics event must never break onboarding */
+  }
+}
+
+/**
+ * Record that the email step was seen. Anonymous: distinct id + source only,
+ * never an address. Safe to call on step mount.
+ */
+export function recordOnboardingEmailViewed(): void {
+  capture("onboarding_email_viewed");
+}
+
+/**
+ * Record that the user began typing into the email field. Anonymous: distinct
+ * id + source only, never the (partial) address. Call once, on the first
+ * keystroke.
+ */
+export function recordOnboardingEmailStarted(): void {
+  capture("onboarding_email_started");
+}
+
+/**
+ * Record onboarding completion and attach the email to the PostHog person. This
+ * is the one call that carries PII, so callers MUST gate it behind the consent
+ * checkbox and `isValidEmail`. Best-effort and fire-and-forget.
+ */
+export function recordOnboardingEmailCaptured(email: string): void {
+  const trimmed = email.trim();
+  if (!trimmed) return;
+  capture("onboarding_email_captured", { email: trimmed });
+}

--- a/web/src/styles/onboarding-wizard.css
+++ b/web/src/styles/onboarding-wizard.css
@@ -218,6 +218,12 @@
   color: var(--text-secondary);
 }
 
+/* The optional email field sits under the office name and matches its width so
+   the two read as one stack on the welcome step. */
+.onboarding-meet-email-field {
+  max-width: 360px;
+}
+
 /* ── Team-step inputs (the one real input step) ──────────────────────────── */
 
 .onboarding-team-field {
@@ -367,6 +373,33 @@
 .onboarding-first-issue-hint {
   margin: var(--space-2) 0 0;
   font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+/* The keep-in-touch consent row on the final step. Only rendered when an email
+   was captured; the address is attached to the PostHog person at Finish only
+   while this box is checked. */
+.onboarding-keep-in-touch {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin-top: var(--space-4);
+  max-width: 420px;
+  cursor: pointer;
+}
+
+.onboarding-keep-in-touch-box {
+  margin-top: 2px;
+  width: var(--space-4);
+  height: var(--space-4);
+  flex-shrink: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.onboarding-keep-in-touch-copy {
+  font-size: var(--text-xs);
+  line-height: 1.5;
   color: var(--text-secondary);
 }
 

--- a/web/src/styles/onboarding-wizard.css
+++ b/web/src/styles/onboarding-wizard.css
@@ -224,6 +224,13 @@
   max-width: 360px;
 }
 
+/* Non-blocking "that is not an email" warning under the optional email field.
+   The field never gates advancing, so this nudges in the danger tone without
+   reading as a hard error. */
+.onboarding-meet-email-hint--invalid {
+  color: var(--danger);
+}
+
 /* ── Team-step inputs (the one real input step) ──────────────────────────── */
 
 .onboarding-team-field {


### PR DESCRIPTION
## What

Adds an optional founder email field to the onboarding welcome step and captures it to PostHog with a no-SDK client. The funnel events are anonymous; the email is attached to the PostHog person (`$set`) only on completion, behind a checked-by-default consent box. Dormant unless `VITE_PUBLIC_POSTHOG_KEY` is set at build time.

## Why

WUPHF is local, self-hosted OSS, so we have zero visibility into who installs it. A consented email captured during onboarding turns an anonymous install into a contact, and the `viewed → started → captured` funnel shows conversion.

## How it works

- `web/src/lib/analytics.ts` — thin PostHog capture client (plain `fetch` to `/capture/`, no `posthog-js`: no autocapture, pageviews, or cookies).
  - Anonymous funnel: `onboarding_email_viewed`, `onboarding_email_started` (per-session `distinct_id` + `source` only, never an address).
  - On finish + consent: `onboarding_email_captured` with `properties.$set.email`.
- Dormant by default: every call is a no-op unless `VITE_PUBLIC_POSTHOG_KEY` is set. Host overridable via `VITE_PUBLIC_POSTHOG_HOST` (defaults to `us.i.posthog.com`).
- Email is also persisted locally as `owner_email` (`FormAnswers`), regardless of consent, so the workspace records its founder.
- `release.yml` passes the key (`secrets.POSTHOG_PROJECT_KEY`) into the web build.

## Distribution note

`VITE_*` is inlined at build time. The published `npx wuphf` binary is built once by release CI with the UI baked in, so the key is frozen there. End users cannot set it at runtime; forks and source builds without the secret stay dormant. The `phc_` project key is write-only and safe to ship in client code.

## Dashboard

PostHog → **WUPHF Onboarding · Email Capture**: https://us.posthog.com/project/185073/dashboard/1668265 (funnel + captured-over-time + total).

## Goes live when

This merges to main **and** a release is cut (so the build inlines the key). Until then, dormant.

## Test plan

- [x] `web/src/lib/analytics.test.ts` — dormant/active, funnel anonymity, `$set` on capture, host override, error swallow
- [x] `StepMeet.test.tsx` — funnel wiring (viewed on mount, started once)
- [x] Go `HandleAnswer` persists `owner_email`
- [x] tsc, biome, `go build`, `go vet` green
- [ ] Screenshots of the email field + consent box (wizard needs the full stack to reach; can add via `web/e2e/screenshots`)
- [ ] Live capture verified in PostHog after a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional founder email capture on the onboarding welcome step (non-blocking)
  * "Keep me in touch" consent checkbox on the final onboarding step
  * Onboarding analytics: viewed/started/captured email events with privacy-preserving defaults

* **Tests**
  * Tests for email capture, validation, consent behavior, and analytics event flows

* **Chores**
  * CI updated to surface build-time analytics env vars for the frontend
<!-- end of auto-generated comment: release notes by coderabbit.ai -->