### PR TITLE
feat(agents): view, edit, and AI-draft agent instruction files (Phase 4b + 4c)

### DIFF
--- a/internal/team/agent_files.go
+++ b/internal/team/agent_files.go
@@ -52,6 +52,47 @@ func isAgentInstructionFileName(name string) bool {
 	return false
 }
 
+// aiGeneratableFile reports whether an instruction file is prose worth handing
+// to an LLM to author. IDENTITY and TOOLS are factual (name/role/runtime,
+// tool inventory) and are derived deterministically from member data, so AI
+// generation is deliberately NOT offered for them — only SOUL and OPERATIONS
+// (and, separately, the office USER file) carry prose the model improves.
+func aiGeneratableFile(name string) bool {
+	return name == "SOUL" || name == "OPERATIONS"
+}
+
+// agentFilePurpose returns a one-line description of what a file governs, used
+// to brief the LLM when it authors a richer version.
+func agentFilePurpose(name string) string {
+	switch name {
+	case "SOUL":
+		return "the agent's persona, values, voice, and hard boundaries"
+	case "OPERATIONS":
+		return "how the agent works day to day and when it escalates"
+	case "USER":
+		return "the single human this office serves and how to optimize for their time"
+	default:
+		return "the agent's instructions"
+	}
+}
+
+// stripMarkdownFences removes a single wrapping ```...``` code fence if the
+// model returned one despite being told not to. Idempotent on unfenced input.
+func stripMarkdownFences(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+		s = s[nl+1:]
+	} else {
+		s = strings.TrimPrefix(s, "```")
+	}
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "```")
+	return strings.TrimSpace(s)
+}
+
 // validateAgentFilePath allows ONLY the canonical agent-instruction files:
 // agents/{slug}/{SOUL|IDENTITY|OPERATIONS|TOOLS}.md and office/USER.md. Anything
 // else (arbitrary agents/ paths, traversal, the notebook subtree) is rejected,

--- a/internal/team/agent_files.go
+++ b/internal/team/agent_files.go
@@ -167,6 +167,119 @@ func (r *Repo) CommitAgentFile(ctx context.Context, slug, relPath, content, mode
 	return r.commitAgentFileLocked(ctx, slug, relPath, content, mode, message)
 }
 
+// CommitAgentFileHuman writes one agent instruction file as a HUMAN edit with
+// optimistic-concurrency: the caller passes the per-file short SHA it last saw
+// and the write is rejected with ErrWikiSHAMismatch when HEAD has moved past it.
+// This is the editor's save path (mirrors CommitHuman) — but, like the agent
+// commit path, it does NOT regenerate the team/ article index: instruction
+// files are per-agent and never feed the team catalog. Returns the new short
+// SHA, bytes written, and an error.
+func (r *Repo) CommitAgentFileHuman(ctx context.Context, relPath, content, expectedSHA, message string, identity HumanIdentity) (string, int, error) {
+	// Resolve the effective identity before touching the filesystem so every
+	// downstream git sub-call stamps the same author. Mirrors CommitHuman.
+	name := strings.TrimSpace(identity.Name)
+	email := strings.TrimSpace(identity.Email)
+	slug := strings.TrimSpace(identity.Slug)
+	if name == "" || email == "" || slug == "" {
+		name = FallbackHumanIdentity.Name
+		email = FallbackHumanIdentity.Email
+		slug = FallbackHumanIdentity.Slug
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := validateAgentFilePath(relPath); err != nil {
+		return "", 0, err
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", 0, fmt.Errorf("agent file: content is required")
+	}
+
+	fullPath := filepath.Join(r.root, relPath)
+	exists := false
+	if _, err := os.Stat(fullPath); err == nil {
+		exists = true
+	}
+
+	// Optimistic concurrency pre-check BEFORE any filesystem mutation, so a
+	// rejection leaves the working tree clean (matches CommitHuman).
+	if exists {
+		if expectedSHA == "" {
+			curSHA, serr := r.currentArticleSHALocked(ctx, relPath)
+			if serr != nil {
+				return "", 0, fmt.Errorf("agent file: resolve current sha: %w", serr)
+			}
+			return curSHA, 0, fmt.Errorf("%w: file exists but no expected_sha supplied", ErrWikiSHAMismatch)
+		}
+		curSHA, serr := r.currentArticleSHALocked(ctx, relPath)
+		if serr != nil {
+			return "", 0, fmt.Errorf("agent file: resolve current sha: %w", serr)
+		}
+		if !shaEquivalent(curSHA, expectedSHA) {
+			return curSHA, 0, fmt.Errorf("%w: current %s, expected %s", ErrWikiSHAMismatch, curSHA, expectedSHA)
+		}
+	} else if expectedSHA != "" {
+		return "", 0, fmt.Errorf("%w: file not found but expected_sha supplied", ErrWikiSHAMismatch)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		return "", 0, fmt.Errorf("agent file: mkdir %s: %w", filepath.Dir(fullPath), err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		return "", 0, fmt.Errorf("agent file: write %s: %w", relPath, err)
+	}
+	bytesWritten := len(content)
+
+	relForGit := filepath.ToSlash(relPath)
+	if out, err := r.runGitLockedAs(ctx, name, email, "add", "--", relForGit); err != nil {
+		return "", 0, fmt.Errorf("agent file: git add %s: %w: %s", relPath, err, out)
+	}
+	// Byte-identical re-write short-circuits to current HEAD; mirrors CommitHuman.
+	cachedDiff, err := r.runGitLockedAs(ctx, name, email, "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("agent file: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, herr := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if herr != nil {
+			return "", 0, fmt.Errorf("agent file: resolve HEAD sha: %w", herr)
+		}
+		return strings.TrimSpace(headSha), bytesWritten, nil
+	}
+	// Build the bare message, then stamp the "human:" provenance prefix below
+	// (the agent commit path uses "agent:" instead) so git log --oneline makes
+	// the author class obvious at a glance.
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("update %s", relPath)
+	}
+	if !strings.HasPrefix(commitMsg, "human:") {
+		commitMsg = "human: " + commitMsg
+	}
+	if out, err := r.runGitLockedAs(ctx, name, email, "commit", "-q", "-m", commitMsg); err != nil {
+		return "", 0, fmt.Errorf("agent file: git commit: %w: %s", err, out)
+	}
+	_ = slug // retained for future author_slug plumbing, mirrors CommitHuman.
+	sha, err := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", 0, fmt.Errorf("agent file: resolve HEAD sha: %w", err)
+	}
+	return strings.TrimSpace(sha), bytesWritten, nil
+}
+
+// AgentFileSHA returns the short SHA of the most recent commit touching the
+// agent instruction file at relPath, or "" (no error) when the file has no
+// commit history yet. Used to seed the editor's expected_sha on open.
+func (r *Repo) AgentFileSHA(ctx context.Context, relPath string) (string, error) {
+	if err := validateAgentFilePath(relPath); err != nil {
+		return "", err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.currentArticleSHALocked(ctx, relPath)
+}
+
 // AgentFileRead reads one agent instruction file by repo-relative path. Returns
 // (nil, nil) when the file does not exist so callers can treat "absent" as
 // "empty" without special-casing os.IsNotExist.
@@ -300,6 +413,25 @@ func renderAgentTools(member officeMember) string {
 	b.WriteString("- Prefer the smallest real action over a proof or preview artifact unless the task explicitly asks for one.\n")
 	b.WriteString("- Request a skill or capability when one is missing rather than faking the result.\n")
 	return b.String()
+}
+
+// renderAgentFileContent dispatches to the right deterministic generator for a
+// canonical instruction file name. Returns "" for an unknown name. Used by the
+// HTTP read handler to seed the editor with real content when a file has not
+// been backfilled to disk yet (the first save then persists it).
+func renderAgentFileContent(member officeMember, name string, isLead bool) string {
+	switch name {
+	case "SOUL":
+		return renderAgentSoul(member, isLead)
+	case "IDENTITY":
+		return renderAgentIdentity(member)
+	case "OPERATIONS":
+		return renderAgentOperations(member, isLead)
+	case "TOOLS":
+		return renderAgentTools(member)
+	default:
+		return ""
+	}
 }
 
 func renderOfficeUserFile() string {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -225,14 +225,15 @@ type Broker struct {
 	// (so admit + revoke + invite-create all flow through the same surface)
 	// instead of the legacy HTTP path. Atomic so the controller's read does
 	// not contend with adapter registration on a different goroutine.
-	shareTransport     atomic.Pointer[ShareTransport]
-	generateMemberFn   func(prompt string) (generatedMemberTemplate, error)
-	generateChannelFn  func(context.Context, string) (generatedChannelTemplate, error)
-	policies           []officePolicy // active office operating rules
-	rateLimitBuckets   map[string]ipRateLimitBucket
-	rateLimitWindow    time.Duration
-	rateLimitRequests  int
-	lastRateLimitPrune time.Time
+	shareTransport      atomic.Pointer[ShareTransport]
+	generateMemberFn    func(prompt string) (generatedMemberTemplate, error)
+	generateChannelFn   func(context.Context, string) (generatedChannelTemplate, error)
+	generateAgentFileFn func(ctx context.Context, relPath, hint string) (string, error)
+	policies            []officePolicy // active office operating rules
+	rateLimitBuckets    map[string]ipRateLimitBucket
+	rateLimitWindow     time.Duration
+	rateLimitRequests   int
+	lastRateLimitPrune  time.Time
 
 	// Agent-scoped buckets — applied to authenticated agent traffic even though
 	// the IP-scoped bucket above exempts callers with a valid Bearer token. This
@@ -574,6 +575,7 @@ func (b *Broker) StartOnPort(port int) error {
 	// allowlist and skip the team/ article index. See broker_agent_files_http.go.
 	mux.HandleFunc("/agent-files/read", b.requireAuth(b.handleAgentFileRead))
 	mux.HandleFunc("/agent-files/write", b.requireAuth(b.handleAgentFileWrite))
+	mux.HandleFunc("/agent-files/generate", b.requireAuth(b.handleAgentFileGenerate))
 	mux.HandleFunc("/humans", b.requireAuth(b.handleHumans))
 	mux.HandleFunc("/humans/me", b.handleHumanMe)
 	mux.HandleFunc("/humans/invites", b.requireAuth(b.handleHumanInvites))
@@ -1180,6 +1182,13 @@ func (b *Broker) SetGenerateMemberFn(fn func(string) (generatedMemberTemplate, e
 
 func (b *Broker) SetGenerateChannelFn(fn func(context.Context, string) (generatedChannelTemplate, error)) {
 	b.generateChannelFn = fn
+}
+
+// SetGenerateAgentFileFn injects the LLM authoring path for prose instruction
+// files (SOUL/OPERATIONS/USER). Optional: when unset, /agent-files/generate
+// returns 503 and the UI simply hides the "Generate with AI" affordance.
+func (b *Broker) SetGenerateAgentFileFn(fn func(ctx context.Context, relPath, hint string) (string, error)) {
+	b.generateAgentFileFn = fn
 }
 
 // SetAgentLogRoot overrides where /agent-logs reads task JSONL from.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -569,6 +569,11 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/memory", b.requireAuth(b.handleMemory))
 	mux.HandleFunc("/wiki/write", b.requireAuth(b.handleWikiWrite))
 	mux.HandleFunc("/wiki/write-human", b.requireAuth(b.handleWikiWriteHuman))
+	// Per-agent instruction files (SOUL/IDENTITY/OPERATIONS/TOOLS + office
+	// USER.md). Separate from /wiki/* so they use the strict agent-file path
+	// allowlist and skip the team/ article index. See broker_agent_files_http.go.
+	mux.HandleFunc("/agent-files/read", b.requireAuth(b.handleAgentFileRead))
+	mux.HandleFunc("/agent-files/write", b.requireAuth(b.handleAgentFileWrite))
 	mux.HandleFunc("/humans", b.requireAuth(b.handleHumans))
 	mux.HandleFunc("/humans/me", b.handleHumanMe)
 	mux.HandleFunc("/humans/invites", b.requireAuth(b.handleHumanInvites))

--- a/internal/team/broker_agent_files_http.go
+++ b/internal/team/broker_agent_files_http.go
@@ -1,0 +1,214 @@
+package team
+
+// broker_agent_files_http.go owns the HTTP surface the web UI uses to VIEW and
+// EDIT an agent's instruction files (SOUL / IDENTITY / OPERATIONS / TOOLS) and
+// the office-wide USER.md. Two endpoints:
+//
+//	GET  /agent-files/read?path=agents/{slug}/SOUL.md
+//	POST /agent-files/write   { path, content, commit_message, expected_sha }
+//
+// Design + security notes
+// =======================
+//
+//   - These are deliberately SEPARATE from the /wiki/* endpoints. They route
+//     through the agent-file storage layer (agent_files.go), which validates
+//     with the strict validateAgentFilePath allowlist — agents/{slug}/{canonical
+//     file}.md and office/USER.md only — and never regenerates the team/ article
+//     index. Reusing /wiki/write would have widened the 20-caller
+//     validateArticlePath gate AND pushed instruction files into the team
+//     catalog. A dedicated, tightly-scoped surface is the smaller, safer change.
+//   - The write path is HTTP-only (not exposed via any MCP tool) and is gated
+//     two ways: humanRouteAllowed keeps the human/web token to this path, AND
+//     handleAgentFileWrite hard-requires a human-session actor. The second check
+//     matters because broker-token actors bypass humanRouteAllowed — without it
+//     a compromised agent holding the broker token could rewrite its own (or
+//     another agent's) SOUL/IDENTITY, i.e. prompt-inject via self-modification.
+//     The committing identity is resolved server-side so attribution cannot be
+//     forged.
+//   - Optimistic concurrency mirrors /wiki/write-human exactly: the client sends
+//     the per-file expected_sha it opened against; a 409 carries the current SHA
+//     and bytes so the editor can prompt re-apply without a second round trip.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// agentFileReadResponse is the JSON shape returned by GET /agent-files/read.
+type agentFileReadResponse struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+	SHA     string `json:"sha"`
+	// Exists is false when no file has been committed to disk yet — Content
+	// then carries the deterministic seed so the editor opens with real text,
+	// and the first save (with expected_sha == "") creates the file.
+	Exists bool `json:"exists"`
+}
+
+// handleAgentFileRead returns one agent instruction file's content + SHA.
+//
+//	GET /agent-files/read?path=agents/{slug}/SOUL.md
+//
+// When the file has not been backfilled to disk yet, the handler returns the
+// deterministic seed content (exists:false, sha:"") so the editor never opens
+// blank. The path is validated by the strict agent-file allowlist.
+func (b *Broker) handleAgentFileRead(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "wiki backend is not active"})
+		return
+	}
+	relPath := strings.TrimSpace(r.URL.Query().Get("path"))
+	if err := validateAgentFilePath(relPath); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	data, err := worker.AgentFileRead(relPath)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if len(data) > 0 {
+		sha, err := worker.Repo().AgentFileSHA(r.Context(), relPath)
+		if err != nil {
+			// A committed file with an unresolvable SHA is a real backend fault
+			// (corrupt repo / git failure). Surface it rather than returning an
+			// empty SHA, which would let the editor open as if the file had no
+			// history and silently risk a stale overwrite.
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "resolve sha: " + err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, agentFileReadResponse{
+			Path:    relPath,
+			Content: string(data),
+			SHA:     strings.TrimSpace(sha),
+			Exists:  true,
+		})
+		return
+	}
+
+	// File absent on disk — seed the editor with the deterministic content so
+	// it is never blank. The first save persists it (expected_sha == "").
+	writeJSON(w, http.StatusOK, agentFileReadResponse{
+		Path:    relPath,
+		Content: b.agentFileSeedContent(relPath),
+		SHA:     "",
+		Exists:  false,
+	})
+}
+
+// agentFileSeedContent renders the deterministic seed for an absent instruction
+// file so the read endpoint can return real text instead of a blank editor.
+// Returns "" when the slug is not a current roster member (the editor then
+// opens empty, which is the correct fallback for a stale path).
+func (b *Broker) agentFileSeedContent(relPath string) string {
+	clean := strings.TrimSpace(relPath)
+	if clean == officeUserFileRel {
+		return renderOfficeUserFile()
+	}
+	parts := strings.Split(clean, "/")
+	if len(parts) != 3 || parts[0] != "agents" {
+		return ""
+	}
+	slug := parts[1]
+	name := strings.TrimSuffix(parts[2], ".md")
+	members := b.OfficeMembers()
+	leadSlug, _ := leadSlugAndName(members)
+	for _, m := range members {
+		if strings.TrimSpace(m.Slug) == slug {
+			return renderAgentFileContent(m, name, slug == strings.TrimSpace(leadSlug))
+		}
+	}
+	return ""
+}
+
+// handleAgentFileWrite saves a human edit to one agent instruction file.
+//
+//	POST /agent-files/write
+//	{ "path": "agents/ceo/SOUL.md", "content": "...",
+//	  "commit_message": "human: tighten boundaries", "expected_sha": "abc123" }
+//
+// Responses mirror /wiki/write-human:
+//
+//	200 { "path", "commit_sha", "bytes_written" }
+//	400 { "error" }            malformed JSON / bad path / empty content
+//	409 { "error", "current_sha", "current_content" }   concurrent write
+//	503 { "error" }            wiki backend not active
+//	500 { "error" }            other failure
+func (b *Broker) handleAgentFileWrite(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Hard-require a human-session actor. humanRouteAllowed already keeps the
+	// human/web token to this path, but broker-token actors bypass that check —
+	// an agent must never rewrite an instruction file (its own or another's),
+	// since those files are loaded into the system prompt. Writes are human-only.
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok || actor.Kind != requestActorKindHuman {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "human session required"})
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "wiki backend is not active"})
+		return
+	}
+	// Cap the body: instruction files are small, and an unbounded decode on a
+	// fast loopback connection could exhaust memory before the read timeout.
+	r.Body = http.MaxBytesReader(w, r.Body, 512*1024)
+	var body struct {
+		Path          string `json:"path"`
+		Content       string `json:"content"`
+		CommitMessage string `json:"commit_message"`
+		ExpectedSHA   string `json:"expected_sha"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	// Pre-validate BEFORE the commit so a rejection never touches the tree.
+	if err := validateAgentFilePath(body.Path); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(body.Content) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
+		return
+	}
+
+	// actor is a verified human (checked above); resolve its git identity so the
+	// commit is attributed server-side and cannot be forged by the client.
+	identity := humanIdentityFromActor(actor)
+
+	sha, n, err := worker.Repo().CommitAgentFileHuman(
+		r.Context(), body.Path, body.Content, body.ExpectedSHA, body.CommitMessage, identity,
+	)
+	if err != nil {
+		if errors.Is(err, ErrWikiSHAMismatch) {
+			// Return the current bytes so the editor can show the reload prompt
+			// without a second round trip. sha carries the current SHA here.
+			current, _ := worker.AgentFileRead(body.Path)
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":           err.Error(),
+				"current_sha":     sha,
+				"current_content": string(current),
+			})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"path":          body.Path,
+		"commit_sha":    sha,
+		"bytes_written": n,
+	})
+}

--- a/internal/team/broker_agent_files_http.go
+++ b/internal/team/broker_agent_files_http.go
@@ -30,10 +30,12 @@ package team
 //     and bytes so the editor can prompt re-apply without a second round trip.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 )
 
 // agentFileReadResponse is the JSON shape returned by GET /agent-files/read.
@@ -211,4 +213,66 @@ func (b *Broker) handleAgentFileWrite(w http.ResponseWriter, r *http.Request) {
 		"commit_sha":    sha,
 		"bytes_written": n,
 	})
+}
+
+// handleAgentFileGenerate authors a richer DRAFT of one prose instruction file
+// with the LLM and returns it for human review. It never commits — the editor
+// opens with the draft and the human saves (or discards) it.
+//
+//	POST /agent-files/generate  { path, hint }
+//	200 { "path", "content" }
+//	400 / 403 / 500 / 503 { "error" }
+//
+// Human-only (same as write): triggering a model call is a human authoring
+// action, not something an agent should drive over HTTP.
+func (b *Broker) handleAgentFileGenerate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	actor, ok := requestActorFromContext(r.Context())
+	if !ok || actor.Kind != requestActorKindHuman {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "human session required"})
+		return
+	}
+	if b.generateAgentFileFn == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "agent-file generation is not available"})
+		return
+	}
+	var body struct {
+		Path string `json:"path"`
+		Hint string `json:"hint"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	if err := validateAgentFilePath(body.Path); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 90*time.Second)
+	defer cancel()
+
+	type genResult struct {
+		content string
+		err     error
+	}
+	ch := make(chan genResult, 1)
+	go func() {
+		c, e := b.generateAgentFileFn(ctx, body.Path, body.Hint)
+		ch <- genResult{c, e}
+	}()
+	select {
+	case <-ctx.Done():
+		writeJSON(w, http.StatusGatewayTimeout, map[string]string{"error": "generation timed out"})
+		return
+	case res := <-ch:
+		if res.err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": res.err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"path": body.Path, "content": res.content})
+	}
 }

