### PR TITLE
fix(web): call l.Kill() in signal handler to clean up temp files on Ctrl+C

### DIFF
--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -708,16 +708,18 @@ func runWeb(args []string, packSlug string, unsafe bool, webPort int, opusCEO bo
 	shareController := newWebShareController(webPort)
 	tunnelController := newWebTunnelController()
 
-	// Clean up tunnel/share subprocesses when the process receives SIGINT or
-	// SIGTERM. Without this, cloudflared is left running as an orphan after
-	// Ctrl+C — especially problematic on Windows where child processes are not
-	// automatically reaped.
+	// Clean up tunnel/share subprocesses, the launcher (headless workers,
+	// broker, per-agent temp files), and then exit when the process receives
+	// SIGINT or SIGTERM. Without l.Kill() the per-launch temp directory
+	// ($TMPDIR/wuphf-launch-*) containing MCP configs and broker tokens
+	// would linger on disk after every Ctrl+C.
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 		sig := <-sigCh
 		_ = shareController.stop()
 		_ = tunnelController.stop()
+		_ = l.Kill()
 		// POSIX convention: a process killed by signal N exits with 128+N
 		// so process supervisors (systemd, npm, foreman) can distinguish a
 		// clean exit from an interrupted run. os.Exit(0) here would mask


### PR DESCRIPTION
## Summary

- Add `l.Kill()` to the web UI signal handler in `runWeb()` so that Ctrl+C properly cleans up the per-launch temp directory (`$TMPDIR/wuphf-launch-*`) containing MCP configs and broker tokens.
- The legacy TUI path already did this via `defer l.Kill()`; the web UI path was missing it.

Closes #1035

## How to test

**1. Clean up any existing stale directories:**

```bash
rm -rf $TMPDIR/wuphf-launch-*
```

**2. Build and launch:**

```bash
go build -o wuphf ./cmd/wuphf
./wuphf
```

**3. Trigger an agent turn** — send any message in the web UI (e.g. "hello @ceo") so the temp directory gets created.

**4. Verify the temp directory exists:**

```bash
ls $TMPDIR/wuphf-launch-*
# Should see: wuphf-mcp-ceo.json, wuphf-team-mcp.json, etc.
```

**5. Ctrl+C the broker.**

**6. Verify the temp directory was removed:**

```bash
ls $TMPDIR/wuphf-launch-* 2>&1
# Should see: "no matches found" (zsh) or "No such file or directory" (bash)
```

**Before this fix**, step 6 would still show the directory. After the fix, it is cleaned up on shutdown.

## Scope

One line added to `cmd/wuphf/main.go` (`_ = l.Kill()`), plus an updated comment. No changes to broker, frontend, or tests. Existing test `TestLauncherShutdown_CleansAgentTempFiles` already validates that `Kill()` calls `cleanupAgentTempFiles()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application shutdown process to ensure all components are properly terminated when receiving termination signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->