### PR TITLE
fix(avatar): show Pam's desk face on her archivist bylines everywhere

### DIFF
--- a/web/e2e/screenshots/pam-avatar-consistency.mjs
+++ b/web/e2e/screenshots/pam-avatar-consistency.mjs
@@ -1,0 +1,117 @@
+// Verify Pam the librarian wears one consistent face everywhere.
+//
+// Pam's Wiki desk avatar uses slug "pam" (→ hybridPam sprite), but every
+// wiki edit she makes is committed under the "archivist" git identity, so
+// her bylines/audit/history render `<PixelAvatar slug="archivist" />`.
+// Before this fix "archivist" was absent from the slug map and fell back to
+// a procedural portrait — a different face. This probe paints the REAL
+// `drawPixelAvatar` output for each identity so the match is visible.
+//
+// Why a probe and not the live Wiki view: the wiki article route on `main`
+// currently hits a pre-existing "Maximum update depth exceeded" render loop
+// (channel-chat/Shell, tracked separately, unrelated to this change) that
+// prevents the harness from mounting the article. The fix here is a pure
+// function (resolvePortraitSprite/drawPixelAvatar), so rendering the sprite
+// output directly is a faithful — and more precise — verification.
+//
+// Run via the wrapper:
+//   web/e2e/screenshots/publish.sh pam-avatar-consistency <pr-number>
+
+import process from "node:process";
+
+import { launchBrowser, shotElement } from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const BASE = process.env.BASE_URL ?? "http://localhost:5273";
+
+const { browser, page, errors } = await launchBrowser({
+  viewport: { width: 960, height: 520 },
+});
+
+// Establish the dev-server origin so the module import below resolves, then
+// discard the SPA root entirely (it would otherwise spin in the unrelated
+// render loop). The avatar probe is independent of React.
+await page.goto(`${BASE}/`, { waitUntil: "domcontentloaded" });
+
+await page.evaluate(async (slugs) => {
+  document.documentElement.innerHTML =
+    "<head></head><body><div id='probe'></div></body>";
+  const { drawPixelAvatar, resolvePortraitSprite, getAgentColor } =
+    await import("/src/lib/pixelAvatar.ts");
+
+  const probe = document.getElementById("probe");
+  Object.assign(probe.style, {
+    display: "flex",
+    gap: "28px",
+    padding: "40px",
+    background: "#0d1117",
+    fontFamily:
+      "ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+    alignItems: "flex-start",
+  });
+
+  for (const { slug, note } of slugs) {
+    const cell = document.createElement("div");
+    Object.assign(cell.style, {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      gap: "10px",
+      width: "150px",
+      textAlign: "center",
+    });
+
+    const ring = document.createElement("div");
+    const accent = getAgentColor(slug);
+    Object.assign(ring.style, {
+      width: "112px",
+      height: "112px",
+      display: "grid",
+      placeItems: "center",
+      borderRadius: "16px",
+      background: "#161b22",
+      border: `2px solid ${accent}`,
+    });
+    const canvas = document.createElement("canvas");
+    canvas.style.imageRendering = "pixelated";
+    drawPixelAvatar(canvas, slug, 96);
+    ring.appendChild(canvas);
+
+    const label = document.createElement("div");
+    label.textContent = `slug "${slug}"`;
+    Object.assign(label.style, { color: "#e6edf3", fontSize: "13px", fontWeight: "600" });
+
+    const sub = document.createElement("div");
+    const sprite = resolvePortraitSprite(slug);
+    sub.textContent = `→ ${sprite.id}`;
+    Object.assign(sub.style, { color: "#8b949e", fontSize: "12px" });
+
+    const tag = document.createElement("div");
+    tag.textContent = note;
+    Object.assign(tag.style, { color: accent, fontSize: "11px" });
+
+    cell.append(ring, label, sub, tag);
+    probe.appendChild(cell);
+  }
+}, [
+  { slug: "pam", note: "Wiki desk" },
+  { slug: "archivist", note: "wiki byline identity" },
+  { slug: "librarian", note: "librarian label" },
+  { slug: "ceo", note: "different agent" },
+]);
+
+await page.waitForTimeout(300);
+await shotElement(page, "#probe", OUT, "01-pam-one-face-everywhere");
+
+console.log(`captured 1 screenshot to ${OUT}`);
+// The SPA root we discarded leaves render-loop noise in the console; that is
+// the pre-existing main bug, not this change. Only surface genuine probe
+// failures (a pageerror from the import/draw path).
+const real = errors.filter((e) => e.startsWith("[pageerror]"));
+if (real.length > 0) console.error("probe errors:", real);
+await browser.close();

--- a/web/src/lib/pixelAvatar.test.ts
+++ b/web/src/lib/pixelAvatar.test.ts
@@ -41,6 +41,21 @@ describe("pixel avatar sprite resolution", () => {
     expect(resolvePortraitSprite("jim-halpert").id).toBe("office20");
   });
 
