### PR TITLE
fix(wiki): stop full-history git log on every article open

### DIFF
--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -463,20 +463,26 @@ func (r *Repo) backlinksFor(ctx context.Context, target string) ([]Backlink, err
 	// leave author_slug empty rather than abort. Surface the underlying
 	// error at warn level — silent swallow used to mask corrupt-repo and
 	// `git log` failures so backlinks rendered with no author + no signal.
-	commitBounds, err := r.commitBoundsByPath(ctx)
+	//
+	// Scope the lookup to just the hit paths. The old path walked the entire
+	// repo history (commitBoundsByPath → AuditLog over every commit) on every
+	// article open, which made wiki article loads block past the client's
+	// patience window on busy wikis. Backlink attribution only needs the latest
+	// author of the handful of articles that actually link here.
+	hitPaths := make([]string, len(hits))
+	for i, h := range hits {
+		hitPaths[i] = h.relPath
+	}
+	authorByPath, err := r.latestCommitAuthorsByPath(ctx, hitPaths)
 	if err != nil {
-		log.Printf("wiki backlinks: commitBoundsByPath failed, author_slug fields will be empty: %v", err)
+		log.Printf("wiki backlinks: latest-author lookup failed, author_slug fields will be empty: %v", err)
 	}
 	backs := make([]Backlink, 0, len(hits))
 	for _, h := range hits {
-		author := ""
-		if bounds, ok := commitBounds[h.relPath]; ok && bounds.Has {
-			author = bounds.Latest.Author
-		}
 		backs = append(backs, Backlink{
 			Path:       h.relPath,
 			Title:      h.title,
-			AuthorSlug: author,
+			AuthorSlug: authorByPath[h.relPath],
 		})
 	}
 	return backs, nil

--- a/internal/team/wiki_article_test.go
+++ b/internal/team/wiki_article_test.go
@@ -212,6 +212,57 @@ func TestBuildArticle_Backlinks(t *testing.T) {
 	}
 }
 