--- a/internal/team/broker_agent_files_http_test.go
+++ b/internal/team/broker_agent_files_http_test.go
@@ -1,0 +1,269 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// postAgentFile is a small helper that POSTs to /agent-files/write and returns
+// the recorder. expectedSha == "" means "create".
+func postAgentFile(t *testing.T, b *Broker, path, content, expectedSha string) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{
+		"path":           path,
+		"content":        content,
+		"commit_message": "edit",
+		"expected_sha":   expectedSha,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/agent-files/write", bytes.NewReader(raw))
+	// The write handler hard-requires a human-session actor; inject one the same
+	// way withAuth does in production.
+	req = requestWithActor(req, requestActor{Kind: requestActorKindHuman, Slug: "human", DisplayName: "Human"})
+	rec := httptest.NewRecorder()
+	b.handleAgentFileWrite(rec, req)
+	return rec
+}
+
+func getAgentFile(t *testing.T, b *Broker, path string) (*httptest.ResponseRecorder, agentFileReadResponse) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/agent-files/read?path="+path, nil)
+	rec := httptest.NewRecorder()
+	b.handleAgentFileRead(rec, req)
+	var out agentFileReadResponse
+	if rec.Code == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("unmarshal read body: %v (body=%s)", err, rec.Body.String())
+		}
+	}
+	return rec, out
+}
+
+// TestAgentFileWriteThenRead covers the core editor round-trip: create a file
+// via the write endpoint, then read it back with content + a real SHA + exists.
+func TestAgentFileWriteThenRead(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+
+	path := "agents/ceo/SOUL.md"
+	if rec := postAgentFile(t, b, path, "# SOUL — @ceo\nbe excellent", ""); rec.Code != http.StatusOK {
+		t.Fatalf("create write: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	rec, got := getAgentFile(t, b, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("read: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if !got.Exists {
+		t.Errorf("expected exists=true after create")
+	}
+	if got.SHA == "" {
+		t.Errorf("expected a non-empty sha for a committed file")
+	}
+	if !strings.Contains(got.Content, "be excellent") {
+		t.Errorf("content round-trip failed: %q", got.Content)
+	}
+}
+
+// TestAgentFileReadMissSeedsOfficeUser verifies that reading a not-yet-written
+// office/USER.md returns the deterministic seed (never a blank editor) with
+// exists=false and an empty sha so the first save creates it.
+func TestAgentFileReadMissSeedsOfficeUser(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+
+	rec, got := getAgentFile(t, b, officeUserFileRel)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("read miss: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got.Exists {
+		t.Errorf("expected exists=false for an un-written file")
+	}
+	if got.SHA != "" {
+		t.Errorf("expected empty sha for an un-written file, got %q", got.SHA)
+	}
+	if !strings.Contains(got.Content, "USER") {
+		t.Errorf("expected seeded USER content, got %q", got.Content)
+	}
+}
+
+// TestAgentFileReadMissSeedsAgentFromRoster verifies the agents/{slug}/*.md
+// seed path: with a roster member present, a read-miss renders that member's
+// deterministic SOUL so the editor opens with real text.
+func TestAgentFileReadMissSeedsAgentFromRoster(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+	b.members = []officeMember{{
+		Slug:        "growth",
+		Name:        "Growth Lead",
+		Role:        "growth lead",
+		Personality: "Relentless about pipeline.",
+		Provider:    provider.ProviderBinding{Kind: "codex"},
+	}}
+
+	rec, got := getAgentFile(t, b, "agents/growth/SOUL.md")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("read miss: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got.Exists {
+		t.Errorf("expected exists=false before any write")
+	}
+	if !strings.Contains(got.Content, "# SOUL — @growth") || !strings.Contains(got.Content, "Relentless about pipeline") {
+		t.Errorf("expected seeded SOUL for the roster member, got %q", got.Content)
+	}
+}
+
+// TestAgentFileWrite409OnStaleSHA verifies optimistic concurrency: a replace
+// against a stale sha is rejected with 409 + the current sha and bytes.
+func TestAgentFileWrite409OnStaleSHA(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+	path := "agents/ceo/OPERATIONS.md"
+
+	if rec := postAgentFile(t, b, path, "# OPERATIONS — @ceo\nv1", ""); rec.Code != http.StatusOK {
+		t.Fatalf("create: %d (%s)", rec.Code, rec.Body.String())
+	}
+	_, first := getAgentFile(t, b, path)
+	// Land a second edit so HEAD moves past `first.SHA`.
+	if rec := postAgentFile(t, b, path, "# OPERATIONS — @ceo\nv2", first.SHA); rec.Code != http.StatusOK {
+		t.Fatalf("second edit: %d (%s)", rec.Code, rec.Body.String())
+	}
+	// A save still using the stale first.SHA must 409.
+	rec := postAgentFile(t, b, path, "# OPERATIONS — @ceo\nstale", first.SHA)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("stale save: want 409, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var conflict map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &conflict); err != nil {
+		t.Fatalf("unmarshal conflict: %v", err)
+	}
+	if conflict["current_sha"] == "" {
+		t.Errorf("conflict missing current_sha: %v", conflict)
+	}
+	if cur, ok := conflict["current_content"].(string); !ok || !strings.Contains(cur, "v2") {
+		t.Errorf("conflict current_content stale/missing: %v", conflict["current_content"])
+	}
+}
+
+// TestAgentFileWriteRejectsNonAgentPath ensures the strict validator blocks any
+// attempt to use this endpoint to write outside the agent-file allowlist.
+func TestAgentFileWriteRejectsNonAgentPath(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+
+	for _, bad := range []string{
+		"team/people/ceo.md",       // wiki article subtree
+		"agents/ceo/MEMORY.md",     // not a canonical file
+		"agents/ceo/notebook/x.md", // notebook subtree
+		"../etc/passwd",            // traversal
+		"agents/ceo/../eng/SOUL.md",
+	} {
+		rec := postAgentFile(t, b, bad, "x", "")
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("path %q: want 400, got %d (%s)", bad, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// TestAgentFileReadRejectsNonAgentPath mirrors the write guard for reads.
+func TestAgentFileReadRejectsNonAgentPath(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+
+	rec, _ := getAgentFile(t, b, "team/people/ceo.md")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 for non-agent read path, got %d", rec.Code)
+	}
+}
+
+// TestAgentFileWriteRequiresHumanActor verifies the write handler rejects a
+// non-human (e.g. broker-token) actor — an agent must never rewrite an
+// instruction file, since those feed the system prompt.
+func TestAgentFileWriteRequiresHumanActor(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+
+	raw, _ := json.Marshal(map[string]any{
+		"path":    "agents/ceo/SOUL.md",
+		"content": "# SOUL — @ceo\nagent self-edit",
+	})
+	// No actor in context (or a broker actor) must be rejected.
+	for _, actor := range []*requestActor{nil, {Kind: requestActorKindBroker}} {
+		req := httptest.NewRequest(http.MethodPost, "/agent-files/write", bytes.NewReader(raw))
+		if actor != nil {
+			req = requestWithActor(req, *actor)
+		}
+		rec := httptest.NewRecorder()
+		b.handleAgentFileWrite(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("actor=%v: want 403, got %d (%s)", actor, rec.Code, rec.Body.String())
+		}
+	}
+}
+
+// TestHumanRouteAllowedAgentFiles locks the human/web token's access to the new
+// endpoints: GET read and POST write are allowed; other methods are not.
+func TestHumanRouteAllowedAgentFiles(t *testing.T) {
+	cases := []struct {
+		method, path string
+		want         bool
+	}{
+		{http.MethodGet, "/agent-files/read", true},
+		{http.MethodPost, "/agent-files/write", true},
+		{http.MethodPost, "/agent-files/read", false},
+		{http.MethodGet, "/agent-files/write", false},
+		{http.MethodDelete, "/agent-files/write", false},
+	}
+	for _, c := range cases {
+		req := httptest.NewRequest(c.method, c.path, nil)
+		if got := humanRouteAllowed(req); got != c.want {
+			t.Errorf("humanRouteAllowed(%s %s) = %v, want %v", c.method, c.path, got, c.want)
+		}
+	}
+}
+
+// TestCommitAgentFileHumanRoundTrip exercises the repo-level human-write path:
+// create, replace with the correct sha, and a stale-sha replace that must be
+// rejected with ErrWikiSHAMismatch.
+func TestCommitAgentFileHumanRoundTrip(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	rel := agentFileRel("ceo", "TOOLS")
+
+	sha1, n, err := repo.CommitAgentFileHuman(ctx, rel, "# TOOLS — @ceo\nv1", "", "seed", HumanIdentity{})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if sha1 == "" || n == 0 {
+		t.Fatalf("unexpected create result sha=%q n=%d", sha1, n)
+	}
+	// Correct-sha replace succeeds and advances HEAD.
+	sha2, _, err := repo.CommitAgentFileHuman(ctx, rel, "# TOOLS — @ceo\nv2", sha1, "edit", HumanIdentity{})
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if sha2 == "" || sha2 == sha1 {
+		t.Fatalf("expected new sha after replace, got %q (was %q)", sha2, sha1)
+	}
+	// Stale-sha replace is rejected.
+	if _, _, err := repo.CommitAgentFileHuman(ctx, rel, "# TOOLS — @ceo\nstale", sha1, "stale", HumanIdentity{}); !errors.Is(err, ErrWikiSHAMismatch) {
+		t.Fatalf("want ErrWikiSHAMismatch on stale write, got %v", err)
+	}
+}

--- a/internal/team/broker_agent_files_http_test.go
+++ b/internal/team/broker_agent_files_http_test.go
@@ -236,6 +236,106 @@ func TestHumanRouteAllowedAgentFiles(t *testing.T) {
 	}
 }
 
+func postGenerate(t *testing.T, b *Broker, path string, human bool) *httptest.ResponseRecorder {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{"path": path, "hint": ""})
+	req := httptest.NewRequest(http.MethodPost, "/agent-files/generate", bytes.NewReader(raw))
+	if human {
+		req = requestWithActor(req, requestActor{Kind: requestActorKindHuman, Slug: "human"})
+	}
+	rec := httptest.NewRecorder()
+	b.handleAgentFileGenerate(rec, req)
+	return rec
+}
+
+// TestAgentFileGenerateEndpoint covers the draft-authoring endpoint: a human
+// gets the generated content, a non-human is rejected, a missing generator is
+// 503, a bad path is 400, and a generator error surfaces as 500.
+func TestAgentFileGenerateEndpoint(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+	b.SetGenerateAgentFileFn(func(_ context.Context, relPath, _ string) (string, error) {
+		return "# SOUL — generated\nrich content for " + relPath, nil
+	})
+
+	// Happy path: human gets a draft, never committed.
+	rec := postGenerate(t, b, "agents/growth/SOUL.md", true)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("generate: want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var out map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	if c, _ := out["content"].(string); !strings.Contains(c, "rich content") {
+		t.Errorf("expected generated content, got %v", out["content"])
+	}
+	// The file must NOT have been written (generate is review-only).
+	if data, _ := worker.AgentFileRead("agents/growth/SOUL.md"); len(data) != 0 {
+		t.Errorf("generate must not commit; file exists: %q", data)
+	}
+
+	// Non-human is rejected.
+	if rec := postGenerate(t, b, "agents/growth/SOUL.md", false); rec.Code != http.StatusForbidden {
+		t.Errorf("non-human generate: want 403, got %d", rec.Code)
+	}
+	// Bad path is rejected.
+	if rec := postGenerate(t, b, "team/people/x.md", true); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad path: want 400, got %d", rec.Code)
+	}
+	// Generator error surfaces as 500.
+	b.SetGenerateAgentFileFn(func(_ context.Context, _, _ string) (string, error) {
+		return "", errors.New("model unavailable")
+	})
+	if rec := postGenerate(t, b, "agents/growth/SOUL.md", true); rec.Code != http.StatusInternalServerError {
+		t.Errorf("generator error: want 500, got %d", rec.Code)
+	}
+	// No generator wired -> 503.
+	b.SetGenerateAgentFileFn(nil)
+	if rec := postGenerate(t, b, "agents/growth/SOUL.md", true); rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("nil generator: want 503, got %d", rec.Code)
+	}
+}
+
+// TestGenerateAgentFileGating verifies the prose-only allowlist (SOUL/OPERATIONS
+// + office USER) and the test stub short-circuit, without needing a real model.
+func TestGenerateAgentFileGating(t *testing.T) {
+	t.Setenv("WUPHF_AGENT_FILE_STUB", "# stub content")
+	l := &Launcher{}
+	ctx := context.Background()
+
+	for _, ok := range []string{"agents/x/SOUL.md", "agents/x/OPERATIONS.md", officeUserFileRel} {
+		got, err := l.GenerateAgentFileFromContext(ctx, ok, "")
+		if err != nil || got != "# stub content" {
+			t.Errorf("path %q: want stub content, got %q err=%v", ok, got, err)
+		}
+	}
+	// Factual files are not AI-generatable.
+	for _, bad := range []string{"agents/x/IDENTITY.md", "agents/x/TOOLS.md"} {
+		if _, err := l.GenerateAgentFileFromContext(ctx, bad, ""); err == nil {
+			t.Errorf("path %q: expected gating error, got nil", bad)
+		}
+	}
+	// An invalid path is rejected before anything else.
+	if _, err := l.GenerateAgentFileFromContext(ctx, "team/people/x.md", ""); err == nil {
+		t.Error("invalid path must be rejected")
+	}
+}
+
+// TestStripMarkdownFences guards the fence-stripping helper used on model output.
+func TestStripMarkdownFences(t *testing.T) {
+	cases := map[string]string{
+		"# Title\nbody":             "# Title\nbody",
+		"```markdown\n# Title\n```": "# Title",
+		"```\n# Title\nbody\n```":   "# Title\nbody",
+		"  \n# Title\n":             "# Title",
+	}
+	for in, want := range cases {
+		if got := stripMarkdownFences(in); got != want {
+			t.Errorf("stripMarkdownFences(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 // TestCommitAgentFileHumanRoundTrip exercises the repo-level human-write path:
 // create, replace with the correct sha, and a stale-sha replace that must be
 // rejected with ErrWikiSHAMismatch.

--- a/internal/team/broker_auth.go
+++ b/internal/team/broker_auth.go
@@ -125,6 +125,7 @@ func humanRouteAllowed(r *http.Request) bool {
 			path == "/wiki/visual",
 			path == "/wiki/sections",
 			path == "/wiki/diff",
+			path == "/agent-files/read",
 			path == "/notebook/visual-artifacts",
 			path == "/review/list",
 			path == "/entity/facts",
@@ -193,6 +194,11 @@ func humanRouteAllowed(r *http.Request) bool {
 			// identity is resolved server-side. Allowed here so the restore
 			// action does not 403 in a human session.
 			"/wiki/restore",
+			// POST /agent-files/write — a human edit to an agent's instruction
+			// file. On the same footing as /wiki/write-human: HTTP-only, never
+			// exposed via MCP, identity resolved server-side. Allowed here so the
+			// agent-profile editor does not 403 in a human session.
+			"/agent-files/write",
 			"/notebook/visual-artifacts":
 			return true
 		}

--- a/internal/team/broker_auth.go
+++ b/internal/team/broker_auth.go
@@ -199,6 +199,9 @@ func humanRouteAllowed(r *http.Request) bool {
 			// exposed via MCP, identity resolved server-side. Allowed here so the
 			// agent-profile editor does not 403 in a human session.
 			"/agent-files/write",
+			// POST /agent-files/generate — human-triggered LLM authoring of a
+			// prose instruction file (returns a draft for review, never commits).
+			"/agent-files/generate",
 			"/notebook/visual-artifacts":
 			return true
 		}

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -122,6 +122,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 
 	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)
 	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPromptCtx)
+	l.broker.SetGenerateAgentFileFn(l.GenerateAgentFileFromContext)
 	if err := l.broker.ServeWebUI(webPort); err != nil {
 		// The broker is already running and the office PID file is on
 		// disk (above). On a port-bind failure we exit, so tear both

--- a/internal/team/template.go
+++ b/internal/team/template.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
 
@@ -119,6 +120,100 @@ func parseGeneratedMemberTemplate(raw string) (generatedMemberTemplate, error) {
 	}
 	tmpl.Model = strings.TrimSpace(tmpl.Model)
 	return tmpl, nil
+}
+
+// GenerateAgentFileFromContext authors a richer version of one prose
+// instruction file (SOUL / OPERATIONS, or the office USER.md) for human review.
+// It NEVER commits — the caller hands the result to the editor so the human
+// approves it with a save. On any LLM failure it returns an error (the file
+// already exists, so there is nothing to half-initialize); the UI surfaces it.
+//
+// Reuses the same one-shot provider call as member/channel generation. The
+// WUPHF_AGENT_FILE_STUB env var short-circuits the model for tests.
+func (l *Launcher) GenerateAgentFileFromContext(ctx context.Context, relPath, hint string) (string, error) {
+	if err := validateAgentFilePath(relPath); err != nil {
+		return "", err
+	}
+	relPath = strings.TrimSpace(relPath)
+
+	var slug, name string
+	if relPath == officeUserFileRel {
+		name = "USER"
+	} else {
+		parts := strings.Split(relPath, "/") // agents/<slug>/<NAME>.md
+		slug = parts[1]
+		name = strings.TrimSuffix(parts[2], ".md")
+	}
+	if name != "USER" && !aiGeneratableFile(name) {
+		return "", fmt.Errorf("AI generation is available only for SOUL, OPERATIONS, and USER; got %q", name)
+	}
+
+	if stub := strings.TrimSpace(os.Getenv("WUPHF_AGENT_FILE_STUB")); stub != "" {
+		return stub, nil
+	}
+
+	leadSlug := l.targeter().LeadSlug()
+	var info strings.Builder
+	var example string
+	if name == "USER" {
+		if cb := strings.TrimSpace(config.CompanyContextBlock()); cb != "" {
+			fmt.Fprintf(&info, "Company context:\n%s\n", cb)
+		}
+		example = renderOfficeUserFile()
+	} else {
+		member := l.officeMemberBySlug(slug)
+		isLead := slug == leadSlug
+		fmt.Fprintf(&info, "Agent: @%s\n", slug)
+		if r := strings.TrimSpace(member.Role); r != "" {
+			fmt.Fprintf(&info, "Role: %s\n", r)
+		}
+		if len(member.Expertise) > 0 {
+			fmt.Fprintf(&info, "Expertise: %s\n", strings.Join(member.Expertise, ", "))
+		}
+		if p := strings.TrimSpace(member.Personality); p != "" {
+			fmt.Fprintf(&info, "Persona: %s\n", p)
+		}
+		if isLead {
+			info.WriteString("This agent is the office lead: it coordinates and delegates rather than doing all the work itself.\n")
+		}
+		example = renderAgentFileContent(member, name, isLead)
+	}
+
+	systemPrompt := l.buildPrompt(leadSlug) + fmt.Sprintf(`
+
+You are authoring the %s.md instruction file for a WUPHF office agent. This
+file is loaded verbatim into the agent's system prompt, so write it as direct
+second-person instructions to that agent ("You ...").
+
+Purpose of %s.md: %s
+
+Return ONLY the markdown body of the file. Do not wrap it in code fences and do
+not explain your reasoning. Start with a level-1 heading.
+
+Match the section structure and style of the current version below, but make
+the content specific, vivid, and genuinely useful — not generic filler.
+
+----- CURRENT VERSION -----
+%s
+---------------------------
+`, name, name, agentFilePurpose(name), example)
+
+	var ub strings.Builder
+	ub.WriteString(info.String())
+	if hint = strings.TrimSpace(hint); hint != "" {
+		fmt.Fprintf(&ub, "\nExtra guidance from the human:\n%s\n", hint)
+	}
+	fmt.Fprintf(&ub, "\nWrite the improved %s.md now.", name)
+
+	raw, err := provider.RunConfiguredOneShotCtx(ctx, systemPrompt, ub.String(), l.cwd)
+	if err != nil {
+		return "", err
+	}
+	content := stripMarkdownFences(raw)
+	if content == "" {
+		return "", fmt.Errorf("model returned no content")
+	}
+	return content, nil
 }
 
 type generatedChannelTemplate struct {

--- a/web/e2e/screenshots/agent-instruction-files.mjs
+++ b/web/e2e/screenshots/agent-instruction-files.mjs
@@ -1,0 +1,276 @@
+// Capture the Phase 4b agent instruction-file surfaces:
+//   01: AgentProfilePanel — instructions section, file list (collapsed)
+//   02: AgentProfilePanel — SOUL expanded (rendered markdown + Edit)
+//   03: AgentProfilePanel — SOUL in the editor (reused wiki rich editor)
+//   04: AgentProfilePanel (lead) — office USER.md card expanded
+//   05: AgentWizard manual — Soul field that seeds SOUL.md
+//
+// Run via:
+//   web/e2e/screenshots/publish.sh agent-instruction-files <pr-number>
+
+import process from "node:process";
+
+import {
+  bootShell,
+  installCommonMocks,
+  launchBrowser,
+  shotElement,
+  shotPage,
+} from "./lib.mjs";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+const LLM_KINDS = ["claude-code", "codex", "opencode", "mlx-lm", "ollama", "exo"];
+
+const CONFIG = {
+  llm_provider: "claude-code",
+  llm_provider_configured: true,
+  llm_provider_priority: [],
+  llm_provider_kinds: LLM_KINDS,
+  gateway_kinds: ["openclaw", "openclaw-http", "hermes-agent"],
+  provider_endpoints: {},
+  memory_backend: "markdown",
+  action_provider: "auto",
+  team_lead_slug: "ceo",
+  company_name: "Northwind",
+  config_path: "/Users/you/.wuphf/config.json",
+};
+
+const MEMBERS = {
+  members: [
+    {
+      slug: "ceo",
+      name: "CEO",
+      role: "Office lead",
+      emoji: "🎯",
+      status: "idle",
+      activity: "idle",
+      built_in: true,
+      online: true,
+      provider: { kind: "claude-code", model: "claude-opus-4-8" },
+    },
+    {
+      slug: "growth",
+      name: "Growth Lead",
+      role: "Demand generation and pipeline",
+      emoji: "📈",
+      status: "active",
+      activity: "drafting a launch plan",
+      built_in: false,
+      online: true,
+      provider: { kind: "codex", model: "gpt-5.4" },
+    },
+  ],
+};
+
+// Realistic instruction-file content, keyed by repo-relative path, so the
+// rendered-markdown view reads like a real operating manual.
+const FILES = {
+  "agents/growth/SOUL.md": `# SOUL — @growth
+
+## Who you are
+Relentless about pipeline, allergic to vanity metrics. You would rather ship one
+real experiment than write three decks about it.
+
+## Values
+- Bias to action: leave durable state (tasks, records, deliverables), not just narration.
+- Reuse first: an existing teammate, task, or wiki article beats creating a new one.
+- Tell the human the truth, including failures. Never fabricate outcomes or proof artifacts.
+
+## Voice
+Direct and concrete. Lead with the number, then the plan.
+
+## Boundaries
+- Stay in your lane (demand generation) on execution; route cross-cutting scope calls through the lead.
+- Do the smallest real step that moves the work; avoid substitute or busywork artifacts.
+`,
+  "agents/growth/IDENTITY.md": `# IDENTITY — @growth
+
+- Name: Growth Lead
+- Slug: growth
+- Role: Demand generation and pipeline
+- Expertise: acquisition, lifecycle, funnel analytics
+- Runtime: codex / gpt-5.4
+`,
+  "agents/growth/OPERATIONS.md": `# OPERATIONS — @growth
+
+## How you work
+- Take work from durable tasks: claim with team_task, post status as you go, then submit for review or complete. A channel reply alone does not move the work.
+- Work in your task's channel and worktree. Escalate scope changes to the lead.
+- Write durable decisions to your notebook; @librarian curates notebooks into the team wiki.
+
+## Escalation
+- If blocked on something you cannot resolve, post the blocker and notify the owner/lead instead of producing a substitute artifact.
+`,
+  "agents/growth/TOOLS.md": `# TOOLS — @growth
+
+## Available tools
+- team_task
+- team_status
+- team_broadcast
+
+## Notes
+- Prefer the smallest real action over a proof or preview artifact unless the task explicitly asks for one.
+- Request a skill or capability when one is missing rather than faking the result.
+`,
+  "agents/ceo/SOUL.md": `# SOUL — @ceo
+
+## Who you are
+The office lead. You coordinate, decompose, and make the final call.
+
+## Boundaries
+- You are the lead: you coordinate, decompose, and make the final call. Delegate execution to specialists rather than doing it all yourself.
+`,
+  "office/USER.md": `# USER — the human this office serves
+
+Northwind is a seed-stage B2B startup. The operator is the founder.
+
+This WUPHF office serves a single human operator. Optimize for their time:
+- Handle routine work autonomously; surface only the decisions that genuinely need them.
+- Be candid. Report outcomes, tradeoffs, and failures plainly.
+- One human owns approvals (plan gates, new-agent creation, external actions). Wait for them on those.
+`,
+};
+
+async function mockFeature(context) {
+  await context.route("**/api/config", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(CONFIG) }),
+  );
+  await context.route("**/api/office-members", (r) =>
+    r.fulfill({ contentType: "application/json", body: JSON.stringify(MEMBERS) }),
+  );
+  await context.route("**/api/status/local-providers", (r) =>
+    r.fulfill({ contentType: "application/json", body: "[]" }),
+  );
+  await context.route("**/api/skills*", (r) =>
+    r.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ skills: [] }),
+    }),
+  );
+  await context.route("**/api/agent-files/read*", (route) => {
+    const url = new URL(route.request().url());
+    const p = url.searchParams.get("path") || "";
+    const content = FILES[p] ?? "# (not written yet)\n";
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ path: p, content, sha: "a1b2c3d", exists: true }),
+    });
+  });
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1440, height: 1000 },
+});
+
+async function openProfile(slug) {
+  // The /agents/<slug> route mounts AgentProfilePanel directly (AgentsTool's
+  // AgentDetail), which is far more deterministic than clicking through the
+  // restructured sidebar.
+  await page.evaluate((s) => {
+    window.location.hash = `/agents/${s}`;
+  }, slug);
+  await page.waitForSelector(".agent-profile-panel", { timeout: 10_000 });
+  await page.waitForTimeout(400);
+}
+
+async function expandCard(label) {
+  const header = page
+    .locator(".agent-file-card-header")
+    .filter({ hasText: label })
+    .first();
+  await header.scrollIntoViewIfNeeded();
+  await header.click();
+  await page.waitForTimeout(350);
+}
+
+// ── 01 + 02 + 03: specialist instruction files ─────────────────────────
+await installCommonMocks(context, { extra: mockFeature });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await openProfile("growth");
+
+// Bring the instructions section into view, then capture the collapsed list.
+await page
+  .locator(".agent-profile-section-title", { hasText: "instructions" })
+  .first()
+  .scrollIntoViewIfNeeded();
+await page.waitForTimeout(250);
+await shotElement(page, ".agent-profile-panel", OUT, "01-instructions-list");
+
+// Expand SOUL → rendered markdown + Edit affordance.
+await expandCard("SOUL");
+await page
+  .locator(".agent-file-view")
+  .first()
+  .waitFor({ state: "visible", timeout: 8_000 });
+await shotElement(page, ".agent-profile-panel", OUT, "02-soul-expanded");
+
+// Enter the editor (reused wiki rich editor). Lazy Tiptap chunk — give it room;
+// fall back to a debug shot rather than failing the whole capture if it stalls.
+try {
+  await page.getByRole("button", { name: "Edit" }).first().click();
+  await page.waitForSelector(".wk-editor", { timeout: 12_000 });
+  // Wait for the rich editor surface (or its loading fallback to resolve).
+  await page
+    .locator(".wk-editor-rich, .wk-editor-rich-fallback")
+    .first()
+    .waitFor({ state: "visible", timeout: 12_000 });
+  await page.waitForTimeout(900);
+  await shotElement(page, ".agent-profile-panel", OUT, "03-soul-editor");
+} catch (err) {
+  console.warn(`editor shot skipped: ${err.message}`);
+  await shotPage(page, OUT, "03-soul-editor-DEBUG");
+}
+
+// ── 04: lead office USER.md ────────────────────────────────────────────
+await installCommonMocks(context, { extra: mockFeature });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+await openProfile("ceo");
+await page
+  .locator(".agent-file-office-label")
+  .first()
+  .scrollIntoViewIfNeeded();
+await page.waitForTimeout(200);
+await expandCard("USER");
+await page
+  .locator(".agent-file-view")
+  .first()
+  .waitFor({ state: "visible", timeout: 8_000 });
+await shotElement(page, ".agent-profile-panel", OUT, "04-office-user-file");
+
+// ── 05: AgentWizard manual — the Soul field ────────────────────────────
+await installCommonMocks(context, { extra: mockFeature });
+await bootShell(page, { afterFlipSelector: ".status-bar" });
+// Land on the Agents app, which hosts the "New agent" affordance.
+await page.evaluate(() => {
+  window.location.hash = "/agents";
+});
+await page.waitForTimeout(600);
+await page
+  .getByRole("button", { name: /new agent|add agent|create agent/i })
+  .first()
+  .click()
+  .catch(async () => {
+    await page
+      .locator('[aria-label*="agent" i], [title*="agent" i]')
+      .first()
+      .click();
+  });
+await page.waitForSelector("text=Create agent", { timeout: 5_000 });
+await page.getByRole("button", { name: "Manual" }).click();
+await page.waitForTimeout(200);
+await page.getByLabel("Name").fill("Revenue Ops");
+await page
+  .getByLabel(/Soul/i)
+  .fill(
+    "Relentless about pipeline, allergic to vanity metrics. Direct, never fluffy.",
+  );
+await page.waitForTimeout(200);
+await shotPage(page, OUT, "05-wizard-soul-field");
+
+console.log(`captured screenshots to ${OUT}`);
+await browser.close();