+  it("renders Pam's archivist byline identity with the desk avatar", () => {
+    // The wiki desk avatar uses slug "pam"; Pam's commits are authored under
+    // the "archivist" git identity, so her bylines/audit/history arrive with
+    // that slug. Both must resolve to the same sprite — not a procedural face.
+    const desk = resolvePortraitSprite("pam");
+    expect(desk.id).toBe("hybridPam");
+
+    for (const slug of ["archivist", "librarian", " Archivist "]) {
+      const avatar = resolvePortraitSprite(slug);
+      expect(avatar.id).toBe(desk.id);
+      expect(avatar.palette).toEqual(desk.palette);
+      expect(avatar.portrait).toEqual(desk.portrait);
+    }
+  });
+
   it("keeps arbitrary new-agent slugs on generated office sprites", () => {
     const avatar = resolvePortraitSprite("custom-ops-agent");
     const idParts = avatar.id.split(":");
@@ -85,6 +100,8 @@ describe("pixel avatar sprite resolution", () => {
     expect(getAgentColor("growth")).toBe(getAgentColor("gtm"));
     expect(getAgentColor("halpert")).toBe(getAgentColor("jim"));
     expect(getAgentColor("jim-halpert")).toBe(getAgentColor("jim"));
+    expect(getAgentColor("archivist")).toBe(getAgentColor("pam"));
+    expect(getAgentColor("librarian")).toBe(getAgentColor("pam"));
     expect(getAgentColor("operator")).toBe(getAgentColor("nex"));
   });
 

--- a/web/src/lib/pixelAvatar.ts
+++ b/web/src/lib/pixelAvatar.ts
@@ -32,6 +32,12 @@ const AGENT_COLORS: Record<string, string> = {
 const AGENT_COLOR_ALIASES: Record<string, string> = {
   halpert: "jim",
   "jim-halpert": "jim",
+  // Pam the librarian commits to the wiki under the "archivist" git identity
+  // (see ArchivistAuthor in internal/team). Bylines, audit rows, and history
+  // therefore arrive with slug "archivist" — alias it (and "librarian") onto
+  // Pam so her accent colour matches the desk avatar everywhere she appears.
+  archivist: "pam",
+  librarian: "pam",
   planner: "pm",
   product: "pm",
   "product-manager": "pm",
@@ -105,6 +111,13 @@ const PORTRAIT_SPRITE_ALIASES: Record<string, string> = {
   jim: "office20",
   halpert: "office20",
   "jim-halpert": "office20",
+  // Pam's wiki contributions are authored under the "archivist" git identity,
+  // so her bylines/audit/edit-log surface with slug "archivist" rather than
+  // "pam". Map both that identity and the "librarian" label onto the exact
+  // sprite the desk avatar uses (slug "pam" → hybridPam) so Pam wears one face
+  // everywhere, not a procedural fallback.
+  archivist: "hybridPam",
+  librarian: "hybridPam",
 };
 
 function hashSlug(slug: string): number {


### PR DESCRIPTION
## Problem

Pam the librarian renders with the `hybridPam` pixel sprite on her **Wiki desk** (`<PixelAvatar slug="pam" />`). But every wiki edit she makes is committed under the **`archivist`** git identity (`ArchivistAuthor` in `internal/team`). So her bylines, audit rows, edit log, facts-on-file, sources, referenced-by, and the catalog all render `<PixelAvatar slug="archivist" />`.

`"archivist"` is **not** in the avatar slug map, so all of those surfaces fell back to a *procedural* (deterministic-but-random-looking) portrait — a different face from the one sitting on the desk.

## Fix

Alias `archivist` (and the `librarian` label) onto Pam's desk sprite and accent colour via the existing hand-written alias maps in `web/src/lib/pixelAvatar.ts` — the same seam already used for Jim Halpert, consulted *before* the generated catalog:

- `PORTRAIT_SPRITE_ALIASES`: `archivist` / `librarian` → `"hybridPam"`
- `AGENT_COLOR_ALIASES`: `archivist` / `librarian` → `"pam"`

Because the fix sits at the shared `resolvePortraitSprite` / `getAgentColor` chokepoint, **every** `PixelAvatar` consumer is covered at once — Pam wears one consistent face wherever she appears.

I deliberately did **not** edit the generated `avatarSprites.generated.ts` or run `scripts/generate-avatar-sprites.mjs`: that generator has drifted (it still emits Go to a stale `cmd/wuphf/` path with `package main`, while the live file is `internal/avatar/office_sprites.go`), so running it would break the build. The hand-written alias layer is the intended seam for this.

## Scope note

The Go avatar map (`internal/avatar`) also lacks `archivist`, but it only feeds the **terminal** channel UI, where the wiki / Pam bylines don't render — so there's no visible gap there. Left out to keep the change surgical.

## Test plan

- [x] `bash scripts/test-web.sh web/src/lib/pixelAvatar.test.ts` — added a test asserting `archivist` / `librarian` resolve to the **same id, palette, and portrait** as the desk's `pam`, plus color-alias assertions (9 passed)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` on changed files — clean

Screenshots to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-pam-one-face-everywhere](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1054/01-pam-one-face-everywhere.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent identities "archivist" and "librarian" now display with consistent pixel avatars.

* **Tests**
  * Added E2E screenshot testing for avatar consistency verification.
  * Expanded unit tests to validate agent identity avatar resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->