### PR TITLE
feat(slack): Block Kit approval gate [PR-D]

### DIFF
--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -642,9 +642,28 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	status, msg := b.answerRequestFromActor(answerActor, body.ID, body.ChoiceID, body.ChoiceText, body.CustomText)
+	if status != http.StatusOK {
+		http.Error(w, msg, status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
+// answerRequestFromActor resolves an active human interview through the broker's
+// canonical answer path and returns an HTTP-style (status, message) pair. It is
+// the single home of the answer side effects — scheduler completion, dependent
+// unblocking, skill activation/archival, self-heal task creation, the answer
+// chat message, and the audit log entry — so every caller (the HTTP handler and
+// the Slack Block Kit gate) fires the exact same effects in the exact same
+// order. answerActor is the resolved sender string (e.g. "human:mira" or "you"),
+// already namespaced by the caller; only a human actor reaches this path because
+// the approval gate is human-only. On success it returns (http.StatusOK, "").
+func (b *Broker) answerRequestFromActor(answerActor, id, choiceIDRaw, choiceTextRaw, customTextRaw string) (int, string) {
 	b.mu.Lock()
 	for i := range b.requests {
-		if b.requests[i].ID != body.ID {
+		if b.requests[i].ID != id {
 			continue
 		}
 		// Reject answers for requests that are no longer active. Without
@@ -655,17 +674,15 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		// immutable after it lands.
 		if !requestIsActive(b.requests[i]) {
 			b.mu.Unlock()
-			http.Error(w, "request is not active", http.StatusConflict)
-			return
+			return http.StatusConflict, "request is not active"
 		}
-		choiceID := strings.TrimSpace(body.ChoiceID)
-		choiceText := strings.TrimSpace(body.ChoiceText)
-		customText := strings.TrimSpace(body.CustomText)
+		choiceID := strings.TrimSpace(choiceIDRaw)
+		choiceText := strings.TrimSpace(choiceTextRaw)
+		customText := strings.TrimSpace(customTextRaw)
 		option := findRequestOption(b.requests[i], choiceID)
 		if choiceID != "" && option == nil {
 			b.mu.Unlock()
-			http.Error(w, "unknown request option", http.StatusBadRequest)
-			return
+			return http.StatusBadRequest, "unknown request option"
 		}
 		if option != nil {
 			if choiceText == "" {
@@ -677,14 +694,12 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 					hint = "custom_text required for this response"
 				}
 				b.mu.Unlock()
-				http.Error(w, hint, http.StatusBadRequest)
-				return
+				return http.StatusBadRequest, hint
 			}
 		}
 		if choiceID == "" && choiceText == "" && customText == "" {
 			b.mu.Unlock()
-			http.Error(w, "choice_text or custom_text required", http.StatusBadRequest)
-			return
+			return http.StatusBadRequest, "choice_text or custom_text required"
 		}
 		// Skill proposals carry an irreversible side-effect (activate
 		// vs archive) that hangs off choiceID == "accept". Without an
@@ -696,8 +711,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 				// ok
 			default:
 				b.mu.Unlock()
-				http.Error(w, "skill_proposal answers require choice_id of 'accept' or 'reject'", http.StatusBadRequest)
-				return
+				return http.StatusBadRequest, "skill_proposal answers require choice_id of 'accept' or 'reject'"
 			}
 		}
 		answer := &interviewAnswer{
@@ -762,18 +776,14 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		b.appendActionLocked("request_answered", "office", b.requests[i].Channel, answerActor, truncateSummary(msg.Content, 140), b.requests[i].ID)
 		if err := b.saveLocked(); err != nil {
 			b.mu.Unlock()
-			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
-			return
+			return http.StatusInternalServerError, "failed to persist broker state"
 		}
 		b.flushPendingAutoNotebookTransitionsLocked(pendingCascade, "system")
 		b.mu.Unlock()
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
-		return
+		return http.StatusOK, ""
 	}
 	b.mu.Unlock()
-	http.Error(w, "request not found", http.StatusNotFound)
+	return http.StatusNotFound, "request not found"
 }
 
 func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) []pendingTaskTransition {

--- a/internal/team/slack_gate.go
+++ b/internal/team/slack_gate.go
@@ -1,0 +1,336 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/slack-go/slack"
+)
+
+// slack_gate.go renders the office's human approval/decision requests
+// (humanInterview) as Slack Block Kit messages with one button per option, and
+// turns a button click back into an answer through the broker's canonical
+// answer path (Broker.answerRequestFromActor). This makes the first-egress /
+// external-action approval gate — the same data the web ExternalActionApprovalCard
+// renders — natively actionable inside a Slack-bridged channel.
+//
+// Outbound (render): formatSlackInterviewBlocks builds the blocks; the transport's
+// Send looks up the active decision for the target channel and posts them.
+//
+// Inbound (click): handleInteractive parses a block_actions InteractionCallback,
+// resolves the clicking Slack user to a human requestActor, answers the interview,
+// and rewrites the original message in place to show the resolved decision and drop
+// the buttons. The gate is human-only by construction: a human pressed a button in
+// Slack, so the actor is always a human.
+
+// slackGateActionBlock is the block_id carried on the approval action block so the
+// inbound handler can recognise (and, if needed, ignore) clicks that originate
+// from this gate vs any other future interactive surface.
+const slackGateActionBlock = "wuphf_interview_options"
+
+// slackGateValueSep separates the interview id from the option id in a button's
+// value (e.g. "request-7|approve"). Option ids are normalised to [a-z0-9-_] by
+// normalizeRequestOptionID, and interview ids are broker-minted "request-N", so a
+// single "|" never collides with either side.
+const slackGateValueSep = "|"
+
+// slackGateValue encodes an interview id + option id into a button value. The
+// value round-trips through Slack untouched and is the only state the click
+// callback needs to answer the right request with the right choice.
+func slackGateValue(interviewID, optionID string) string {
+	return strings.TrimSpace(interviewID) + slackGateValueSep + strings.TrimSpace(optionID)
+}
+
+// parseSlackGateValue inverts slackGateValue. ok is false when the value is not a
+// well-formed "<interviewID>|<optionID>" pair (both halves non-empty).
+func parseSlackGateValue(value string) (interviewID, optionID string, ok bool) {
+	idx := strings.Index(value, slackGateValueSep)
+	if idx < 0 {
+		return "", "", false
+	}
+	interviewID = strings.TrimSpace(value[:idx])
+	optionID = strings.TrimSpace(value[idx+len(slackGateValueSep):])
+	if interviewID == "" || optionID == "" {
+		return "", "", false
+	}
+	return interviewID, optionID, true
+}
+
+// formatSlackInterviewBlocks renders a humanInterview as Slack Block Kit: a header
+// section with the question and (optional) context, a masked one-line action
+// summary when the request carries a structured external action, a warning when
+// the connection is unverified, and one button per option. The recommended option
+// is styled primary. Every dynamic field is escaped with slackEscape so hostile
+// agent-authored text cannot smuggle Slack control sequences into the rendered
+// card.
+func formatSlackInterviewBlocks(req humanInterview) []slack.Block {
+	var blocks []slack.Block
+
+	header := "📋 *Decision needed*"
+	if from := strings.TrimSpace(req.From); from != "" {
+		header += " from @" + slackEscape(from)
+	}
+	blocks = append(blocks, slack.NewSectionBlock(
+		slack.NewTextBlockObject(slack.MarkdownType, header, false, false), nil, nil))
+
+	question := strings.TrimSpace(req.Question)
+	if question == "" {
+		question = strings.TrimSpace(req.Title)
+	}
+	if question != "" {
+		blocks = append(blocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, slackEscape(question), false, false), nil, nil))
+	}
+
+	if ctx := strings.TrimSpace(req.Context); ctx != "" {
+		blocks = append(blocks, slack.NewContextBlock("",
+			slack.NewTextBlockObject(slack.MarkdownType, slackEscape(ctx), false, false)))
+	}
+
+	if summary := slackActionSummary(req.Action); summary != "" {
+		blocks = append(blocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, "🔌 *Action*: "+summary, false, false), nil, nil))
+	}
+
+	if req.ConnectionUnverified {
+		blocks = append(blocks, slack.NewContextBlock("",
+			slack.NewTextBlockObject(slack.MarkdownType,
+				"⚠️ Connection unverified — the office could not confirm this integration is connected.", false, false)))
+	}
+
+	if buttons := slackInterviewButtons(req); len(buttons) > 0 {
+		blocks = append(blocks, slack.NewActionBlock(slackGateActionBlock, buttons...))
+	}
+
+	return blocks
+}
+
+// slackInterviewButtons builds one button per option, capped at the Slack action
+// block limit (5 elements per action block). Buttons beyond the cap are dropped
+// rather than split across blocks: the gate's canonical kinds (approval/connect/
+// fallback/confirm/choice) all define ≤5 options, so the cap only ever bites a
+// malformed request. The recommended option is styled primary; a "reject"/"skip"
+// option is styled danger so the destructive choice reads as such.
+func slackInterviewButtons(req humanInterview) []slack.BlockElement {
+	const maxButtons = 5
+	var buttons []slack.BlockElement
+	for _, opt := range req.Options {
+		id := strings.TrimSpace(opt.ID)
+		if id == "" {
+			continue
+		}
+		label := strings.TrimSpace(opt.Label)
+		if label == "" {
+			label = id
+		}
+		btn := slack.NewButtonBlockElement(
+			id,
+			slackGateValue(req.ID, id),
+			slack.NewTextBlockObject(slack.PlainTextType, slackEscape(label), true, false),
+		)
+		switch {
+		case id == strings.TrimSpace(req.RecommendedID):
+			btn = btn.WithStyle(slack.StylePrimary)
+		case id == "reject" || id == "skip" || strings.HasPrefix(id, "reject"):
+			btn = btn.WithStyle(slack.StyleDanger)
+		}
+		buttons = append(buttons, btn)
+		if len(buttons) >= maxButtons {
+			break
+		}
+	}
+	return buttons
+}
+
+// slackActionSummary renders a one-line, already-masked summary of a structured
+// external action for the approval card. It reads only the typed, non-secret
+// fields (verb/name/platform + the envelope method/url); the broker re-masks the
+// envelope on store (sanitizeApprovalActionPayload), so no secret reaches here.
+// Returns "" when there is no action to summarise.
+func slackActionSummary(action *approvalActionPayload) string {
+	if action == nil {
+		return ""
+	}
+	label := strings.TrimSpace(action.Name)
+	if label == "" {
+		label = strings.TrimSpace(action.Verb)
+	}
+	if label == "" {
+		label = strings.TrimSpace(action.ActionID)
+	}
+	platform := strings.TrimSpace(action.Platform)
+
+	var parts []string
+	if label != "" {
+		parts = append(parts, slackEscape(label))
+	}
+	if platform != "" {
+		parts = append(parts, "on "+slackEscape(platform))
+	}
+	if env := action.RawEnvelope; env != nil {
+		method := strings.TrimSpace(env.Method)
+		url := strings.TrimSpace(env.URL)
+		switch {
+		case method != "" && url != "":
+			parts = append(parts, "("+slackEscape(strings.ToUpper(method))+" "+slackEscape(url)+")")
+		case url != "":
+			parts = append(parts, "("+slackEscape(url)+")")
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, " "))
+}
+
+// activeDecisionForChannel returns the most-recently-created active human
+// decision for the given office channel slug, or ok=false when none is pending.
+// "Most recent" matches the message the office just posted: a decision message
+// and its underlying request are created together, so the newest active decision
+// in the channel is the one the outbound message is rendering. Requests with no
+// options (nothing to click) are skipped so Send falls back to plain text.
+func (t *SlackTransport) activeDecisionForChannel(slug string) (humanInterview, bool) {
+	if t.Broker == nil {
+		return humanInterview{}, false
+	}
+	reqs := t.Broker.Requests(slug, false)
+	var best humanInterview
+	var found bool
+	for _, req := range reqs {
+		if !isHumanDecisionKind(req.Kind) || len(req.Options) == 0 {
+			continue
+		}
+		if !found || req.CreatedAt > best.CreatedAt {
+			best = req
+			found = true
+		}
+	}
+	return best, found
+}
+
+// handleInteractive processes one block_actions interaction: it resolves the
+// clicking Slack user to a human actor, answers the matching interview through
+// the broker's canonical answer path, and on success rewrites the original Slack
+// message to show the resolved decision (dropping the buttons). It always reports
+// true so the socket runner Acks the interaction — a failed answer is surfaced to
+// the clicker via an ephemeral message, never via a Slack retry (retrying a click
+// would just re-hit the same terminal/invalid state).
+func (t *SlackTransport) handleInteractive(ctx context.Context, callback slack.InteractionCallback) bool {
+	if callback.Type != slack.InteractionTypeBlockActions {
+		return true
+	}
+	actions := callback.ActionCallback.BlockActions
+	if len(actions) == 0 {
+		return true
+	}
+
+	channelID := callback.Channel.ID
+	messageTS := callback.Message.Timestamp
+	if messageTS == "" {
+		messageTS = callback.MessageTs
+	}
+
+	for _, action := range actions {
+		if action == nil || action.BlockID != slackGateActionBlock {
+			continue
+		}
+		interviewID, optionID, ok := parseSlackGateValue(action.Value)
+		if !ok {
+			log.Printf("[slack] gate: malformed action value %q", action.Value)
+			t.postGateEphemeral(ctx, channelID, callback.User.ID, "Sorry — that button is no longer valid.")
+			continue
+		}
+
+		// The clicker is a human pressing a button in Slack; the gate is
+		// human-only. Resolve their display name (best-effort) for the answer
+		// actor and the message rewrite.
+		name, _ := t.resolveUser(ctx, callback.User.ID)
+		actorSlug := slackHumanActorSlug(callback.User.ID, name)
+		answerActor := humanMessageSender(actorSlug)
+
+		status, msg := t.Broker.answerRequestFromActor(answerActor, interviewID, optionID, "", "")
+		if status != http.StatusOK {
+			reason := strings.TrimSpace(msg)
+			if reason == "" {
+				reason = "could not record your answer"
+			}
+			log.Printf("[slack] gate: answer %s/%s failed (%d): %s", interviewID, optionID, status, reason)
+			t.postGateEphemeral(ctx, channelID, callback.User.ID,
+				"This request is no longer active: "+reason+".")
+			return true
+		}
+
+		t.updateGateMessage(ctx, channelID, messageTS, optionID, name)
+		return true
+	}
+	return true
+}
+
+// updateGateMessage rewrites the original Block Kit message in place to show the
+// resolved decision and remove the buttons. Best-effort: a failed chat.update is
+// logged but never fails the interaction (the answer already landed).
+func (t *SlackTransport) updateGateMessage(ctx context.Context, channelID, messageTS, optionID, byName string) {
+	if channelID == "" || messageTS == "" {
+		return
+	}
+	resolved := slackGateResolutionText(optionID, byName)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, _, _, err := t.api.UpdateMessageContext(ctx, channelID, messageTS,
+		slack.MsgOptionBlocks(slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, resolved, false, false), nil, nil)),
+		slack.MsgOptionText(slackStripMarkdown(resolved), false),
+	); err != nil {
+		log.Printf("[slack] gate: update message %s/%s: %v", channelID, messageTS, err)
+	}
+}
+
+// postGateEphemeral sends a transient, only-visible-to-the-clicker notice. Used
+// when a click cannot be honoured (expired/unknown/terminal request). Best-effort.
+func (t *SlackTransport) postGateEphemeral(ctx context.Context, channelID, userID, text string) {
+	if channelID == "" || userID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	if _, err := t.api.PostEphemeralContext(ctx, channelID, userID, slack.MsgOptionText(text, false)); err != nil {
+		log.Printf("[slack] gate: ephemeral to %s in %s: %v", userID, channelID, err)
+	}
+}
+
+// slackGateResolutionText renders the "resolved" headline a decision message is
+// rewritten to after a click. A reject/skip choice reads as a stop; everything
+// else reads as an approval/answer. byName is the friendly clicker name.
+func slackGateResolutionText(optionID, byName string) string {
+	by := strings.TrimSpace(byName)
+	if by == "" {
+		by = "a teammate"
+	}
+	by = slackEscape(by)
+	id := strings.TrimSpace(optionID)
+	if id == "reject" || id == "skip" || strings.HasPrefix(id, "reject") {
+		return fmt.Sprintf("🚫 Rejected by @%s", by)
+	}
+	return fmt.Sprintf("✅ Approved by @%s", by)
+}
+
+// slackHumanActorSlug derives a stable human actor slug for the answer path from a
+// Slack user. It prefers the resolved display name (so audit entries read
+// "human:mira"), falling back to the Slack user id so the actor is never empty.
+func slackHumanActorSlug(userID, name string) string {
+	if slug := normalizeHumanSessionSlug(name); slug != "" {
+		return slug
+	}
+	if slug := normalizeHumanSessionSlug(userID); slug != "" {
+		return slug
+	}
+	return "team-member"
+}
+
+// slackStripMarkdown reduces a small mrkdwn string to plain text for the
+// notification/fallback text of an updated message. It only strips the markers
+// this gate emits (*bold*); it is not a general mrkdwn parser.
+func slackStripMarkdown(s string) string {
+	return strings.ReplaceAll(s, "*", "")
+}

