### PR TITLE
fix(e2e): align web shell specs with removed console app

### DIFF
--- a/web/e2e/tests/app-routes.spec.ts
+++ b/web/e2e/tests/app-routes.spec.ts
@@ -7,11 +7,6 @@ import {
 } from "./_helpers";
 
 const APP_CASES = [
-  {
-    app: "console",
-    label: "Console",
-    content: /wuphf office|Slash/i,
-  },
   // Tasks were consolidated into Issues (#1002): no "Tasks" sidebar slot
   // remains. /tasks redirects are covered in route-matrix.spec.ts.
   // Phase 2b retired the standalone RequestsApp surface; /apps/requests
@@ -45,11 +40,6 @@ const APP_CASES = [
     content: /Loading office activity|Office activity/i,
   },
   {
-    app: "receipts",
-    label: "Receipts",
-    content: /Receipts|Loading|No receipts|Could not load receipts/i,
-  },
-  {
     app: "health-check",
     label: "Access & Health",
     content: /Checking health|Could not reach health endpoint|Access & Health/i,
@@ -74,24 +64,6 @@ async function expectAppRoute(
   await expect(appPage).toContainText(content, { timeout: 10_000 });
 }
 
-async function fetchBrokerCommandNames(page: Page): Promise<string[]> {
-  return page.evaluate(async () => {
-    const response = await fetch("/api/commands");
-    if (!response.ok) {
-      throw new Error(`GET /api/commands failed: ${response.status}`);
-    }
-    const commands = (await response.json()) as Array<{ name?: unknown }>;
-    return commands
-      .map((command) => {
-        if (typeof command.name !== "string" || !command.name.trim()) {
-          throw new Error("GET /api/commands returned an invalid command row");
-        }
-        return `/${command.name}`;
-      })
-      .sort((a, b) => a.localeCompare(b));
-  });
-}
-
 test.describe("app route isolation", () => {
   test("each sidebar app renders its own page", async ({ page }) => {
     const getErrors = collectReactErrors(page);
@@ -107,86 +79,20 @@ test.describe("app route isolation", () => {
 
     // Switch between two real sidebar apps to confirm app-route swapping
     // still works.
-    await page.goto("/#/apps/console");
+    await page.goto("/#/apps/graph");
     await waitForReactMount(page);
+    await page
+      .locator(".sidebar-apps .sidebar-item", { hasText: "Policies" })
+      .click();
+    await expectAppRoute(page, "policies", /Office operating rules/i);
+    await expect(page.getByTestId("app-page-graph")).toHaveCount(0);
+
     await page
       .locator(".sidebar-apps .sidebar-item", { hasText: "Graph" })
       .click();
     await expectAppRoute(page, "graph", /Entity Graph/i);
-    await expect(page.getByTestId("console-app")).toHaveCount(0);
-
-    await page
-      .locator(".sidebar-apps .sidebar-item", { hasText: "Console" })
-      .click();
-    await expectAppRoute(page, "console", /wuphf office|Slash/i);
-    await expect(page.getByTestId("app-page-graph")).toHaveCount(0);
+    await expect(page.getByTestId("app-page-policies")).toHaveCount(0);
 
     await expectNoReactErrors(page, getErrors, "while switching app routes");
-  });
-
-  test("console input accepts typing and slash command insertion", async ({
-    page,
-  }) => {
-    const getErrors = collectReactErrors(page);
-
-    await page.goto("/#/apps/console");
-    await waitForReactMount(page);
-
-    const consoleApp = page.getByTestId("console-app");
-    const input = consoleApp.getByTestId("console-input");
-    await expect(input).toBeVisible();
-    await expect(consoleApp.getByText("Apps", { exact: true })).toHaveCount(0);
-
-    await input.click();
-    await input.pressSequentially("hello");
-    await expect(input).toHaveValue("hello");
-    await input.fill("");
-
-    await consoleApp.locator('[data-command="/reset-dm"]').click();
-    await expect(input).toHaveValue("/reset-dm ");
-    await input.fill("");
-
-    await consoleApp.locator('[data-command="/ask"]').click();
-    await expect(input).toHaveValue("/ask ");
-    await input.fill("/ask route-check");
-    await expect(input).toHaveValue("/ask route-check");
-    await input.press("Enter");
-    await expect(input).toHaveValue("");
-    await expect(
-      consoleApp.locator(".console-line-content", {
-        hasText: "/ask route-check",
-      }),
-    ).toBeVisible();
-
-    await expectNoReactErrors(page, getErrors, "while using console input");
-  });
-
-  test("console renders every broker command", async ({ page }) => {
-    const getErrors = collectReactErrors(page);
-
-    await page.goto("/#/apps/console");
-    await waitForReactMount(page);
-
-    const expectedCommands = await fetchBrokerCommandNames(page);
-    expect(expectedCommands).toContain("/reset-dm");
-
-    const consoleApp = page.getByTestId("console-app");
-    const rows = consoleApp.locator(".console-command");
-    await expect(rows).toHaveCount(expectedCommands.length, {
-      timeout: 10_000,
-    });
-
-    const renderedCommands = (
-      await rows.evaluateAll((nodes) =>
-        nodes.map((node) => node.getAttribute("data-command") ?? ""),
-      )
-    ).sort((a, b) => a.localeCompare(b));
-
-    expect(renderedCommands).toEqual(expectedCommands);
-    await expectNoReactErrors(
-      page,
-      getErrors,
-      "while rendering console commands",
-    );
   });
 });

--- a/web/e2e/tests/route-regressions.spec.ts
+++ b/web/e2e/tests/route-regressions.spec.ts
@@ -55,34 +55,19 @@ test.afterEach(async ({ request }) => {
 });
 
 test.describe("PR #634 review pins", () => {
-  test("Console keeps the user's last-visited channel after nav off-conversation", async ({
+  test("/apps/console no longer mounts a Console app panel", async ({
     page,
   }) => {
-    // Repro: legacy `s.currentChannel` retained the last-visited slug
-    // across non-conversation navigation. After the TanStack migration,
-    // ConsoleApp read `useChannelSlug() ?? "general"` directly off the
-    // URL, so opening Console from #launch silently snapped to #general.
-    // useFallbackChannelSlug threads URL → lastConversationalChannel →
-    // "general" so the user's working channel survives the hop.
+    // The Console surface was intentionally removed in #1055. The generic
+    // /apps/$appId route still accepts the URL, but MainContent must narrow
+    // it into the unknown-app fallback instead of trying to mount stale UI.
     const getErrors = collectReactErrors(page);
-    await seedTestChannel(page);
-    await gotoShell(page, "/");
-    await gotoShell(page, `/#/channels/${TEST_CHANNEL}`);
-    await expect(page.locator(".composer-input")).toHaveAttribute(
-      "placeholder",
-      `Message #${TEST_CHANNEL}`,
-    );
-
     await page.goto(`/#/apps/console`);
     const consolePage = page.getByTestId("app-page-console");
     await expect(consolePage).toBeVisible({ timeout: 10_000 });
-    // ConsoleApp echoes the channel in two visible places: the header
-    // chip and the prompt. Both should track #launch, not #general.
-    await expect(consolePage).toContainText(`#${TEST_CHANNEL}`);
-    await expect(consolePage).toContainText(`wuphf:${TEST_CHANNEL}$`);
-    await expect(consolePage).not.toContainText("wuphf:general$");
+    await expect(consolePage).toContainText("Unknown app: console");
 
-    await expectNoReactErrors(page, getErrors, "during console fallback");
+    await expectNoReactErrors(page, getErrors, "console app removal");
   });
 
   test("Legacy /#/apps/requests redirects to the unified Inbox", async ({
@@ -140,8 +125,8 @@ test.describe("PR #634 review pins", () => {
 
     // Leaving the conversation surface closes the panel, so the per-channel
     // toggle can never render against a non-conversation route.
-    await page.goto("/#/apps/console");
-    await expect(page.getByTestId("app-page-console")).toBeVisible({
+    await page.goto("/#/apps/graph");
+    await expect(page.getByTestId("app-page-graph")).toBeVisible({
       timeout: 10_000,
     });
     await expect(page.locator(".agent-panel")).toHaveCount(0);
@@ -155,7 +140,7 @@ test.describe("PR #634 review pins", () => {
   }) => {
     // Repro: activeThreadId was a bare string on the store; ThreadPanel
     // resolved its channel via `useChannelSlug() ?? "general"`. Open a
-    // thread on #launch, navigate to /apps/console, and the panel
+    // thread on #launch, navigate to /apps/graph, and the panel
     // header silently flipped to "#general" — and any reply posted from
     // there would land in general. The fix promotes activeThread to
     // {id, channelSlug} captured at open time so the panel header (and
@@ -211,8 +196,8 @@ test.describe("PR #634 review pins", () => {
 
     // Navigate to a non-conversation route. ThreadPanel is mounted in
     // Shell so it persists across navigation.
-    await page.goto("/#/apps/console");
-    await expect(page.getByTestId("app-page-console")).toBeVisible({
+    await page.goto("/#/apps/graph");
+    await expect(page.getByTestId("app-page-graph")).toBeVisible({
       timeout: 10_000,
     });
 

--- a/web/e2e/tests/telegram-connect.spec.ts
+++ b/web/e2e/tests/telegram-connect.spec.ts
@@ -110,6 +110,11 @@ async function openTelegramWizard(page: Page) {
   await expect(page.getByTestId("tg-step-token")).toBeVisible();
 }
 
+async function gotoCommandChannel(page: Page) {
+  await page.goto("/#/channels/general");
+  await waitForShellReady(page);
+}
+
 async function verifyTokenToMode(page: Page, token = "123456:ABC") {
   await page.getByTestId("tg-token-input").fill(token);
   await page.getByTestId("tg-token-submit").click();
@@ -130,8 +135,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   test("[1] /connect telegram opens the Telegram wizard at the token step", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await openTelegramWizard(page);
     await expect(page.getByTestId("tg-step-token")).toBeVisible();
@@ -140,8 +144,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   test("[1a] bare /connect opens the provider picker with TUI parity", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     const composer = page.locator(".composer-input");
     await composer.click();
@@ -167,8 +170,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   test("[1b] picker → Telegram advances to the token step", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     const composer = page.locator(".composer-input");
     await composer.click();
@@ -187,8 +189,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     // previous behaviour silently routed every /connect to Telegram, which
     // was the bug bornaware reported. This test guards against regressing
     // back to that.
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     const composer = page.locator(".composer-input");
     await composer.click();
@@ -202,8 +203,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   });
 
   test("[2,3] empty token shows inline validation", async ({ page }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
     await openTelegramWizard(page);
 
     // Click verify with the input still empty — should NOT call the broker.
@@ -219,8 +219,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   });
 
   test("[4] verify failure keeps user on token step", async ({ page }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) =>
       route.fulfill(verifyFail),
@@ -235,8 +234,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   });
 
   test("[5,7] verify success → pick → connect → done", async ({ page }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
     await page.route("**/telegram/discover", (route) =>
@@ -272,8 +270,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
   test("[6] empty group list shows retry/manual/dm controls", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
     await page.route("**/telegram/discover", (route) =>
@@ -294,8 +291,7 @@ test.describe("wuphf web /connect Telegram wizard connect modes", () => {
   test("[8] manual chat ID validates and posts integer chat_id", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
     await page.route("**/telegram/discover", (route) =>
@@ -340,8 +336,7 @@ test.describe("wuphf web /connect Telegram wizard connect modes", () => {
   test("[8b] manual connect failure stays on the manual step", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
     await page.route("**/telegram/discover", (route) =>
@@ -363,8 +358,7 @@ test.describe("wuphf web /connect Telegram wizard connect modes", () => {
   });
 
   test("[9] choosing DM mode posts chat_id=0", async ({ page }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
 
@@ -387,8 +381,7 @@ test.describe("wuphf web /connect Telegram wizard connect modes", () => {
   test("[10] connect failure keeps picker step active with error", async ({
     page,
   }) => {
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
     await page.route("**/telegram/discover", (route) =>
@@ -424,8 +417,7 @@ test.describe("wuphf web /connect Telegram wizard regressions", () => {
     // catch this — the testids were present, just unstyled. We assert the
     // computed background and border on the modal card so any future
     // "class exists but variables undefined" regression fails loudly.
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
     await page.route("**/telegram/verify", (r) => r.fulfill(verifyOK));
     await openTelegramWizard(page);
 
@@ -470,8 +462,7 @@ test.describe("wuphf web /connect Telegram wizard regressions", () => {
     // styles correctly regardless of route. This test guards against a
     // regression where a contributor scopes the variables back to
     // .wiki-root, which would re-introduce the unstyled-modal bug.
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
     await page.route("**/telegram/verify", (r) => r.fulfill(verifyOK));
     await openTelegramWizard(page);
 
@@ -505,8 +496,7 @@ test.describe("wuphf web /connect Telegram wizard regressions", () => {
     // token, sees 401, types a good token, and the modal advances. If
     // verifyAndDiscover doesn't clear `error` on the new attempt, the
     // banner sticks around on the picker step — confusing at best.
-    await page.goto("/");
-    await waitForShellReady(page);
+    await gotoCommandChannel(page);
 
     let verifyCallCount = 0;
     await page.route("**/telegram/verify", async (route) => {

--- a/web/src/routes/useCurrentRoute.ts
+++ b/web/src/routes/useCurrentRoute.ts
@@ -253,9 +253,9 @@ export function useCurrentTaskId(): string | null {
 }
 
 /**
- * Channel slug consumers that work outside conversation routes (Console,
- * Requests, sidebar request badge) should use this hook so they keep
- * pointing at the user's last-visited channel rather than silently
+ * Channel slug consumers that work outside conversation routes (thread
+ * panels, request badges, cross-surface actions) should use this hook so
+ * they keep pointing at the user's last-visited channel rather than silently
  * collapsing to `"general"` whenever the URL is on `/apps/...` or
  * `/wiki/...`. Falls through to `"general"` only on a cold start where
  * the user has not yet visited any conversation route.


### PR DESCRIPTION
## Summary
- remove stale Console and Receipts app assertions from the app-route E2E matrix
- pin /apps/console to the unknown-app fallback after the Console surface removal in #1055
- keep cross-route regression tests on a live non-conversation route and update Telegram E2E setup to start from #general

## Verification
- cd web && bunx biome check --write e2e/tests/app-routes.spec.ts e2e/tests/route-regressions.spec.ts e2e/tests/telegram-connect.spec.ts src/routes/useCurrentRoute.ts
- bash scripts/test-web.sh web/src/routes/useCurrentRoute.test.ts web/src/routes/routeRegistry.test.ts
- exact CI web-e2e spec list locally: 37 passed
- bash web/e2e/run-local.sh shell: 51 passed

## Screenshots
Skipped: test-only E2E alignment with no visible UI delta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end tests to improve routing validation and app navigation patterns.
  * Enhanced Telegram wizard test navigation setup.
  * Refined internal documentation for routing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->