### PR TITLE
feat(agents): per-agent instruction files loaded into prompts (Phase 4a)

### DIFF
--- a/internal/team/agent_files.go
+++ b/internal/team/agent_files.go
@@ -72,6 +72,14 @@ func validateAgentFilePath(relPath string) error {
 		return fmt.Errorf("agent file: path must not contain ..; got %q", relPath)
 	}
 	clean := filepath.ToSlash(filepath.Clean(relPath))
+	// Require the input to already be canonical. Cleaning collapses inputs like
+	// "agents/ceo/SOUL.md/." or a trailing slash to a valid in-tree path, but the
+	// write/read callers use the RAW relPath for the filesystem op — so a
+	// non-canonical input that only passes after Clean could create unintended
+	// directories or fail mid-write. Reject the divergence outright.
+	if clean != filepath.ToSlash(relPath) {
+		return fmt.Errorf("agent file: path must be canonical; got %q", relPath)
+	}
 	if clean == officeUserFileRel {
 		return nil
 	}
@@ -275,13 +283,17 @@ func renderAgentTools(member officeMember) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# TOOLS — @%s\n\n", member.Slug)
 	b.WriteString("## Available tools\n")
-	if len(member.AllowedTools) > 0 {
-		for _, t := range member.AllowedTools {
-			if t = strings.TrimSpace(t); t != "" {
-				fmt.Fprintf(&b, "- %s\n", t)
-			}
+	// Track whether any non-blank tool was written: an AllowedTools slice of
+	// only whitespace entries has len>0 but yields no lines, which would leave
+	// an empty section — fall back to the default toolset in that case too.
+	wroteTool := false
+	for _, t := range member.AllowedTools {
+		if t = strings.TrimSpace(t); t != "" {
+			fmt.Fprintf(&b, "- %s\n", t)
+			wroteTool = true
 		}
-	} else {
+	}
+	if !wroteTool {
 		b.WriteString("- The default office toolset (team_task, team_status, team_broadcast, notebook, wiki, and any skills enabled for you).\n")
 	}
 	b.WriteString("\n## Notes\n")

--- a/internal/team/agent_files.go
+++ b/internal/team/agent_files.go
@@ -1,0 +1,308 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// agent_files.go owns the per-agent instruction file set that makes an agent's
+// "soul" real, inspectable, and editable. Each agent has, under the wiki git
+// repo at agents/{slug}/:
+//
+//   - SOUL.md       — persona, values, voice, boundaries
+//   - IDENTITY.md   — name, slug, role, expertise, runtime
+//   - OPERATIONS.md — how the agent works + escalation (the AGENTS.md role)
+//   - TOOLS.md      — tool inventory + usage notes
+//
+// plus one office-wide office/USER.md describing the single human the office
+// serves. Memory is the Notebook subsystem (agents/{slug}/notebook/), so there
+// is no MEMORY.md; cadence is the scheduler, so there is no HEARTBEAT.md.
+//
+// These files live in the same git repo as notebooks and team articles, so they
+// are versioned, diffable, and Librarian-visible. They are loaded into the
+// agent's system prompt at build time (see prompt_builder.go). This file mirrors
+// the notebook write/read path (CommitNotebook / NotebookRead) so agent files
+// get the same OS-lock + git-commit guarantees without polluting the team/
+// article index.
+
+// agentInstructionFiles is the canonical per-agent file set, in prompt order.
+var agentInstructionFiles = []string{"SOUL", "IDENTITY", "OPERATIONS", "TOOLS"}
+
+// officeUserFileRel is the office-wide human-context file (one per office).
+const officeUserFileRel = "office/USER.md"
+
+// agentFileRel builds agents/{slug}/{NAME}.md for a per-agent instruction file.
+func agentFileRel(slug, name string) string {
+	return "agents/" + strings.TrimSpace(slug) + "/" + strings.TrimSpace(name) + ".md"
+}
+
+// isAgentInstructionFileName reports whether name is one of the canonical
+// per-agent file names (SOUL/IDENTITY/OPERATIONS/TOOLS).
+func isAgentInstructionFileName(name string) bool {
+	for _, f := range agentInstructionFiles {
+		if f == name {
+			return true
+		}
+	}
+	return false
+}
+
+// validateAgentFilePath allows ONLY the canonical agent-instruction files:
+// agents/{slug}/{SOUL|IDENTITY|OPERATIONS|TOOLS}.md and office/USER.md. Anything
+// else (arbitrary agents/ paths, traversal, the notebook subtree) is rejected,
+// so this path can never be used to clobber a notebook entry or escape the repo.
+func validateAgentFilePath(relPath string) error {
+	relPath = strings.TrimSpace(relPath)
+	if relPath == "" {
+		return fmt.Errorf("agent file: path is required")
+	}
+	if filepath.IsAbs(relPath) {
+		return fmt.Errorf("agent file: path must be relative; got %q", relPath)
+	}
+	// Reject any "." path segment outright (raw, before Clean collapses it).
+	// The file names are fixed and slugs never contain dots, so a legitimate
+	// path has no "." or ".." segment — refusing them keeps one agent from
+	// addressing another's file via a normalizing path.
+	if strings.Contains(relPath, "..") {
+		return fmt.Errorf("agent file: path must not contain ..; got %q", relPath)
+	}
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	if clean == officeUserFileRel {
+		return nil
+	}
+	parts := strings.Split(clean, "/")
+	if len(parts) != 3 || parts[0] != "agents" {
+		return fmt.Errorf("agent file: path must be agents/{slug}/{FILE}.md or %s; got %q", officeUserFileRel, relPath)
+	}
+	if err := validateNotebookSlug(parts[1]); err != nil {
+		return err
+	}
+	name := strings.TrimSuffix(parts[2], ".md")
+	if name == parts[2] || !isAgentInstructionFileName(name) {
+		return fmt.Errorf("agent file: name must be one of %v (.md); got %q", agentInstructionFiles, parts[2])
+	}
+	return nil
+}
+
+// commitAgentFileLocked writes + commits one agent instruction file. Mirrors
+// commitNotebookLocked: it does NOT regenerate the team/ article index (agent
+// files are per-agent and do not feed the team catalog). Caller holds r.mu.
+func (r *Repo) commitAgentFileLocked(ctx context.Context, slug, relPath, content, mode, message string) (string, int, error) {
+	if err := validateAgentFilePath(relPath); err != nil {
+		return "", 0, err
+	}
+	author := strings.TrimSpace(slug)
+	if author == "" {
+		author = "wuphf-bootstrap"
+	}
+	fullPath := filepath.Join(r.root, relPath)
+
+	switch mode {
+	case "create":
+		if _, err := os.Stat(fullPath); err == nil {
+			return "", 0, fmt.Errorf("agent file: already exists at %q; use replace", relPath)
+		}
+	case "replace":
+		// overwrite fine
+	default:
+		return "", 0, fmt.Errorf("agent file: unknown write mode %q; expected create|replace", mode)
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", 0, fmt.Errorf("agent file: content is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		return "", 0, fmt.Errorf("agent file: mkdir %s: %w", filepath.Dir(fullPath), err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		return "", 0, fmt.Errorf("agent file: write %s: %w", relPath, err)
+	}
+	bytesWritten := len(content)
+
+	relForGit := filepath.ToSlash(relPath)
+	if out, err := r.runGitLocked(ctx, author, "add", "--", relForGit); err != nil {
+		return "", 0, fmt.Errorf("agent file: git add %s: %w: %s", relPath, err, out)
+	}
+	cachedDiff, err := r.runGitLocked(ctx, "system", "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("agent file: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, err := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if err != nil {
+			return "", 0, fmt.Errorf("agent file: resolve HEAD sha: %w", err)
+		}
+		return strings.TrimSpace(headSha), bytesWritten, nil
+	}
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("agent: update %s", relPath)
+	}
+	if out, err := r.runGitLocked(ctx, author, "commit", "-q", "-m", commitMsg); err != nil {
+		return "", 0, fmt.Errorf("agent file: git commit: %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, author, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", 0, fmt.Errorf("agent file: resolve HEAD sha: %w", err)
+	}
+	return strings.TrimSpace(sha), bytesWritten, nil
+}
+
+// CommitAgentFile writes + commits one agent instruction file under r.mu.
+func (r *Repo) CommitAgentFile(ctx context.Context, slug, relPath, content, mode, message string) (string, int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.commitAgentFileLocked(ctx, slug, relPath, content, mode, message)
+}
+
+// AgentFileRead reads one agent instruction file by repo-relative path. Returns
+// (nil, nil) when the file does not exist so callers can treat "absent" as
+// "empty" without special-casing os.IsNotExist.
+func (w *WikiWorker) AgentFileRead(relPath string) ([]byte, error) {
+	if err := validateAgentFilePath(relPath); err != nil {
+		return nil, err
+	}
+	if w == nil || w.repo == nil {
+		return nil, nil
+	}
+	w.repo.mu.Lock()
+	defer w.repo.mu.Unlock()
+	data, err := os.ReadFile(filepath.Join(w.repo.Root(), relPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+// AgentFileWrite validates + commits one agent instruction file via the repo.
+func (w *WikiWorker) AgentFileWrite(ctx context.Context, slug, relPath, content, mode, commitMsg string) (string, int, error) {
+	if w == nil || w.repo == nil {
+		return "", 0, ErrWorkerStopped
+	}
+	if err := validateAgentFilePath(relPath); err != nil {
+		return "", 0, err
+	}
+	return w.repo.CommitAgentFile(ctx, slug, relPath, content, mode, commitMsg)
+}
+
+// ---- Deterministic content generation -------------------------------------
+//
+// v1 seeds the file set from data the office already has (persona, role,
+// expertise, tools, runtime) with no LLM call — so every existing agent gets a
+// real, editable instruction set immediately and a generation failure can never
+// half-initialize an agent. Richer LLM-authored content is a later slice.
+
+func renderAgentSoul(member officeMember, isLead bool) string {
+	persona := strings.TrimSpace(member.Personality)
+	if persona == "" {
+		persona = inferOfficePersonality(member.Slug, member.Role)
+	}
+	role := strings.TrimSpace(member.Role)
+	if role == "" {
+		role = member.Slug
+	}
+	lane := "Stay in your lane (" + role + ") on execution; route cross-cutting scope calls through the lead."
+	if isLead {
+		lane = "You are the lead: you coordinate, decompose, and make the final call. Delegate execution to specialists rather than doing it all yourself."
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "# SOUL — @%s\n\n", member.Slug)
+	b.WriteString("## Who you are\n")
+	b.WriteString(persona + "\n\n")
+	b.WriteString("## Values\n")
+	b.WriteString("- Bias to action: leave durable state (tasks, records, deliverables), not just narration.\n")
+	b.WriteString("- Reuse first: an existing teammate, task, or wiki article beats creating a new one.\n")
+	b.WriteString("- Tell the human the truth, including failures. Never fabricate outcomes or proof artifacts.\n\n")
+	b.WriteString("## Voice\n")
+	b.WriteString(teamVoiceForSlug(member.Slug) + "\n\n")
+	b.WriteString("## Boundaries\n")
+	b.WriteString("- " + lane + "\n")
+	b.WriteString("- Do the smallest real step that moves the work; avoid substitute or busywork artifacts.\n")
+	return b.String()
+}
+
+func renderAgentIdentity(member officeMember) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# IDENTITY — @%s\n\n", member.Slug)
+	fmt.Fprintf(&b, "- Name: %s\n", firstNonEmpty(member.Name, member.Slug))
+	fmt.Fprintf(&b, "- Slug: %s\n", member.Slug)
+	fmt.Fprintf(&b, "- Role: %s\n", firstNonEmpty(member.Role, member.Slug))
+	expertise := member.Expertise
+	if len(expertise) == 0 {
+		expertise = inferOfficeExpertise(member.Slug, member.Role)
+	}
+	if len(expertise) > 0 {
+		fmt.Fprintf(&b, "- Expertise: %s\n", strings.Join(expertise, ", "))
+	}
+	runtime := strings.TrimSpace(member.Provider.Kind)
+	if m := strings.TrimSpace(member.Provider.Model); m != "" {
+		runtime = strings.TrimSpace(runtime + " / " + m)
+	}
+	if runtime != "" {
+		fmt.Fprintf(&b, "- Runtime: %s\n", runtime)
+	}
+	if member.BuiltIn {
+		b.WriteString("- Built-in: yes\n")
+	}
+	return b.String()
+}
+
+func renderAgentOperations(member officeMember, isLead bool) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# OPERATIONS — @%s\n\n", member.Slug)
+	b.WriteString("## How you work\n")
+	if isLead {
+		b.WriteString("- Take a goal, decompose it into owned sub-tasks (team_task, parent_issue_id), assign existing specialists, and let them run in parallel. Aggregate at the parent.\n")
+		b.WriteString("- Create durable task state before you broadcast a kickoff. Proposing a new agent requires explicit human approval.\n")
+	} else {
+		b.WriteString("- Take work from durable tasks: claim with team_task, post status as you go, then submit for review or complete. A channel reply alone does not move the work.\n")
+		b.WriteString("- Work in your task's channel and worktree. Escalate scope changes to the lead.\n")
+	}
+	b.WriteString("- Write durable decisions to your notebook; @librarian curates notebooks into the team wiki.\n\n")
+	b.WriteString("## Escalation\n")
+	b.WriteString("- If blocked on something you cannot resolve, post the blocker and notify the owner/lead instead of producing a substitute artifact.\n")
+	return b.String()
+}
+
+func renderAgentTools(member officeMember) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# TOOLS — @%s\n\n", member.Slug)
+	b.WriteString("## Available tools\n")
+	if len(member.AllowedTools) > 0 {
+		for _, t := range member.AllowedTools {
+			if t = strings.TrimSpace(t); t != "" {
+				fmt.Fprintf(&b, "- %s\n", t)
+			}
+		}
+	} else {
+		b.WriteString("- The default office toolset (team_task, team_status, team_broadcast, notebook, wiki, and any skills enabled for you).\n")
+	}
+	b.WriteString("\n## Notes\n")
+	b.WriteString("- Prefer the smallest real action over a proof or preview artifact unless the task explicitly asks for one.\n")
+	b.WriteString("- Request a skill or capability when one is missing rather than faking the result.\n")
+	return b.String()
+}
+
+func renderOfficeUserFile() string {
+	var b strings.Builder
+	b.WriteString("# USER — the human this office serves\n\n")
+	if ctx := strings.TrimSpace(config.CompanyContextBlock()); ctx != "" {
+		b.WriteString(ctx)
+		if !strings.HasSuffix(ctx, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("This WUPHF office serves a single human operator. Optimize for their time:\n")
+	b.WriteString("- Handle routine work autonomously; surface only the decisions that genuinely need them.\n")
+	b.WriteString("- Be candid. Report outcomes, tradeoffs, and failures plainly.\n")
+	b.WriteString("- One human owns approvals (plan gates, new-agent creation, external actions). Wait for them on those.\n")
+	return b.String()
+}

--- a/internal/team/agent_files_test.go
+++ b/internal/team/agent_files_test.go
@@ -65,6 +65,8 @@ func TestValidateAgentFilePath(t *testing.T) {
 
 	bad := []string{
 		"",
+		"agents/ceo/SOUL.md/.",                // non-canonical (trailing /.)
+		"agents/ceo/SOUL.md/",                 // non-canonical (trailing slash)
 		"agents/ceo/MEMORY.md",                // not a canonical file
 		"agents/ceo/HEARTBEAT.md",             // dropped by design
 		"agents/ceo/soul.md",                  // wrong case
@@ -134,6 +136,11 @@ func TestRenderAgentFilesDeterministic(t *testing.T) {
 	// Empty allowed-tools falls back to the default toolset line.
 	if fallback := renderAgentTools(officeMember{Slug: "x"}); !strings.Contains(fallback, "default office toolset") {
 		t.Errorf("empty tools should fall back to default toolset:\n%s", fallback)
+	}
+	// Blank-only allowed-tools (whitespace entries) must also fall back, not
+	// emit an empty "Available tools" section.
+	if fallback := renderAgentTools(officeMember{Slug: "x", AllowedTools: []string{" ", "\t"}}); !strings.Contains(fallback, "default office toolset") {
+		t.Errorf("blank-only tools should fall back to default toolset:\n%s", fallback)
 	}
 
 	if user := renderOfficeUserFile(); !strings.Contains(user, "# USER") || !strings.Contains(user, "single human operator") {

--- a/internal/team/agent_files_test.go
+++ b/internal/team/agent_files_test.go
@@ -1,0 +1,182 @@
+package team
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// TestRepoCommitAndReadAgentFile exercises the storage layer end to end against
+// a real on-disk git wiki: validated write -> git commit -> read back, plus the
+// no-clobber (create twice fails), replace, and path-rejection contracts.
+func TestRepoCommitAndReadAgentFile(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	rel := agentFileRel("ceo", "SOUL")
+
+	sha, n, err := repo.CommitAgentFile(ctx, "ceo", rel, "# SOUL — @ceo\nbe excellent", "create", "")
+	if err != nil {
+		t.Fatalf("commit create: %v", err)
+	}
+	if sha == "" || n == 0 {
+		t.Fatalf("expected sha+bytes, got sha=%q n=%d", sha, n)
+	}
+	if data, err := os.ReadFile(filepath.Join(repo.Root(), rel)); err != nil || !strings.Contains(string(data), "be excellent") {
+		t.Fatalf("read back: err=%v data=%q", err, data)
+	}
+
+	// create-again must fail so a human's file is never silently clobbered.
+	if _, _, err := repo.CommitAgentFile(ctx, "ceo", rel, "x", "create", ""); err == nil {
+		t.Fatal("second create must fail")
+	}
+	// replace updates it.
+	if _, _, err := repo.CommitAgentFile(ctx, "ceo", rel, "# SOUL — @ceo\nrevised", "replace", ""); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if data, _ := os.ReadFile(filepath.Join(repo.Root(), rel)); !strings.Contains(string(data), "revised") {
+		t.Fatalf("replace should update content: %q", data)
+	}
+	// a non-agent path is rejected by the validator inside Commit.
+	if _, _, err := repo.CommitAgentFile(ctx, "ceo", "team/people/x.md", "x", "create", ""); err == nil {
+		t.Fatal("invalid agent-file path must be rejected")
+	}
+}
+
+func TestValidateAgentFilePath(t *testing.T) {
+	ok := []string{
+		"agents/ceo/SOUL.md",
+		"agents/eng/IDENTITY.md",
+		"agents/growth-ops/OPERATIONS.md",
+		"agents/pam/TOOLS.md",
+		"office/USER.md",
+	}
+	for _, p := range ok {
+		if err := validateAgentFilePath(p); err != nil {
+			t.Errorf("expected %q valid, got %v", p, err)
+		}
+	}
+
+	bad := []string{
+		"",
+		"agents/ceo/MEMORY.md",                // not a canonical file
+		"agents/ceo/HEARTBEAT.md",             // dropped by design
+		"agents/ceo/soul.md",                  // wrong case
+		"agents/ceo/notebook/2026-01-01-x.md", // notebook subtree is off-limits
+		"agents/ceo/SOUL",                     // missing .md
+		"team/people/ceo.md",                  // article subtree
+		"agents/../etc/passwd",                // traversal
+		"agents/ceo/../eng/SOUL.md",           // traversal into another agent
+		"/agents/ceo/SOUL.md",                 // absolute
+		"agents/ceo/sub/SOUL.md",              // nested
+		"USER.md",                             // office file only at office/USER.md
+		"agents/Bad Slug/SOUL.md",             // invalid slug
+	}
+	for _, p := range bad {
+		if err := validateAgentFilePath(p); err == nil {
+			t.Errorf("expected %q rejected, got nil", p)
+		}
+	}
+}
+
+func TestRenderAgentFilesDeterministic(t *testing.T) {
+	member := officeMember{
+		Slug:         "growth",
+		Name:         "Growth Lead",
+		Role:         "growth lead",
+		Expertise:    []string{"acquisition", "funnels"},
+		Personality:  "Relentless about pipeline; allergic to vanity metrics.",
+		AllowedTools: []string{"team_task", "team_broadcast"},
+		Provider:     provider.ProviderBinding{Kind: "codex", Model: "gpt-5.4"},
+	}
+
+	soul := renderAgentSoul(member, false)
+	for _, want := range []string{"# SOUL — @growth", "Relentless about pipeline", "## Values", "## Boundaries", "growth lead"} {
+		if !strings.Contains(soul, want) {
+			t.Errorf("SOUL missing %q:\n%s", want, soul)
+		}
+	}
+	// Lead vs specialist SOUL boundary differs.
+	if strings.Contains(soul, "You are the lead") {
+		t.Error("specialist SOUL must not claim the lead boundary")
+	}
+	if leadSoul := renderAgentSoul(member, true); !strings.Contains(leadSoul, "You are the lead") {
+		t.Errorf("lead SOUL must carry the lead boundary:\n%s", leadSoul)
+	}
+
+	identity := renderAgentIdentity(member)
+	for _, want := range []string{"# IDENTITY — @growth", "Name: Growth Lead", "Slug: growth", "Expertise: acquisition, funnels", "Runtime: codex / gpt-5.4"} {
+		if !strings.Contains(identity, want) {
+			t.Errorf("IDENTITY missing %q:\n%s", want, identity)
+		}
+	}
+
+	ops := renderAgentOperations(member, false)
+	if !strings.Contains(ops, "# OPERATIONS — @growth") || !strings.Contains(ops, "claim with team_task") {
+		t.Errorf("specialist OPERATIONS unexpected:\n%s", ops)
+	}
+	if leadOps := renderAgentOperations(member, true); !strings.Contains(leadOps, "decompose it into owned sub-tasks") {
+		t.Errorf("lead OPERATIONS must describe decomposition:\n%s", leadOps)
+	}
+
+	tools := renderAgentTools(member)
+	for _, want := range []string{"# TOOLS — @growth", "- team_task", "- team_broadcast"} {
+		if !strings.Contains(tools, want) {
+			t.Errorf("TOOLS missing %q:\n%s", want, tools)
+		}
+	}
+	// Empty allowed-tools falls back to the default toolset line.
+	if fallback := renderAgentTools(officeMember{Slug: "x"}); !strings.Contains(fallback, "default office toolset") {
+		t.Errorf("empty tools should fall back to default toolset:\n%s", fallback)
+	}
+
+	if user := renderOfficeUserFile(); !strings.Contains(user, "# USER") || !strings.Contains(user, "single human operator") {
+		t.Errorf("USER file unexpected:\n%s", user)
+	}
+}
+
+func TestAgentFilesPromptBlock(t *testing.T) {
+	// No reader wired -> empty (tests that don't mock a wiki backend).
+	if got := (&promptBuilder{}).agentFilesPromptBlock("ceo"); got != "" {
+		t.Errorf("nil reader should produce empty block, got %q", got)
+	}
+
+	// Reader present but all files empty -> empty.
+	empty := &promptBuilder{
+		agentInstruction: func(string, string) string { return "" },
+		officeUser:       func() string { return "" },
+	}
+	if got := empty.agentFilesPromptBlock("ceo"); got != "" {
+		t.Errorf("all-empty files should produce empty block, got %q", got)
+	}
+
+	// Files present -> block contains them, in order, with the authoritative header.
+	pb := &promptBuilder{
+		agentInstruction: func(_, name string) string {
+			switch name {
+			case "SOUL":
+				return "# SOUL — @ceo\nlead persona"
+			case "OPERATIONS":
+				return "# OPERATIONS — @ceo\ndecompose"
+			default:
+				return ""
+			}
+		},
+		officeUser: func() string { return "# USER\nthe human" },
+	}
+	got := pb.agentFilesPromptBlock("ceo")
+	for _, want := range []string{"YOUR FILES (authoritative)", "lead persona", "decompose", "the human"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("block missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "lead persona") > strings.Index(got, "the human") {
+		t.Error("agent files should precede the office USER file in the block")
+	}
+}

--- a/internal/team/broker_agent_files.go
+++ b/internal/team/broker_agent_files.go
@@ -1,0 +1,109 @@
+package team
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+)
+
+// broker_agent_files.go wires the per-agent instruction file set (SOUL /
+// IDENTITY / OPERATIONS / TOOLS + office USER) into the broker: reads for the
+// prompt builder, and a deterministic backfill that seeds the files for every
+// agent in the roster. See agent_files.go for the storage + generation layer.
+
+// ReadAgentInstruction returns the content of one of an agent's instruction
+// files (name = SOUL|IDENTITY|OPERATIONS|TOOLS), or "" when the wiki backend is
+// off or the file is absent. Safe for the prompt hot path (single disk read
+// under the repo lock).
+func (b *Broker) ReadAgentInstruction(slug, name string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" || !isAgentInstructionFileName(strings.TrimSpace(name)) {
+		return ""
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		return ""
+	}
+	data, err := worker.AgentFileRead(agentFileRel(slug, name))
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	return string(data)
+}
+
+// ReadOfficeUserFile returns the office-wide USER.md content, or "" when absent.
+func (b *Broker) ReadOfficeUserFile() string {
+	worker := b.WikiWorker()
+	if worker == nil {
+		return ""
+	}
+	data, err := worker.AgentFileRead(officeUserFileRel)
+	if err != nil || len(data) == 0 {
+		return ""
+	}
+	return string(data)
+}
+
+// backfillAgentFilesForRoster seeds any MISSING instruction file for every agent
+// in the roster (plus the office USER.md) with deterministic content derived
+// from the agent's current persona/role/expertise/tools. Idempotent: existing
+// files are never overwritten, so a human's edits survive. Runs alongside
+// ensureNotebookDirsForRoster so new agents and fresh offices get their files
+// without an LLM call (which could half-initialize an agent on failure).
+func (b *Broker) backfillAgentFilesForRoster() {
+	worker := b.WikiWorker()
+	if worker == nil {
+		return
+	}
+	members := b.OfficeMembers()
+	if len(members) == 0 {
+		return
+	}
+	leadSlug, _ := leadSlugAndName(members)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	writeIfAbsent := func(author, relPath, content string) {
+		if strings.TrimSpace(content) == "" {
+			return
+		}
+		if existing, err := worker.AgentFileRead(relPath); err == nil && len(existing) > 0 {
+			return // never clobber existing content (human edits or prior seed)
+		}
+		if _, _, err := worker.AgentFileWrite(ctx, author, relPath, content, "create", "agent: seed "+relPath); err != nil {
+			// A create race ("already exists") or a transient git error is
+			// non-fatal: the next roster-ensure retries, and a present file is
+			// the desired end state anyway.
+			if !strings.Contains(err.Error(), "already exists") {
+				log.Printf("agent file: seed %s failed: %v", relPath, err)
+			}
+		}
+	}
+
+	seen := make(map[string]struct{}, len(members))
+	for _, member := range members {
+		slug := strings.TrimSpace(member.Slug)
+		if slug == "" {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		isLead := slug == strings.TrimSpace(leadSlug)
+		writeIfAbsent(slug, agentFileRel(slug, "SOUL"), renderAgentSoul(member, isLead))
+		writeIfAbsent(slug, agentFileRel(slug, "IDENTITY"), renderAgentIdentity(member))
+		writeIfAbsent(slug, agentFileRel(slug, "OPERATIONS"), renderAgentOperations(member, isLead))
+		writeIfAbsent(slug, agentFileRel(slug, "TOOLS"), renderAgentTools(member))
+	}
+
+	// Office-wide human-context file (one per office), authored by the lead or
+	// a bootstrap identity.
+	author := strings.TrimSpace(leadSlug)
+	if author == "" {
+		author = "wuphf-bootstrap"
+	}
+	writeIfAbsent(author, officeUserFileRel, renderOfficeUserFile())
+}

--- a/internal/team/broker_notebook.go
+++ b/internal/team/broker_notebook.go
@@ -93,6 +93,10 @@ func (b *Broker) ensureNotebookDirsForRoster() {
 	if sha != "" {
 		log.Printf("notebook: initialized roster shelves %s", sha)
 	}
+	// Seed each agent's instruction file set (SOUL/IDENTITY/OPERATIONS/TOOLS +
+	// office USER) on the same hook. Idempotent and deterministic — never
+	// overwrites existing files, so this is safe to run on every roster-ensure.
+	b.backfillAgentFilesForRoster()
 }
 
 // handleNotebookWrite is the broker HTTP endpoint the MCP subprocess posts to

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -45,12 +45,57 @@ type promptBuilder struct {
 	// Issues already exist and ends up duplicating scope.
 	activeIssues func() []IssueSummary
 
+	// agentInstruction reads one of an agent's instruction files (SOUL /
+	// IDENTITY / OPERATIONS / TOOLS) from the wiki repo, or "" when absent or
+	// the wiki backend is off. officeUser reads the office-wide USER.md. Both
+	// are optional so promptBuilder stays usable from tests that don't wire a
+	// wiki backend; when nil the agent-files block is simply omitted.
+	agentInstruction func(slug, name string) string
+	officeUser       func() string
+
 	// Captured-at-construction config flags. They control major branches
 	// (markdown notebook section, no-Nex fallbacks) and are stable for the
 	// lifetime of a launcher session, so they're snapshot once rather than
 	// re-resolved on every Build call.
 	markdownMemory bool
 	nexDisabled    bool
+}
+
+// agentFilesPromptBlock assembles the per-agent instruction files (SOUL,
+// IDENTITY, OPERATIONS, TOOLS) plus the office-wide USER file into one prompt
+// section, in precedence order. Returns "" when no files are present (or no
+// reader is wired), so callers can append unconditionally. The content is
+// human/seed-authored markdown loaded verbatim; it is authoritative over the
+// inline persona defaults above it.
+func (p *promptBuilder) agentFilesPromptBlock(slug string) string {
+	if p.agentInstruction == nil {
+		return ""
+	}
+	var sections []string
+	for _, name := range agentInstructionFiles {
+		if content := strings.TrimSpace(p.agentInstruction(slug, name)); content != "" {
+			sections = append(sections, content)
+		}
+	}
+	var user string
+	if p.officeUser != nil {
+		user = strings.TrimSpace(p.officeUser())
+	}
+	if len(sections) == 0 && user == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("== YOUR FILES (authoritative) ==\n")
+	b.WriteString("These are your durable instruction files. They take precedence over the brief persona lines above; follow them.\n\n")
+	for _, s := range sections {
+		b.WriteString(s)
+		b.WriteString("\n\n")
+	}
+	if user != "" {
+		b.WriteString(user)
+		b.WriteString("\n\n")
+	}
+	return b.String()
 }
 
 // Build returns the system prompt for the agent identified by slug. The
@@ -115,6 +160,7 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
 		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
 		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString(p.agentFilesPromptBlock(slug))
 		sb.WriteString("== DIRECT SESSION ==\n")
 		sb.WriteString("This is not the shared office. There are no teammates, no channels, and no collaboration mechanics in this mode.\n")
 		sb.WriteString("You are only talking to the human.\n")
@@ -158,6 +204,7 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString(companyCtx)
 		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
 		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString(p.agentFilesPromptBlock(slug))
 		sb.WriteString("== YOUR TEAM ==\n")
 		for _, member := range officeMembers {
 			if member.Slug == slug {
@@ -299,6 +346,7 @@ func (p *promptBuilder) Build(slug string) string {
 		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
 		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
 		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString(p.agentFilesPromptBlock(slug))
 		sb.WriteString("== YOUR TEAM ==\n")
 		sb.WriteString(fmt.Sprintf("- @%s (%s): TEAM LEAD — has final say on decisions\n", lead, p.nameFor(lead)))
 		for _, member := range officeMembers {

--- a/internal/team/prompts.go
+++ b/internal/team/prompts.go
@@ -64,6 +64,18 @@ func (l *Launcher) newPromptBuilder() *promptBuilder {
 			}
 			return l.broker.ListActiveIssueSummariesForPrompt()
 		},
+		agentInstruction: func(slug, name string) string {
+			if l == nil || l.broker == nil {
+				return ""
+			}
+			return l.broker.ReadAgentInstruction(slug, name)
+		},
+		officeUser: func() string {
+			if l == nil || l.broker == nil {
+				return ""
+			}
+			return l.broker.ReadOfficeUserFile()
+		},
 		nameFor: l.targeter().NameFor,
 		learnings: func(slug string) []LearningSearchResult {
 			if l == nil || l.broker == nil || memoryBackend != config.MemoryBackendMarkdown {


### PR DESCRIPTION
## What

Phase 4 of the multi-agent overhaul: give every agent a **real, inspectable, behavior-shaping instruction set** — addressing "I can't see the agent instructions for any agent (does it even exist?)."

Phase 4 is sliced; this is **4a (storage + prompt-load + deterministic backfill)**. The UI viewer/editor (**4b**) and LLM-rich generation (**4c**) follow.

Each agent now has, under the wiki git repo at `agents/{slug}/`:
- **SOUL.md** — persona, values, voice, boundaries
- **IDENTITY.md** — name, role, expertise, runtime
- **OPERATIONS.md** — how it works + escalation (the AGENTS.md role)
- **TOOLS.md** — tool inventory + notes

plus one office-wide **`office/USER.md`** describing the single human the office serves. Memory stays the Notebook subsystem (no `MEMORY.md`); cadence stays the scheduler (no `HEARTBEAT.md`), per the earlier decision.

## How

**Storage** mirrors the proven notebook write/read path (`CommitNotebook`/`NotebookRead`) so agent files get the same OS-lock + git-commit guarantees **without polluting the `team/` article index**:
- `agent_files.go` — `validateAgentFilePath` allows **only** the canonical files (`agents/{slug}/{SOUL,IDENTITY,OPERATIONS,TOOLS}.md` and `office/USER.md`), rejecting traversal, the notebook subtree, and `team/` paths. `Repo.CommitAgentFile` + `WikiWorker.AgentFileRead`/`AgentFileWrite`.
- The wiki `validateArticlePath` requires a `team/` prefix and would block `agents/*.md`, so this uses a dedicated validator + commit path (same approach the notebook subsystem already takes for `agents/{slug}/notebook/`).

**Deterministic generation** (your "deterministic-first, LLM later" call): content is rendered from each agent's existing persona, role, expertise, allowed tools, and runtime (+ config company context for USER), with lead-vs-specialist variants. No LLM call — so a generation failure can never half-initialize an agent, and **every existing agent gets a real, editable file set immediately**.

**Backfill + load:**
- `broker_agent_files.go` — `backfillAgentFilesForRoster` seeds any **missing** file for every agent (idempotent, never clobbers human edits), hooked into `ensureNotebookDirsForRoster` so startup, onboarding, member-create, and wiki-lifecycle all seed.
- `prompt_builder.go` — the files load into every agent's system prompt as an authoritative **"YOUR FILES"** block (SOUL > IDENTITY > OPERATIONS > TOOLS > office USER), **omitted entirely** when absent or the wiki backend is off, so prompt-cache byte-stability and wiki-disabled installs are unaffected.

## Tests
- `validateAgentFilePath` security table (canonical files pass; traversal/notebook/article/wrong-case/raw-`..` rejected).
- Deterministic generators (content markers, lead-vs-specialist variants, empty-tools fallback).
- Prompt-block assembly (nil reader, all-empty, precedence ordering).
- Real on-disk **git round-trip** via `newTestRepo`: create → read-back → no-clobber → replace → reject.
- Full `team` suite green; `gofmt`/`vet` clean.

## Follow-on slices
- **4b:** AgentProfilePanel per-file view/edit (reuse the Tiptap `WikiEditor`) + AgentWizard SOUL field; requires relaxing the wiki read/write/history/diff/restore endpoints to accept `agents/`+`office/` paths.
- **4c (optional):** upgrade the deterministic seeds to LLM-authored files at create time, with deterministic fallback.

Backend only — no web surfaces, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents can store per-agent instruction files plus an office-wide USER file; content is deterministically generated and injected into agent prompts.
  * Create/replace write support with strict path validation and non-clobbering semantics; missing files can be backfilled safely and idempotently.

* **Tests**
  * Added end-to-end and unit tests for file workflow, path validation, deterministic rendering, and prompt composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->