### PR TITLE
fix: v0.218.0 restructure regressions (task chat loader, spec freeze, onboarding, interviews, /issues)

### DIFF
--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -330,7 +330,13 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			SourceDecisionID: strings.TrimSpace(body.SourceDecisionID),
 		}); existing != nil {
 			beforeStatus := existing.status
-			if details := strings.TrimSpace(body.Details); details != "" {
+			// Once the spec is approved (Running+/terminal), a duplicate create
+			// must NOT silently rewrite the human-approved spec BODY (Details).
+			// Owner, classification (TaskType — which the memory-workflow gate
+			// recomputes), and operational metadata stay mutable. See
+			// specIsFrozen.
+			specFrozen := specIsFrozen(existing.LifecycleState)
+			if details := strings.TrimSpace(body.Details); details != "" && !specFrozen {
 				existing.Details = details
 			}
 			if owner := strings.TrimSpace(body.Owner); owner != "" {
@@ -773,13 +779,21 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		default:
 			return TaskResponse{}, taskMutationError(TaskMutationInvalid, "unknown action", nil)
 		}
+		// Spec freeze: after approval (Running+/terminal) the human-approved spec
+		// BODY is locked. Appended feedback/notes (appendDetails: comment,
+		// resume, request_changes, submit) still flow; only a wholesale Details
+		// REWRITE is rejected. To edit an approved spec, reviewers request_changes
+		// it (→ ChangesRequested, which is not frozen). TaskType/ExecutionMode are
+		// classification/routing the system recomputes (e.g. the memory-workflow
+		// gate), so they stay mutable. See specIsFrozen.
+		specFrozen := specIsFrozen(task.LifecycleState)
 		if strings.TrimSpace(body.Details) != "" {
 			if appendDetails {
 				if err := appendTaskDetailLocked(task, body.Details); err != nil {
 					rollbackTask()
 					return TaskResponse{}, taskMutationError(TaskMutationInvalid, err.Error(), err)
 				}
-			} else {
+			} else if !specFrozen {
 				task.Details = strings.TrimSpace(body.Details)
 			}
 		}

--- a/internal/team/broker_tasks_plan.go
+++ b/internal/team/broker_tasks_plan.go
@@ -87,7 +87,13 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 			Owner:   strings.TrimSpace(item.Assignee),
 		}); existing != nil {
 			titleToID[strings.TrimSpace(item.Title)] = existing.ID
-			if details := strings.TrimSpace(item.Details); details != "" {
+			// Spec freeze: a re-plan must not rewrite an already-approved
+			// (Running+/terminal) task's human-approved spec BODY (Details).
+			// Classification/routing (TaskType/ExecutionMode), dependency wiring,
+			// and runtime config (effort/provider/model) stay adjustable — the
+			// system recomputes these. See specIsFrozen.
+			specFrozen := specIsFrozen(existing.LifecycleState)
+			if details := strings.TrimSpace(item.Details); details != "" && !specFrozen {
 				existing.Details = details
 			}
 			if taskType := strings.TrimSpace(item.TaskType); taskType != "" {

--- a/internal/team/plan_mode.go
+++ b/internal/team/plan_mode.go
@@ -25,6 +25,34 @@ func taskIsPreExecution(s LifecycleState) bool {
 	return false
 }
 
+// specIsFrozen reports whether a task's human-approved spec BODY (its Details —
+// the problem / approach / acceptance criteria the human signed off on) may no
+// longer be rewritten. Once the owner is executing an approved plan (Running)
+// or the task has moved into review/decision/blocked or a terminal state, that
+// body is locked: a duplicate create / plan request, or an update, must NOT
+// silently overwrite it. This enforces the product rule "once a spec is
+// approved it must not change after that."
+//
+// Scope note: only Details is frozen. Classification/routing (TaskType,
+// ExecutionMode), dependency wiring (DependsOn), and runtime config
+// (effort/provider/model) are NOT — the system legitimately recomputes them on
+// reuse (e.g. the memory-workflow completion gate keys off TaskType).
+//
+// Editable states are the pre-approval ones (Drafting/Intake/Ready/Planning/
+// QueuedBehindOwner) plus ChangesRequested — the request_changes revise loop
+// intentionally re-opens the spec, so it is NOT frozen. To edit an
+// approved/running spec, a reviewer first request_changes it back into that
+// loop.
+func specIsFrozen(s LifecycleState) bool {
+	switch s {
+	case LifecycleStateRunning, LifecycleStateReview, LifecycleStateDecision,
+		LifecycleStateBlockedOnPRMerge, LifecycleStateApproved,
+		LifecycleStateRejected, LifecycleStateArchived:
+		return true
+	}
+	return false
+}
+
 // planModeDirective is prepended to the work packet for a task in
 // LifecycleStatePlanning. It tells the owner to plan only (no repo changes, no
 // external actions), capture the plan in its notebook, post a summary, and

--- a/internal/team/spec_freeze_test.go
+++ b/internal/team/spec_freeze_test.go
@@ -1,0 +1,74 @@
+package team
+
+import "testing"
+
+// spec_freeze_test.go pins the product rule "once a task's spec is approved it
+// must not change after that" (specIsFrozen + the guards in MutateTask /
+// handleTaskPlan reuse-merge and the MutateTask update branch).
+
+func TestSpecIsFrozen(t *testing.T) {
+	frozen := []LifecycleState{
+		LifecycleStateRunning, LifecycleStateReview, LifecycleStateDecision,
+		LifecycleStateBlockedOnPRMerge, LifecycleStateApproved,
+		LifecycleStateRejected, LifecycleStateArchived,
+	}
+	// Pre-approval states plus ChangesRequested (the request_changes revise
+	// loop deliberately re-opens the spec) must stay editable.
+	editable := []LifecycleState{
+		"", LifecycleStateUnknown, LifecycleStateDrafting, LifecycleStateIntake,
+		LifecycleStateReady, LifecycleStatePlanning, LifecycleStateQueuedBehindOwner,
+		LifecycleStateChangesRequested,
+	}
+	for _, s := range frozen {
+		if !specIsFrozen(s) {
+			t.Errorf("specIsFrozen(%q) = false, want true (approved spec is frozen)", s)
+		}
+	}
+	for _, s := range editable {
+		if specIsFrozen(s) {
+			t.Errorf("specIsFrozen(%q) = true, want false (still editable)", s)
+		}
+	}
+}
+
+// TestSpecFreeze_CreateReusePreservesApprovedSpec: once a task is approved and
+// running, a duplicate team_task `create` (which findReusableTaskLocked folds
+// onto the existing task) must NOT rewrite its approved spec. Compare with
+// TestMutateTaskReusesExistingTask, where an `open`/unset-state task DOES
+// update — proving the freeze is scoped to post-approval states only.
+func TestSpecFreeze_CreateReusePreservesApprovedSpec(t *testing.T) {
+	b := newTestBroker(t)
+	b.channels = []teamChannel{
+		{Slug: "general", Name: "general", Members: []string{"pm"}},
+	}
+	const approvedSpec = "Approved spec: build X precisely, with these criteria."
+	b.tasks = []teamTask{
+		{
+			ID:             "task-1",
+			Channel:        "general",
+			Title:          "Write the plan",
+			Owner:          "alice",
+			status:         "in_progress",
+			Details:        approvedSpec,
+			LifecycleState: LifecycleStateRunning,
+		},
+	}
+
+	got, err := b.MutateTask(TaskPostRequest{
+		Action:    "create",
+		Channel:   "general",
+		Title:     "Write the plan",
+		Details:   "Sneaky rewrite of the approved spec",
+		Owner:     "alice",
+		CreatedBy: "pm",
+	})
+	if err != nil {
+		t.Fatalf("MutateTask create reuse: %v", err)
+	}
+	if got.Task.ID != "task-1" {
+		t.Fatalf("expected the duplicate create to reuse task-1, got %q", got.Task.ID)
+	}
+	if b.tasks[0].Details != approvedSpec {
+		t.Fatalf("approved (Running) task spec must be frozen; Details changed to %q", b.tasks[0].Details)
+	}
+}

--- a/web/e2e/tests/route-matrix.spec.ts
+++ b/web/e2e/tests/route-matrix.spec.ts
@@ -74,12 +74,19 @@ test.describe("canonical route matrix", () => {
     page,
   }) => {
     // Tasks-as-primary reversed the earlier Issues consolidation: /tasks is
-    // now canonical and the legacy /issues + /issues/$id routes redirect to
-    // the /tasks board + /tasks/$id detail (see legacyIssues* in
-    // lib/router.ts).
-    for (const route of ["/#/issues", "/#/issues/OFFICE-7"]) {
+    // now canonical and the legacy /issues routes redirect to the /tasks board,
+    // /tasks/new, and /tasks/$id detail (see legacyIssues* in lib/router.ts).
+    // Assert the EXACT target (anchored $): a previous bug nested new/$id under
+    // legacyIssuesRoute, whose beforeLoad redirect shadowed them so BOTH landed
+    // on the /tasks board — a loose /#\/tasks/ match would not have caught it.
+    const cases: Array<[string, RegExp]> = [
+      ["/#/issues", /#\/tasks$/],
+      ["/#/issues/new", /#\/tasks\/new$/],
+      ["/#/issues/OFFICE-7", /#\/tasks\/OFFICE-7$/],
+    ];
+    for (const [route, expected] of cases) {
       await page.goto(route);
-      await expect(page).toHaveURL(/#\/tasks/, { timeout: 10_000 });
+      await expect(page).toHaveURL(expected, { timeout: 10_000 });
       await expect(page.getByTestId("route-not-found")).toHaveCount(0);
     }
   });

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { AgentPanel } from "../agents/AgentPanel";
 import { CommandPaletteHost } from "../command/CommandPalette";
 import { TeamMemberWelcome } from "../join/TeamMemberWelcome";
+import { InterviewBar } from "../messages/InterviewBar";
 import { ThreadPanel } from "../messages/ThreadPanel";
 import { GettingStartedChecklist } from "../onboarding/GettingStartedChecklist";
 import { SearchModal } from "../search/SearchModal";
@@ -34,6 +35,13 @@ export function Shell({ children }: ShellProps) {
         <ChannelHeader />
         <RuntimeStrip />
         {children}
+        {/* Pending interviews + external-action approvals are answerable from
+            ANY surface, not just the raw channel view. InterviewBar reads the
+            office-wide request queue (useRequests) and is channel-agnostic, so
+            a single global mount here covers the home composer and the task
+            chat — where it used to be absent, leaving an agent's clarifying
+            question unanswerable without navigating to #general. */}
+        <InterviewBar />
         {/* Post-onboarding "Settle into your office" nudge. The component
             self-hides while loading, once dismissed, or after every item is
             done, so an unconditional mount inside the onboarded Shell is

--- a/web/src/components/lifecycle/TaskChannelChat.tsx
+++ b/web/src/components/lifecycle/TaskChannelChat.tsx
@@ -1,135 +1,42 @@
-import { useEffect, useRef, useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-
-import { postTaskComment } from "../../api/lifecycle";
-import { useMessages } from "../../hooks/useMessages";
-import { MessageBubble } from "../messages/MessageBubble";
+import { Composer } from "../messages/Composer";
+import { MessageFeed } from "../messages/MessageFeed";
 
 interface TaskChannelChatProps {
-  taskId: string;
-  channel: string;
   /**
-   * Called after the human posts, so the parent can refresh derived
-   * surfaces (the decision packet, lifecycle queries).
+   * The task's channel slug (`task-<id>`, or the owning channel for legacy /
+   * system tasks). Passed explicitly because the task lives on the
+   * `/tasks/$id` route, where `useChannelSlug()` returns null.
    */
-  onCommentPosted?: () => void;
+  channel: string;
 }
 
 /**
  * TaskChannelChat — the task's real conversation surface.
  *
- * Every task owns a channel (`task-<id>`) whose default members are the
- * owner, the CEO, and the Librarian. This renders that channel's LIVE
- * message stream (the agents' working chat) and lets the human post into
- * it. It replaces the old packet-comments timeline, which only showed a
- * curated subset of comments and hid the agent conversation entirely — so
- * there was no way to actually reach the per-task chat from the task.
+ * Every task owns a channel (`task-<id>`) whose default members are the owner,
+ * the CEO, and the Librarian. This renders that channel's LIVE message stream
+ * and the human's composer.
  *
- * Reuses the same primitives as the rest of the app's chat: `useMessages`
- * (2s live polling, viewer = human) for the stream and `MessageBubble` for
- * rendering. Posting goes through `postTaskComment`, which the broker
- * routes to the task's channel.
+ * It reuses the SAME shared chat primitives as the channel route — `MessageFeed`
+ * (stream + the Office-phrase typing loader + threads + reactions + copy-link +
+ * date separators + sender grouping + `/clear` marker) and `Composer`
+ * (`@mentions`, `/slash` commands, the `@`/`/` autocomplete panel, and
+ * Ctrl+P/N history recall) — passing the task's channel explicitly. An earlier
+ * version reimplemented a thinner chat here (bare bubbles + a plain textarea),
+ * which silently dropped the loader, mentions, slash commands, and threads, and
+ * (via `MessageBubble`'s "general" fallback) posted reactions to the wrong
+ * channel. Routing both through the shared, channel-prop-driven primitives
+ * keeps the task chat and the channel chat at feature parity by construction.
  */
-export function TaskChannelChat({
-  taskId,
-  channel,
-  onCommentPosted,
-}: TaskChannelChatProps) {
-  const { data: messages = [], isPending } = useMessages(channel);
-  const queryClient = useQueryClient();
-  const [body, setBody] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const trimmed = body.trim();
-
-  const mutation = useMutation({
-    mutationFn: (text: string) => postTaskComment(taskId, channel, text),
-    onSuccess: () => {
-      setBody("");
-      setError(null);
-      void queryClient.invalidateQueries({ queryKey: ["messages", channel] });
-      onCommentPosted?.();
-    },
-    onError: (err: unknown) => {
-      setError(err instanceof Error ? err.message : "Could not post message.");
-    },
-  });
-
-  // Follow new messages to the bottom. messages.length is the signal (the
-  // body doesn't read it) — same void-dep pattern used in DMView.
-  const messageCount = messages.length;
-  useEffect(() => {
-    void messageCount;
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
-    }
-  }, [messageCount]);
-
-  function submit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!trimmed || mutation.isPending) return;
-    mutation.mutate(trimmed);
-  }
-
-  function onKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
-    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-      event.preventDefault();
-      if (trimmed && !mutation.isPending) {
-        mutation.mutate(trimmed);
-      }
-    }
-  }
-
+export function TaskChannelChat({ channel }: TaskChannelChatProps) {
   return (
     <section
-      className="task-channel-chat"
+      className="task-channel-chat conversation-chat"
       aria-label="Task channel conversation"
       data-testid="task-channel-chat"
     >
-      <div className="task-channel-chat-messages messages" ref={scrollRef}>
-        {isPending ? (
-          <p className="task-channel-chat-empty">Loading the conversation…</p>
-        ) : messages.length === 0 ? (
-          <p
-            className="task-channel-chat-empty"
-            data-testid="task-channel-chat-empty"
-          >
-            No messages yet. The owner, the CEO, and the Librarian work in this
-            channel — post here to talk to them about this task.
-          </p>
-        ) : (
-          messages.map((message) => (
-            <MessageBubble key={message.id} message={message} />
-          ))
-        )}
-      </div>
-
-      <form className="task-channel-chat-composer" onSubmit={submit}>
-        <textarea
-          className="task-channel-chat-input"
-          value={body}
-          onChange={(event) => setBody(event.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder="Message the team on this task… (⌘/Ctrl+Enter to send)"
-          rows={2}
-          data-testid="task-channel-chat-input"
-        />
-        {error ? (
-          <p className="task-channel-chat-error" role="alert">
-            {error}
-          </p>
-        ) : null}
-        <div className="task-channel-chat-actions">
-          <button
-            type="submit"
-            className="task-channel-chat-send"
-            disabled={!trimmed || mutation.isPending}
-            data-testid="task-channel-chat-send"
-          >
-            {mutation.isPending ? "Sending…" : "Send"}
-          </button>
-        </div>
-      </form>
+      <MessageFeed channel={channel} />
+      <Composer channel={channel} />
     </section>
   );
 }

--- a/web/src/components/lifecycle/TaskDocument.tsx
+++ b/web/src/components/lifecycle/TaskDocument.tsx
@@ -1370,17 +1370,7 @@ export function TaskDocument({
       <div className="issue-doc-body issue-doc-body--split">
         <main className="issue-doc-chat" aria-label="Chat">
           <div className="issue-doc-chat-header">Chat</div>
-          <TaskChannelChat
-            taskId={taskId}
-            channel={doc.channel}
-            onCommentPosted={() => {
-              void queryClient.invalidateQueries({
-                queryKey: ["issue", taskId],
-              });
-              void queryClient.invalidateQueries({ queryKey: ["issues"] });
-              void queryClient.invalidateQueries({ queryKey: ["lifecycle"] });
-            }}
-          />
+          <TaskChannelChat channel={doc.channel} />
         </main>
 
         <TaskContextRail

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -140,8 +140,12 @@ function emptyHistoryState(): HistoryState {
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
-export function Composer() {
-  const currentChannel = useChannelSlug() ?? "general";
+export function Composer({ channel }: { channel?: string } = {}) {
+  // Prefer an explicit channel (the task-detail chat passes the task's channel,
+  // where useChannelSlug() is null). Fall back to the channel route slug so the
+  // channel surface behaves exactly as before.
+  const routeChannel = useChannelSlug();
+  const currentChannel = channel ?? routeChannel ?? "general";
   const setLastMessageId = useAppStore((s) => s.setLastMessageId);
   const setChannelClearMarker = useAppStore((s) => s.setChannelClearMarker);
   const pendingComposerDraft = useAppStore((s) => s.pendingComposerDraft);

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -74,6 +74,14 @@ interface MessageBubbleProps {
   onQuoteReply?: (message: Message) => void;
   /** Copy a permalink to this message. Shown as a hover action when provided. */
   onCopyLink?: (id: string) => void;
+  /**
+   * Channel this bubble belongs to. Required on surfaces that are NOT a
+   * `/channels/$slug` route — e.g. the task-detail chat (`/tasks/$id`), where
+   * `useChannelSlug()` returns null and would otherwise fall back to "general",
+   * sending reactions and the artifact-skeleton probe to the wrong channel.
+   * Omit on the channel route to keep deriving it from the URL.
+   */
+  channel?: string;
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
@@ -85,8 +93,10 @@ export function MessageBubble({
   onOpenThread,
   onQuoteReply,
   onCopyLink,
+  channel,
 }: MessageBubbleProps) {
-  const currentChannel = useChannelSlug() ?? "general";
+  const routeChannel = useChannelSlug();
+  const currentChannel = channel ?? routeChannel ?? "general";
   // When the chat is rendered inside a task-detail route, this is that
   // task's id. Task-pointer cards (created / lifecycle) use it to detect a
   // self-reference: a card pointing at the very task you are already viewing

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -40,8 +40,11 @@ export function messagesAfterClearMarker(
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
-export function MessageFeed() {
-  const currentChannel = useChannelSlug() ?? "general";
+export function MessageFeed({ channel }: { channel?: string } = {}) {
+  // Prefer an explicit channel (the task-detail chat passes the task's channel,
+  // where useChannelSlug() is null). Fall back to the channel route slug.
+  const routeChannel = useChannelSlug();
+  const currentChannel = channel ?? routeChannel ?? "general";
   const clearMarkerId = useAppStore(
     (s) => s.clearedMessageIdsByChannel[currentChannel] ?? null,
   );
@@ -106,7 +109,7 @@ export function MessageFeed() {
             Michael would be proud. Probably.
           </span>
         </div>
-        <TypingIndicator />
+        <TypingIndicator channel={currentChannel} />
       </div>
     );
   }
@@ -213,6 +216,7 @@ export function MessageFeed() {
                 setActiveThread({ id, channelSlug: currentChannel })
               }
               onCopyLink={copyMessageLink}
+              channel={currentChannel}
             />
             {hasReplies && (
               <button
@@ -254,6 +258,7 @@ export function MessageFeed() {
                       setActiveThread({ id, channelSlug: currentChannel })
                     }
                     onCopyLink={copyMessageLink}
+                    channel={currentChannel}
                   />
                 ))}
               </div>
@@ -261,7 +266,7 @@ export function MessageFeed() {
           </div>
         );
       })}
-      <TypingIndicator />
+      <TypingIndicator channel={currentChannel} />
     </div>
   );
 }

--- a/web/src/components/messages/TypingIndicator.tsx
+++ b/web/src/components/messages/TypingIndicator.tsx
@@ -21,9 +21,13 @@ import { ThinkingLoader } from "../ui/ThinkingLoader";
  * the typing label. Falls back to the classic typing bubble when no detail is
  * available, so the indicator never goes silent while an agent is active.
  */
-export function TypingIndicator() {
+export function TypingIndicator({ channel }: { channel?: string } = {}) {
   const route = useCurrentRoute();
-  const currentChannel = route.kind === "channel" ? route.channelSlug : "general";
+  // Prefer an explicit channel (the task-detail chat passes it, since
+  // useCurrentRoute reports kind "task-detail" there, not "channel"). Fall back
+  // to the channel route slug so the channel surface keeps working unchanged.
+  const currentChannel =
+    channel ?? (route.kind === "channel" ? route.channelSlug : "general");
   const { data: members = [] } = useOfficeMembers();
   const { data: channelMembers = [] } = useChannelMembers(currentChannel);
   const channelMemberSlugs = new Set(channelMembers.map((m) => m.slug));

--- a/web/src/components/onboarding/wizard/useOnboardingWizard.ts
+++ b/web/src/components/onboarding/wizard/useOnboardingWizard.ts
@@ -21,9 +21,10 @@
  *      team from that blueprint (or synthesizes one when blueprint is empty),
  *      honors the agents filter, posts the first CEO turn, and flips
  *      onboarded=true. An already_completed response is treated as success.
- *   3. Seed the CEO DM composer with the first issue (pendingComposerDraft on
- *      the app store, keyed to directChannelSlug("ceo")) so the office opens
- *      with the issue ready to send.
+ *   3. Seed the home composer with the first issue (pendingComposerDraft on the
+ *      app store, keyed to HOME_COMPOSER_DRAFT_CHANNEL, which the home
+ *      TaskComposer consumes on landing) so the office opens with the issue
+ *      ready to send.
  *   4. Call the caller-supplied onComplete() to flip RootRoute into the office.
  *
  * Errors surface on `error` (never silently swallowed); the caller renders
@@ -42,7 +43,7 @@ import {
   isValidEmail,
   recordOnboardingEmailCaptured,
 } from "../../../lib/analytics";
-import { directChannelSlug, useAppStore } from "../../../stores/app";
+import { HOME_COMPOSER_DRAFT_CHANNEL, useAppStore } from "../../../stores/app";
 import type { BlueprintOption } from "./types";
 import { toBlueprintOption } from "./types";
 import {
@@ -51,9 +52,6 @@ import {
   type OnboardingAnswers,
   type OnboardingWizardStepId,
 } from "./wizardSteps";
-
-/** The CEO agent slug, matching the broker configuration. */
-const CEO_AGENT_SLUG = "ceo";
 
 /**
  * Persist the load-bearing identity fields before completing onboarding.
@@ -279,17 +277,16 @@ export function useOnboardingWizard(
         //     landing in the office. See maybeRecordOnboardingEmail.
         maybeRecordOnboardingEmail(email, answers.keepInTouch);
 
-        // 3. Seed the CEO DM composer so the office opens with the issue ready
-        //    to send (same pendingComposerDraft path the old tour finish used).
-        //    Skipped when the user chose to explore first: there is no issue, so
-        //    the office should open clean rather than with a queued draft.
+        // 3. Seed the home composer so the office opens with the first issue
+        //    ready to send. Keyed to HOME_COMPOSER_DRAFT_CHANNEL, the sentinel
+        //    the home TaskComposer consumes on landing — the old code seeded the
+        //    CEO DM, which the post-restructure home composer never read, so the
+        //    issue was silently dropped. Skipped when the user chose to explore
+        //    first: no issue, so open clean.
         if (!skipTask) {
           useAppStore
             .getState()
-            .setPendingComposerDraft(
-              directChannelSlug(CEO_AGENT_SLUG),
-              firstIssue,
-            );
+            .setPendingComposerDraft(HOME_COMPOSER_DRAFT_CHANNEL, firstIssue);
         }
 
         // 4. Hand control back to the caller to mount the office.

--- a/web/src/components/tasks/TaskComposer.tsx
+++ b/web/src/components/tasks/TaskComposer.tsx
@@ -44,6 +44,7 @@ import {
   runtimeKindFromMember,
 } from "../../lib/providerBinding";
 import { router } from "../../lib/router";
+import { HOME_COMPOSER_DRAFT_CHANNEL, useAppStore } from "../../stores/app";
 
 type CreateMode = "start" | "backlog" | "routine";
 
@@ -67,6 +68,10 @@ function deriveTitle(prompt: string): string {
 
 export function TaskComposer() {
   const queryClient = useQueryClient();
+  const pendingComposerDraft = useAppStore((s) => s.pendingComposerDraft);
+  const consumePendingComposerDraft = useAppStore(
+    (s) => s.consumePendingComposerDraft,
+  );
   const membersQuery = useOfficeMembers();
   const members = useMemo(() => membersQuery.data ?? [], [membersQuery.data]);
 
@@ -131,6 +136,25 @@ export function TaskComposer() {
   useEffect(() => {
     promptRef.current?.focus();
   }, []);
+
+  // Consume the onboarding wizard's first-issue handoff. The wizard seeds a
+  // one-shot draft under HOME_COMPOSER_DRAFT_CHANNEL so a fresh founder lands
+  // here with their issue pre-filled instead of a blank box (the wizard used to
+  // seed the CEO DM, which this home composer never read — the issue was
+  // silently dropped). consumePendingComposerDraft clears it so it never
+  // re-applies on a later mount.
+  useEffect(() => {
+    if (
+      !pendingComposerDraft ||
+      pendingComposerDraft.channel !== HOME_COMPOSER_DRAFT_CHANNEL
+    ) {
+      return;
+    }
+    const draft = consumePendingComposerDraft(HOME_COMPOSER_DRAFT_CHANNEL);
+    if (draft === null) return;
+    setPrompt(draft);
+    requestAnimationFrame(() => promptRef.current?.focus());
+  }, [pendingComposerDraft, consumePendingComposerDraft]);
 
   const modelOptions = useMemo(
     () => modelOptionsForKind(providerKind, localStatuses),

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -165,10 +165,16 @@ export const indexRoute = createRoute({
   path: ROUTE_PATHS.index,
 });
 
-// Back-compat redirects for the legacy /issues surface. Task is the
-// primary primitive now; these forward old bookmarks and chat links to
-// the canonical /tasks routes. legacyIssueNewRoute must be listed BEFORE
-// legacyIssueDetailRoute so the static `new` segment wins over `$issueId`.
+// Back-compat redirects for the legacy /issues surface. Task is the primary
+// primitive now; these forward old bookmarks and chat links to the canonical
+// /tasks routes.
+//
+// All three are FLAT siblings under rootRoute with full paths — NOT
+// parent/child. A child of legacyIssuesRoute would never run: the parent's
+// beforeLoad redirect to /tasks fires top-down and short-circuits, so
+// /issues/new and /issues/OFFICE-7 would both wrongly land on the board
+// instead of /tasks/new and /tasks/OFFICE-7. Static `/issues/new` still
+// out-ranks the dynamic `/issues/$issueId` via TanStack route ranking.
 export const legacyIssuesRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: ROUTE_PATHS.legacyIssues,
@@ -178,16 +184,16 @@ export const legacyIssuesRoute = createRoute({
 });
 
 export const legacyIssueNewRoute = createRoute({
-  getParentRoute: () => legacyIssuesRoute,
-  path: "new",
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.legacyIssueNew,
   beforeLoad: () => {
     throw redirect({ to: "/tasks/new", replace: true });
   },
 });
 
 export const legacyIssueDetailRoute = createRoute({
-  getParentRoute: () => legacyIssuesRoute,
-  path: "$issueId",
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.legacyIssueDetail,
   beforeLoad: ({ params }) => {
     throw redirect({
       to: "/tasks/$taskId",
@@ -282,10 +288,13 @@ export const routeTree = rootRoute.addChildren([
   articleRoute,
   inboxRoute,
   taskDecisionRoute,
-  // Back-compat redirects for the legacy /issues surface.
-  // legacyIssueNewRoute must be listed BEFORE legacyIssueDetailRoute so the
-  // static segment "new" wins over the dynamic "$issueId" catch-all.
-  legacyIssuesRoute.addChildren([legacyIssueNewRoute, legacyIssueDetailRoute]),
+  // Back-compat redirects for the legacy /issues surface. Flat siblings (NOT
+  // children of legacyIssuesRoute, whose beforeLoad redirect would otherwise
+  // shadow them — see their definitions). New before detail so the static
+  // segment "new" wins over the dynamic "$issueId" catch-all.
+  legacyIssuesRoute,
+  legacyIssueNewRoute,
+  legacyIssueDetailRoute,
   routinesRoute,
   routineNewRoute,
   routineDetailRoute,

--- a/web/src/routes/RootRoute.tsx
+++ b/web/src/routes/RootRoute.tsx
@@ -22,7 +22,6 @@ import { Shell } from "../components/layout/Shell";
 import { UpgradeBanner } from "../components/layout/UpgradeBanner";
 import { ChannelParticipants } from "../components/messages/ChannelParticipants";
 import { Composer } from "../components/messages/Composer";
-import { InterviewBar } from "../components/messages/InterviewBar";
 import { MessageFeed } from "../components/messages/MessageFeed";
 import { PrePickScreen } from "../components/onboarding/PrePickScreen";
 import { OfficeTour } from "../components/onboarding/tour/OfficeTour";
@@ -374,7 +373,6 @@ function ConversationView() {
     <div className="conversation-shell">
       <div className="conversation-chat">
         <MessageFeed />
-        <InterviewBar />
         <Composer />
       </div>
       <ChannelParticipants channelSlug={channelSlug} />

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -117,6 +117,15 @@ export function directChannelSlug(
   return a > b ? `${b}__${a}` : `${a}__${b}`;
 }
 
+/**
+ * Sentinel "channel" the onboarding wizard seeds the first-issue draft under so
+ * the home composer (TaskComposer) picks it up on landing. It is NOT a real
+ * channel slug — the leading "@" can never collide with one — so the #general
+ * ConversationView Composer can't consume the handoff out from under the home
+ * surface the founder actually lands on.
+ */
+export const HOME_COMPOSER_DRAFT_CHANNEL = "@home";
+
 export interface AppStore {
   // Connection
   brokerConnected: boolean;


### PR DESCRIPTION
Regression sweep + fixes for issues introduced by the "tasks as the primary primitive" restructure (released as v0.218.0). Found via a 5-agent parallel audit comparing pre/post-restructure behavior; each fix is its own commit.

## Fixes

**fix(chat) — task chat reunification.** The task-detail chat (`/tasks/$id`) was a bespoke reimplementation that dropped the Office-phrase typing loader, `@mentions`, `/slash` commands, autocomplete, history recall, threads, copy-link, and the `/clear` marker — and `MessageBubble`'s `useChannelSlug() ?? "general"` fallback sent emoji reactions + the artifact-skeleton probe to **#general instead of the task channel** (cross-channel corruption). Added an optional `channel` prop to `MessageBubble`/`TypingIndicator`/`MessageFeed`/`Composer` (route-fallback preserved) and rebuilt `TaskChannelChat` on the shared `MessageFeed` + `Composer`.

**fix(tasks) — approved-spec freeze.** Once a task is approved/executing (Running) or terminal, its `Details` (the human-approved spec body) can no longer be silently overwritten by a duplicate create, a re-plan, or a non-append update. `specIsFrozen` guards the three sites; `request_changes` reopens the spec. Scope is `Details` only — `TaskType`/`ExecutionMode`/`DependsOn` are classification/routing the system recomputes (the memory-workflow gate keys off `TaskType`). New unit + integration tests.

**fix(onboarding) — first-issue handoff.** A fresh founder landed on a **blank** home composer because the wizard seeded the first issue to the CEO DM channel, which the home `TaskComposer` never read. Now seeded under a `HOME_COMPOSER_DRAFT_CHANNEL` sentinel that `TaskComposer` consumes on mount (one-shot).

**fix(interviews) — global InterviewBar.** Agent interviews / external-action approvals were answerable only on the raw channel view — invisible on the home composer + task chat. Mounted `InterviewBar` once in `Shell` (it is global-state-driven) and removed the redundant `ConversationView` mount.

**fix(routes) — legacy /issues deep-links.** `/issues/new` and `/issues/$id` landed on the `/tasks` board (the parent redirect shadowed the child routes) instead of `/tasks/new` and `/tasks/$id`. Flattened all three to `rootRoute` siblings; tightened the e2e assertion to the exact target.

## Not regressions / deferred
- **Composio catalog** is present + intact (added in `fa744955`, never removed). It only *looked* gone on a freshly-wiped instance with no `COMPOSIO_API_KEY`. Optional UX (a "Connect Composio" affordance when unconfigured) deferred.
- **Per-agent App-artifact + Calendar tabs** removed by the restructure — confirmed **intentional** (agents are config surfaces now).
- **2 codex answer-text interview fixes** (`require text for direct answers`, `reset answer-text state`) were **not** cherry-picked: they are built on pre-restructure main and conflict across the now-diverged `RequestItem`/`DecisionInbox`/`InterviewBar`. Recommend re-implementing the small intent fresh as a follow-up.

## Verification
- **Go:** gofmt + vet clean; `internal/team` green; full Go suite green (the only `-race` failure is the documented pre-existing `TestSkillScanner` cross-test flake, which passes in isolation).
- **Web:** tsc clean; biome clean; vitest **1967 passed**.
- **Screenshots:** pending (chat/onboarding/interviews are visual) — will capture from a dev broker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task specifications are now protected after approval—existing task details cannot be overwritten once approved, though incremental updates remain supported.
  * Interview interface is now globally accessible from any surface for streamlined workflow.
  * Onboarding wizard now seeds composer drafts in the home channel for improved handoff experience.

* **Bug Fixes**
  * Fixed legacy `/issues` URL redirects to correctly map `/issues/new` and `/issues/{id}` to their canonical `/tasks` paths.

* **Refactor**
  * Unified task chat interface to use shared messaging components for consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->