--- a/web/e2e/screenshots/agent-instruction-files.mjs
+++ b/web/e2e/screenshots/agent-instruction-files.mjs
@@ -161,6 +161,33 @@ async function mockFeature(context) {
       body: JSON.stringify({ path: p, content, sha: "a1b2c3d", exists: true }),
     });
   });
+  // 4c: LLM authoring returns a richer draft for review (never committed).
+  await context.route("**/api/agent-files/generate", (route) => {
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        path: "agents/growth/SOUL.md",
+        content: `# SOUL — @growth
+
+## Who you are
+You are the office's growth engine: every week you turn one sharp hypothesis
+into a live experiment, measure it honestly, and kill it fast if the numbers
+don't move. Pipeline is the only scoreboard you trust.
+
+## Values
+- Evidence over opinion: a 20-lead test beats a 40-slide narrative.
+- Compounding: prefer the channel you can run again next week over a one-off spike.
+- Radical candor with the founder: surface a flat funnel the day you see it.
+
+## Voice
+Crisp, numbers-first, allergic to hedging. Lead with the result, then the why.
+
+## Boundaries
+- Own demand generation end to end; route product or pricing calls to the lead.
+- Never ship a vanity metric as a win. If it didn't move pipeline, say so.`,
+      }),
+    });
+  });
 }
 
 const { browser, context, page } = await launchBrowser({
@@ -209,21 +236,21 @@ await page
   .waitFor({ state: "visible", timeout: 8_000 });
 await shotElement(page, ".agent-profile-panel", OUT, "02-soul-expanded");
 
-// Enter the editor (reused wiki rich editor). Lazy Tiptap chunk — give it room;
-// fall back to a debug shot rather than failing the whole capture if it stalls.
+// 4c: click "Generate with AI" → the LLM drafts a richer SOUL and the reused
+// wiki rich editor opens seeded with it for human review. Lazy Tiptap chunk —
+// give it room; fall back to a debug shot rather than failing the whole run.
 try {
-  await page.getByRole("button", { name: "Edit" }).first().click();
+  await page.getByRole("button", { name: /Generate with AI/i }).first().click();
   await page.waitForSelector(".wk-editor", { timeout: 12_000 });
-  // Wait for the rich editor surface (or its loading fallback to resolve).
   await page
     .locator(".wk-editor-rich, .wk-editor-rich-fallback")
     .first()
     .waitFor({ state: "visible", timeout: 12_000 });
   await page.waitForTimeout(900);
-  await shotElement(page, ".agent-profile-panel", OUT, "03-soul-editor");
+  await shotElement(page, ".agent-profile-panel", OUT, "03-soul-ai-draft");
 } catch (err) {
   console.warn(`editor shot skipped: ${err.message}`);
-  await shotPage(page, OUT, "03-soul-editor-DEBUG");
+  await shotPage(page, OUT, "03-soul-ai-draft-DEBUG");
 }
 
 // ── 04: lead office USER.md ────────────────────────────────────────────

--- a/web/src/api/agentFiles.test.ts
+++ b/web/src/api/agentFiles.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.hoisted(() => vi.fn());
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client", () => ({
+  get: getMock,
+  post: postMock,
+}));
+
+import { agentFilePath, readAgentFile, writeAgentFile } from "./agentFiles";
+
+describe("agentFiles client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds canonical agent file paths", () => {
+    expect(agentFilePath("ceo", "SOUL")).toBe("agents/ceo/SOUL.md");
+    expect(agentFilePath("growth-ops", "OPERATIONS")).toBe(
+      "agents/growth-ops/OPERATIONS.md",
+    );
+  });
+
+  it("reads a file via GET /agent-files/read with the path query", async () => {
+    getMock.mockResolvedValue({
+      path: "agents/ceo/SOUL.md",
+      content: "# SOUL",
+      sha: "abc",
+      exists: true,
+    });
+    const res = await readAgentFile("agents/ceo/SOUL.md");
+    expect(getMock).toHaveBeenCalledWith("/agent-files/read", {
+      path: "agents/ceo/SOUL.md",
+    });
+    expect(res.sha).toBe("abc");
+  });
+
+  it("returns the OK envelope on a successful write", async () => {
+    postMock.mockResolvedValue({
+      path: "agents/ceo/SOUL.md",
+      commit_sha: "def456",
+      bytes_written: 42,
+    });
+    const res = await writeAgentFile({
+      path: "agents/ceo/SOUL.md",
+      content: "# SOUL\nv2",
+      commitMessage: "tighten",
+      expectedSha: "abc123",
+    });
+    expect(postMock).toHaveBeenCalledWith("/agent-files/write", {
+      path: "agents/ceo/SOUL.md",
+      content: "# SOUL\nv2",
+      commit_message: "tighten",
+      expected_sha: "abc123",
+    });
+    expect("commit_sha" in res && res.commit_sha).toBe("def456");
+  });
+
+  it("parses a 409 error body into a typed conflict", async () => {
+    // The shared post() helper surfaces non-2xx as Error(text); for 409 the text
+    // is the JSON conflict envelope.
+    postMock.mockRejectedValue(
+      new Error(
+        JSON.stringify({
+          error: "file changed since it was opened",
+          current_sha: "newsha",
+          current_content: "# SOUL\nsomeone else edited",
+        }),
+      ),
+    );
+    const res = await writeAgentFile({
+      path: "agents/ceo/SOUL.md",
+      content: "# SOUL\nmy edit",
+      commitMessage: "x",
+      expectedSha: "stale",
+    });
+    expect("conflict" in res).toBe(true);
+    if ("conflict" in res) {
+      expect(res.current_sha).toBe("newsha");
+      expect(res.current_content).toContain("someone else edited");
+    }
+  });
+
+  it("rethrows a non-conflict error", async () => {
+    postMock.mockRejectedValue(new Error("human session required"));
+    await expect(
+      writeAgentFile({
+        path: "agents/ceo/SOUL.md",
+        content: "x",
+        commitMessage: "x",
+        expectedSha: "",
+      }),
+    ).rejects.toThrow("human session required");
+  });
+});