--- a/internal/team/slack_gate.go
+++ b/internal/team/slack_gate.go
@@ -242,10 +242,26 @@ func (t *SlackTransport) handleInteractive(ctx context.Context, callback slack.I
 			continue
 		}
 
-		// The clicker is a human pressing a button in Slack; the gate is
-		// human-only. Resolve their display name (best-effort) for the answer
-		// actor and the message rewrite.
-		name, _ := t.resolveUser(ctx, callback.User.ID)
+		// The gate is human-only. Reject the bot's own id and any confirmed
+		// bot/app user so a non-human is never recorded as the approving actor.
+		name, human := t.resolveUser(ctx, callback.User.ID)
+		if callback.User.ID == "" || callback.User.ID == t.botUserID || !human {
+			log.Printf("[slack] gate: rejecting non-human approval actor %q", callback.User.ID)
+			t.postGateEphemeral(ctx, channelID, callback.User.ID, "Only a human can approve this request.")
+			return true
+		}
+
+		// Bind the click to its channel: the interview being answered must be the
+		// ACTIVE decision in the channel the click came from. This stops a crafted
+		// or replayed interaction from resolving another channel's gate by id
+		// (request ids are predictable), independent of option validation.
+		officeSlug := t.channelSlugForID(channelID)
+		decision, found := t.activeDecisionForChannel(officeSlug)
+		if officeSlug == "" || !found || decision.ID != interviewID {
+			t.postGateEphemeral(ctx, channelID, callback.User.ID, "This decision is no longer available in this channel.")
+			return true
+		}
+
 		actorSlug := slackHumanActorSlug(callback.User.ID, name)
 		answerActor := humanMessageSender(actorSlug)
 
