### PR TITLE
feat(tasks): per-task concurrency for the CEO (Phase 2)

### DIFF
--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -137,11 +138,14 @@ type headlessCodexActiveTurn struct {
 // headlessLane identifies one serialized dispatch lane. An agent used to have
 // exactly one lane (its slug); parallel instances split an agent into several
 // lanes so it can run more than one task at once. The key is the turn's
-// resolved git worktree path, so two turns share a lane — and therefore
-// serialize — exactly when they would write the same directory. Turns with no
-// isolated worktree (chat, office-mode, external) and all lead turns use the
-// agent's default lane (key ""), preserving today's per-agent serialization.
-// Keying on the workspace (not the task id) makes the scheduler intrinsically
+// resolved git worktree path (worktree tasks) or "task:"+id (office/external
+// tasks), so two turns share a lane — and therefore serialize — exactly when
+// they would write the same directory or are the same office task. Turns with
+// no task (chat / channel triage) use the agent's default lane (key ""),
+// preserving conversational coherence; this is true for the lead too, but a
+// lead turn that DOES carry a task id now gets its own per-task lane (CEO
+// multitasking — non-dependent tasks run concurrently). Keying on the workspace
+// (not the task id) for worktree tasks makes the scheduler intrinsically
 // collision-proof: distinct worktrees ⇒ distinct lanes ⇒ safe to run at once;
 // a shared worktree (e.g. a dependency reusing its parent's tree) ⇒ same lane
 // ⇒ serialized, regardless of how admission control routed the tasks.
@@ -163,6 +167,72 @@ func taskLane(slug, taskID string) headlessLane {
 	return headlessLane{slug: slug, key: "task:" + taskID}
 }
 
+// Headless concurrency caps bound how many dispatch lanes may run a turn at
+// once — the cost guard that keeps CEO multitasking (per-task lead lanes) from
+// spawning an unbounded number of concurrent LLM subprocesses.
+//
+// Semantics: a pool cap field <= 0 means "unlimited" for that dimension. The
+// zero value is therefore unlimited, so a bare &Launcher{} (and every existing
+// concurrency test) is NOT retroactively throttled. Production resolves
+// positive caps at boot via resolveHeadlessConcurrencyCaps; tests that exercise
+// the cap set l.headless.maxConcurrent / maxConcurrentPerAgent directly.
+const headlessCapGlobalClamp = 6 // upper clamp on the cores-derived global default
+
+// resolveHeadlessConcurrencyCaps sets this launcher's caps from the environment
+// with strong-opinion defaults (global ≈ clamp(cores, 2, 6); per-agent 3).
+// Called once at launcher boot so production is always bounded.
+func (l *Launcher) resolveHeadlessConcurrencyCaps() {
+	cores := runtime.NumCPU()
+	global := cores
+	if global < 2 {
+		global = 2 // allow some concurrency even on a single-core host
+	}
+	if global > headlessCapGlobalClamp {
+		global = headlessCapGlobalClamp
+	}
+	// envIntDefault (notebook_signal_scanner.go) returns the env value as-is when
+	// set, so an explicit WUPHF_MAX_CONCURRENT_TURNS=0 disables the cap (unlimited
+	// — see headlessConcurrencyCaps); an unset value falls back to the default.
+	l.headless.maxConcurrent = envIntDefault("WUPHF_MAX_CONCURRENT_TURNS", global)
+	l.headless.maxConcurrentPerAgent = envIntDefault("WUPHF_MAX_CONCURRENT_PER_AGENT", 3)
+}
+
+// headlessConcurrencyCaps returns this launcher's effective (global, per-agent)
+// caps. <= 0 means unlimited for that dimension.
+func (l *Launcher) headlessConcurrencyCaps() (global, perAgent int) {
+	return l.headless.maxConcurrent, l.headless.maxConcurrentPerAgent
+}
+
+// headlessLaneMayStartLocked reports whether starting a turn on lane would stay
+// within the global and per-agent concurrency caps. Caller holds l.headless.mu.
+// The lane being checked has no active turn at call time (the worker just
+// finished its previous turn before looping back to begin), so counting active
+// lanes never double-counts the candidate.
+func (l *Launcher) headlessLaneMayStartLocked(lane headlessLane) bool {
+	global, perAgent := l.headlessConcurrencyCaps()
+	if global <= 0 && perAgent <= 0 {
+		return true
+	}
+	total := 0
+	sameAgent := 0
+	for activeLane, active := range l.headless.active {
+		if active == nil {
+			continue
+		}
+		total++
+		if activeLane.slug == lane.slug {
+			sameAgent++
+		}
+	}
+	if global > 0 && total >= global {
+		return false
+	}
+	if perAgent > 0 && sameAgent >= perAgent {
+		return false
+	}
+	return true
+}
+
 // headlessWorkerPool groups the per-launcher headless-dispatch state
 // (PLAN.md §C7). All fields are lowercase package-internal — the pool
 // is never used outside `internal/team` and stays an embedded value
@@ -173,18 +243,26 @@ func taskLane(slug, taskID string) headlessLane {
 //
 // The maps are keyed by headlessLane (was: by slug). Slug-level coordination
 // (the lead queue-hold/wake, activeHeadlessSlugs) iterates lanes and groups by
-// lane.slug. deferredLead stays a single pointer because the lead always runs
-// in its one default lane.
+// lane.slug. deferredLead stays a single pointer because only no-task lead
+// turns (channel triage) are ever deferred — those always run on the lead's one
+// default lane; task-carrying lead turns run on per-task lanes and are not held.
+//
+// maxConcurrent / maxConcurrentPerAgent bound how many lanes may run a turn at
+// once (the cost guard for CEO multitasking). 0 ⇒ use the env/default resolved
+// by headlessConcurrencyCaps; a negative value ⇒ unlimited (tests). Production
+// always resolves to a positive cap so concurrency can't blow up LLM spend.
 type headlessWorkerPool struct {
-	mu           sync.Mutex
-	ctx          context.Context
-	cancel       context.CancelFunc
-	workers      map[headlessLane]bool
-	active       map[headlessLane]*headlessCodexActiveTurn
-	queues       map[headlessLane][]headlessCodexTurn
-	deferredLead *headlessCodexTurn
-	stopCh       chan struct{}
-	workerWg     sync.WaitGroup
+	mu                    sync.Mutex
+	ctx                   context.Context
+	cancel                context.CancelFunc
+	workers               map[headlessLane]bool
+	active                map[headlessLane]*headlessCodexActiveTurn
+	queues                map[headlessLane][]headlessCodexTurn
+	deferredLead          *headlessCodexTurn
+	stopCh                chan struct{}
+	workerWg              sync.WaitGroup
+	maxConcurrent         int
+	maxConcurrentPerAgent int
 }
 
 // headlessCodexWorkspaceStatusSnapshotFn is the seam type swapped by tests

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -524,19 +524,42 @@ func (l *Launcher) finishHeadlessTurn(lane headlessLane) {
 		deferredLead = &turn
 		shouldWakeLead = false
 	}
-	// A turn just finished, freeing an active slot. Re-spawn any lane the
-	// concurrency cap parked (queued work but no running worker). Collect under
+	// A turn just finished, freeing an active slot. Re-spawn the lanes the
+	// concurrency cap parked (queued work but no running worker). Only the
+	// subset that fits the newly-available global/per-agent slots is woken:
+	// we simulate admission under the lock — seed counts from the lanes still
+	// active, then admit parked lanes one at a time, incrementing the running
+	// tallies as we go — so a single completion never spawns the whole herd
+	// only to have almost all of them immediately re-park and exit (O(n)
+	// goroutine/log churn per finished turn under a tight cap). Collect under
 	// the lock and mark workers=true so a concurrent enqueue won't also spawn;
 	// the actual spawn happens after unlocking. Only meaningful when a cap is
 	// active — with no cap every queued lane already has a worker.
 	var parkedLanes []headlessLane
 	if global, perAgent := l.headlessConcurrencyCaps(); global > 0 || perAgent > 0 {
+		total := 0
+		byAgent := map[string]int{}
+		for activeLane, active := range l.headless.active {
+			if active == nil {
+				continue
+			}
+			total++
+			byAgent[activeLane.slug]++
+		}
 		for parkedLane, queue := range l.headless.queues {
 			if len(queue) == 0 || l.headless.workers[parkedLane] {
 				continue
 			}
+			if global > 0 && total >= global {
+				break
+			}
+			if perAgent > 0 && byAgent[parkedLane.slug] >= perAgent {
+				continue
+			}
 			l.headless.workers[parkedLane] = true
 			parkedLanes = append(parkedLanes, parkedLane)
+			total++
+			byAgent[parkedLane.slug]++
 		}
 	}
 	l.headless.mu.Unlock()

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -36,8 +36,9 @@ func taskRunsInIsolatedWorktree(task *teamTask) bool {
 // l.headless.mu; the broker lookup respects the established headless.mu →
 // broker.mu order (see headlessLeadTurnNeedsImmediateWakeLocked).
 //
-//   - chat turns (no task) and all lead turns → the agent's default lane (""):
-//     conversational coherence for the agent, and the coordinator never forks.
+//   - chat / channel-triage turns (no task) → the agent's default lane (""):
+//     conversational coherence, and the lead's triage never forks. This is the
+//     ONLY lane the lead (CEO) uses for non-task turns.
 //   - worktree tasks → keyed by worktree PATH: distinct worktrees run in
 //     parallel; a shared worktree (a dependent reusing its parent's tree)
 //     collapses to one serialized lane. A worktree task with no path assigned
@@ -45,14 +46,14 @@ func taskRunsInIsolatedWorktree(task *teamTask) bool {
 //   - office / live_external / other → keyed by TASK id: no shared worktree to
 //     collide on (concurrent office turns share cwd exactly as different agents'
 //     turns already do; the broker mediates shared state), so each task runs in
-//     its own lane and non-dependent tasks of one agent run at once.
+//     its own lane and non-dependent tasks of one agent run at once. This now
+//     applies to the LEAD too: a CEO turn carrying a task id gets its own
+//     per-task lane so the CEO can work several tasks concurrently. A lead turn
+//     with no task id still serializes on the default lane (channel triage).
 func (l *Launcher) laneForTurn(slug string, turn headlessCodexTurn) headlessLane {
 	slug = strings.TrimSpace(slug)
 	taskID := strings.TrimSpace(turn.TaskID)
 	if taskID == "" || l == nil || l.broker == nil {
-		return slugLane(slug)
-	}
-	if slug == l.targeter().LeadSlug() {
 		return slugLane(slug)
 	}
 	task := l.broker.TaskByID(taskID)
@@ -162,17 +163,23 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 			}
 		}
 	}
-	// For the lead (CEO) agent, suppress the notification if any other specialist
-	// is still active or has pending work. The lead should only step in when all
-	// parallel work is done — not when one specialist finishes while others are
-	// still running. This eliminates the race condition where CEO fires after the
-	// first specialist completes and redundantly re-routes to still-running agents.
-	// Scans every non-lead lane (an agent may now hold several).
+	// For the lead (CEO) agent, suppress a NO-TASK triage notification if any
+	// other specialist is still active or has pending work. The lead should only
+	// step in on general channel chatter when all parallel work is done — not
+	// when one specialist finishes while others are still running. This is where
+	// the re-route race lives (the CEO reacting to chatter mid-flight and
+	// redundantly re-routing to still-running agents). Scans every non-lead lane
+	// (an agent may now hold several).
+	//
+	// A TASK-carrying lead turn is NOT held here: the CEO runs it on its own
+	// per-task lane so non-dependent tasks proceed concurrently (CEO
+	// multitasking). The same-task drop/replace above already prevents
+	// double-dispatching the same task, and the concurrency cap bounds the total.
 	//
 	// Human turns bypass this hold: a person addressing the lead must be absorbed
 	// immediately even if specialists are still working — the lead can decide
 	// whether to stop, give a status update, or queue the request for later.
-	if isLead && !urgentLeadTurn && !humanPriority {
+	if isLead && !urgentLeadTurn && !humanPriority && strings.TrimSpace(turn.TaskID) == "" {
 		for workerLane, queue := range l.headless.queues {
 			if workerLane.slug == slug {
 				continue
@@ -196,13 +203,15 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 			}
 		}
 	}
-	// For the lead (CEO) agent, cap the pending queue at 1 turn.
+	// For the lead (CEO) agent, cap the pending queue at 1 turn PER LANE.
 	// Multiple rapid-fire notifications (agent completions, status pings) can
 	// stack up redundant CEO turns that each re-route the same task. One pending
 	// turn is enough to catch the latest state; extras are dropped — except for
 	// urgent task wakes and human-originated messages, which replace the pending
 	// turn so the freshest signal wins instead of being silently dropped.
-	// The lead always runs in its one default lane, so the cap is per-lane.
+	// The lead now runs several lanes (one per task + the default triage lane),
+	// and the cap is checked against THIS turn's lane (l.headless.queues[lane]),
+	// so each task lane keeps its own single-pending budget independently.
 	const leadMaxPending = 1
 	if isLead && len(l.headless.queues[lane]) >= leadMaxPending {
 		if urgentLeadTurn || humanPriority {
@@ -499,9 +508,15 @@ func (l *Launcher) finishHeadlessTurn(lane headlessLane) {
 		}
 	}
 	// Check if the lead already has work queued — no need to wake it. The lead
-	// always runs in its one default lane.
-	if shouldWakeLead && len(l.headless.queues[slugLane(lead)]) > 0 {
-		shouldWakeLead = false
+	// now runs several lanes (its default triage lane + one per task), so scan
+	// every lead lane; any queued lead work means it'll process state on its own.
+	if shouldWakeLead {
+		for workerLane, queue := range l.headless.queues {
+			if workerLane.slug == lead && len(queue) > 0 {
+				shouldWakeLead = false
+				break
+			}
+		}
 	}
 	if shouldWakeLead && l.headless.deferredLead != nil {
 		turn := *l.headless.deferredLead
@@ -509,7 +524,26 @@ func (l *Launcher) finishHeadlessTurn(lane headlessLane) {
 		deferredLead = &turn
 		shouldWakeLead = false
 	}
+	// A turn just finished, freeing an active slot. Re-spawn any lane the
+	// concurrency cap parked (queued work but no running worker). Collect under
+	// the lock and mark workers=true so a concurrent enqueue won't also spawn;
+	// the actual spawn happens after unlocking. Only meaningful when a cap is
+	// active — with no cap every queued lane already has a worker.
+	var parkedLanes []headlessLane
+	if global, perAgent := l.headlessConcurrencyCaps(); global > 0 || perAgent > 0 {
+		for parkedLane, queue := range l.headless.queues {
+			if len(queue) == 0 || l.headless.workers[parkedLane] {
+				continue
+			}
+			l.headless.workers[parkedLane] = true
+			parkedLanes = append(parkedLanes, parkedLane)
+		}
+	}
 	l.headless.mu.Unlock()
+
+	for _, parked := range parkedLanes {
+		l.spawnHeadlessWorker(parked)
+	}
 
 	if deferredLead != nil {
 		l.enqueueHeadlessCodexTurn(lead, deferredLead.Prompt, deferredLead.Channel)
@@ -631,6 +665,17 @@ func (l *Launcher) beginHeadlessCodexTurn(lane headlessLane) (headlessCodexTurn,
 	}
 
 	turn := queue[0]
+	// Concurrency cap (cost guard for CEO multitasking): if starting this lane
+	// would exceed the global or per-agent in-flight cap, PARK the worker without
+	// consuming the queued turn — the lane keeps its queued work and
+	// finishHeadlessTurn re-spawns parked lanes as active slots free. A
+	// human-priority turn bypasses the cap so a real person is never starved
+	// behind agent work.
+	if !turn.FromHuman && !l.headlessLaneMayStartLocked(lane) {
+		delete(l.headless.workers, lane)
+		appendHeadlessCodexLog(slug, "queue-park: at concurrency cap, deferring lane until a slot frees")
+		return headlessCodexTurn{}, nil, time.Time{}, 0, false
+	}
 	if len(queue) == 1 {
 		delete(l.headless.queues, lane)
 	} else {

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1115,8 +1115,12 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.broker = b
-	l.headless.workers[headlessLane{slug: "ceo"}] = true
-	l.headless.active[headlessLane{slug: "ceo"}] = &headlessCodexActiveTurn{
+	// The lead now runs office tasks on their own per-task lane (CEO
+	// multitasking), so the in-flight turn for this task lives on taskLane,
+	// not the default slug lane.
+	leadLane := taskLane("ceo", task.ID)
+	l.headless.workers[leadLane] = true
+	l.headless.active[leadLane] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
 			Prompt: "first prompt about #" + task.ID,
 			TaskID: task.ID,
@@ -1133,7 +1137,7 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 		EnqueuedAt: time.Now(),
 	})
 
-	if got := len(l.headless.queues[headlessLane{slug: "ceo"}]); got != 1 {
+	if got := len(l.headless.queues[leadLane]); got != 1 {
 		t.Fatalf("expected urgent lead wake to queue behind same task, got %d", got)
 	}
 	if !cancelled {

--- a/internal/team/headless_parallel_test.go
+++ b/internal/team/headless_parallel_test.go
@@ -219,8 +219,13 @@ func TestLeadSameTaskTurnDedupesWhileActive(t *testing.T) {
 		EnqueuedAt: time.Now(),
 	})
 
-	if got := len(l.headless.queues[lane]); got != 0 {
-		t.Fatalf("expected duplicate lead turn for same task to be dropped, got %d queued", got)
+	// Read queue depth under the lock — the pool maps are guarded by mu and a
+	// worker goroutine may touch them concurrently (race-clean assertion).
+	l.headless.mu.Lock()
+	queued := len(l.headless.queues[lane])
+	l.headless.mu.Unlock()
+	if queued != 0 {
+		t.Fatalf("expected duplicate lead turn for same task to be dropped, got %d queued", queued)
 	}
 }
 
@@ -245,11 +250,20 @@ func TestLeadTaskTurnNotHeldByUnrelatedSpecialist(t *testing.T) {
 		EnqueuedAt: time.Now(),
 	})
 
-	if l.headless.deferredLead != nil {
+	// Snapshot the pool maps under the lock before asserting — a worker goroutine
+	// spawned by the enqueue can be mutating workers/queues concurrently, so an
+	// unlocked read here is a data race (and a potential map panic under -race).
+	l.headless.mu.Lock()
+	deferredLead := l.headless.deferredLead
+	lane := taskLane("ceo", "task-ceo")
+	workerRunning := l.headless.workers[lane]
+	queued := len(l.headless.queues[lane])
+	l.headless.mu.Unlock()
+
+	if deferredLead != nil {
 		t.Fatal("task-carrying lead turn must not be deferred by an unrelated busy specialist")
 	}
-	lane := taskLane("ceo", "task-ceo")
-	if !l.headless.workers[lane] && len(l.headless.queues[lane]) == 0 {
+	if !workerRunning && queued == 0 {
 		t.Fatal("expected the lead task turn to be queued/dispatched on its own per-task lane")
 	}
 }
@@ -268,7 +282,12 @@ func TestLeadTriageTurnStillHeldByBusySpecialist(t *testing.T) {
 	// → treated as channel triage, which still honors the hold.
 	l.enqueueHeadlessCodexTurn("ceo", "general status, anything I should know?")
 
-	if l.headless.deferredLead == nil {
+	// Read deferredLead under the lock — it is guarded by mu and may be touched
+	// by a worker goroutine concurrently (race-clean assertion).
+	l.headless.mu.Lock()
+	deferredLead := l.headless.deferredLead
+	l.headless.mu.Unlock()
+	if deferredLead == nil {
 		t.Fatal("expected a no-task lead triage turn to be deferred while a specialist is active")
 	}
 }
@@ -328,5 +347,74 @@ func TestHeadlessConcurrencyCapParksAndDrains(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("expected the parked lead task to start after a slot freed")
+	}
+}
+
+// TestHeadlessGlobalConcurrencyCapParksAndDrains is the GLOBAL-pool sibling of
+// the per-agent cap test: with maxConcurrent=1 (and the per-agent cap left
+// unset/0), two non-dependent office tasks owned by DIFFERENT agents cannot both
+// run — only the GLOBAL cap binds — so one starts, the other PARKS, and the
+// parked lane DRAINS once the first turn finishes and frees the single slot.
+func TestHeadlessGlobalConcurrencyCapParksAndDrains(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-eng", Title: "eng work", Owner: "eng", status: "in_progress", ExecutionMode: "office"},
+		teamTask{ID: "task-gtm", Title: "gtm work", Owner: "gtm", status: "in_progress", ExecutionMode: "office"},
+	)
+	// Register the second owner so its task resolves to a real member lane.
+	b.mu.Lock()
+	b.members = append(b.members, officeMember{Slug: "gtm", Name: "gtm"})
+	b.memberIndex = nil
+	b.mu.Unlock()
+
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+	l.headless.maxConcurrent = 1 // only one turn may run across the whole pool
+
+	started := make(chan string, 8)
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+		select {
+		case started <- headlessTurnTaskID(ctx):
+		default:
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	l.enqueueHeadlessCodexTurnRecord("eng", headlessCodexTurn{Prompt: "work #task-eng", Channel: "general", TaskID: "task-eng"})
+	l.enqueueHeadlessCodexTurnRecord("gtm", headlessCodexTurn{Prompt: "work #task-gtm", Channel: "general", TaskID: "task-gtm"})
+
+	// Exactly one should start; the other parks under the global cap.
+	var first string
+	select {
+	case first = <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the first task to start")
+	}
+	select {
+	case second := <-started:
+		t.Fatalf("global cap=1 violated: a second task (%s) started while %s was active", second, first)
+	case <-time.After(250 * time.Millisecond):
+		// correct: the second lane is parked behind the global cap
+	}
+
+	// Free the single slot by cancelling the active turn; the parked lane drains.
+	firstOwner := "eng"
+	if first == "task-gtm" {
+		firstOwner = "gtm"
+	}
+	firstLane := taskLane(firstOwner, first)
+	l.headless.mu.Lock()
+	if active := l.headless.active[firstLane]; active != nil && active.Cancel != nil {
+		active.Cancel()
+	}
+	l.headless.mu.Unlock()
+
+	select {
+	case second := <-started:
+		if second == first {
+			t.Fatalf("expected the parked task to drain, but %s started again", second)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the parked task to start after the global slot freed")
 	}
 }

--- a/internal/team/headless_parallel_test.go
+++ b/internal/team/headless_parallel_test.go
@@ -23,11 +23,13 @@ func brokerWithTasks(t *testing.T, tasks ...teamTask) *Broker {
 }
 
 // TestLaneForTurnKeysByWorktree pins the core safety invariant of parallel
-// instances: a turn earns its own dispatch lane only when it is a non-lead turn
-// for an isolated-worktree task, and the lane key is that worktree path. Two
+// instances: a turn earns its own dispatch lane when it is a task turn, keyed by
+// worktree path (isolated-worktree tasks) or task id (office/external). Two
 // turns therefore share a lane — and serialize — exactly when they write the
-// same directory. Everything else (office-mode, chat, lead) collapses to the
-// agent's default lane.
+// same directory or are the same office task. Chat / channel-triage turns (no
+// task) collapse to the agent's default lane. This is true for the LEAD too: a
+// lead turn carrying a task id gets its own per-task lane (CEO multitasking),
+// while a lead turn with no task id stays on the default triage lane.
 func TestLaneForTurnKeysByWorktree(t *testing.T) {
 	b := brokerWithTasks(t,
 		teamTask{ID: "task-a", Title: "a", Owner: "eng", status: "in_progress", ExecutionMode: "local_worktree", WorktreePath: "/wt/a"},
@@ -37,7 +39,8 @@ func TestLaneForTurnKeysByWorktree(t *testing.T) {
 		teamTask{ID: "task-office2", Title: "d2", Owner: "eng", status: "in_progress", ExecutionMode: "office"},
 		teamTask{ID: "task-ext", Title: "x", Owner: "eng", status: "in_progress", ExecutionMode: "live_external"},
 		teamTask{ID: "task-nopath", Title: "e", Owner: "eng", status: "in_progress", ExecutionMode: "local_worktree"},
-		teamTask{ID: "task-lead", Title: "f", Owner: "ceo", status: "in_progress", ExecutionMode: "local_worktree", WorktreePath: "/wt/lead"},
+		teamTask{ID: "task-lead-office", Title: "f", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+		teamTask{ID: "task-lead-wt", Title: "g", Owner: "ceo", status: "in_progress", ExecutionMode: "local_worktree", WorktreePath: "/wt/lead"},
 	)
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
@@ -56,7 +59,9 @@ func TestLaneForTurnKeysByWorktree(t *testing.T) {
 		{"live_external task -> own per-task lane", "eng", headlessCodexTurn{TaskID: "task-ext"}, headlessLane{slug: "eng", key: "task:task-ext"}},
 		{"worktree without a path yet -> default lane", "eng", headlessCodexTurn{TaskID: "task-nopath"}, headlessLane{slug: "eng"}},
 		{"chat turn (no task) -> default lane", "eng", headlessCodexTurn{}, headlessLane{slug: "eng"}},
-		{"lead never forks -> default lane", "ceo", headlessCodexTurn{TaskID: "task-lead"}, headlessLane{slug: "ceo"}},
+		{"lead office task -> own per-task lane", "ceo", headlessCodexTurn{TaskID: "task-lead-office"}, headlessLane{slug: "ceo", key: "task:task-lead-office"}},
+		{"lead worktree task -> own worktree lane", "ceo", headlessCodexTurn{TaskID: "task-lead-wt"}, headlessLane{slug: "ceo", key: "/wt/lead"}},
+		{"lead triage turn (no task) -> default lane", "ceo", headlessCodexTurn{}, headlessLane{slug: "ceo"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -149,5 +154,179 @@ func TestParallelInstancesRunNonDependentOfficeTasksConcurrently(t *testing.T) {
 	}
 	if !got["task-a"] || !got["task-b"] {
 		t.Fatalf("expected both office tasks to run concurrently, got %v", got)
+	}
+}
+
+// TestLeadRunsNonDependentTasksConcurrently is the headline Phase 2 behavior:
+// the LEAD (ceo) owning two non-dependent office tasks runs BOTH at once, each
+// on its own per-task lane. Before per-task lead lanes, every lead turn
+// serialized on one default lane and only one would start in the window.
+func TestLeadRunsNonDependentTasksConcurrently(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-a", Title: "a", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+		teamTask{ID: "task-b", Title: "b", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+	)
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+
+	started := make(chan string, 8)
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+		select {
+		case started <- headlessTurnTaskID(ctx):
+		default:
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{Prompt: "work #task-a", Channel: "general", TaskID: "task-a"})
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{Prompt: "work #task-b", Channel: "general", TaskID: "task-b"})
+
+	got := map[string]bool{}
+	deadline := time.After(10 * time.Second)
+	for len(got) < 2 {
+		select {
+		case id := <-started:
+			got[id] = true
+		case <-deadline:
+			t.Fatalf("only %d/2 lead instances started concurrently (serialized?): %v", len(got), got)
+		}
+	}
+	if !got["task-a"] || !got["task-b"] {
+		t.Fatalf("expected both lead tasks to run concurrently, got %v", got)
+	}
+}
+
+// TestLeadSameTaskTurnDedupesWhileActive pins the anti-double-dispatch guard:
+// even with per-task lead lanes, a second lead turn for a task already in flight
+// on that lane is dropped (not piled up). urgentLeadTurn is false here (the task
+// is plain in_progress, not review/blocked), so the same-task drop applies.
+func TestLeadSameTaskTurnDedupesWhileActive(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-x", Title: "x", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+	)
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+	lane := taskLane("ceo", "task-x")
+	l.headless.active[lane] = &headlessCodexActiveTurn{
+		Turn:      headlessCodexTurn{Prompt: "first #task-x", TaskID: "task-x"},
+		StartedAt: time.Now(),
+	}
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{
+		Prompt:     "second #task-x",
+		TaskID:     "task-x",
+		EnqueuedAt: time.Now(),
+	})
+
+	if got := len(l.headless.queues[lane]); got != 0 {
+		t.Fatalf("expected duplicate lead turn for same task to be dropped, got %d queued", got)
+	}
+}
+
+// TestLeadTaskTurnNotHeldByUnrelatedSpecialist proves the per-task scoping of
+// the lead-hold: a lead turn that CARRIES a task id is NOT deferred just because
+// an unrelated specialist is busy — non-dependent tasks proceed concurrently.
+func TestLeadTaskTurnNotHeldByUnrelatedSpecialist(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-ceo", Title: "ceo work", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+	)
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+	// An unrelated specialist is mid-flight on its own task.
+	l.headless.active[taskLane("eng", "task-eng")] = &headlessCodexActiveTurn{
+		Turn:      headlessCodexTurn{Prompt: "specialist working #task-eng", TaskID: "task-eng"},
+		StartedAt: time.Now(),
+	}
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{
+		Prompt:     "advance #task-ceo",
+		TaskID:     "task-ceo",
+		EnqueuedAt: time.Now(),
+	})
+
+	if l.headless.deferredLead != nil {
+		t.Fatal("task-carrying lead turn must not be deferred by an unrelated busy specialist")
+	}
+	lane := taskLane("ceo", "task-ceo")
+	if !l.headless.workers[lane] && len(l.headless.queues[lane]) == 0 {
+		t.Fatal("expected the lead task turn to be queued/dispatched on its own per-task lane")
+	}
+}
+
+// TestLeadTriageTurnStillHeldByBusySpecialist is the other half of the scoping:
+// a NO-TASK lead turn (channel triage) still respects the hold while a
+// specialist is active — that is where the redundant-re-route race lives.
+func TestLeadTriageTurnStillHeldByBusySpecialist(t *testing.T) {
+	l := newHeadlessLauncherForTest(t) // lead = "ceo" by default
+	l.headless.active[headlessLane{slug: "eng"}] = &headlessCodexActiveTurn{
+		Turn:      headlessCodexTurn{Prompt: "specialist still working"},
+		StartedAt: time.Now(),
+	}
+
+	// 2-arg enqueue with a prompt that has no #task- prefix → TaskID stays empty
+	// → treated as channel triage, which still honors the hold.
+	l.enqueueHeadlessCodexTurn("ceo", "general status, anything I should know?")
+
+	if l.headless.deferredLead == nil {
+		t.Fatal("expected a no-task lead triage turn to be deferred while a specialist is active")
+	}
+}
+
+// TestHeadlessConcurrencyCapParksAndDrains proves the cost guard: with the
+// per-agent cap set to 1, the lead's two task lanes cannot both run at once —
+// one starts, the other PARKS (queued, no worker) — and the parked lane DRAINS
+// once the first turn finishes and frees a slot.
+func TestHeadlessConcurrencyCapParksAndDrains(t *testing.T) {
+	b := brokerWithTasks(t,
+		teamTask{ID: "task-a", Title: "a", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+		teamTask{ID: "task-b", Title: "b", Owner: "ceo", status: "in_progress", ExecutionMode: "office"},
+	)
+	l := newHeadlessLauncherForTest(t)
+	l.broker = b
+	l.headless.maxConcurrentPerAgent = 1 // CEO may run only one task at a time
+
+	started := make(chan string, 8)
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+		select {
+		case started <- headlessTurnTaskID(ctx):
+		default:
+		}
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{Prompt: "work #task-a", Channel: "general", TaskID: "task-a"})
+	l.enqueueHeadlessCodexTurnRecord("ceo", headlessCodexTurn{Prompt: "work #task-b", Channel: "general", TaskID: "task-b"})
+
+	// Exactly one should start; the other parks under the cap.
+	var first string
+	select {
+	case first = <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the first lead task to start")
+	}
+	select {
+	case second := <-started:
+		t.Fatalf("cap=1 violated: a second task (%s) started while %s was active", second, first)
+	case <-time.After(250 * time.Millisecond):
+		// correct: the second lane is parked behind the cap
+	}
+
+	// Free the slot by cancelling the active turn; the parked lane must drain.
+	firstLane := taskLane("ceo", first)
+	l.headless.mu.Lock()
+	if active := l.headless.active[firstLane]; active != nil && active.Cancel != nil {
+		active.Cancel()
+	}
+	l.headless.mu.Unlock()
+
+	select {
+	case second := <-started:
+		if second == first {
+			t.Fatalf("expected the parked task to drain, but %s started again", second)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the parked lead task to start after a slot freed")
 	}
 }

--- a/internal/team/launcher_boot.go
+++ b/internal/team/launcher_boot.go
@@ -155,6 +155,7 @@ func (l *Launcher) Launch() error {
 	// Headless context for per-turn Claude invocations. Used by both TUI and
 	// web modes since agent dispatch is headless by default.
 	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
+	l.resolveHeadlessConcurrencyCaps()
 	l.resumeInFlightWork()
 
 	go func() { defer recoverPanicTo("watchChannelPaneLoop", ""); l.watchChannelPaneLoop(channelCmd) }()
@@ -214,6 +215,7 @@ func (l *Launcher) launchHeadlessCodex() error {
 	}
 
 	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
+	l.resolveHeadlessConcurrencyCaps()
 
 	l.resumeInFlightWork()
 	go l.notifyAgentsLoop()

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -144,6 +144,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	// Headless context is used for codex runtime, default dispatch, and
 	// per-turn operations that don't fit a long-lived pane session.
 	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
+	l.resolveHeadlessConcurrencyCaps()
 	l.resumeInFlightWork()
 
 	// Stream tmux pane output to the web UI's per-agent stream so users see

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -349,6 +349,11 @@ func (b *notificationContextBuilder) TaskNotificationContext(channelSlug, slug s
 
 	result := "Active tasks:\n" + strings.Join(lines, "\n")
 	if slug == lead {
+		// Concurrency awareness: the lead runs one dispatch lane per task, so the
+		// tasks above may be advancing in parallel right now (its own lanes and
+		// specialists'). Push non-dependent tasks forward together rather than
+		// serializing them, and reuse a live task before creating an overlapping one.
+		result += "\nCoordination: your tasks run on separate lanes and may be progressing in parallel right now. Advance non-dependent tasks together instead of one at a time, and reuse or update a task already listed above before creating a new one for the same work."
 		reviewCount := 0
 		for _, task := range tasks {
 			if strings.EqualFold(strings.TrimSpace(task.status), "done") {

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -353,7 +353,24 @@ func (b *notificationContextBuilder) TaskNotificationContext(channelSlug, slug s
 		// tasks above may be advancing in parallel right now (its own lanes and
 		// specialists'). Push non-dependent tasks forward together rather than
 		// serializing them, and reuse a live task before creating an overlapping one.
-		result += "\nCoordination: your tasks run on separate lanes and may be progressing in parallel right now. Advance non-dependent tasks together instead of one at a time, and reuse or update a task already listed above before creating a new one for the same work."
+		// The phrasing avoids implying the printed list is complete — the list is
+		// truncated to `limit`, so a reusable task may not be shown.
+		result += "\nCoordination: your tasks run on separate lanes and may be progressing in parallel right now. Advance non-dependent tasks together instead of one at a time, and reuse or update an existing task for the same work before creating a new one."
+		// If more eligible (non-done) tasks exist than were shown, the reusable
+		// task the lead should update may have been truncated away. Tell it to
+		// check the full list before creating a new one, so it doesn't duplicate.
+		// Dedup by ID to mirror the `seen` filter the printed list applies, so a
+		// repeated task can't trip a false-positive truncation cue.
+		eligibleIDs := make(map[string]struct{}, len(tasks))
+		for _, task := range tasks {
+			if strings.EqualFold(strings.TrimSpace(task.status), "done") {
+				continue
+			}
+			eligibleIDs[task.ID] = struct{}{}
+		}
+		if len(eligibleIDs) > len(lines) {
+			result += "\nNote: more active tasks exist than shown here — check the full task list before creating a new one."
+		}
 		reviewCount := 0
 		for _, task := range tasks {
 			if strings.EqualFold(strings.TrimSpace(task.status), "done") {


### PR DESCRIPTION
## What

Phase 2 of the multi-agent overhaul: let the **lead (CEO) work multiple tasks at once** instead of serializing every turn onto one dispatch lane.

Specialists already ran per-task lanes (one worker goroutine per `headlessLane{slug, key}`), with panic isolation and resume-on-restart already built. The re-audit confirmed the **only** bottleneck was the lead: it forced all of its turns onto a single default lane and deferred them whenever *any* specialist was busy. So this PR is surgical — almost entirely in the headless dispatch scheduler.

## Changes

**A. Lead per-task lanes** (`laneForTurn`) — a lead turn carrying a `TaskID` now resolves to its own per-task lane (`taskLane` / `worktreeLane`) exactly like a specialist, so non-dependent CEO tasks run concurrently. A lead turn with **no** `TaskID` (channel triage / conversational chat) still serializes on the default lane for coherence.

**B. Per-task-scoped lead-hold** — the "defer the lead while a specialist is busy" guard now applies **only** to no-`TaskID` triage turns, where the redundant-re-route race actually lives. A task-carrying lead turn is no longer held by an unrelated busy specialist. The existing same-task drop/replace still prevents double-dispatching one task.

**C. Concurrency caps (cost guard)** — global + per-agent caps on simultaneously-active lanes so CEO multitasking can't spawn unbounded LLM subprocesses. Env `WUPHF_MAX_CONCURRENT_TURNS` / `WUPHF_MAX_CONCURRENT_PER_AGENT`; defaults `clamp(cores, 2, 6)` / `3`, resolved at boot. Over-cap lanes **park** (queued, no worker) and **drain** as slots free in `finishHeadlessTurn`. Human-priority turns bypass the cap so a person is never starved. Zero-value pool fields mean *unlimited*, so existing concurrency tests are not retroactively throttled.

**D. Cross-task coordination** — one line in the lead's Active-tasks packet noting its tasks run on separate lanes in parallel, so it should advance non-dependent tasks together and reuse a listed task before creating an overlapping one. (Durable cross-task / cross-agent context already flows through the live task list, Notebooks, and the Wiki — no new IPC.)

## Out of scope (decided)

Separate-process instances / instance-to-instance IPC; a separate persisted lane registry (resume-via-task-lifecycle already covers restart).

## Tests

New tests in `internal/team`:
- lead runs two non-dependent tasks **concurrently** (the headline behavior)
- same-task lead turn still **dedupes** (no double-dispatch)
- task-carrying lead turn **not held** by an unrelated busy specialist
- no-task triage turn **still held** while a specialist is active
- concurrency cap **parks** the excess lane, then **drains** it when a slot frees

Updated `TestLaneForTurnKeysByWorktree` (+ the urgent-same-task test) to pin the new per-task lead-lane behavior.

## Verification

- Full Go suite via `scripts/test-go.sh` green, except two pre-existing **wiki/obsidian git flakes** (`git add -A: segmentation fault`, "HEAD advanced unexpectedly") — both confirmed environmental (obsidian watcher's background git-commit goroutine racing under parallel load), pass 3/3 in isolation, and do not touch any code this PR changes.
- Headless / lead / lane / parallel / concurrency paths green **3×** and under **`-race`**.
- `gofmt` + `go vet` clean.

Backend-only — no web surfaces touched, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lead tasks can now execute concurrently on separate lanes instead of being serialized.
  * Configurable concurrency caps via environment variables with intelligent lane parking when limits are reached.

* **Documentation**
  * Updated guidance for lead agents on coordinating non-dependent tasks in parallel.

* **Tests**
  * Added comprehensive concurrency behavior tests covering parallel task execution, deduplication, and cap enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->