--- a/web/src/api/agentFiles.ts
+++ b/web/src/api/agentFiles.ts
@@ -1,0 +1,86 @@
+/**
+ * Agent instruction-file API client — view + edit an agent's SOUL / IDENTITY /
+ * OPERATIONS / TOOLS files and the office-wide USER.md.
+ *
+ * These hit the dedicated /agent-files/* broker endpoints (NOT /wiki/*): the
+ * files live in the same git repo as the wiki but use a strict path allowlist
+ * (agents/{slug}/{canonical}.md + office/USER.md) and never enter the team
+ * article index. The write envelope is byte-compatible with the wiki editor's
+ * `writeHumanArticle` so AgentInstructionsSection can reuse WikiEditor's
+ * draft/conflict/SHA state machine unchanged.
+ */
+
+import { get, post } from "./client";
+import { tryParseConflict, type WriteHumanResult } from "./wiki";
+
+/** Canonical per-agent instruction files, in prompt-precedence order. */
+export const AGENT_INSTRUCTION_FILES = [
+  "SOUL",
+  "IDENTITY",
+  "OPERATIONS",
+  "TOOLS",
+] as const;
+
+export type AgentInstructionFile = (typeof AGENT_INSTRUCTION_FILES)[number];
+
+/** Office-wide human-context file (one per office). */
+export const OFFICE_USER_FILE_PATH = "office/USER.md";
+
+/** Repo-relative path for one of an agent's instruction files. */
+export function agentFilePath(
+  slug: string,
+  name: AgentInstructionFile,
+): string {
+  return `agents/${slug}/${name}.md`;
+}
+
+/**
+ * Response from GET /agent-files/read. `exists` is false when the file has not
+ * been committed to disk yet — `content` then carries the deterministic seed so
+ * the editor opens with real text, and the first save creates the file.
+ */
+export interface AgentFileResponse {
+  path: string;
+  content: string;
+  sha: string;
+  exists: boolean;
+}
+
+/** Read one agent instruction file (or the office USER file). */
+export async function readAgentFile(path: string): Promise<AgentFileResponse> {
+  return get<AgentFileResponse>("/agent-files/read", { path });
+}
+
+/**
+ * Save a human edit to one agent instruction file. Mirrors `writeHumanArticle`:
+ * the caller passes the per-file SHA they opened against (or '' for a file with
+ * no history); the broker rejects with 409 when HEAD moved past it, returning
+ * the current bytes so the editor can prompt re-apply.
+ */
+export async function writeAgentFile(params: {
+  path: string;
+  content: string;
+  commitMessage: string;
+  expectedSha: string;
+}): Promise<WriteHumanResult> {
+  try {
+    return await post<{
+      path: string;
+      commit_sha: string;
+      bytes_written: number;
+    }>("/agent-files/write", {
+      path: params.path,
+      content: params.content,
+      commit_message: params.commitMessage,
+      expected_sha: params.expectedSha,
+    });
+  } catch (err: unknown) {
+    // The shared post() helper surfaces non-2xx as Error(text). For 409 the
+    // body is a JSON conflict envelope — parse it out so the editor can show
+    // the reload prompt instead of a generic error.
+    const message = err instanceof Error ? err.message : String(err);
+    const parsed = tryParseConflict(message);
+    if (parsed) return parsed;
+    throw err;
+  }
+}