+// latestCommitAuthorsByPath returns the most-recent author per path and is
+// scoped to the supplied paths only. This is the hot-path replacement for the
+// full-history commitBoundsByPath walk on article open, so its two invariants
+// matter: (1) latest commit wins when a path is edited by multiple authors,
+// and (2) paths not in the argument list are absent from the result even if
+// they have commits.
+func TestLatestCommitAuthorsByPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	root := t.TempDir()
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "bak"))
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// a.md is created by ceo, then edited by cro — latest author is cro.
+	if _, _, err := repo.Commit(ctx, "ceo", "team/people/a.md", "# A\n\nv1\n", "create", "add a"); err != nil {
+		t.Fatalf("Commit a v1: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "cro", "team/people/a.md", "# A\n\nv2 edited\n", "replace", "edit a"); err != nil {
+		t.Fatalf("Commit a v2: %v", err)
+	}
+	// b.md exists but is intentionally left out of the query set.
+	if _, _, err := repo.Commit(ctx, "pm", "team/people/b.md", "# B\n\nv1\n", "create", "add b"); err != nil {
+		t.Fatalf("Commit b: %v", err)
+	}
+
+	authors, err := repo.latestCommitAuthorsByPath(ctx, []string{"team/people/a.md"})
+	if err != nil {
+		t.Fatalf("latestCommitAuthorsByPath: %v", err)
+	}
+	if got := authors["team/people/a.md"]; got != "cro" {
+		t.Errorf("a.md author = %q, want cro (latest edit wins)", got)
+	}
+	if _, present := authors["team/people/b.md"]; present {
+		t.Errorf("b.md should be absent: not requested, got %q", authors["team/people/b.md"])
+	}
+
+	// Empty input is a cheap no-op, not a full-repo log.
+	empty, err := repo.latestCommitAuthorsByPath(ctx, nil)
+	if err != nil {
+		t.Fatalf("latestCommitAuthorsByPath(nil): %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("empty input = %v, want empty map", empty)
+	}
+}
+
 // BuildArticle on a missing article returns an error without panicking.
 func TestBuildArticle_NotFound(t *testing.T) {
 	if testing.Short() {

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -744,6 +744,49 @@ func (r *Repo) RestoreToCommit(ctx context.Context, relPath, sha string, identit
 	return commitSHA, nil
 }
 
+// latestCommitAuthorsByPath returns the most-recent commit author for each
+// supplied path, in a single git invocation scoped to just those paths.
+//
+// This is the hot-path alternative to commitBoundsByPath for callers that only
+// need the latest author of a known, small set of articles (e.g. backlink
+// attribution on article open). Unlike AuditLog/commitBoundsByPath, it does NOT
+// walk the entire repo history — git limits the log to commits touching the
+// given pathspecs, so cost scales with those files' history rather than the
+// whole wiki. Paths absent from the result simply have no recorded commit.
+func (r *Repo) latestCommitAuthorsByPath(ctx context.Context, paths []string) (map[string]string, error) {
+	if len(paths) == 0 {
+		return map[string]string{}, nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	args := []string{
+		"log",
+		"--format=%h%x1f%an%x1f%aI%x1f%s",
+		"--name-only",
+		"--no-merges",
+		"--",
+	}
+	for _, p := range paths {
+		args = append(args, filepath.ToSlash(p))
+	}
+	out, err := r.runGitLocked(ctx, "system", args...)
+	if err != nil {
+		return nil, fmt.Errorf("wiki: latest-author log: %w", err)
+	}
+	// parseAuditLog returns commits most-recent-first; the first author we see
+	// for a path is therefore its latest committer.
+	authors := make(map[string]string, len(paths))
+	for _, entry := range parseAuditLog(out) {
+		for _, p := range entry.Paths {
+			if _, seen := authors[p]; !seen {
+				authors[p] = entry.Author
+			}
+		}
+	}
+	return authors, nil
+}
+
 // AuditEntry is a single cross-article commit surfaced by AuditLog. Unlike
 // CommitRef (which powers per-article history), this carries the list of
 // files touched by the commit so reviewers can reconstruct the full diff


### PR DESCRIPTION
## Problem

Opening a wiki article would hang past the client's patience window on busy wikis — the UI sits "still waiting on the broker" and the request never returns in time. This is a backend performance bug, not a frontend timeout.

Every article open runs `BuildArticle` → `backlinksFor` → `commitBoundsByPath` → **`AuditLog(ctx, zero, 0)`**, which shells out to `git log --name-only` over the **entire wiki history** just to attribute an author to a handful of backlinks. Two compounding costs:

1. **O(total repo history)** git work on the hot read path — grows unbounded as the wiki accumulates commits.
2. It holds the shared `r.mu` git lock, so reads also queue behind any in-flight wiki write / synthesis.

The web-UI proxy uses `http.DefaultClient` (no timeout) and the frontend `get()` has none either, so a slow build just hangs the spinner indefinitely.

## Fix

- Add `latestCommitAuthorsByPath`: a single `git log` scoped to **just the backlinked paths** via pathspec, so git limits history to those few files instead of the whole repo. Same result (latest committer per backlink path), but work is now O(hit files' history) instead of O(repo history).
- `backlinksFor` uses it instead of the full-history walk.
- `commitBoundsByPath` stays — the archiver (oldest-commit age) and section attribution genuinely need full bounds.

## Verification

- Existing `TestBuildArticle_Backlinks` still asserts exact per-path author slugs → behavior preserved.
- New `TestLatestCommitAuthorsByPath` locks the latest-author-wins + path-scoping invariants.
- `gofmt` / `go vet` / `golangci-lint` clean on changed files.
- Full `internal/team` suite green (102s).

Backend-only; no `web/` changes, so no screenshots.

## Follow-up (not in this PR)

The web-UI proxy (`broker_web_proxy.go`) has no per-request timeout, so a future slow handler could hang the same way. Bounding it safely needs care (some calls are legitimately long, e.g. 65s channel generation) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Posted messages now automatically convert common emoji (🎉, 🚀, ✅) to Slack-style shortcode format for enhanced platform compatibility.
  * Wiki article backlinks now accurately display the latest author attribution with improved performance through optimized lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->