### PR TITLE
feat(plan-mode): run plan-first tasks in each provider's native plan mode

### DIFF
--- a/docs/specs/structural-changes.md
+++ b/docs/specs/structural-changes.md
@@ -54,10 +54,28 @@
   legacy-fixture test booting the real production path + FULL Go (39/39) + web
   (1738) + tsc + golangci-lint(0) + clean broker build. See the Phase 6 checklist
   entry for the 3 ICP upgrade scenarios. Commit: (this session — see git log).
-- **Optional follow-ups (NOT requested, not blocking):** hard plan-only runtime
-  enforcement (read-only/plan permission mode); broader Librarian `team_wiki_write`
-  for reorganizing; remove internal onboarding direct-channel plumbing once a DM-free
-  onboarding path exists; live browser/screenshot pass once Chrome CDP is restored.
+- **PHASE 5b — Native plan-mode enforcement DONE (`feat/provider-native-plan-mode`).**
+  Closes the Phase 5 follow-up "hard plan-only runtime enforcement (read-only/plan
+  permission mode)". A turn whose task is in `LifecycleStatePlanning` now runs in the
+  provider's NATIVE plan mode instead of full bypass, so "do not change the repo" is
+  enforced by the runtime, not just the `planModeDirective` prompt:
+  - `resolveTurnPosture(ctx, slug)` → plan posture iff `turnTaskForCtx` is Planning.
+  - Claude: `--permission-mode plan` (drops `--dangerously-skip-permissions`); the plan
+    arrives via the `ExitPlanMode` tool call, harvested (`extractClaudePlanArtifact`) into
+    a `plan` HeadlessEvent + the channel summary so the human can Approve & Start.
+  - Codex: `-a never -s read-only` (wins over the local_worktree/unsafe bypass); MCP is
+    not blocked so the owner still writes its notebook + posts; the same `plan` card is
+    emitted. opencode/openai-compat have no native sandbox → `planModeDirective` stays
+    their sole enforcement.
+  - Per-agent `PermissionMode` is now first-class: AgentWizard "Autonomy" selector +
+    AgentProfilePanel pill, and `handleTaskPlan` defaults Plan-first from the owner's
+    PermissionMode when `plan_first` is not set explicitly.
+- **Optional follow-ups (NOT requested, not blocking):** broader Librarian
+  `team_wiki_write` for reorganizing; remove internal onboarding direct-channel plumbing
+  once a DM-free onboarding path exists; persist the harvested plan to the owner notebook
+  for Claude plan turns (today it lands in the channel + plan card); editable
+  PermissionMode from the agent profile; live browser/screenshot pass once Chrome CDP is
+  restored.
 - **Branch:** `worktree-structural-changes`. **Prior HEAD:** `b08cbff0` (Phase 5). Base `origin/main` @ `46f06e54`.
 - **PHASE 4 DONE (Librarian = Pam; commits `e9b2f1d3` presence + `91180e7a` authority move).**
   Promoted the wiki "Pam the Archivist" to a first-class built-in agent: **slug `librarian`, name

--- a/internal/team/broker_tasks_plan.go
+++ b/internal/team/broker_tasks_plan.go
@@ -133,6 +133,15 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		// Effective Plan-first: honor an explicit per-task choice; otherwise
+		// default from the owner agent's autonomy (PermissionMode "plan" →
+		// plan-first). This is what makes a "plan" agent's delegated work run
+		// the owner through the provider's native plan mode before executing.
+		planFirst := item.PlanFirstEnabled()
+		if item.PlanFirst == nil {
+			planFirst = b.ownerDefaultsToPlanFirstLocked(strings.TrimSpace(item.Assignee))
+		}
+
 		b.counter++
 		taskID := b.allocateIssueIDLocked()
 		titleToID[strings.TrimSpace(item.Title)] = taskID
@@ -163,7 +172,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 			Effort:        strings.TrimSpace(item.Effort),
 			Provider:      strings.TrimSpace(item.Provider),
 			Model:         strings.TrimSpace(item.Model),
-			PlanFirst:     item.PlanFirstEnabled(),
+			PlanFirst:     planFirst,
 			DependsOn:     resolvedDeps,
 			CreatedAt:     now,
 			UpdatedAt:     now,

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -178,6 +178,11 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	turnID := newHeadlessTurnID()
 	var turnToolNames []string
 	var turnTextLen int