@@ -294,7 +310,9 @@ func (t *SlackTransport) postGateEphemeral(ctx context.Context, channelID, userI
 	}
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	if _, err := t.api.PostEphemeralContext(ctx, channelID, userID, slack.MsgOptionText(text, false)); err != nil {
+	// escapeText=true: the text can include request-derived reasons (e.g. an
+	// option's TextHint), so neutralize any injected Slack control sequences.
+	if _, err := t.api.PostEphemeralContext(ctx, channelID, userID, slack.MsgOptionText(text, true)); err != nil {
 		log.Printf("[slack] gate: ephemeral to %s in %s: %v", userID, channelID, err)
 	}
 }

--- a/internal/team/slack_gate_test.go
+++ b/internal/team/slack_gate_test.go
@@ -254,7 +254,7 @@ func TestSlackGateClickUnknownInterviewIsEphemeral(t *testing.T) {
 	if len(eph) != 1 {
 		t.Fatalf("expected 1 ephemeral notice, got %d", len(eph))
 	}
-	if eph[0].UserID != "U999" || !strings.Contains(eph[0].Text, "no longer active") {
+	if eph[0].UserID != "U999" || !strings.Contains(eph[0].Text, "no longer available in this channel") {
 		t.Fatalf("ephemeral notice wrong: %+v", eph[0])
 	}
 }
@@ -284,8 +284,32 @@ func TestSlackGateClickExpiredInterviewIsEphemeral(t *testing.T) {
 		t.Fatalf("second click should not rewrite the message again, got %d updates", len(up))
 	}
 	eph := api.snapshotEphemerals()
-	if len(eph) != 1 || !strings.Contains(eph[0].Text, "no longer active") {
+	if len(eph) != 1 || !strings.Contains(eph[0].Text, "no longer available in this channel") {
 		t.Fatalf("expected one 'no longer active' ephemeral, got %+v", eph)
+	}
+}
+
+// A confirmed bot/app user must never resolve a human-only approval gate.
+func TestSlackGateRejectsNonHumanClicker(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["UBOT"] = &slack.User{ID: "UBOT", IsBot: true, Profile: slack.UserProfile{DisplayName: "Notetaker"}}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	id := seedSlackDecision(t, b, "slack-general")
+
+	cb := blockActionsCallback("C0123", "1700000000.0001", "UBOT", slackGateValue(id, "approve"))
+	if !tr.handleInteractive(context.Background(), cb) {
+		t.Fatalf("handleInteractive returned false")
+	}
+	// The gate must stay unanswered and the bot gets an ephemeral, not an approval.
+	if got := findRequestByID(b, id); got.Answered != nil {
+		t.Fatalf("a bot click resolved the gate: %+v", got.Answered)
+	}
+	if up := api.snapshotUpdates(); len(up) != 0 {
+		t.Fatalf("bot click should not rewrite the message, got %d", len(up))
+	}
+	eph := api.snapshotEphemerals()
+	if len(eph) != 1 || !strings.Contains(eph[0].Text, "Only a human") {
+		t.Fatalf("expected a human-only ephemeral, got %+v", eph)
 	}
 }
 

--- a/internal/team/slack_gate_test.go
+++ b/internal/team/slack_gate_test.go
@@ -1,0 +1,360 @@
+package team
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// seedSlackDecision appends an active approval interview (with canonical options)
+// to the broker on the given office channel and returns its id. It mirrors the
+// shape the action gate produces: an "approval" kind with normalized options and
+// a recommended id.
+func seedSlackDecision(t *testing.T, b *Broker, channel string) string {
+	t.Helper()
+	options, recommended := normalizeRequestOptions("approval", "approve", nil)
+	req := humanInterview{
+		ID:            "request-gate-1",
+		Kind:          "approval",
+		Status:        "pending",
+		From:          "ceo",
+		Channel:       channel,
+		Title:         "Send the launch email",
+		Question:      "Approve sending the launch email to the list?",
+		Context:       "Drafted by RevOps; 4,200 recipients.",
+		Options:       options,
+		RecommendedID: recommended,
+		Blocking:      true,
+		CreatedAt:     "2026-01-01T00:00:00Z",
+		UpdatedAt:     "2026-01-01T00:00:00Z",
+	}
+	b.mu.Lock()
+	b.requests = append(b.requests, req)
+	b.mu.Unlock()
+	return req.ID
+}
+
+// --- Outbound render ---
+
+func TestFormatSlackInterviewBlocksOneButtonPerOption(t *testing.T) {
+	options, recommended := normalizeRequestOptions("approval", "approve", nil)
+	req := humanInterview{
+		ID:            "request-7",
+		Kind:          "approval",
+		From:          "ceo",
+		Question:      "Ship it?",
+		Context:       "context line",
+		Options:       options,
+		RecommendedID: recommended,
+		Action: &approvalActionPayload{
+			Platform: "gmail",
+			Verb:     "send",
+			Name:     "Send email",
+			RawEnvelope: &approvalActionEnvelope{
+				Method: "post",
+				URL:    "https://gmail.example/send",
+			},
+		},
+		ConnectionUnverified: true,
+	}
+
+	blocks := formatSlackInterviewBlocks(req)
+
+	var action *slack.ActionBlock
+	for _, blk := range blocks {
+		if ab, ok := blk.(*slack.ActionBlock); ok {
+			action = ab
+		}
+	}
+	if action == nil {
+		t.Fatalf("expected an action block in %d blocks", len(blocks))
+	}
+	if action.BlockID != slackGateActionBlock {
+		t.Fatalf("action block id = %q, want %q", action.BlockID, slackGateActionBlock)
+	}
+	if got, want := len(action.Elements.ElementSet), len(options); got != want {
+		t.Fatalf("button count = %d, want %d (one per option)", got, want)
+	}
+
+	var sawRecommendedPrimary bool
+	for i, el := range action.Elements.ElementSet {
+		btn, ok := el.(*slack.ButtonBlockElement)
+		if !ok {
+			t.Fatalf("element %d is not a button: %T", i, el)
+		}
+		wantValue := slackGateValue(req.ID, options[i].ID)
+		if btn.Value != wantValue {
+			t.Fatalf("button %d value = %q, want %q", i, btn.Value, wantValue)
+		}
+		if _, optID, ok := parseSlackGateValue(btn.Value); !ok || optID != options[i].ID {
+			t.Fatalf("button %d value %q does not round-trip to option %q", i, btn.Value, options[i].ID)
+		}
+		if options[i].ID == recommended && btn.Style == slack.StylePrimary {
+			sawRecommendedPrimary = true
+		}
+	}
+	if !sawRecommendedPrimary {
+		t.Fatalf("recommended option %q was not styled primary", recommended)
+	}
+}
+
+func TestSlackSendDecisionRendersBlocks(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	seedSlackDecision(t, b, "slack-general")
+
+	out, ok := tr.FormatOutbound(channelMessage{
+		Channel: "slack-general",
+		From:    "ceo",
+		Kind:    "approval",
+		Content: "Approve sending the launch email to the list?",
+	})
+	if !ok {
+		t.Fatalf("FormatOutbound returned ok=false")
+	}
+	if !isSlackDecisionText(out.Text) {
+		t.Fatalf("decision outbound text not recognised as decision: %q", out.Text)
+	}
+	if err := tr.Send(context.Background(), out); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	posts := api.snapshotPosts()
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posts))
+	}
+	if posts[0].Blocks == "" {
+		t.Fatalf("decision post carried no blocks")
+	}
+	if !strings.Contains(posts[0].Blocks, slackGateActionBlock) {
+		t.Fatalf("decision post blocks missing action block id: %s", posts[0].Blocks)
+	}
+}
+
+func TestSlackSendNonDecisionStaysPlainText(t *testing.T) {
+	api := newFakeSlackAPI()
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	// An active decision exists in the channel, but this is an ordinary chat
+	// message — it must NOT be upgraded to buttons.
+	seedSlackDecision(t, b, "slack-general")
+
+	out, ok := tr.FormatOutbound(channelMessage{
+		Channel: "slack-general",
+		From:    "pm",
+		Content: "just a normal message",
+	})
+	if !ok {
+		t.Fatalf("FormatOutbound returned ok=false")
+	}
+	if err := tr.Send(context.Background(), out); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	posts := api.snapshotPosts()
+	if len(posts) != 1 {
+		t.Fatalf("expected 1 post, got %d", len(posts))
+	}
+	if posts[0].Blocks != "" {
+		t.Fatalf("ordinary message should not carry blocks, got: %s", posts[0].Blocks)
+	}
+}
+
+// --- Inbound click → answer ---
+
+func blockActionsCallback(channelID, messageTS, userID, value string) slack.InteractionCallback {
+	cb := slack.InteractionCallback{
+		Type: slack.InteractionTypeBlockActions,
+	}
+	cb.Channel.ID = channelID
+	cb.Message.Timestamp = messageTS
+	cb.User.ID = userID
+	cb.ActionCallback.BlockActions = []*slack.BlockAction{
+		{BlockID: slackGateActionBlock, Value: value},
+	}
+	return cb
+}
+
+func TestSlackGateClickApprovesInterview(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U999"] = &slack.User{ID: "U999", Profile: slack.UserProfile{DisplayName: "Mira"}}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	id := seedSlackDecision(t, b, "slack-general")
+
+	cb := blockActionsCallback("C0123", "1700000000.0001", "U999", slackGateValue(id, "approve"))
+	if !tr.handleInteractive(context.Background(), cb) {
+		t.Fatalf("handleInteractive returned false (should always ack)")
+	}
+
+	// The interview flipped to answered with the right choice + human actor.
+	got := findRequestByID(b, id)
+	if got.Status != "answered" || got.Answered == nil {
+		t.Fatalf("interview not answered: status=%q answered=%v", got.Status, got.Answered)
+	}
+	if got.Answered.ChoiceID != "approve" {
+		t.Fatalf("answer choice = %q, want approve", got.Answered.ChoiceID)
+	}
+	assertAnswerActor(t, b, id, "human:mira")
+
+	// The original message was rewritten to the resolved state with no buttons.
+	updates := api.snapshotUpdates()
+	if len(updates) != 1 {
+		t.Fatalf("expected 1 message update, got %d", len(updates))
+	}
+	if updates[0].ChannelID != "C0123" || updates[0].Timestamp != "1700000000.0001" {
+		t.Fatalf("update targeted wrong message: %+v", updates[0])
+	}
+	if !strings.Contains(updates[0].Text, "Approved by") || !strings.Contains(updates[0].Text, "Mira") {
+		t.Fatalf("update text not the resolved approval: %q", updates[0].Text)
+	}
+	if strings.Contains(updates[0].Blocks, slackGateActionBlock) {
+		t.Fatalf("resolved message still carries the action block (buttons not removed): %s", updates[0].Blocks)
+	}
+	if eph := api.snapshotEphemerals(); len(eph) != 0 {
+		t.Fatalf("successful click should post no ephemeral, got %d", len(eph))
+	}
+}
+
+func TestSlackGateClickRejectsInterview(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U999"] = &slack.User{ID: "U999", Profile: slack.UserProfile{DisplayName: "Mira"}}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	id := seedSlackDecision(t, b, "slack-general")
+
+	cb := blockActionsCallback("C0123", "1700000000.0001", "U999", slackGateValue(id, "reject"))
+	if !tr.handleInteractive(context.Background(), cb) {
+		t.Fatalf("handleInteractive returned false")
+	}
+
+	got := findRequestByID(b, id)
+	if got.Answered == nil || got.Answered.ChoiceID != "reject" {
+		t.Fatalf("interview not rejected: %+v", got.Answered)
+	}
+	updates := api.snapshotUpdates()
+	if len(updates) != 1 || !strings.Contains(updates[0].Text, "Rejected by") {
+		t.Fatalf("reject did not rewrite message to rejected state: %+v", updates)
+	}
+}
+
+func TestSlackGateClickUnknownInterviewIsEphemeral(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U999"] = &slack.User{ID: "U999", Profile: slack.UserProfile{DisplayName: "Mira"}}
+	tr, _ := newTestSlackTransport(t, "C0123", api)
+
+	// No interview seeded → the value references a request that does not exist.
+	cb := blockActionsCallback("C0123", "1700000000.0001", "U999", slackGateValue("request-missing", "approve"))
+	if !tr.handleInteractive(context.Background(), cb) {
+		t.Fatalf("handleInteractive returned false (should ack even on failure)")
+	}
+
+	if up := api.snapshotUpdates(); len(up) != 0 {
+		t.Fatalf("unknown interview should not rewrite any message, got %d updates", len(up))
+	}
+	eph := api.snapshotEphemerals()
+	if len(eph) != 1 {
+		t.Fatalf("expected 1 ephemeral notice, got %d", len(eph))
+	}
+	if eph[0].UserID != "U999" || !strings.Contains(eph[0].Text, "no longer active") {
+		t.Fatalf("ephemeral notice wrong: %+v", eph[0])
+	}
+}
+
+func TestSlackGateClickExpiredInterviewIsEphemeral(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U999"] = &slack.User{ID: "U999", Profile: slack.UserProfile{DisplayName: "Mira"}}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	id := seedSlackDecision(t, b, "slack-general")
+
+	// First click answers it; the second click hits a terminal (no-longer-active)
+	// request and must degrade to an ephemeral notice, not a second answer.
+	first := blockActionsCallback("C0123", "1700000000.0001", "U999", slackGateValue(id, "approve"))
+	tr.handleInteractive(context.Background(), first)
+
+	second := blockActionsCallback("C0123", "1700000000.0001", "U999", slackGateValue(id, "reject"))
+	if !tr.handleInteractive(context.Background(), second) {
+		t.Fatalf("second click returned false")
+	}
+
+	// Still answered with the FIRST choice (approve), not overwritten by reject.
+	got := findRequestByID(b, id)
+	if got.Answered == nil || got.Answered.ChoiceID != "approve" {
+		t.Fatalf("second click overwrote terminal state: %+v", got.Answered)
+	}
+	if up := api.snapshotUpdates(); len(up) != 1 {
+		t.Fatalf("second click should not rewrite the message again, got %d updates", len(up))
+	}
+	eph := api.snapshotEphemerals()
+	if len(eph) != 1 || !strings.Contains(eph[0].Text, "no longer active") {
+		t.Fatalf("expected one 'no longer active' ephemeral, got %+v", eph)
+	}
+}
+
+func TestSlackGateMalformedValueIsEphemeral(t *testing.T) {
+	api := newFakeSlackAPI()
+	api.users["U999"] = &slack.User{ID: "U999"}
+	tr, b := newTestSlackTransport(t, "C0123", api)
+	id := seedSlackDecision(t, b, "slack-general")
+
+	cb := blockActionsCallback("C0123", "1700000000.0001", "U999", "garbage-no-separator")
+	if !tr.handleInteractive(context.Background(), cb) {
+		t.Fatalf("handleInteractive returned false")
+	}
+	// Interview untouched.
+	if got := findRequestByID(b, id); got.Answered != nil {
+		t.Fatalf("malformed click answered the interview: %+v", got.Answered)
+	}
+	if eph := api.snapshotEphemerals(); len(eph) != 1 {
+		t.Fatalf("malformed click should post one ephemeral, got %d", len(eph))
+	}
+}
+
+func TestParseSlackGateValue(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantID  string
+		wantOpt string
+		wantOK  bool
+	}{
+		{"request-7|approve", "request-7", "approve", true},
+		{"request-7|reject_with_steer", "request-7", "reject_with_steer", true},
+		{"noseparator", "", "", false},
+		{"|approve", "", "", false},
+		{"request-7|", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tc := range cases {
+		id, opt, ok := parseSlackGateValue(tc.in)
+		if ok != tc.wantOK || id != tc.wantID || opt != tc.wantOpt {
+			t.Fatalf("parseSlackGateValue(%q) = (%q,%q,%v), want (%q,%q,%v)",
+				tc.in, id, opt, ok, tc.wantID, tc.wantOpt, tc.wantOK)
+		}
+	}
+}
+
+// --- helpers ---
+
+func findRequestByID(b *Broker, id string) humanInterview {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, req := range b.requests {
+		if req.ID == id {
+			return req
+		}
+	}
+	return humanInterview{}
+}
+
+func assertAnswerActor(t *testing.T, b *Broker, id, wantActor string) {
+	t.Helper()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, action := range b.actions {
+		if action.Kind == "request_answered" && action.RelatedID == id {
+			if action.Actor != wantActor {
+				t.Fatalf("answer actor = %q, want %q", action.Actor, wantActor)
+			}
+			return
+		}
+	}
+	t.Fatalf("no request_answered audit entry for %s", id)
+}

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -496,6 +496,15 @@ func (t *SlackTransport) channelIDForSlug(slug string) string {
 	return ""
 }
 
+// channelSlugForID returns the office channel slug bound to a Slack channel id,
+// or "" if the channel is not bridged. Used by the gate handler to bind a click
+// to the channel it came from.
+func (t *SlackTransport) channelSlugForID(channelID string) string {
+	t.mapsMu.RLock()
+	defer t.mapsMu.RUnlock()
+	return t.ChannelMap[channelID]
+}
+
 // resolveUser maps a Slack user id to an office member slug (or display name
 // fallback) and reports whether the user is a human. The result is cached in
 // UserMap so repeat senders skip the users.info round-trip. A lookup failure

--- a/internal/team/slack_transport.go
+++ b/internal/team/slack_transport.go
@@ -47,6 +47,12 @@ type slackAPI interface {
 	// GetUsersInConversationContext lists the member ids of a channel, used to
 	// pre-warm the user → member-slug map.
 	GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error)
+	// UpdateMessageContext edits a previously-posted message in place (chat.update),
+	// used by the approval gate to rewrite a decision card to its resolved state.
+	UpdateMessageContext(ctx context.Context, channelID, timestamp string, opts ...slack.MsgOption) (string, string, string, error)
+	// PostEphemeralContext posts a message visible only to one user (chat.postEphemeral),
+	// used by the approval gate to tell a clicker that a request is no longer active.
+	PostEphemeralContext(ctx context.Context, channelID, userID string, opts ...slack.MsgOption) (string, error)
 }
 
 // slackUserInfo is the cached resolution of a Slack user id.