--- a/web/src/api/agentFiles.ts
+++ b/web/src/api/agentFiles.ts
@@ -84,3 +84,25 @@ export async function writeAgentFile(params: {
     throw err;
   }
 }
+
+/** Files the broker will author with the LLM (prose only; IDENTITY/TOOLS are
+ *  factual and excluded). Gates the "Generate with AI" affordance. */
+export function isAIGeneratableFile(label: string): boolean {
+  return label === "SOUL" || label === "OPERATIONS" || label === "USER";
+}
+
+/**
+ * Ask the broker to author a richer DRAFT of one prose instruction file with
+ * the LLM. Returns the draft markdown — NOT committed; the caller opens the
+ * editor with it so the human reviews and saves (or discards). Throws on any
+ * failure (the file already exists, so there is nothing to fall back to).
+ */
+export async function generateAgentFile(
+  path: string,
+  hint = "",
+): Promise<{ path: string; content: string }> {
+  return post<{ path: string; content: string }>("/agent-files/generate", {
+    path,
+    hint,
+  });
+}

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -91,7 +91,12 @@ export async function writeHumanArticle(params: {
   }
 }
 
-function tryParseConflict(text: string): WriteHumanConflict | null {
+/**
+ * Parse a 409 conflict body (raw error text from the shared post() helper) into
+ * a typed WriteHumanConflict, or null when the text is not a conflict envelope.
+ * Shared by the wiki and agent-file write clients (same 409 shape).
+ */
+export function tryParseConflict(text: string): WriteHumanConflict | null {
   try {
     const data = JSON.parse(text) as Partial<WriteHumanConflict> & {
       error?: string;

--- a/web/src/components/agents/AgentInstructionsSection.test.tsx
+++ b/web/src/components/agents/AgentInstructionsSection.test.tsx
@@ -1,0 +1,151 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const readAgentFileMock = vi.hoisted(() => vi.fn());
+const writeAgentFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/agentFiles", async () => {
+  const actual = await vi.importActual<typeof import("../../api/agentFiles")>(
+    "../../api/agentFiles",
+  );
+  return {
+    ...actual,
+    readAgentFile: readAgentFileMock,
+    writeAgentFile: writeAgentFileMock,
+  };
+});
+
+// Stub the heavy Tiptap editor: assert the wiring (path + save/cancel) without
+// loading the lazy rich-editor chunk in jsdom.
+vi.mock("../wiki/WikiEditor", () => ({
+  default: ({
+    path,
+    onSaved,
+    onCancel,
+  }: {
+    path: string;
+    onSaved: (sha: string) => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid="wiki-editor-stub">
+      <span data-testid="editor-path">{path}</span>
+      <button type="button" onClick={() => onSaved("newsha")}>
+        stub-save
+      </button>
+      <button type="button" onClick={onCancel}>
+        stub-cancel
+      </button>
+    </div>
+  ),
+}));
+
+import type { OfficeMember } from "../../api/client";
+import { AgentInstructionsSection } from "./AgentInstructionsSection";
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function wrap(ui: ReactNode) {
+  return <QueryClientProvider client={makeQC()}>{ui}</QueryClientProvider>;
+}
+
+const specialist: OfficeMember = {
+  slug: "growth",
+  name: "Growth Lead",
+  role: "growth lead",
+  built_in: false,
+};
+
+const lead: OfficeMember = {
+  slug: "ceo",
+  name: "CEO",
+  role: "lead",
+  built_in: true,
+};
+
+describe("<AgentInstructionsSection>", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readAgentFileMock.mockResolvedValue({
+      path: "agents/growth/SOUL.md",
+      content: "# SOUL — @growth\nbe relentless",
+      sha: "abc123",
+      exists: true,
+    });
+  });
+
+  it("lists the four instruction files and does not fetch until expanded", () => {
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+    for (const name of ["SOUL", "IDENTITY", "OPERATIONS", "TOOLS"]) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+    // Collapsed cards must not fetch.
+    expect(readAgentFileMock).not.toHaveBeenCalled();
+  });
+
+  it("does not show the office USER file for a non-lead agent", () => {
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+    expect(screen.queryByText("USER")).not.toBeInTheDocument();
+    expect(screen.queryByText(/office context/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the office USER file for the lead agent", () => {
+    render(wrap(<AgentInstructionsSection agent={lead} />));
+    expect(screen.getByText("USER")).toBeInTheDocument();
+    expect(screen.getByText(/office context/i)).toBeInTheDocument();
+  });
+
+  it("fetches and renders a file's content when its card is expanded", async () => {
+    const user = userEvent.setup();
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+
+    await user.click(screen.getByText("SOUL"));
+
+    await waitFor(() => {
+      expect(readAgentFileMock).toHaveBeenCalledWith("agents/growth/SOUL.md");
+    });
+    expect(await screen.findByText(/be relentless/)).toBeInTheDocument();
+    // Edit affordance is present in view mode.
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  it("opens the editor on Edit and returns to view on save", async () => {
+    const user = userEvent.setup();
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+
+    await user.click(screen.getByText("SOUL"));
+    await screen.findByText("Edit");
+    await user.click(screen.getByText("Edit"));
+
+    const editor = await screen.findByTestId("wiki-editor-stub");
+    expect(editor).toBeInTheDocument();
+    expect(screen.getByTestId("editor-path")).toHaveTextContent(
+      "agents/growth/SOUL.md",
+    );
+
+    // Saving exits edit mode (back to the view with the Edit button).
+    await user.click(screen.getByText("stub-save"));
+    await waitFor(() => {
+      expect(screen.queryByTestId("wiki-editor-stub")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  it("surfaces the seeded badge when a file has not been written yet", async () => {
+    readAgentFileMock.mockResolvedValue({
+      path: "agents/growth/SOUL.md",
+      content: "# SOUL — @growth\nseed",
+      sha: "",
+      exists: false,
+    });
+    const user = userEvent.setup();
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+
+    await user.click(screen.getByText("SOUL"));
+    expect(await screen.findByText(/seeded/)).toBeInTheDocument();
+  });
+});

--- a/web/src/components/agents/AgentInstructionsSection.test.tsx
+++ b/web/src/components/agents/AgentInstructionsSection.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const readAgentFileMock = vi.hoisted(() => vi.fn());
 const writeAgentFileMock = vi.hoisted(() => vi.fn());
+const generateAgentFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../api/agentFiles", async () => {
   const actual = await vi.importActual<typeof import("../../api/agentFiles")>(
@@ -15,6 +16,7 @@ vi.mock("../../api/agentFiles", async () => {
     ...actual,
     readAgentFile: readAgentFileMock,
     writeAgentFile: writeAgentFileMock,
+    generateAgentFile: generateAgentFileMock,
   };
 });
 
@@ -23,15 +25,18 @@ vi.mock("../../api/agentFiles", async () => {
 vi.mock("../wiki/WikiEditor", () => ({
   default: ({
     path,
+    initialContent,
     onSaved,
     onCancel,
   }: {
     path: string;
+    initialContent: string;
     onSaved: (sha: string) => void;
     onCancel: () => void;
   }) => (
     <div data-testid="wiki-editor-stub">
       <span data-testid="editor-path">{path}</span>
+      <span data-testid="editor-initial">{initialContent}</span>
       <button type="button" onClick={() => onSaved("newsha")}>
         stub-save
       </button>
@@ -147,5 +152,65 @@ describe("<AgentInstructionsSection>", () => {
 
     await user.click(screen.getByText("SOUL"));
     expect(await screen.findByText(/seeded/)).toBeInTheDocument();
+  });
+
+  it("offers Generate with AI on prose files but not factual ones", async () => {
+    const user = userEvent.setup();
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+
+    // SOUL (prose) → Generate offered.
+    await user.click(screen.getByText("SOUL"));
+    await screen.findByText("Edit");
+    expect(screen.getByText("Generate with AI")).toBeInTheDocument();
+
+    // IDENTITY (factual) → no Generate affordance.
+    readAgentFileMock.mockResolvedValue({
+      path: "agents/growth/IDENTITY.md",
+      content: "# IDENTITY — @growth",
+      sha: "i1",
+      exists: true,
+    });
+    await user.click(screen.getByText("IDENTITY"));
+    await waitFor(() => {
+      expect(screen.getAllByText("Edit").length).toBeGreaterThan(0);
+    });
+    // Only the SOUL card's Generate button exists; IDENTITY adds none.
+    expect(screen.getAllByText("Generate with AI")).toHaveLength(1);
+  });
+
+  it("generates a draft and opens the editor seeded with it", async () => {
+    generateAgentFileMock.mockResolvedValue({
+      path: "agents/growth/SOUL.md",
+      content: "# SOUL — @growth\nAI-authored, vivid and specific",
+    });
+    const user = userEvent.setup();
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+
+    await user.click(screen.getByText("SOUL"));
+    await user.click(await screen.findByText("Generate with AI"));
+
+    await waitFor(() => {
+      expect(generateAgentFileMock).toHaveBeenCalledWith(
+        "agents/growth/SOUL.md",
+      );
+    });
+    // Editor opens seeded with the generated draft (not the on-disk content).
+    const editor = await screen.findByTestId("wiki-editor-stub");
+    expect(editor).toBeInTheDocument();
+    expect(screen.getByTestId("editor-initial")).toHaveTextContent(
+      "AI-authored, vivid and specific",
+    );
+  });
+
+  it("surfaces a generation error without opening the editor", async () => {
+    generateAgentFileMock.mockRejectedValue(new Error("model unavailable"));
+    const user = userEvent.setup();
+    render(wrap(<AgentInstructionsSection agent={specialist} />));
+
+    await user.click(screen.getByText("SOUL"));
+    await user.click(await screen.findByText("Generate with AI"));
+
+    expect(await screen.findByText("model unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("wiki-editor-stub")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/agents/AgentInstructionsSection.tsx
+++ b/web/src/components/agents/AgentInstructionsSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { EditPencil, NavArrowDown, NavArrowRight } from "iconoir-react";
+import { EditPencil, NavArrowDown, NavArrowRight, Sparks } from "iconoir-react";
 import remarkGfm from "remark-gfm";
 
 import {
@@ -9,6 +9,8 @@ import {
   type AgentFileResponse,
   type AgentInstructionFile,
   agentFilePath,
+  generateAgentFile,
+  isAIGeneratableFile,
   OFFICE_USER_FILE_PATH,
   readAgentFile,
   writeAgentFile,
@@ -35,6 +37,12 @@ function AgentFileCard({ path, label, description }: FileCardConfig) {
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
   const [editing, setEditing] = useState(false);
+  // An LLM-authored draft, held only for the editor session (never written to
+  // the query cache, so disk stays the source of truth). When set, the editor
+  // opens seeded with it; Save commits it, Cancel discards it.
+  const [generatedDraft, setGeneratedDraft] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [genError, setGenError] = useState<string | null>(null);
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["agent-file", path],
@@ -47,10 +55,36 @@ function AgentFileCard({ path, label, description }: FileCardConfig) {
   const toggle = () => {
     setExpanded((v) => {
       const next = !v;
-      if (!next) setEditing(false);
+      if (!next) {
+        setEditing(false);
+        setGeneratedDraft(null);
+        setGenError(null);
+      }
       return next;
     });
   };
+
+  const closeEditor = () => {
+    setEditing(false);
+    setGeneratedDraft(null);
+  };
+
+  async function handleGenerate() {
+    setGenerating(true);
+    setGenError(null);
+    try {
+      const { content } = await generateAgentFile(path);
+      // Open the editor seeded with the draft so the human reviews + saves it.
+      setGeneratedDraft(content);
+      setEditing(true);
+    } catch (err: unknown) {
+      setGenError(err instanceof Error ? err.message : "Generation failed");
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  const canGenerate = isAIGeneratableFile(label);
 
   return (
     <div className={`agent-file-card${expanded ? " expanded" : ""}`}>
@@ -84,7 +118,7 @@ function AgentFileCard({ path, label, description }: FileCardConfig) {
           ) : editing && data ? (
             <WikiEditor
               path={path}
-              initialContent={data.content}
+              initialContent={generatedDraft ?? data.content}
               expectedSha={data.sha}
               writeArticle={writeAgentFile}
               hideWikiHelp={true}
@@ -100,9 +134,9 @@ function AgentFileCard({ path, label, description }: FileCardConfig) {
                 void queryClient.invalidateQueries({
                   queryKey: ["agent-file", path],
                 });
-                setEditing(false);
+                closeEditor();
               }}
-              onCancel={() => setEditing(false)}
+              onCancel={closeEditor}
             />
           ) : data ? (
             <>
@@ -111,16 +145,34 @@ function AgentFileCard({ path, label, description }: FileCardConfig) {
                   {data.content || "_This file is empty._"}
                 </ReactMarkdown>
               </div>
+              {genError ? (
+                <div className="agent-file-card-error" role="alert">
+                  {genError}
+                </div>
+              ) : null}
               <div className="agent-file-card-actions">
                 {!data.exists ? (
                   <span className="agent-file-card-badge">
                     not saved yet — seeded
                   </span>
                 ) : null}
+                {canGenerate ? (
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm agent-file-generate"
+                    onClick={handleGenerate}
+                    disabled={generating}
+                    title="Draft a richer version with AI for your review"
+                  >
+                    <Sparks width={13} height={13} />
+                    {generating ? "Generating…" : "Generate with AI"}
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className="btn btn-ghost btn-sm agent-file-edit"
                   onClick={() => setEditing(true)}
+                  disabled={generating}
                 >
                   <EditPencil width={13} height={13} />
                   Edit

--- a/web/src/components/agents/AgentInstructionsSection.tsx
+++ b/web/src/components/agents/AgentInstructionsSection.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import ReactMarkdown from "react-markdown";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { EditPencil, NavArrowDown, NavArrowRight } from "iconoir-react";
+import remarkGfm from "remark-gfm";
+
+import {
+  AGENT_INSTRUCTION_FILES,
+  type AgentFileResponse,
+  type AgentInstructionFile,
+  agentFilePath,
+  OFFICE_USER_FILE_PATH,
+  readAgentFile,
+  writeAgentFile,
+} from "../../api/agentFiles";
+import type { OfficeMember } from "../../api/client";
+import WikiEditor from "../wiki/WikiEditor";
+
+// One-line descriptions for each instruction file, shown under the file name so
+// the human knows what each one governs without opening it.
+const FILE_DESCRIPTIONS: Record<AgentInstructionFile, string> = {
+  SOUL: "Persona, values, voice, and boundaries",
+  IDENTITY: "Name, role, expertise, and runtime",
+  OPERATIONS: "How this agent works and escalates",
+  TOOLS: "Tool inventory and usage notes",
+};
+
+interface FileCardConfig {
+  path: string;
+  label: string;
+  description: string;
+}
+
+function AgentFileCard({ path, label, description }: FileCardConfig) {
+  const queryClient = useQueryClient();
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ["agent-file", path],
+    queryFn: () => readAgentFile(path),
+    // Only fetch once the card is opened — keeps the panel light (4-5 files).
+    enabled: expanded,
+    staleTime: 15_000,
+  });
+
+  const toggle = () => {
+    setExpanded((v) => {
+      const next = !v;
+      if (!next) setEditing(false);
+      return next;
+    });
+  };
+
+  return (
+    <div className={`agent-file-card${expanded ? " expanded" : ""}`}>
+      <button
+        type="button"
+        className="agent-file-card-header"
+        onClick={toggle}
+        aria-expanded={expanded}
+      >
+        <span className="agent-file-card-chevron">
+          {expanded ? (
+            <NavArrowDown width={14} height={14} />
+          ) : (
+            <NavArrowRight width={14} height={14} />
+          )}
+        </span>
+        <span className="agent-file-card-titles">
+          <span className="agent-file-card-name">{label}</span>
+          <span className="agent-file-card-desc">{description}</span>
+        </span>
+      </button>
+
+      {expanded ? (
+        <div className="agent-file-card-body">
+          {isLoading ? (
+            <div className="agent-file-card-loading">Loading…</div>
+          ) : isError ? (
+            <div className="agent-file-card-error" role="alert">
+              {error instanceof Error ? error.message : "Failed to load file"}
+            </div>
+          ) : editing && data ? (
+            <WikiEditor
+              path={path}
+              initialContent={data.content}
+              expectedSha={data.sha}
+              writeArticle={writeAgentFile}
+              hideWikiHelp={true}
+              onSaved={(newSha) => {
+                // Promote the new SHA into the cache immediately so re-opening
+                // the card before the refetch lands does not seed the editor
+                // with a stale expected_sha; then refetch for fresh content.
+                queryClient.setQueryData(
+                  ["agent-file", path],
+                  (old: AgentFileResponse | undefined) =>
+                    old ? { ...old, sha: newSha, exists: true } : old,
+                );
+                void queryClient.invalidateQueries({
+                  queryKey: ["agent-file", path],
+                });
+                setEditing(false);
+              }}
+              onCancel={() => setEditing(false)}
+            />
+          ) : data ? (
+            <>
+              <div className="agent-file-view">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {data.content || "_This file is empty._"}
+                </ReactMarkdown>
+              </div>
+              <div className="agent-file-card-actions">
+                {!data.exists ? (
+                  <span className="agent-file-card-badge">
+                    not saved yet — seeded
+                  </span>
+                ) : null}
+                <button
+                  type="button"
+                  className="btn btn-ghost btn-sm agent-file-edit"
+                  onClick={() => setEditing(true)}
+                >
+                  <EditPencil width={13} height={13} />
+                  Edit
+                </button>
+              </div>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface AgentInstructionsSectionProps {
+  agent: OfficeMember;
+}
+
+// AgentInstructionsSection surfaces an agent's instruction file set — the
+// SOUL/IDENTITY/OPERATIONS/TOOLS that are loaded into its system prompt — as a
+// viewable + editable accordion. The office-wide USER.md (the human the office
+// serves) is shown on the lead agent's panel since it is shared by everyone.
+export function AgentInstructionsSection({
+  agent,
+}: AgentInstructionsSectionProps) {
+  const isLead = agent.built_in === true || agent.slug === "ceo";
+
+  const files: FileCardConfig[] = AGENT_INSTRUCTION_FILES.map((name) => ({
+    path: agentFilePath(agent.slug, name),
+    label: name,
+    description: FILE_DESCRIPTIONS[name],
+  }));
+
+  return (
+    <div className="agent-profile-section">
+      <div className="agent-profile-section-title">instructions</div>
+      <p className="agent-instructions-blurb">
+        These files shape how this agent thinks and works. Each one is loaded
+        into its system prompt — edits take effect on the next turn.
+      </p>
+      <div className="agent-file-list">
+        {files.map((f) => (
+          <AgentFileCard key={f.path} {...f} />
+        ))}
+      </div>
+
+      {isLead ? (
+        <div className="agent-file-office">
+          <div className="agent-file-office-label">
+            office context — shared by all agents
+          </div>
+          <div className="agent-file-list">
+            <AgentFileCard
+              path={OFFICE_USER_FILE_PATH}
+              label="USER"
+              description="The human this office serves"
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/src/components/agents/AgentProfilePanel.tsx
+++ b/web/src/components/agents/AgentProfilePanel.tsx
@@ -35,6 +35,7 @@ import {
 import { router } from "../../lib/router";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
+import { AgentInstructionsSection } from "./AgentInstructionsSection";
 
 const PROVIDER_LABELS: Record<LLMRuntimeKind, string> = {
   "claude-code": "Claude Code",
@@ -921,6 +922,9 @@ export function AgentProfilePanel({ agent, onClose }: AgentProfilePanelProps) {
             <p className="agent-profile-current-task">{agent.task}</p>
           </div>
         ) : null}
+
+        {/* Instruction files (SOUL / IDENTITY / OPERATIONS / TOOLS + office USER) */}
+        <AgentInstructionsSection agent={agent} />
 
         {/* Per-agent runtime picker */}
         <RuntimeSection agent={agent} defaultHarness={defaultHarness} />

--- a/web/src/components/agents/AgentWizard.test.tsx
+++ b/web/src/components/agents/AgentWizard.test.tsx
@@ -84,4 +84,49 @@ describe("<AgentWizard>", () => {
     expect(path).toBe("/office-members");
     expect((body as { permission_mode?: string }).permission_mode).toBe("auto");
   });
+
+  it("sends the soul field as `personality` in the create body", async () => {
+    postMock.mockResolvedValue({});
+    render(
+      wrap(<AgentWizard open={true} onClose={vi.fn()} onCreated={vi.fn()} />),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Manual" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Revenue Ops" },
+    });
+    fireEvent.change(screen.getByLabelText(/Soul/i), {
+      target: { value: "Relentless about pipeline." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [url, body] = postMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(url).toBe("/office-members");
+    expect(body).toMatchObject({
+      action: "create",
+      personality: "Relentless about pipeline.",
+    });
+  });
+
+  it("omits `personality` when the soul field is left blank", async () => {
+    postMock.mockResolvedValue({});
+    render(wrap(<AgentWizard open={true} onClose={vi.fn()} />));
+
+    fireEvent.click(screen.getByRole("button", { name: "Manual" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Quiet Agent" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    const [, body] = postMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(body.personality).toBeUndefined();
+  });
 });

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -43,6 +43,7 @@ interface AgentFormData {
   model: string;
   expertise: string;
   permissionMode: PermissionModeChoice;
+  soul: string;
 }
 
 const INITIAL_FORM: AgentFormData = {
@@ -54,6 +55,7 @@ const INITIAL_FORM: AgentFormData = {
   model: "",
   expertise: "",
   permissionMode: "plan",
+  soul: "",
 };
 
 // Human-readable labels for the runtime picker. Kinds the broker hasn't
@@ -236,6 +238,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
         model: tmpl.model || "",
         expertise: (tmpl.expertise || []).join(", "),
         permissionMode: "plan",
+        soul: tmpl.personality || "",
       });
       setSlugEdited(generatedSlug.length > 0);
       setMode("manual");
@@ -298,6 +301,9 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
         provider: providerBody,
         expertise: expertiseTags.length > 0 ? expertiseTags : undefined,
         permission_mode: form.permissionMode,
+        // The soul/personality seeds the agent's SOUL.md (its persona, voice,
+        // and boundaries) — the file the broker loads into the system prompt.
+        personality: form.soul.trim() || undefined,
       };
 
       await post("/office-members", body);
@@ -500,6 +506,37 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
                 {form.permissionMode === "plan"
                   ? "This agent's tasks plan first: it runs read-only in the provider's native plan mode and waits for your Approve & Start before executing."
                   : "This agent executes its tasks immediately, with no planning gate. Per-task “Plan first” can still override this."}
+              </span>
+            </div>
+
+            {/* Soul / personality — seeds SOUL.md */}
+            <div className="agent-wizard-field">
+              <label className="label" htmlFor="agent-soul">
+                Soul{" "}
+                <span
+                  style={{ fontWeight: 400, color: "var(--text-tertiary)" }}
+                >
+                  (personality, voice, boundaries — optional)
+                </span>
+              </label>
+              <textarea
+                id="agent-soul"
+                className="input"
+                placeholder="e.g. Relentless about pipeline, allergic to vanity metrics. Direct, never fluffy."
+                value={form.soul}
+                onChange={(e) => updateField("soul", e.target.value)}
+                rows={3}
+                style={{
+                  minHeight: 72,
+                  resize: "vertical",
+                  padding: "10px 12px",
+                  lineHeight: 1.5,
+                }}
+              />
+              <span className="op-hint">
+                Seeds this agent's SOUL.md — the persona loaded into its system
+                prompt. You can refine it (and the other instruction files)
+                anytime from the agent's profile.
               </span>
             </div>
 

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback, useMemo } from "react";
 
-import type { WikiCatalogEntry } from "../../api/wiki";
+import type { WikiCatalogEntry, WriteHumanResult } from "../../api/wiki";
 import { useWikiEditorController } from "../../hooks/useWikiEditorController";
 
 /**
@@ -27,6 +27,23 @@ interface WikiEditorProps {
   onSaved: (newSha: string) => void;
   /** Called when the user cancels. */
   onCancel: () => void;
+  /**
+   * Override the save transport. Defaults to the wiki human-write endpoint.
+   * AgentInstructionsSection passes an agent-file writer so the same editor can
+   * edit SOUL/IDENTITY/OPERATIONS/TOOLS/USER without touching the wiki path.
+   */
+  writeArticle?: (params: {
+    path: string;
+    content: string;
+    commitMessage: string;
+    expectedSha: string;
+  }) => Promise<WriteHumanResult>;
+  /**
+   * Hide the wiki-specific footer hint (wikilinks / mention picker). Set true
+   * when editing a non-wiki file (e.g. an agent instruction file) where those
+   * affordances don't apply.
+   */
+  hideWikiHelp?: boolean;
 }
 
 function formatAgo(isoOrMs: string): string {
@@ -64,6 +81,8 @@ export default function WikiEditor({
   catalog = [],
   onSaved,
   onCancel,
+  writeArticle,
+  hideWikiHelp = false,
 }: WikiEditorProps) {
   const {
     content,
@@ -84,6 +103,7 @@ export default function WikiEditor({
     expectedSha,
     serverLastEditedTs,
     onSaved,
+    writeHumanArticle: writeArticle,
   });
 
   const catalogSlugs = useMemo(
@@ -205,13 +225,22 @@ export default function WikiEditor({
           Cancel
         </button>
       </div>
-      <p className="wk-editor-help">
-        <code>[[slug]]</code> creates a wikilink. Saved as commit author{" "}
-        <strong>Human &lt;human@wuphf.local&gt;</strong>. Type <code>/</code>{" "}
-        for inserts; <code>@</code> opens the mention picker. Select text, then{" "}
-        <code>Mod-e</code> adds a link and <code>Mod-Shift-h</code> toggles
-        highlight.
-      </p>
+      {hideWikiHelp ? (
+        <p className="wk-editor-help">
+          Saved as commit author{" "}
+          <strong>Human &lt;human@wuphf.local&gt;</strong>. This file is loaded
+          into the agent's system prompt — changes take effect on the agent's
+          next turn.
+        </p>
+      ) : (
+        <p className="wk-editor-help">
+          <code>[[slug]]</code> creates a wikilink. Saved as commit author{" "}
+          <strong>Human &lt;human@wuphf.local&gt;</strong>. Type <code>/</code>{" "}
+          for inserts; <code>@</code> opens the mention picker. Select text,
+          then <code>Mod-e</code> adds a link and <code>Mod-Shift-h</code>{" "}
+          toggles highlight.
+        </p>
+      )}
     </div>
   );
 }

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -1158,3 +1158,213 @@
   letter-spacing: 0.04em;
   z-index: 1;
 }
+
+/* ─── Agent instruction files (SOUL / IDENTITY / OPERATIONS / TOOLS + USER) ───
+   The viewer/editor accordion rendered inside the agent profile panel. Each
+   file is loaded into the agent's system prompt; this surface makes that real,
+   inspectable, and editable. Token-only so it holds across every theme. */
+
+.agent-instructions-blurb {
+  margin: 0 0 10px;
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+
+.agent-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.agent-file-card {
+  border: 1px solid var(--border-light);
+  border-radius: 8px;
+  background: var(--bg-card);
+  overflow: hidden;
+}
+
+.agent-file-card.expanded {
+  border-color: var(--border);
+}
+
+.agent-file-card-header {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 9px 11px;
+  background: transparent;
+  border: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  transition: background var(--motion-fast, 120ms) ease;
+}
+
+.agent-file-card-header:hover {
+  background: var(--bg-subtle);
+}
+
+.agent-file-card-chevron {
+  flex-shrink: 0;
+  display: inline-flex;
+  color: var(--text-tertiary);
+}
+
+.agent-file-card-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.agent-file-card-name {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.agent-file-card-desc {
+  font-size: var(--text-2xs);
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-file-card-body {
+  padding: 11px 12px;
+  border-top: 1px solid var(--border-light);
+}
+
+.agent-file-card-loading,
+.agent-file-card-error {
+  font-size: var(--text-sm);
+  color: var(--text-tertiary);
+  padding: 4px 0;
+}
+
+.agent-file-card-error {
+  color: var(--error-400, var(--accent));
+}
+
+.agent-file-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.agent-file-card-badge {
+  margin-right: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-tertiary);
+}
+
+.agent-file-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.agent-file-office {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--border-light);
+}
+
+.agent-file-office-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  margin-bottom: 7px;
+}
+
+/* Rendered markdown inside a file's view mode. ReactMarkdown emits raw
+   heading, paragraph, list, and code elements; scope the document typography
+   here so instruction files read like a clean operating manual, not raw HTML. */
+.agent-file-view {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.55;
+  word-break: break-word;
+}
+
+.agent-file-view > :first-child {
+  margin-top: 0;
+}
+
+.agent-file-view > :last-child {
+  margin-bottom: 0;
+}
+
+.agent-file-view h1,
+.agent-file-view h2,
+.agent-file-view h3 {
+  font-weight: 600;
+  color: var(--text);
+  line-height: 1.3;
+  margin: 14px 0 6px;
+}
+
+.agent-file-view h1 {
+  font-size: var(--text-base);
+}
+
+.agent-file-view h2 {
+  font-size: var(--text-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+.agent-file-view h3 {
+  font-size: var(--text-sm);
+}
+
+.agent-file-view p {
+  margin: 6px 0;
+}
+
+.agent-file-view ul,
+.agent-file-view ol {
+  margin: 6px 0;
+  padding-left: 18px;
+}
+
+.agent-file-view li {
+  margin: 2px 0;
+}
+
+.agent-file-view code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--bg-subtle);
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+
+.agent-file-view pre {
+  background: var(--bg-subtle);
+  padding: 10px 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.agent-file-view pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.agent-file-view a {
+  color: var(--accent);
+  text-decoration: underline;
+}

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -924,7 +924,9 @@
   background: var(--bg-card, var(--bg));
   border: 1px solid var(--border);
   border-radius: 8px;
-  transition: border-color 120ms ease, background-color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease;
 }
 
 .agent-skills-row:hover {
@@ -981,7 +983,10 @@
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
 .agent-skills-row-add:hover:not(:disabled) {
@@ -1054,7 +1059,9 @@
   font-weight: 500;
   color: var(--text-secondary);
   cursor: pointer;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
 }
 
 .agent-skills-mode-btn:hover {
@@ -1117,7 +1124,10 @@
   font-weight: 500;
   color: var(--text);
   cursor: pointer;
-  transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
 }
 
 .agent-skills-card-btn:hover:not(:disabled) {
@@ -1265,7 +1275,8 @@
   color: var(--text-tertiary);
 }
 
-.agent-file-edit {
+.agent-file-edit,
+.agent-file-generate {
   display: inline-flex;
   align-items: center;
   gap: 4px;


### PR DESCRIPTION
## Phase 4b — agent instruction files become visible and editable in the UI

**Stacked on #1060 (Phase 4a).** Base is `feat/agent-files`; this PR's diff is 4b-only. Merge #1060 first (or this PR will auto-retarget to `main` when 4a lands).

Phase 4a made every agent's instruction files real and loaded into its system prompt (`SOUL`/`IDENTITY`/`OPERATIONS`/`TOOLS` + office `USER.md`), but they lived only on disk + in the prompt. **4b makes them visible and editable in the app** — the slice that actually resolves the "I can't see the agent's instructions" pain.

### Backend — dedicated, tightly-scoped endpoints (not a `/wiki/*` widening)
- New `GET /agent-files/read` + `POST /agent-files/write` over the strict 4a storage layer. They validate with `validateAgentFilePath` (only `agents/{slug}/{SOUL|IDENTITY|OPERATIONS|TOOLS}.md` + `office/USER.md`) and **never regenerate the team article index**, so instruction files stay out of the wiki catalog. This deliberately avoids loosening the 20-caller `validateArticlePath` gate (the "Risk 4" audit).
- `CommitAgentFileHuman` — optimistic-concurrency human write mirroring `CommitHuman` (per-file `expected_sha`, 409 + current bytes on mismatch), minus the index regen.
- Read **seeds the deterministic content on a miss** so the editor never opens blank; the first save persists it.
- Security posture identical to `/wiki/write-human`: HTTP-only, **not exposed via any MCP tool**, human-route-allowlisted, identity resolved server-side (attribution can't be forged). Agents cannot reach it.

### Frontend
- `AgentInstructionsSection` in the agent profile panel: a per-file accordion (lazy-fetches on expand), rendered-markdown view + **Edit** that reuses `WikiEditor` via a new `writeArticle` override + `hideWikiHelp` prop. The office `USER.md` appears on the lead agent's panel (shared by all agents).
- `AgentWizard` gains a **Soul** field that seeds `SOUL.md` through the existing `personality` create field (deterministic-first, no LLM) and pre-fills from "Describe" generation.

### Tests
- Go: agent-file HTTP round-trip, read-miss seed (office + roster), 409 stale-sha, path rejection, human-route allowlist, repo-level human commit (create/replace/conflict).
- Web: `AgentInstructionsSection` view/edit flow + lead-only USER card + seeded badge; wizard soul→personality wiring (set + omit-when-blank).

## Test plan
- [x] `go test ./internal/team/` (full suite green, 155s)
- [x] `bunx tsc --noEmit` clean
- [x] `bunx vitest run` — 1997 passed / 40 skipped
- [x] `biome check` — clean (warnings only, pre-existing)
- [x] gofmt + `go vet` clean
- [x] Screenshots via publish.sh — posted as a PR comment (light + dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Phase 4c — AI-drafted instruction files (added to this PR)

A **Generate with AI** action on the prose files (SOUL / OPERATIONS / office USER) drafts a richer version with the model and opens it in the editor for review — nothing commits until the human saves. IDENTITY and TOOLS are factual (derived from member data), so AI generation is deliberately not offered for them. New `POST /agent-files/generate` is human-only, ctx-bounded, never commits, and surfaces an honest error on failure (no silent fallback). Reuses `provider.RunConfiguredOneShotCtx` like the member/channel generators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * View and edit agent instruction files (SOUL, IDENTITY, OPERATIONS, TOOLS) directly from agent profiles
  * AI-assisted generation for instruction files to jumpstart agent configurations
  * Define agent personality during agent creation
  * Office-wide USER.md file available for leads
  * Conflict detection prevents accidental overwrites of concurrently edited files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->