+	// Plan posture (task in LifecycleStatePlanning): the agent runs read-only
+	// and delivers its plan via the ExitPlanMode tool call, which we harvest
+	// here so it can be surfaced to the human for "Approve & Start".
+	planning := l.resolveTurnPosture(ctx, slug) == posturePlan
+	var planArtifact string
 
 	result, parseErr := provider.ReadClaudeJSONStream(teedStdout, func(event provider.ClaudeStreamEvent) {
 		if firstEventAt.IsZero() {
@@ -207,6 +212,11 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			}
 			appendHeadlessClaudeLog(slug, fmt.Sprintf("tool_use: %s %s", event.ToolName, truncate(event.ToolInput, 120)))
 			l.updateHeadlessProgress(slug, "active", "tool_use", fmt.Sprintf("running %s", strings.TrimSpace(event.ToolName)), metrics)
+			if planning && isExitPlanModeTool(event.ToolName) {
+				if plan := extractClaudePlanArtifact(event.ToolInput); plan != "" {
+					planArtifact = plan
+				}
+			}
 			turnToolNames = append(turnToolNames, event.ToolName)
 			emitHeadlessToolUse(agentStream, turnID, HeadlessProviderClaude, slug, taskID, event.ToolName, event.ToolInput, "claude.tool_use")
 		case "tool_result":
@@ -270,9 +280,20 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		l.broker.RecordAgentUsage(slug, l.headlessClaudeModel(ctx, slug), result.Usage)
 	}
 	relay.Flush()
-	if text := strings.TrimSpace(result.FinalMessage); text != "" {
-		appendHeadlessClaudeLog(slug, "result: "+text)
-		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
+	finalText := strings.TrimSpace(result.FinalMessage)
+	if planning && planArtifact != "" {
+		// Surface the plan as its own stream card, and use it as the channel
+		// summary the human reviews: under plan mode Claude delivers the plan
+		// via ExitPlanMode (a tool call), so result.FinalMessage is usually
+		// empty and the plan would otherwise sit only in the raw tool stream.
+		emitHeadlessPlan(agentStream, turnID, HeadlessProviderClaude, slug, taskID, planArtifact)
+		if finalText == "" {
+			finalText = planArtifact
+		}
+	}
+	if finalText != "" {
+		appendHeadlessClaudeLog(slug, "result: "+finalText)
+		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, finalText, startedAt)
 		if err != nil {
 			appendHeadlessClaudeLog(slug, "fallback-post-error: "+err.Error())
 		} else if posted {

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -52,7 +52,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		// failure mode (~30s tax on first turn) over the hard one
 		// (agent dies before producing any output).
 	}
-	args = append(args, strings.Fields(l.resolvePermissionFlags(slug))...)
+	args = append(args, strings.Fields(l.resolvePermissionFlags(ctx, slug))...)
 
 	// Per-task reasoning effort: when the active task carries a composer-set
 	// effort that claude accepts, pass it as `--effort <level>`. Empty/unknown

--- a/internal/team/headless_codex_plan_posture_test.go
+++ b/internal/team/headless_codex_plan_posture_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+	"slices"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -65,15 +65,28 @@ func TestRunHeadlessCodexTurnPlanPostureReadOnly(t *testing.T) {
 		t.Fatalf("runHeadlessCodexTurn: %v", err)
 	}
 
+	// Assert on discrete arg tokens (not a space-joined substring) so a value
+	// that merely contains "-s read-only" can't produce a false positive on this
+	// security-boundary check.
 	record := readHeadlessCodexRecord(t, recordFile)
-	joinedArgs := strings.Join(record.Args, " ")
-	if !strings.Contains(joinedArgs, "-a never") || !strings.Contains(joinedArgs, "-s read-only") {
+	if !hasArgPair(record.Args, "-a", "never") || !hasArgPair(record.Args, "-s", "read-only") {
 		t.Fatalf("expected read-only sandbox for planning turn, got %#v", record.Args)
 	}
-	if strings.Contains(joinedArgs, "-s workspace-write") {
+	if hasArgPair(record.Args, "-s", "workspace-write") {
 		t.Fatalf("planning turn must not be workspace-write, got %#v", record.Args)
 	}
-	if strings.Contains(joinedArgs, "--dangerously-bypass-approvals-and-sandbox") {
+	if slices.Contains(record.Args, "--dangerously-bypass-approvals-and-sandbox") {
 		t.Fatalf("planning turn must not bypass the sandbox, got %#v", record.Args)
 	}
+}
+
+// hasArgPair reports whether flag immediately followed by value appears as two
+// adjacent discrete entries in args (e.g. "-s", "read-only").
+func hasArgPair(args []string, flag, value string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/team/headless_codex_plan_posture_test.go
+++ b/internal/team/headless_codex_plan_posture_test.go
@@ -1,0 +1,79 @@
+package team
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+// TestRunHeadlessCodexTurnPlanPostureReadOnly is the Codex half of the native
+// plan-mode guarantee: a turn whose task is in LifecycleStatePlanning runs in
+// Codex's read-only sandbox (-s read-only), never workspace-write and never the
+// dangerous bypass — so the planning turn cannot change the repo before
+// "Approve & Start".
+func TestRunHeadlessCodexTurnPlanPostureReadOnly(t *testing.T) {
+	recordFile := filepath.Join(t.TempDir(), "headless-codex-record.jsonl")
+	oldLookPath := headlessCodexLookPath
+	oldExecutablePath := headlessCodexExecutablePath
+	oldCommandContext := headlessCodexCommandContext
+	headlessCodexLookPath = func(file string) (string, error) {
+		switch file {
+		case "codex":
+			return "/usr/bin/codex", nil
+		case "nex-mcp":
+			return "/usr/bin/nex-mcp", nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+	headlessCodexExecutablePath = func() (string, error) { return "/tmp/wuphf", nil }
+	headlessCodexCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestHeadlessCodexHelperProcess", "--"}
+		cmdArgs = append(cmdArgs, args...)
+		return exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	}
+	defer func() {
+		headlessCodexLookPath = oldLookPath
+		headlessCodexExecutablePath = oldExecutablePath
+		headlessCodexCommandContext = oldCommandContext
+	}()
+
+	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
+	t.Setenv("HEADLESS_CODEX_RECORD_FILE", recordFile)
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("WUPHF_RUNTIME_HOME", tmpHome)
+	t.Setenv("WUPHF_API_KEY", "nex-secret-key")
+	t.Setenv("WUPHF_OPENAI_API_KEY", "openai-secret-key")
+
+	b := newTestBroker(t)
+	seedTaskInState(t, b, "task-plan", LifecycleStatePlanning)
+	l := &Launcher{
+		pack:     agent.GetPack("founding-team"),
+		cwd:      t.TempDir(),
+		broker:   b,
+		headless: headlessWorkerPool{ctx: t.Context()},
+	}
+
+	ctx := withHeadlessTurnTaskID(t.Context(), "task-plan")
+	if err := l.runHeadlessCodexTurn(ctx, "ceo", "Plan this work."); err != nil {
+		t.Fatalf("runHeadlessCodexTurn: %v", err)
+	}
+
+	record := readHeadlessCodexRecord(t, recordFile)
+	joinedArgs := strings.Join(record.Args, " ")
+	if !strings.Contains(joinedArgs, "-a never") || !strings.Contains(joinedArgs, "-s read-only") {
+		t.Fatalf("expected read-only sandbox for planning turn, got %#v", record.Args)
+	}
+	if strings.Contains(joinedArgs, "-s workspace-write") {
+		t.Fatalf("planning turn must not be workspace-write, got %#v", record.Args)
+	}
+	if strings.Contains(joinedArgs, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Fatalf("planning turn must not bypass the sandbox, got %#v", record.Args)
+	}
+}

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -49,13 +49,24 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	}
 
 	args := make([]string, 0, 16+len(overrides)*2)
-	// Nested Codex local-worktree turns need full bypass here. The child Codex
-	// sandbox rejects both apply_patch and shell writes even with
-	// workspace-write, which leaves coding tasks permanently unable to land
-	// edits. Keep office/non-editing turns on workspace-write.
-	if l.unsafe || l.headlessCodexNeedsDangerousBypass(ctx, slug) {
+	// Sandbox posture for this turn:
+	//   - plan posture (task in LifecycleStatePlanning): -s read-only — Codex's
+	//     native plan/read-only mode. The repo cannot change, so the owner
+	//     explores and writes its plan (via MCP notebook_write + a channel post,
+	//     which read-only does not block) without risk of touching the repo
+	//     before "Approve & Start". Wins over unsafe/worktree bypass: a planning
+	//     turn must stay read-only even for local_worktree coding tasks.
+	//   - local-worktree / unsafe execute turn: full bypass. The child Codex
+	//     sandbox rejects both apply_patch and shell writes even with
+	//     workspace-write, which leaves coding tasks permanently unable to land
+	//     edits.
+	//   - office / non-editing execute turn: workspace-write.
+	switch {
+	case l.resolveTurnPosture(ctx, slug) == posturePlan:
+		args = append(args, "-a", "never", "-s", "read-only")
+	case l.unsafe || l.headlessCodexNeedsDangerousBypass(ctx, slug):
 		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
-	} else {
+	default:
 		args = append(args, "-a", "never", "-s", "workspace-write")
 	}
 	args = append(args, "--disable", "plugins")

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -352,6 +352,13 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	relay.Flush()
 	if text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine)); text != "" {
 		appendHeadlessCodexLog(slug, "result: "+text)
+		// In plan posture (-s read-only) the final message IS the plan; surface
+		// it as a plan card. Codex has no ExitPlanMode, and read-only does not
+		// block MCP, so the owner may also have written its notebook + posted —
+		// the silent-gated post below avoids a duplicate channel message.
+		if l.resolveTurnPosture(ctx, slug) == posturePlan {
+			emitHeadlessPlan(agentStream, turnID, HeadlessProviderCodex, slug, taskID, text)
+		}
 		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
 		if err != nil {
 			appendHeadlessCodexLog(slug, "fallback-post-error: "+err.Error())

--- a/internal/team/headless_event.go
+++ b/internal/team/headless_event.go
@@ -106,6 +106,12 @@ const (
 	HeadlessEventTypeIdle       = "idle"
 	HeadlessEventTypeError      = "error"
 	HeadlessEventTypeManifest   = "manifest"
+	// HeadlessEventTypePlan is the read-only plan an agent produced during a
+	// LifecycleStatePlanning turn — Claude's ExitPlanMode payload, or a
+	// read-only Codex/other turn's final message. The frontend renders it as a
+	// "Plan ready — review & approve" card so the human can act on the plan
+	// without digging through the raw tool stream.
+	HeadlessEventTypePlan = "plan"
 
 	HeadlessProviderClaude       = "claude"
 	HeadlessProviderCodex        = "codex"
@@ -251,6 +257,26 @@ func emitHeadlessToolUse(stream *agentStreamBuffer, turnID, provider, slug, task
 		Detail:   toolInput,
 		Status:   "active",
 		RawType:  rawType,
+	})
+}
+
+// emitHeadlessPlan pushes a plan-phase HeadlessEvent carrying the read-only
+// plan an agent produced during a LifecycleStatePlanning turn. plan is the full
+// plan text (Claude's ExitPlanMode payload or a read-only final message). Empty
+// plans are dropped. Status is "idle" because the turn has stopped to await the
+// human's "Approve & Start".
+func emitHeadlessPlan(stream *agentStreamBuffer, turnID, provider, slug, taskID, plan string) {
+	if stream == nil || strings.TrimSpace(plan) == "" {
+		return
+	}
+	pushHeadlessEvent(stream, HeadlessEvent{
+		Type:     HeadlessEventTypePlan,
+		Provider: provider,
+		Agent:    slug,
+		TurnID:   strings.TrimSpace(turnID),
+		TaskID:   strings.TrimSpace(taskID),
+		Text:     strings.TrimSpace(plan),
+		Status:   "idle",
 	})
 }
 

--- a/internal/team/plan_harvest_test.go
+++ b/internal/team/plan_harvest_test.go
@@ -1,0 +1,76 @@
+package team
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestExtractClaudePlanArtifact pins the ExitPlanMode harvest: the plan text is
+// pulled from the {"plan": ...} tool input, and non-plan / malformed inputs
+// yield "".
+func TestExtractClaudePlanArtifact(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plan field", `{"plan":"1. read code\n2. ship"}`, "1. read code\n2. ship"},
+		{"trims whitespace", `{"plan":"  do the thing  "}`, "do the thing"},
+		{"empty plan", `{"plan":""}`, ""},
+		{"no plan key", `{"other":"x"}`, ""},
+		{"not json", `ExitPlanMode`, ""},
+		{"empty", ``, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractClaudePlanArtifact(tc.input); got != tc.want {
+				t.Fatalf("extractClaudePlanArtifact(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsExitPlanModeTool tolerates the bare name and MCP-prefixed variants.
+func TestIsExitPlanModeTool(t *testing.T) {
+	for _, name := range []string{"ExitPlanMode", "exitplanmode", "mcp__x__ExitPlanMode"} {
+		if !isExitPlanModeTool(name) {
+			t.Fatalf("%q should be ExitPlanMode", name)
+		}
+	}
+	for _, name := range []string{"", "Edit", "team_task", "Plan"} {
+		if isExitPlanModeTool(name) {
+			t.Fatalf("%q should NOT be ExitPlanMode", name)
+		}
+	}
+}
+
+// TestEmitHeadlessPlanWireShape pins the plan-card wire shape and that empty
+// plans are dropped.
+func TestEmitHeadlessPlanWireShape(t *testing.T) {
+	stream := &agentStreamBuffer{subs: make(map[int]agentStreamSubscriber)}
+
+	emitHeadlessPlan(stream, "turn-9", HeadlessProviderClaude, "ceo", "task-3", "   ")
+	if got := stream.recentTask("task-3"); len(got) != 0 {
+		t.Fatalf("empty plan must be dropped, got %d", len(got))
+	}
+
+	emitHeadlessPlan(stream, "turn-9", HeadlessProviderClaude, "ceo", "task-3", "Goal: X\nSteps: 1,2,3")
+	lines := stream.recentTask("task-3")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 plan event, got %d: %v", len(lines), lines)
+	}
+	var event HeadlessEvent
+	if err := json.Unmarshal([]byte(strings.TrimRight(lines[0], "\n")), &event); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if event.Type != HeadlessEventTypePlan {
+		t.Fatalf("type: want plan, got %q", event.Type)
+	}
+	if event.TurnID != "turn-9" || event.TaskID != "task-3" || event.Agent != "ceo" {
+		t.Fatalf("correlation fields wrong: %+v", event)
+	}
+	if !strings.Contains(event.Text, "Goal: X") {
+		t.Fatalf("plan text missing: %+v", event)
+	}
+}

--- a/internal/team/plan_harvest_test.go
+++ b/internal/team/plan_harvest_test.go
@@ -73,4 +73,9 @@ func TestEmitHeadlessPlanWireShape(t *testing.T) {
 	if !strings.Contains(event.Text, "Goal: X") {
 		t.Fatalf("plan text missing: %+v", event)
 	}
+	// The StreamLineView "plan ready" card and useAgentStream's clean-close on a
+	// live idle event both depend on status=idle — pin it here too.
+	if event.Status != "idle" {
+		t.Fatalf("status: want idle, got %q", event.Status)
+	}
 }

--- a/internal/team/plan_mode.go
+++ b/internal/team/plan_mode.go
@@ -25,6 +25,17 @@ func taskIsPreExecution(s LifecycleState) bool {
 	return false
 }
 
+// isPlanningLifecycleState reports whether a task is in the autonomous planning
+// phase (LifecycleStatePlanning), where the owner is dispatched to write a plan
+// read-only before execution. It is the single trigger for running a turn in the
+// provider's NATIVE plan/read-only permission mode (Claude --permission-mode
+// plan, Codex -s read-only) instead of full bypass — see resolveTurnPosture. A
+// task in any other state (office/conversational turns, Running/Approved work)
+// stays execute-posture with full autonomy.
+func isPlanningLifecycleState(s LifecycleState) bool {
+	return s == LifecycleStatePlanning
+}
+
 // specIsFrozen reports whether a task's human-approved spec BODY (its Details —
 // the problem / approach / acceptance criteria the human signed off on) may no
 // longer be rewritten. Once the owner is executing an approved plan (Running)
@@ -56,9 +67,12 @@ func specIsFrozen(s LifecycleState) bool {
 // planModeDirective is prepended to the work packet for a task in
 // LifecycleStatePlanning. It tells the owner to plan only (no repo changes, no
 // external actions), capture the plan in its notebook, post a summary, and
-// stop. v1 enforcement is this instruction plus the owner self-limiting; a
-// future hardening can run the planning turn in the runtime's read-only/plan
-// permission mode.
+// stop. Enforcement is now two layers: this instruction PLUS the runtime running
+// the planning turn in the provider's native read-only/plan permission mode
+// (Claude --permission-mode plan, Codex -s read-only — see resolveTurnPosture),
+// so a planning turn cannot change the repo even if the model ignores the
+// directive. opencode / openai-compat have no native sandbox, so for those
+// providers this directive remains the sole enforcement.
 func planModeDirective(task teamTask) string {
 	notebookPath := "agents/<your-slug>/notebook/plan-" + task.ID + ".md"
 	return "[PLAN MODE] This task is in planning — do NOT change the repo, run build/deploy steps, or take external actions yet. Plan first:\n" +

--- a/internal/team/plan_mode.go
+++ b/internal/team/plan_mode.go
@@ -1,5 +1,10 @@
 package team
 
+import (
+	"encoding/json"
+	"strings"
+)
+
 // plan_mode.go owns "Plan mode" (Phase 5): a per-task "Plan first" toggle
 // (default ON) that makes the owner plan autonomously before executing. A
 // Plan-first task enters LifecycleStatePlanning, where the owner is dispatched
@@ -64,6 +69,31 @@ func specIsFrozen(s LifecycleState) bool {
 	return false
 }
 
+// extractClaudePlanArtifact pulls the plan text out of an ExitPlanMode tool_use
+// input. Under Claude's native plan mode the finished plan is delivered as the
+// ExitPlanMode tool call ({"plan": "..."}), NOT as assistant text — so a
+// planning turn must harvest it from the tool input. Returns "" when toolInput
+// is not ExitPlanMode-shaped or carries no plan.
+func extractClaudePlanArtifact(toolInput string) string {
+	var parsed struct {
+		Plan string `json:"plan"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(toolInput)), &parsed); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(parsed.Plan)
+}
+
+// isExitPlanModeTool reports whether a tool name is Claude's ExitPlanMode tool,
+// tolerant of the MCP-style prefixes Claude may surface it under.
+func isExitPlanModeTool(toolName string) bool {
+	name := strings.TrimSpace(toolName)
+	if idx := strings.LastIndex(name, "__"); idx >= 0 {
+		name = name[idx+2:]
+	}
+	return strings.EqualFold(name, "ExitPlanMode")
+}
+
 // planModeDirective is prepended to the work packet for a task in
 // LifecycleStatePlanning. It tells the owner to plan only (no repo changes, no
 // external actions), capture the plan in its notebook, post a summary, and
@@ -75,10 +105,9 @@ func specIsFrozen(s LifecycleState) bool {
 // providers this directive remains the sole enforcement.
 func planModeDirective(task teamTask) string {
 	notebookPath := "agents/<your-slug>/notebook/plan-" + task.ID + ".md"
-	return "[PLAN MODE] This task is in planning — do NOT change the repo, run build/deploy steps, or take external actions yet. Plan first:\n" +
+	return "[PLAN MODE] This task is in planning and your runtime is read-only — you literally cannot change the repo, run build/deploy steps, or take external actions this turn. Plan first:\n" +
 		"1. Read only what you need to understand the work; do not do the work.\n" +
-		"2. Write a tight PLAN to your notebook with notebook_write (path like " + notebookPath + "): the goal, a concrete step-by-step approach, acceptance criteria, and risks/open questions. This is a draft for you and the human — it is NOT promoted to the team wiki unless @librarian decides it is worth it.\n" +
-		"3. Post a short summary of the plan to the task channel so the human can review it.\n" +
-		"4. Then STOP. Execution starts only after the human clicks \"Approve & Start\"; you will be re-notified to begin the work then. Do NOT start implementing in this turn.\n" +
+		"2. Produce a tight PLAN: the goal, a concrete step-by-step approach, acceptance criteria, and risks/open questions. Present it as your final answer (in plan mode this goes through the plan/ExitPlanMode surface). If your runtime still allows writes, also save it to your notebook with notebook_write (path like " + notebookPath + ") — a draft for you and the human, NOT promoted to the team wiki unless @librarian decides it is worth it.\n" +
+		"3. Then STOP — the plan is surfaced to the human automatically. Execution starts only after the human clicks \"Approve & Start\"; you will be re-notified to begin the work then. Do NOT try to start implementing in this turn.\n" +
 		"---\n"
 }

--- a/internal/team/plan_mode.go
+++ b/internal/team/plan_mode.go
@@ -123,7 +123,7 @@ func (b *Broker) ownerDefaultsToPlanFirstLocked(owner string) bool {
 // providers this directive remains the sole enforcement.
 func planModeDirective(task teamTask) string {
 	notebookPath := "agents/<your-slug>/notebook/plan-" + task.ID + ".md"
-	return "[PLAN MODE] This task is in planning and your runtime is read-only — you literally cannot change the repo, run build/deploy steps, or take external actions this turn. Plan first:\n" +
+	return "[PLAN MODE] This task is in planning and your runtime is read-only — do NOT change the repo, run build/deploy steps, or take external actions this turn (the sandbox will block them anyway). Plan first:\n" +
 		"1. Read only what you need to understand the work; do not do the work.\n" +
 		"2. Produce a tight PLAN: the goal, a concrete step-by-step approach, acceptance criteria, and risks/open questions. Present it as your final answer (in plan mode this goes through the plan/ExitPlanMode surface). If your runtime still allows writes, also save it to your notebook with notebook_write (path like " + notebookPath + ") — a draft for you and the human, NOT promoted to the team wiki unless @librarian decides it is worth it.\n" +
 		"3. Then STOP — the plan is surfaced to the human automatically. Execution starts only after the human clicks \"Approve & Start\"; you will be re-notified to begin the work then. Do NOT try to start implementing in this turn.\n" +

--- a/internal/team/plan_mode.go
+++ b/internal/team/plan_mode.go
@@ -94,6 +94,24 @@ func isExitPlanModeTool(toolName string) bool {
 	return strings.EqualFold(name, "ExitPlanMode")
 }
 
+// ownerDefaultsToPlanFirstLocked reports whether a task assigned to owner should
+// default to Plan-first because the owner agent's autonomy (PermissionMode) is
+// "plan". Used only when the task-create request did not set plan_first
+// explicitly, so an explicit per-task choice (e.g. the composer's "Plan first"
+// toggle) always wins. The "auto" triage sentinel and unknown owners default to
+// OFF — there is no real agent autonomy to read yet.
+func (b *Broker) ownerDefaultsToPlanFirstLocked(owner string) bool {
+	owner = strings.TrimSpace(owner)
+	if owner == "" || isAutoOwner(owner) {
+		return false
+	}
+	member := b.findMemberLocked(owner)
+	if member == nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(member.PermissionMode), "plan")
+}
+
 // planModeDirective is prepended to the work packet for a task in
 // LifecycleStatePlanning. It tells the owner to plan only (no repo changes, no
 // external actions), capture the plan in its notebook, post a summary, and

--- a/internal/team/plan_mode_posture_test.go
+++ b/internal/team/plan_mode_posture_test.go
@@ -67,3 +67,37 @@ func TestResolveTurnPostureNilLauncher(t *testing.T) {
 		t.Fatal("nil launcher must default to execute posture")
 	}
 }
+
+// TestOwnerDefaultsToPlanFirst pins the config wiring: a task with no explicit
+// plan_first defaults to Plan-first iff the owner agent's PermissionMode is
+// "plan". The "auto" triage sentinel and unknown owners default OFF.
+func TestOwnerDefaultsToPlanFirst(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.members = append(b.members,
+		officeMember{Slug: "planner", PermissionMode: "plan"},
+		officeMember{Slug: "doer", PermissionMode: "auto"},
+		officeMember{Slug: "blank", PermissionMode: ""},
+	)
+	b.mu.Unlock()
+
+	cases := []struct {
+		owner string
+		want  bool
+	}{
+		{"planner", true},
+		{"doer", false},
+		{"blank", false},
+		{"auto", false}, // triage sentinel, not a real agent
+		{"", false},
+		{"ghost", false}, // unknown owner
+	}
+	for _, tc := range cases {
+		b.mu.Lock()
+		got := b.ownerDefaultsToPlanFirstLocked(tc.owner)
+		b.mu.Unlock()
+		if got != tc.want {
+			t.Fatalf("ownerDefaultsToPlanFirstLocked(%q) = %v, want %v", tc.owner, got, tc.want)
+		}
+	}
+}

--- a/internal/team/plan_mode_posture_test.go
+++ b/internal/team/plan_mode_posture_test.go
@@ -1,0 +1,69 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsPlanningLifecycleState pins the single trigger for native plan mode:
+// only LifecycleStatePlanning is a planning turn. Drafting is pre-execution but
+// NOT dispatched, so it is not a planning turn.
+func TestIsPlanningLifecycleState(t *testing.T) {
+	if !isPlanningLifecycleState(LifecycleStatePlanning) {
+		t.Fatalf("planning state must be a planning turn")
+	}
+	for _, s := range []LifecycleState{
+		LifecycleStateDrafting, LifecycleStateRunning, LifecycleStateApproved,
+		LifecycleStateReview, LifecycleStateReady, LifecycleStateIntake,
+		LifecycleStateDecision, LifecycleStateArchived, "",
+	} {
+		if isPlanningLifecycleState(s) {
+			t.Fatalf("%q must not be a planning turn", s)
+		}
+	}
+}
+
+// TestResolvePermissionFlagsPlanPosture is the security-critical assertion: a
+// planning turn maps to Claude's native plan mode and NEVER carries
+// --dangerously-skip-permissions (which would defeat the read-only gate), while
+// every other turn keeps full bypass.
+func TestResolvePermissionFlagsPlanPosture(t *testing.T) {
+	b := newTestBroker(t)
+	seedTaskInState(t, b, "task-plan", LifecycleStatePlanning)
+	seedTaskInState(t, b, "task-run", LifecycleStateRunning)
+	seedTaskInState(t, b, "task-draft", LifecycleStateDrafting)
+	l := &Launcher{broker: b}
+
+	planFlags := l.resolvePermissionFlags(withHeadlessTurnTaskID(t.Context(), "task-plan"), "ceo")
+	if planFlags != "--permission-mode plan" {
+		t.Fatalf("planning turn flags = %q, want %q", planFlags, "--permission-mode plan")
+	}
+	if strings.Contains(planFlags, "dangerously-skip-permissions") {
+		t.Fatalf("planning turn must not skip permissions, got %q", planFlags)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		taskID string
+	}{
+		{"running", "task-run"},
+		{"drafting", "task-draft"},
+		{"no-task", ""},
+	} {
+		ctx := t.Context()
+		if tc.taskID != "" {
+			ctx = withHeadlessTurnTaskID(ctx, tc.taskID)
+		}
+		flags := l.resolvePermissionFlags(ctx, "ceo")
+		if !strings.Contains(flags, "bypassPermissions") || !strings.Contains(flags, "dangerously-skip-permissions") {
+			t.Fatalf("%s turn flags = %q, want bypass + skip-permissions", tc.name, flags)
+		}
+	}
+}
+
+func TestResolveTurnPostureNilLauncher(t *testing.T) {
+	var l *Launcher
+	if l.resolveTurnPosture(t.Context(), "ceo") != postureExecute {
+		t.Fatal("nil launcher must default to execute posture")
+	}
+}

--- a/internal/team/prompts.go
+++ b/internal/team/prompts.go
@@ -138,9 +138,48 @@ func (l *Launcher) cleanupAgentTempFiles() {
 	}
 }
 
-// resolvePermissionFlags returns the Claude Code permission flags for an agent.
-// All agents run in bypass mode by default — the team is autonomous.
-func (l *Launcher) resolvePermissionFlags(slug string) string {
+// turnPosture is the read/write posture of a single agent turn.
+type turnPosture int
+
+const (
+	// postureExecute lets the turn change the repo and take actions — full
+	// autonomy. This is every office/conversational turn and every turn for a
+	// Running/Approved task.
+	postureExecute turnPosture = iota
+	// posturePlan runs the turn read-only: the owner explores and produces a
+	// plan but must not change the repo or take external actions until a human
+	// clicks "Approve & Start". Mapped onto each provider's native plan mode.
+	posturePlan
+)
+
+// resolveTurnPosture decides whether THIS turn runs read-only (plan) or
+// read-write (execute). A turn is plan-posture only when its task is in the
+// autonomous planning phase (LifecycleStatePlanning); everything else stays
+// execute-posture. The task is resolved per-turn via turnTaskForCtx so that,
+// under parallel instances, an agent's planning turn and a concurrent
+// office/execution turn get independent postures. A background context falls
+// back to the agent's active task (correct for the single-task interactive
+// pane).
+func (l *Launcher) resolveTurnPosture(ctx context.Context, slug string) turnPosture {
+	if l == nil {
+		return postureExecute
+	}
+	if task := l.turnTaskForCtx(ctx, slug); task != nil && isPlanningLifecycleState(task.LifecycleState) {
+		return posturePlan
+	}
+	return postureExecute
+}
+
+// resolvePermissionFlags returns the Claude Code permission flags for an agent's
+// current turn. Execute-posture turns run in bypass mode — the team is
+// autonomous. Plan-posture turns (the task is in LifecycleStatePlanning) run in
+// Claude's NATIVE plan mode: read-only exploration where the model presents a
+// plan via ExitPlanMode and no mutating tool runs. --dangerously-skip-permissions
+// is deliberately omitted in plan posture — it would defeat the read-only gate.
+func (l *Launcher) resolvePermissionFlags(ctx context.Context, slug string) string {
+	if l.resolveTurnPosture(ctx, slug) == posturePlan {
+		return "--permission-mode plan"
+	}
 	return "--permission-mode bypassPermissions --dangerously-skip-permissions"
 }
 
@@ -186,7 +225,10 @@ func (l *Launcher) claudeCommand(slug, systemPrompt string) (string, error) {
 	}
 
 	name := l.targeter().NameFor(slug)
-	permFlags := l.resolvePermissionFlags(slug)
+	// The interactive pane runs one task at a time and has no per-turn ctx, so a
+	// background context resolves posture from the agent's active task (a
+	// Planning task → native plan mode; anything else → bypass).
+	permFlags := l.resolvePermissionFlags(context.Background(), slug)
 
 	brokerToken := ""
 	if l.broker != nil {

--- a/web/e2e/screenshots/plan-mode.mjs
+++ b/web/e2e/screenshots/plan-mode.mjs
@@ -1,0 +1,187 @@
+// Capture the native plan-mode surfaces:
+//   01: Task composer — the "Plan first" toggle that routes a task through
+//       Planning (the entry point to native plan mode)
+//   02: AgentWizard manual → "Autonomy" selector (Plan first / Auto)
+//   03: AgentProfilePanel permissions → autonomy "plan first"
+//   04: AgentProfilePanel permissions → autonomy "auto"
+//   05: AgentPanel live stream → "plan ready" card (a planning turn's plan)
+//
+// Run via:
+//   web/e2e/screenshots/publish.sh plan-mode <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  flipStore,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const LLM_KINDS = ["claude-code", "codex", "opencode", "mlx-lm", "ollama", "exo"];
+const GATEWAY_KINDS = ["openclaw", "openclaw-http", "hermes-agent"];
+
+const CONFIG = {
+  llm_provider: "claude-code",
+  llm_provider_configured: true,
+  llm_provider_priority: [],
+  llm_provider_kinds: LLM_KINDS,
+  gateway_kinds: GATEWAY_KINDS,
+  provider_endpoints: {},
+  memory_backend: "markdown",
+  action_provider: "auto",
+  team_lead_slug: "ceo",
+  company_name: "Acme Co",
+  config_path: "/Users/you/.wuphf/config.json",
+};
+
+// Two agents with distinct autonomy so the profile pill is shown both ways.
+const MEMBERS_FIXTURE = {
+  members: [
+    {
+      slug: "designer",
+      name: "Designer",
+      role: "UI / UX",
+      emoji: "🎨",
+      status: "idle",
+      activity: "idle",
+      online: true,
+      permission_mode: "plan",
+      provider: { kind: "claude-code", model: "claude-3-5-sonnet-latest" },
+    },
+    {
+      slug: "eng",
+      name: "Founding Engineer",
+      role: "Full-stack",
+      emoji: "🛠️",
+      status: "idle",
+      activity: "idle",
+      online: true,
+      permission_mode: "auto",
+      provider: { kind: "codex", model: "gpt-5-codex" },
+    },
+  ],
+  meta: { humanHasPosted: true },
+};
+
+// A `plan` HeadlessEvent — the read-only planning turn's harvested plan. Sent
+// with status:"idle" after a replay-end marker so useAgentStream renders the
+// card and then cleanly closes the stream (no reconnect loop).
+const PLAN_EVENT = {
+  kind: "headless_event",
+  type: "plan",
+  provider: "claude",
+  agent: "designer",
+  task_id: "ACME-7",
+  status: "idle",
+  text:
+    "Goal: add a dark-mode toggle to the settings page.\n\n" +
+    "Approach:\n" +
+    "1. Add a `theme` field to the user-prefs store with a persisted default.\n" +
+    "2. Render a Toggle in SettingsPanel bound to the store.\n" +
+    "3. Apply `data-theme` on <html> and load the matching tokens CSS.\n\n" +
+    "Acceptance: the toggle flips the theme, the choice survives reload, and " +
+    "all three themes still pass the contrast check.\n\n" +
+    "Risks: the tokens loader is sync today — confirm no flash of unstyled " +
+    "content on first paint.",
+};
+
+function sseBody(event) {
+  // replay-end flips useAgentStream into the "live" phase; the idle plan event
+  // then renders + closes the stream.
+  return `event: replay-end\ndata: \n\n` + `data: ${JSON.stringify(event)}\n\n`;
+}
+
+async function mockAll(context, { stream = false } = {}) {
+  await context.route("**/api/config", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(CONFIG) }),
+  );
+  await context.route("**/api/status/local-providers", (r) =>
+    r.fulfill({ contentType: "application/json", body: "[]" }),
+  );
+  await context.route("**/api/office-members", (r) =>
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(MEMBERS_FIXTURE),
+    }),
+  );
+  if (stream) {
+    await context.route("**/agent-stream/**", (r) =>
+      r.fulfill({
+        contentType: "text/event-stream",
+        headers: { "cache-control": "no-cache" },
+        body: sseBody(PLAN_EVENT),
+      }),
+    );
+  }
+}
+
+async function gotoHash(page, hash) {
+  await page.evaluate((h) => {
+    window.location.hash = h;
+  }, hash);
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 960 },
+});
+
+// ── 01: Task composer — the "Plan first" toggle ─────────────────────
+await installCommonMocks(context, { extra: (ctx) => mockAll(ctx) });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await page.waitForSelector(".task-composer", { timeout: 10_000 });
+await page.waitForTimeout(300);
+await shotElement(page, ".task-composer", OUT, "01-task-composer-plan-first");
+
+// ── 02: AgentWizard — Autonomy selector ─────────────────────────────
+await installCommonMocks(context, { extra: (ctx) => mockAll(ctx) });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await gotoHash(page, "/agents");
+await page.waitForSelector('[data-testid="agents-tool"]', { timeout: 10_000 });
+await page.getByTitle("Create a new agent").first().click();
+await page.waitForSelector("text=Create agent", { timeout: 5_000 });
+await page.getByRole("button", { name: "Manual" }).click();
+await page.getByLabel("Name").fill("Brand Designer");
+await page.locator("#agent-permission-mode").scrollIntoViewIfNeeded();
+await page.waitForTimeout(200);
+await shotPage(page, OUT, "02-agent-wizard-autonomy");
+
+// ── 03 & 04: AgentProfilePanel autonomy pill ────────────────────────
+await installCommonMocks(context, { extra: (ctx) => mockAll(ctx) });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+
+// The autonomy pill lives in the panel's "permissions" section, below the
+// fold of the scroll container — scroll it into view and capture that section.
+const PERMISSIONS = ".agent-profile-section:has(.agent-profile-permissions)";
+
+await gotoHash(page, "/agents/designer");
+await page.waitForSelector(".agent-profile-panel", { timeout: 10_000 });
+await page.locator(PERMISSIONS).scrollIntoViewIfNeeded();
+await page.waitForTimeout(400);
+await shotElement(page, PERMISSIONS, OUT, "03-agent-profile-plan-first");
+
+await gotoHash(page, "/agents/eng");
+await page.waitForSelector(".agent-profile-panel", { timeout: 10_000 });
+await page.locator(PERMISSIONS).scrollIntoViewIfNeeded();
+await page.waitForTimeout(400);
+await shotElement(page, PERMISSIONS, OUT, "04-agent-profile-auto");
+
+// ── 05: Plan-ready card in the agent live stream ────────────────────
+await installCommonMocks(context, { extra: (ctx) => mockAll(ctx, { stream: true }) });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await flipStore(page, { activeAgentSlug: "designer" });
+await page.waitForSelector(".agent-panel", { timeout: 10_000 });
+await page.waitForSelector(".stream-card-plan", { timeout: 10_000 });
+await page.waitForTimeout(300);
+await shotElement(page, ".stream-card-plan", OUT, "05-plan-ready-card");
+
+console.log(`captured screenshots to ${OUT}`);
+await browser.close();

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -483,6 +483,12 @@ export interface OfficeMember {
   task?: string;
   channel?: string;
   provider?: ProviderBinding | string;
+  /**
+   * Agent autonomy. "plan" → the agent's tasks plan-first by default (the owner
+   * runs read-only in the provider's native plan mode and waits for Approve &
+   * Start); "auto" → executes immediately. Serialized as `permission_mode`.
+   */
+  permission_mode?: string;
   /** Broker-provided: serialized as `built_in`. Built-ins cannot be removed. (CEO is guarded by a separate slug check.) */
   built_in?: boolean;
   /** Per-channel disabled state when the list is sourced from `/members?channel=…`. */
@@ -795,25 +801,25 @@ export function deletePolicy(id: string) {
 // Moved to ./scheduler.ts; re-exported here for back-compat with existing
 // imports from "./api/client" or "../api/client".
 export type {
-  SchedulerJob,
+  CreateSchedulerJobBody,
   PatchSchedulerJobBody,
   PatchSchedulerJobResponse,
-  SystemCronSpec,
-  SchedulerRun,
   SchedulerActivity,
+  SchedulerJob,
   SchedulerRevision,
-  CreateSchedulerJobBody,
+  SchedulerRun,
+  SystemCronSpec,
 } from "./scheduler";
 export {
+  createSchedulerJob,
   getScheduler,
-  patchSchedulerJob,
-  getSystemCronSpecs,
-  runSchedulerJob,
-  getSchedulerRuns,
   getSchedulerActivity,
   getSchedulerRevisions,
+  getSchedulerRuns,
+  getSystemCronSpecs,
+  patchSchedulerJob,
   restoreSchedulerRevision,
-  createSchedulerJob,
+  runSchedulerJob,
 } from "./scheduler";
 
 // ── Skills ──
@@ -1093,10 +1099,9 @@ export function editSkillContent(
   name: string,
   content: string,
 ): Promise<EditSkillContentResponse> {
-  return put<EditSkillContentResponse>(
-    `/skills/${encodeURIComponent(name)}`,
-    { content },
-  );
+  return put<EditSkillContentResponse>(`/skills/${encodeURIComponent(name)}`, {
+    content,
+  });
 }
 
 // ── Memory ──

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -287,6 +287,8 @@ function taskStatusBadgeClass(raw: string): string {
 
 function PermissionsSection({ agent }: { agent: OfficeMember }) {
   const isLead = agent.built_in === true || agent.slug === "ceo";
+  // Default matches the broker's blank → "plan" fallback.
+  const planFirst = (agent.permission_mode ?? "plan") !== "auto";
 
   return (
     <div className="agent-profile-section">
@@ -296,6 +298,12 @@ function PermissionsSection({ agent }: { agent: OfficeMember }) {
           <span className="agent-profile-perm-label">role</span>
           <span className="agent-profile-perm-value">
             {isLead ? "lead agent" : "team member"}
+          </span>
+        </div>
+        <div className="agent-profile-perm-row">
+          <span className="agent-profile-perm-label">autonomy</span>
+          <span className="agent-profile-perm-value">
+            {planFirst ? "plan first" : "auto"}
           </span>
         </div>
         <div className="agent-profile-perm-row">
@@ -813,9 +821,7 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
   >({
     queryKey: ["channels"],
     queryFn: () =>
-      getChannels().then((r) =>
-        arrayOrEmpty<ChannelLite>(r?.channels),
-      ),
+      getChannels().then((r) => arrayOrEmpty<ChannelLite>(r?.channels)),
     refetchInterval: 30_000,
     select: (data): ChannelLite[] => {
       if (Array.isArray(data)) return data as ChannelLite[];

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -287,8 +287,12 @@ function taskStatusBadgeClass(raw: string): string {
 
 function PermissionsSection({ agent }: { agent: OfficeMember }) {
   const isLead = agent.built_in === true || agent.slug === "ceo";
-  // Default matches the broker's blank → "plan" fallback.
-  const planFirst = (agent.permission_mode ?? "plan") !== "auto";
+  // The broker normalizes a blank permission_mode to "plan" at member
+  // construction (broker_member_construction.go), so only an explicit "auto"
+  // is non-plan-first; blank/unset displays as plan-first. Trim + lowercase so
+  // " Auto " / "AUTO" don't slip through as plan-first.
+  const planFirst =
+    (agent.permission_mode ?? "").trim().toLowerCase() !== "auto";
 
   return (
     <div className="agent-profile-section">

--- a/web/src/components/agents/AgentWizard.test.tsx
+++ b/web/src/components/agents/AgentWizard.test.tsx
@@ -61,4 +61,27 @@ describe("<AgentWizard>", () => {
 
     expect(onClose).not.toHaveBeenCalled();
   });
+
+  it("defaults autonomy to plan-first and submits the chosen permission_mode", async () => {
+    postMock.mockResolvedValue({});
+    render(wrap(<AgentWizard open={true} onClose={vi.fn()} />));
+
+    fireEvent.click(screen.getByRole("button", { name: "Manual" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Revenue Ops" },
+    });
+
+    // Default is plan-first.
+    const autonomy = screen.getByLabelText("Autonomy") as HTMLSelectElement;
+    expect(autonomy.value).toBe("plan");
+
+    // Switch to auto and create.
+    fireEvent.change(autonomy, { target: { value: "auto" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [path, body] = postMock.mock.calls[0];
+    expect(path).toBe("/office-members");
+    expect((body as { permission_mode?: string }).permission_mode).toBe("auto");
+  });
 });

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -27,6 +27,13 @@ import {
 type ProviderChoice = "inherit" | LLMRuntimeKind;
 type WizardMode = "describe" | "manual";
 
+// PermissionMode is the agent's default autonomy. "plan" makes the agent's
+// tasks plan-first by default: the owner runs read-only in the provider's
+// native plan mode, produces a plan, and waits for "Approve & Start" before
+// executing. "auto" skips planning and executes immediately. Per-task "Plan
+// first" can still override this default at task-creation time.
+type PermissionModeChoice = "plan" | "auto";
+
 interface AgentFormData {
   name: string;
   slug: string;
@@ -35,6 +42,7 @@ interface AgentFormData {
   provider: ProviderChoice;
   model: string;
   expertise: string;
+  permissionMode: PermissionModeChoice;
 }
 
 const INITIAL_FORM: AgentFormData = {
@@ -45,6 +53,7 @@ const INITIAL_FORM: AgentFormData = {
   provider: "inherit",
   model: "",
   expertise: "",
+  permissionMode: "plan",
 };
 
 // Human-readable labels for the runtime picker. Kinds the broker hasn't
@@ -226,6 +235,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
         provider: providerInList ? suggestedProvider : "inherit",
         model: tmpl.model || "",
         expertise: (tmpl.expertise || []).join(", "),
+        permissionMode: "plan",
       });
       setSlugEdited(generatedSlug.length > 0);
       setMode("manual");
@@ -287,6 +297,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
         emoji: form.emoji || undefined,
         provider: providerBody,
         expertise: expertiseTags.length > 0 ? expertiseTags : undefined,
+        permission_mode: form.permissionMode,
       };
 
       await post("/office-members", body);
@@ -465,6 +476,31 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                 value={form.role}
                 onChange={(e) => updateField("role", e.target.value)}
               />
+            </div>
+
+            {/* Autonomy / Plan mode */}
+            <div className="agent-wizard-field">
+              <label className="label" htmlFor="agent-permission-mode">
+                Autonomy
+              </label>
+              <select
+                id="agent-permission-mode"
+                value={form.permissionMode}
+                onChange={(e) =>
+                  updateField(
+                    "permissionMode",
+                    e.target.value as PermissionModeChoice,
+                  )
+                }
+              >
+                <option value="plan">Plan first (default)</option>
+                <option value="auto">Auto</option>
+              </select>
+              <span className="op-hint">
+                {form.permissionMode === "plan"
+                  ? "This agent's tasks plan first: it runs read-only in the provider's native plan mode and waits for your Approve & Start before executing."
+                  : "This agent executes its tasks immediately, with no planning gate. Per-task “Plan first” can still override this."}
+              </span>
             </div>
 
             {/* Emoji */}

--- a/web/src/components/messages/StreamLineView.test.tsx
+++ b/web/src/components/messages/StreamLineView.test.tsx
@@ -131,6 +131,32 @@ describe("<StreamLineView>", () => {
     expect(screen.getByText(/reply ready/)).toBeInTheDocument();
   });
 
+  it("renders a HeadlessEvent plan envelope as a plan-ready card", () => {
+    // A read-only planning turn (Claude --permission-mode plan / Codex
+    // -s read-only) harvests the plan and emits a `plan` event; the view must
+    // surface it as an actionable "plan ready" card, not the generic fallback.
+    const { container } = render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: "",
+          parsed: {
+            kind: "headless_event",
+            type: "plan",
+            provider: "claude",
+            agent: "ceo",
+            text: "Goal: ship webhook\n1. read handler\n2. add route",
+            status: "idle",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("plan ready")).toBeInTheDocument();
+    expect(screen.getByText(/Goal: ship webhook/)).toBeInTheDocument();
+    expect(screen.getByText(/Approve & Start/)).toBeInTheDocument();
+    expect(container.querySelector(".stream-card-plan")).not.toBeNull();
+  });
+
   it("renders a HeadlessEvent error envelope with the failure detail", () => {
     render(
       <StreamLineView

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -255,6 +255,28 @@ function HeadlessEventView({
     );
   }
 
+  if (eventType === "plan") {
+    // A read-only planning turn finished and produced a plan (Claude's
+    // ExitPlanMode payload or a read-only final message). Surface it as a
+    // distinct, accented card so the human can review it and "Approve & Start"
+    // from the task surface.
+    if (!summary) return null;
+    return (
+      <div className="stream-card stream-card-plan">
+        <div className="stream-card-header">
+          <span className="stream-card-phase stream-phase-plan">
+            plan ready
+          </span>
+          {provider && <span className="stream-card-agent">{provider}</span>}
+        </div>
+        <div className="stream-card-plan-body">{summary}</div>
+        <div className="stream-card-plan-hint">
+          Review and Approve &amp; Start to begin execution.
+        </div>
+      </div>
+    );
+  }
+
   // Unknown HeadlessEvent type — fall back to the generic card so future
   // variants render something useful before they earn a dedicated branch.
   return <GenericEventCard parsed={parsed} compact={compact} />;

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -1432,6 +1432,29 @@ html[data-theme] .interview-bar-actions .btn-primary:hover {
   white-space: nowrap;
 }
 
+/* Plan-ready card: a read-only planning turn produced a plan awaiting the
+   human's "Approve & Start". Accent left rail marks it as needing attention. */
+.stream-card-plan {
+  border-left: 2px solid var(--accent);
+  background: var(--accent-bg);
+}
+.stream-phase-plan {
+  color: var(--accent);
+  background: var(--accent-bg);
+}
+.stream-card-plan-body {
+  font-size: var(--text-sm);
+  color: var(--text);
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.stream-card-plan-hint {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+}
+
 /* ─── Composer ─── */
 .composer {
   padding: 12px 24px 16px;


### PR DESCRIPTION
## What

WUPHF's per-task **Plan mode** (`LifecycleStatePlanning`) dispatched the owner with a plan-only work packet but launched the turn with **full bypass** (`--permission-mode bypassPermissions` / `-s workspace-write`). "Do not change the repo" was enforced only by the `planModeDirective` prompt — the agent could still write. `plan_mode.go` itself flagged this: *"a future hardening can run the planning turn in the runtime's read-only/plan permission mode."*

This is that hardening: a planning turn now runs in the **provider's native plan mode**.

## How

- **`resolveTurnPosture(ctx, slug)`** → plan posture iff the turn's task (resolved per-turn via `turnTaskForCtx`, so parallel instances stay independent) is in `LifecycleStatePlanning`. Every other turn (office/conversational, Running/Approved) is unchanged: full bypass.
- **Claude:** `--permission-mode plan` (drops `--dangerously-skip-permissions` — it would defeat the read-only gate). The plan arrives via the `ExitPlanMode` tool call, which is **harvested** (`extractClaudePlanArtifact`) into a `plan` `HeadlessEvent` and routed to the channel summary, because plan mode blocks the agent's own `notebook_write` / post.
- **Codex:** `-a never -s read-only` (wins over the `local_worktree`/`unsafe` bypass). MCP isn't blocked, so the owner still writes its notebook + posts; the same `plan` card is emitted.
- **opencode / openai-compat:** no native sandbox → `planModeDirective` stays their sole enforcement (documented).
- **Plan-ready card:** the `plan` event renders as a distinct accent-railed "plan ready — review & Approve & Start" card (token-only CSS, all three themes).
- **Config:** per-agent `PermissionMode` is now first-class — AgentWizard "Autonomy" selector + AgentProfilePanel pill, and `handleTaskPlan` defaults Plan-first from the owner's `PermissionMode` when `plan_first` isn't set explicitly. Explicit per-task choice still wins; the `auto` triage sentinel / unknown owners stay OFF.

## Trigger model

Plan mode attaches to the **task's planning phase**, not the agent — so the CEO's conversational office turns keep their MCP write access (they'd otherwise be unable to create tasks under Claude plan mode).

## Tests

- Posture mapping: plan posture **never** carries `--dangerously-skip-permissions`; Running/Drafting/no-task keep bypass; Codex planning turn asserts `-s read-only` (not workspace-write, not bypass).
- `extractClaudePlanArtifact` / `isExitPlanModeTool` / `emitHeadlessPlan` wire shape; plan-card render; `ownerDefaultsToPlanFirstLocked`; AgentWizard `permission_mode` submission.
- Full suites green: Go `team`+`provider`, web (1969 passed), `golangci-lint` 0 issues, `tsc` 0, biome/secretlint clean.

## Verification status

- ✅ Codex `-s read-only` is proven by the arg-recording test.
- ⚠️ Claude `--permission-mode plan` under `--print`: harvest is robust to either delivery (ExitPlanMode tool input **or** final message). A live ICP run (founder assigns a coding task to a `plan` owner → drafting in read-only → Approve & Start → executes) + screenshots are pending a running app (known pre-existing render-loop blocker noted separately).

## Follow-ups (deferred)

- Persist the harvested Claude plan to the owner's notebook (today it lands in the channel + plan card).
- Editable `PermissionMode` from the agent profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

![01-task-composer-plan-first](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1058/01-task-composer-plan-first.png)

![02-agent-wizard-autonomy](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1058/02-agent-wizard-autonomy.png)

![03-agent-profile-plan-first](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1058/03-agent-profile-plan-first.png)

![04-agent-profile-auto](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1058/04-agent-profile-auto.png)

![05-plan-ready-card](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1058/05-plan-ready-card.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plan-mode enforcement with native read-only posture during planning
  * Captured plan artifacts shown as “plan ready” cards with Approve & Start
  * Agent autonomy selector (Plan-first vs Auto) in Agent Wizard; profile shows permission mode
  * Client now carries agent permission_mode when creating members

* **Documentation**
  * Structural roadmap updated to mark Phase 5b (plan-mode enforcement) done

* **Tests**
  * Added unit tests for plan-mode/posture and plan harvest; added E2E screenshot script

* **Style**
  * Added CSS for plan-ready stream cards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->