@@ -74,6 +80,14 @@ func (c *slackClient) AuthTestContext(ctx context.Context) (*slack.AuthTestRespo
 
 func (c *slackClient) GetUsersInConversationContext(ctx context.Context, params *slack.GetUsersInConversationParameters) ([]string, string, error) {
 	return c.api.GetUsersInConversationContext(ctx, params)
+}
+
+func (c *slackClient) UpdateMessageContext(ctx context.Context, channelID, timestamp string, opts ...slack.MsgOption) (string, string, string, error) {
+	return c.api.UpdateMessageContext(ctx, channelID, timestamp, opts...)
+}
+
+func (c *slackClient) PostEphemeralContext(ctx context.Context, channelID, userID string, opts ...slack.MsgOption) (string, error) {
+	return c.api.PostEphemeralContext(ctx, channelID, userID, opts...)
 }
 
 // socketRunner is the inbound seam: it blocks reading Socket Mode events and
@@ -340,6 +354,16 @@ func (t *SlackTransport) handleEvent(ctx context.Context, host transport.Host, e
 			log.Printf("[slack] route inbound error (leaving un-acked for redelivery): %v", err)
 			return false
 		}
+	case socketmode.EventTypeInteractive:
+		// Block Kit interactions (a human clicking an approval/decision button).
+		// handleInteractive always reports handled=true: a click is answered
+		// once and any failure is surfaced to the clicker ephemerally, never
+		// retried, so the interaction is always Ack'd.
+		callback, ok := evt.Data.(slack.InteractionCallback)
+		if !ok {
+			return true
+		}
+		return t.handleInteractive(ctx, callback)
 	}
 	return true
 }
@@ -418,6 +442,20 @@ func (t *SlackTransport) Send(ctx context.Context, msg transport.Outbound) error
 		return fmt.Errorf("slack: no channel mapped for %q", msg.Binding.ChannelSlug)
 	}
 	opts := []slack.MsgOption{slack.MsgOptionText(msg.Text, false)}
+	// A decision/interview message renders as an interactive Block Kit card with
+	// one button per option, so a human can approve/reject natively in Slack.
+	// transport.Outbound is text-only (shared kernel type, not Slack-specific), so
+	// the decision is re-derived here: only an outbound that formatSlackOutbound
+	// already rendered as a decision (the "📋 Decision needed" prefix from
+	// formatSlackDecision) is upgraded to blocks — ordinary chat posted while a
+	// decision is pending is left as plain text. When matched, the blocks REPLACE
+	// the plain text, keeping msg.Text as the notification fallback. No match (no
+	// active decision, or the request carries no options) falls through unchanged.
+	if isSlackDecisionText(msg.Text) {
+		if decision, ok := t.activeDecisionForChannel(msg.Binding.ChannelSlug); ok {
+			opts = append(opts, slack.MsgOptionBlocks(formatSlackInterviewBlocks(decision)...))
+		}
+	}
 	if msg.ThreadKey != "" {
 		opts = append(opts, slack.MsgOptionTS(msg.ThreadKey))
 	}
@@ -612,11 +650,23 @@ func formatSlackOutbound(msg channelMessage) string {
 	}
 }
 
+// slackDecisionPrefix is the leading marker every decision/interview message
+// carries. Send uses it (via isSlackDecisionText) to recognise the one outbound
+// message that should be upgraded from plain text to an interactive Block Kit
+// card, leaving ordinary chat posted during a pending decision as plain text.
+const slackDecisionPrefix = "📋 *Decision needed*"
+
+// isSlackDecisionText reports whether an outbound body was rendered as a decision
+// by formatSlackDecision (and therefore should be upgraded to interactive blocks).
+func isSlackDecisionText(text string) bool {
+	return strings.HasPrefix(text, slackDecisionPrefix)
+}
+
 // formatSlackDecision renders a human decision/interview message as Slack mrkdwn.
 // Dynamic fields are escaped (see formatSlackOutbound).
 func formatSlackDecision(msg channelMessage) string {
 	var sb strings.Builder
-	sb.WriteString("📋 *Decision needed*")
+	sb.WriteString(slackDecisionPrefix)
 	if msg.From != "" {
 		sb.WriteString(" from @")
 		sb.WriteString(slackEscape(msg.From))

--- a/internal/team/slack_transport_test.go
+++ b/internal/team/slack_transport_test.go
@@ -3,6 +3,9 @@ package team
 import (
 	"context"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strconv"
 	"sync"
@@ -14,6 +17,46 @@ import (
 
 	teamTransport "github.com/nex-crm/wuphf/internal/team/transport"
 )
+
+// slackFormFromOptions renders the same form values Slack receives for a chat.*
+// call: text + thread_ts via UnsafeApplyMsgOptions, plus the JSON-encoded blocks
+// that slack-go only serialises when a request is actually built. It lets the
+// fake observe attached blocks exactly as Slack would, without a network round
+// trip. channelID seeds the same base values the real builder uses.
+func slackFormFromOptions(channelID string, opts ...slack.MsgOption) (url.Values, error) {
+	_, values, err := slack.UnsafeApplyMsgOptions("token", channelID, "https://slack.test/api/", opts...)
+	if err != nil {
+		return nil, err
+	}
+	// UnsafeApplyMsgOptions omits blocks (they are marshalled only at request
+	// build time). Re-derive them: a real *slack.Client against a recording
+	// server is overkill here, so drive slack-go's own message builder via a
+	// throwaway client and read back the rendered blocks form value.
+	if blocks := blocksFormValue(opts...); blocks != "" {
+		values.Set("blocks", blocks)
+	}
+	return values, nil
+}
+
+// blocksRecorder captures the blocks JSON slack-go serialises for a chat.* call.
+// It runs the options through a real *slack.Client pointed at an in-process
+// recording server exactly once per call, returning the "blocks" form field (or
+// "" when no blocks were attached).
+func blocksFormValue(opts ...slack.MsgOption) string {
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		if v, err := url.ParseQuery(string(raw)); err == nil {
+			captured = v.Get("blocks")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true,"channel":"C0123","ts":"1700000000.0001"}`)
+	}))
+	defer srv.Close()
+	client := slack.New("xoxb-test", slack.OptionAPIURL(srv.URL+"/"))
+	_, _, _ = client.PostMessage("C0123", opts...)
+	return captured
+}
 
 // fakeSlackAPI is an in-memory slackAPI used by both the transport and bridge
 // tests. It records every PostMessageContext call (rendered to channel/text/
@@ -36,12 +79,32 @@ type fakeSlackAPI struct {
 
 	members    map[string][]string
 	membersErr error
+
+	updates   []fakeUpdate
+	updateErr error
+
+	ephemerals   []fakeEphemeral
+	ephemeralErr error
 }
 
 type fakePost struct {
 	ChannelID string
 	Text      string
 	ThreadTS  string
+	Blocks    string
+}
+
+type fakeUpdate struct {
+	ChannelID string
+	Timestamp string
+	Text      string
+	Blocks    string
+}
+
+type fakeEphemeral struct {
+	ChannelID string
+	UserID    string
+	Text      string
 }
 
 func newFakeSlackAPI() *fakeSlackAPI {
@@ -59,7 +122,7 @@ func (f *fakeSlackAPI) PostMessageContext(_ context.Context, channelID string, o
 	if f.postErr != nil && (f.postErrAt == 0 || f.postErrAt == f.postCalls) {
 		return "", "", f.postErr
 	}
-	_, values, err := slack.UnsafeApplyMsgOptions("token", channelID, "https://slack.test/api/", opts...)
+	values, err := slackFormFromOptions(channelID, opts...)
 	if err != nil {
 		return "", "", err
 	}
@@ -68,8 +131,62 @@ func (f *fakeSlackAPI) PostMessageContext(_ context.Context, channelID string, o
 		ChannelID: channelID,
 		Text:      firstValue(values, "text"),
 		ThreadTS:  firstValue(values, "thread_ts"),
+		Blocks:    firstValue(values, "blocks"),
 	})
 	return channelID, ts, nil
+}
+
+func (f *fakeSlackAPI) UpdateMessageContext(_ context.Context, channelID, timestamp string, opts ...slack.MsgOption) (string, string, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.updateErr != nil {
+		return "", "", "", f.updateErr
+	}
+	values, err := slackFormFromOptions(channelID, opts...)
+	if err != nil {
+		return "", "", "", err
+	}
+	f.updates = append(f.updates, fakeUpdate{
+		ChannelID: channelID,
+		Timestamp: timestamp,
+		Text:      firstValue(values, "text"),
+		Blocks:    firstValue(values, "blocks"),
+	})
+	return channelID, timestamp, firstValue(values, "text"), nil
+}
+
+func (f *fakeSlackAPI) PostEphemeralContext(_ context.Context, channelID, userID string, opts ...slack.MsgOption) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.ephemeralErr != nil {
+		return "", f.ephemeralErr
+	}
+	_, values, err := slack.UnsafeApplyMsgOptions("token", channelID, "https://slack.test/api/", opts...)
+	if err != nil {
+		return "", err
+	}
+	f.ephemerals = append(f.ephemerals, fakeEphemeral{
+		ChannelID: channelID,
+		UserID:    userID,
+		Text:      firstValue(values, "text"),
+	})
+	return "1700000000.9999", nil
+}
+
+func (f *fakeSlackAPI) snapshotUpdates() []fakeUpdate {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeUpdate, len(f.updates))
+	copy(out, f.updates)
+	return out
+}
+
+func (f *fakeSlackAPI) snapshotEphemerals() []fakeEphemeral {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeEphemeral, len(f.ephemerals))
+	copy(out, f.ephemerals)
+	return out
 }
 
 func (f *fakeSlackAPI) GetUserInfoContext(_ context.Context, userID string) (*slack.User, error) {


### PR DESCRIPTION
**Stacked on the integration branch** (needs both the Slack transport from #1061 and the #1049 gate internals, both present there). Final piece of the Slack agent-coordination series.

## What
Renders an approval `humanInterview` natively in Slack and makes it actionable:
- **Render** (`slack_gate.go`): a decision message becomes a Block Kit card — header / question / context / masked action summary / connection-unverified warning + one button per option (recommended = primary, reject/skip = danger). All dynamic text escaped. `Send` upgrades only the decision message (gated on the `📋 Decision needed` prefix), leaving ordinary chat plain.
- **Interact** (`slack_transport.go`): a new `EventTypeInteractive` branch → `handleInteractive` parses the `block_actions` callback, resolves the clicking user to a **human actor**, answers the interview, and rewrites the message to "✅ Approved by @user" / "🚫 Rejected by @user" (buttons removed). Always acks; unknown/expired/malformed clicks degrade to an ephemeral notice with **no state mutation / no replayed side effect**.
- **Answer wiring** (option a): extracted `Broker.answerRequestFromActor` from `handlePostRequestAnswer` — the resolution body moved **verbatim** (scheduler completion, dependent/task unblocking, skill activate/archive, self-heal, answer message, audit), same order, same status codes. The HTTP handler and the Slack gate now share the one code path. No behavior change.

## Review
Built by a subagent, then independently verified by me: `answerRequestFromActor` is a faithful extraction (HTTP semantics preserved); the interactive handler is human-only, replay-safe (the active-gate check rejects already-answered requests), and fails closed to an ephemeral. A defense-in-depth verification agent pass is noted in the thread.

## Test plan
- [x] `go test ./internal/team/ -run 'Slack|Interview|RequestAnswer' -race` — green. Covers render/value round-trip, click-approve + correct human actor + message rewrite, reject, unknown/expired/malformed → ephemeral (no mutation), `parseSlackGateValue` table, Send attaches blocks only for a decision.
- [x] full `internal/team` suite green; `gofmt`/`vet`/`golangci-lint` — 0 issues; `go build ./...` OK.
- [ ] Live button validation in the test workspace (the merged-test session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)