### PR TITLE
[codex] filter connected runtime providers

### DIFF
--- a/internal/team/broker_tasks_auto_test.go
+++ b/internal/team/broker_tasks_auto_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
 func TestIsAutoOwner(t *testing.T) {
@@ -29,6 +31,10 @@ func TestIsAutoOwner(t *testing.T) {
 //   - Start now + Auto → owner "auto", not dispatched, and a @ceo triage
 //     message posted in the task's channel.
 func TestBrokerTaskPlanParkAndAuto(t *testing.T) {
+	withWuphfHomeDir(t)
+	if err := config.Save(config.Config{LLMProvider: "codex"}); err != nil {
+		t.Fatalf("seed provider config: %v", err)
+	}
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	if err := b.StartOnPort(0); err != nil {

--- a/internal/team/broker_tasks_plan.go
+++ b/internal/team/broker_tasks_plan.go
@@ -2,11 +2,16 @@ package team
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
 )
+
+var errTaskPlanProviderConfigLoad = errors.New("task-plan provider config load failed")
 
 func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
@@ -81,6 +86,12 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 				resolvedDeps = append(resolvedDeps, dep) // assume it's a task ID
 			}
 		}
+		providerKind, err := validateTaskPlanProvider(item.Provider)
+		if err != nil {
+			rollbackPlan()
+			writeTaskPlanProviderError(w, err)
+			return
+		}
 		if existing := b.findReusableTaskLocked(taskReuseMatch{
 			Channel: taskChannel,
 			Title:   strings.TrimSpace(item.Title),
@@ -105,8 +116,8 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 			if effort := strings.TrimSpace(item.Effort); effort != "" {
 				existing.Effort = effort
 			}
-			if prov := strings.TrimSpace(item.Provider); prov != "" {
-				existing.Provider = prov
+			if providerKind != "" {
+				existing.Provider = providerKind
 			}
 			if model := strings.TrimSpace(item.Model); model != "" {
 				existing.Model = model
@@ -170,7 +181,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 			TaskType:      strings.TrimSpace(item.TaskType),
 			ExecutionMode: strings.TrimSpace(item.ExecutionMode),
 			Effort:        strings.TrimSpace(item.Effort),
-			Provider:      strings.TrimSpace(item.Provider),
+			Provider:      providerKind,
 			Model:         strings.TrimSpace(item.Model),
 			PlanFirst:     planFirst,
 			DependsOn:     resolvedDeps,
@@ -235,6 +246,37 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(TaskListResponse{Tasks: created})
+}
+
+func validateTaskPlanProvider(raw string) (string, error) {
+	kind := strings.TrimSpace(strings.ToLower(raw))
+	if kind == "" {
+		return "", nil
+	}
+	if !config.IsLLMProviderKindAllowed(kind) {
+		return "", fmt.Errorf("unsupported task provider %q", kind)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", errTaskPlanProviderConfigLoad, err)
+	}
+	for _, configured := range cfg.LLMProviderPriority {
+		if strings.EqualFold(strings.TrimSpace(configured), kind) {
+			return kind, nil
+		}
+	}
+	if len(cfg.LLMProviderPriority) == 0 && strings.EqualFold(strings.TrimSpace(cfg.LLMProvider), kind) {
+		return kind, nil
+	}
+	return "", fmt.Errorf("task provider %q is not configured", kind)
+}
+
+func writeTaskPlanProviderError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errTaskPlanProviderConfigLoad) {
+		http.Error(w, "failed to load provider configuration", http.StatusInternalServerError)
+		return
+	}
+	http.Error(w, err.Error(), http.StatusBadRequest)
 }
 
 type plannedTaskInput struct {

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -856,6 +856,100 @@ func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
 	}
 }
 
+func TestBrokerTaskPlanPersistsConfiguredProvider(t *testing.T) {
+	t.Setenv("WUPHF_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	if err := config.Save(config.Config{
+		LLMProvider:         "claude-code",
+		LLMProviderPriority: []string{"claude-code", "codex"},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "operator", "Operator")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	body, _ := json.Marshal(map[string]any{
+		"channel":    "general",
+		"created_by": "operator",
+		"tasks": []map[string]any{
+			{
+				"title":    "Wire provider picker",
+				"assignee": "builder",
+				"provider": "codex",
+			},
+		},
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/task-plan", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("task plan request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("unexpected status %d: %s", resp.StatusCode, raw)
+	}
+
+	var result struct {
+		Tasks []teamTask `json:"tasks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode task plan response: %v", err)
+	}
+	if len(result.Tasks) != 1 || result.Tasks[0].Provider != "codex" {
+		t.Fatalf("expected codex provider on created task, got %+v", result.Tasks)
+	}
+}
+
+func TestBrokerTaskPlanRejectsUnconfiguredProvider(t *testing.T) {
+	t.Setenv("WUPHF_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	if err := config.Save(config.Config{
+		LLMProvider:         "claude-code",
+		LLMProviderPriority: []string{"claude-code"},
+	}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "operator", "Operator")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	body, _ := json.Marshal(map[string]any{
+		"channel":    "general",
+		"created_by": "operator",
+		"tasks": []map[string]any{
+			{
+				"title":    "Wire provider picker",
+				"assignee": "builder",
+				"provider": "codex",
+			},
+		},
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/task-plan", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("task plan request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected bad request for unconfigured provider, got %d: %s", resp.StatusCode, raw)
+	}
+}
+
 func TestBrokerTaskCreateAddsAssignedOwnerToChannelMembers(t *testing.T) {
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "youtube-factory", "operator", "Operator")

--- a/packages/llm-router/src/providers/anthropic-pricing.ts
+++ b/packages/llm-router/src/providers/anthropic-pricing.ts
@@ -70,12 +70,13 @@ export interface AnthropicModelPricing {
 export type AnthropicPricingTable = Readonly<Record<string, AnthropicModelPricing>>;
 
 /**
- * Built-in pricing for the Claude 4.x family, current as of 2026-05.
+ * Built-in pricing for the Claude 4.x and Fable families, current as of 2026-06.
  *
  *   Opus 4.5 / 4.6 / 4.7:  $5  / $25 / $0.50 / $6.25  per MTok
  *   Opus 4.1 (legacy):     $15 / $75 / $1.50 / $18.75 per MTok
  *   Sonnet 4.5 / 4.6:      $3  / $15 / $0.30 / $3.75  per MTok
  *   Haiku 4.5:             $1  / $5  / $0.10 / $1.25  per MTok
+ *   Fable 5:               $10 / $50 / $1.00 / $12.50 per MTok
  *
  * Opus 4.5+ dropped 3x from the 4.1 generation per Anthropic's
  * 2025-11 announcement. The previous draft of this table used 4.1
@@ -117,6 +118,13 @@ export const DEFAULT_ANTHROPIC_PRICING: AnthropicPricingTable = Object.freeze({
     outputMicroUsdPerMTok: 25_000_000,
     cacheReadMicroUsdPerMTok: 500_000,
     cacheCreationMicroUsdPerMTok: 6_250_000,
+  }),
+  // Fable 5: $10 / $50 / $1 / $12.50 per MTok.
+  "claude-fable-5": Object.freeze({
+    inputMicroUsdPerMTok: 10_000_000,
+    outputMicroUsdPerMTok: 50_000_000,
+    cacheReadMicroUsdPerMTok: 1_000_000,
+    cacheCreationMicroUsdPerMTok: 12_500_000,
   }),
   // Sonnet 4.x family ($3 / $15 / $0.30 / $3.75 per MTok)
   "claude-sonnet-4-5": Object.freeze({

--- a/packages/llm-router/tests/providers/anthropic.spec.ts
+++ b/packages/llm-router/tests/providers/anthropic.spec.ts
@@ -198,6 +198,7 @@ describe("AnthropicProvider", () => {
     const provider = createAnthropicProvider({ client: fakeClient(() => emptyMessage()).client });
     expect(provider.models).toEqual(Object.keys(DEFAULT_ANTHROPIC_PRICING));
     expect(provider.models).toContain("claude-opus-4-7");
+    expect(provider.models).toContain("claude-fable-5");
     expect(provider.models).toContain("claude-sonnet-4-6");
     expect(provider.models).toContain("claude-haiku-4-5");
   });

--- a/web/e2e/screenshots/provider-selection.mjs
+++ b/web/e2e/screenshots/provider-selection.mjs
@@ -1,0 +1,204 @@
+import { launchBrowser, shotElement, shotPage } from "./lib.mjs";
+import process from "node:process";
+
+const OUT = process.env.WUPHF_SCREENSHOTS_OUT;
+const BASE = process.env.BASE_URL ?? "http://localhost:5273";
+if (!OUT) {
+  console.error("WUPHF_SCREENSHOTS_OUT is not set; run via publish.sh");
+  process.exit(2);
+}
+
+function prereq(name, found) {
+  return {
+    name,
+    required: false,
+    found,
+    ok: found,
+    version: found ? `${name}-1.0.0` : undefined,
+  };
+}
+
+function localProvider(kind, connected) {
+  return {
+    kind,
+    binary_installed: connected,
+    endpoint: `http://localhost/${kind}`,
+    model: `${kind}-model`,
+    reachable: connected,
+    probed: true,
+    platform_supported: true,
+  };
+}
+
+const SHELL_RESPONSES = {
+  "/actions": { actions: [] },
+  "/channels": { channels: [{ slug: "general", name: "general" }] },
+  "/commands": [],
+  "/company": { name: "Screenshot Office" },
+  "/decisions": { decisions: [] },
+  "/health": { ok: true },
+  "/humans/me": { human: { slug: "you" } },
+  "/inbox/items": { items: [] },
+  "/messages": { messages: [] },
+  "/office-members": { members: [] },
+  "/requests": { requests: [] },
+  "/review/list": { items: [] },
+  "/scheduler": { jobs: [] },
+  "/skills": { skills: [] },
+  "/tasks": { tasks: [] },
+  "/tasks/inbox": { items: [] },
+  "/upgrade-check": { update_available: false },
+  "/usage": { total_usd: 0, daily_usd: 0 },
+  "/watchdogs": { watchdogs: [] },
+  "/workspaces/list": { workspaces: [] },
+};
+
+function apiMockResponse(path, request, onboarded) {
+  if (path === "/onboarding/state") return { body: { onboarded } };
+  if (path === "/onboarding/prereqs") {
+    return {
+      body: {
+        prereqs: [
+          prereq("claude", true),
+          prereq("codex", false),
+          prereq("opencode", true),
+        ],
+      },
+    };
+  }
+  if (path === "/status/local-providers") {
+    return {
+      body: [
+        localProvider("ollama", true),
+        localProvider("exo", true),
+        localProvider("mlx-lm", false),
+      ],
+    };
+  }
+  if (path === "/config" && request.method() === "POST") {
+    return { body: { ok: true } };
+  }
+  if (path === "/config") {
+    return {
+      body: {
+        llm_provider: "claude-code",
+        llm_provider_priority: [
+          "claude-code",
+          "codex",
+          "opencode",
+          "ollama",
+          "exo",
+          "mlx-lm",
+        ],
+      },
+    };
+  }
+  if (path === "/task-plan") {
+    return {
+      body: { tasks: [{ id: "shot-task-1", title: "Provider smoke task" }] },
+    };
+  }
+  if (path === "/events") return { eventStream: true };
+  if (Object.hasOwn(SHELL_RESPONSES, path)) {
+    return { body: SHELL_RESPONSES[path] };
+  }
+  throw new Error(`Unhandled screenshot API mock: ${path}`);
+}
+
+async function installProviderMocks(browserContext, { onboarded }) {
+  await browserContext.unrouteAll().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`provider-selection route cleanup failed: ${message}`);
+  });
+  await browserContext.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    if (url.pathname === "/api-token") {
+      return route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          token: "stub",
+          broker_url: `${BASE}/api`,
+        }),
+      });
+    }
+    if (!url.pathname.startsWith("/api/")) return route.continue();
+
+    const path = url.pathname.replace(/^\/api/, "") || "/";
+    const response = apiMockResponse(path, request, onboarded);
+    if (response.eventStream) {
+      return route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: "",
+      });
+    }
+    return json(route, response.body);
+  });
+}
+
+async function json(route, body) {
+  await route.fulfill({
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function openShellRoute(targetPage, path) {
+  await targetPage.goto(`${BASE}${path}`, { waitUntil: "load" });
+  await targetPage.evaluate(async () => {
+    const m = await import("/src/stores/app.ts");
+    m.useAppStore.setState({
+      brokerConnected: true,
+      onboardingComplete: true,
+    });
+  });
+  await targetPage.locator(".status-bar").waitFor({ timeout: 10_000 });
+}
+
+const { browser, context, page } = await launchBrowser({
+  viewport: { width: 1400, height: 980 },
+});
+
+try {
+  await installProviderMocks(context, { onboarded: false });
+  await page.goto(`${BASE}/#/channels/general`, { waitUntil: "load" });
+  await page.getByTestId("pre-pick-card-claude-code").click();
+  await page.getByTestId("pre-pick-card-opencode").click();
+  await page.getByTestId("pre-pick-local-tile-ollama").click();
+  await page.getByText("Selected: Claude Code, Opencode, Ollama").waitFor();
+  await shotPage(page, OUT, "01-onboarding-multi-provider-selection");
+
+  await installProviderMocks(context, { onboarded: true });
+  await openShellRoute(page, "/#/apps/activity");
+  await page.getByText("4 providers connected").waitFor();
+  await shotElement(
+    page,
+    "#connected-providers",
+    OUT,
+    "02-overview-connected-providers",
+  );
+
+  await openShellRoute(page, "/#/apps/settings");
+  await page.getByText("Available providers").waitFor();
+  await shotElement(
+    page,
+    "label:has-text('Claude Code')",
+    OUT,
+    "03-settings-provider-row",
+  );
+
+  await openShellRoute(page, "/#/tasks/new");
+  await page.getByTestId("issue-new").waitFor();
+  await page.getByTestId("issue-new-provider").selectOption("exo");
+  await shotElement(
+    page,
+    ".issue-new-form",
+    OUT,
+    "04-task-create-provider-select",
+  );
+
+  console.log(`captured 4 screenshots to ${OUT}`);
+} finally {
+  await browser.close();
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1223,7 +1223,8 @@ export interface ConfigSnapshot {
 }
 
 export type ConfigUpdate = Partial<{
-  llm_provider: LLMProvider;
+  llm_provider: LLMProvider | "";
+  llm_provider_priority: LLMRuntimeKind[];
   provider_endpoints: Record<string, ProviderEndpoint>;
   memory_backend: MemoryBackend;
   action_provider: ActionProvider;

--- a/web/src/api/tasks.test.ts
+++ b/web/src/api/tasks.test.ts
@@ -40,6 +40,22 @@ describe("tasks api client", () => {
     });
   });
 
+  it("createTasks forwards an optional provider", async () => {
+    const response: api.CreateTasksResponse = { tasks: [] };
+    const postSpy = vi.spyOn(client, "post").mockResolvedValue(response);
+
+    await expect(
+      api.createTasks([
+        { title: "Write contract", assignee: "pm", provider: "codex" },
+      ]),
+    ).resolves.toEqual(response);
+    expect(postSpy).toHaveBeenCalledWith("/task-plan", {
+      channel: "general",
+      created_by: "human",
+      tasks: [{ title: "Write contract", assignee: "pm", provider: "codex" }],
+    });
+  });
+
   it("updateTaskStatus includes memory workflow override evidence", async () => {
     const response: api.TaskResponse = {
       task: { id: "task-1", title: "Write contract", status: "done" },

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -2,8 +2,11 @@
 import { useQuery } from "@tanstack/react-query";
 
 import {
+  get,
   getActions,
+  getConfig,
   getDecisions,
+  getLocalProvidersStatus,
   getOfficeMembers,
   getScheduler,
   getWatchdogs,
@@ -13,8 +16,14 @@ import { getOfficeTasks } from "../../api/tasks";
 import { formatTokens } from "../../lib/format";
 import { isAgentActive, normalizeStatus } from "../../lib/officeStatus";
 import { keyedByOccurrence } from "../../lib/reactKeys";
+import { router } from "../../lib/router";
+import {
+  configuredConnectedRuntimeProviders,
+  type RuntimeProviderOption,
+} from "../../lib/runtimeProviders";
 import { type Insight, InsightsList } from "../activity/InsightsList";
 import { Timeline, type TimelineEvent } from "../activity/Timeline";
+import type { PrereqResult } from "../onboarding/runtimes";
 import { ActiveTasksPanel } from "./shared/ActiveTasksPanel";
 import { AgentPulsePanel } from "./shared/AgentPulsePanel";
 
@@ -111,6 +120,22 @@ export function ArtifactsApp() {
     queryFn: () => getOfficeMembers(),
     refetchInterval: 15_000,
   });
+  const config = useQuery({
+    queryKey: ["activity-config"],
+    queryFn: getConfig,
+    staleTime: 15_000,
+  });
+  const prereqs = useQuery({
+    queryKey: ["activity-runtime-prereqs"],
+    queryFn: () =>
+      get<{ prereqs?: PrereqResult[] } | PrereqResult[]>("/onboarding/prereqs"),
+    staleTime: 15_000,
+  });
+  const localProviders = useQuery({
+    queryKey: ["activity-local-providers"],
+    queryFn: getLocalProvidersStatus,
+    staleTime: 15_000,
+  });
 
   const isLoading =
     tasks.isLoading ||
@@ -149,6 +174,17 @@ export function ArtifactsApp() {
   const allJobs = (scheduler.data?.jobs ?? []) as unknown as SchedulerJobRaw[];
   const usageData = usage.data;
   const allMembers = members.data?.members ?? [];
+  const prereqList = Array.isArray(prereqs.data)
+    ? prereqs.data
+    : (prereqs.data?.prereqs ?? []);
+  const connectedProviders = config.data
+    ? configuredConnectedRuntimeProviders(config.data, {
+        prereqs: prereqList,
+        localStatuses: localProviders.data,
+      })
+    : [];
+  const providersIsFetched =
+    config.isFetched && prereqs.isFetched && localProviders.isFetched;
 
   const activeTasks = allTasks.filter((t) => {
     const s = normalizeStatus(t.status);
@@ -264,6 +300,10 @@ export function ArtifactsApp() {
           })}
         </div>
       </div>
+
+      {providersIsFetched && connectedProviders.length > 0 ? (
+        <ConnectedProvidersSection providers={connectedProviders} />
+      ) : null}
 
       {/* Stat grid */}
       <div
@@ -428,6 +468,104 @@ export function ArtifactsApp() {
 }
 
 /* ── Shared sub-components ── */
+
+function goToSettings(): void {
+  void router.navigate({ to: "/apps/$appId", params: { appId: "settings" } });
+}
+
+function goToHealthCheck(): void {
+  void router.navigate({
+    to: "/apps/$appId",
+    params: { appId: "health-check" },
+  });
+}
+
+function ConnectedProvidersSection({
+  providers,
+}: {
+  providers: RuntimeProviderOption[];
+}) {
+  return (
+    <section
+      id="connected-providers"
+      aria-label="Connected providers"
+      style={{
+        background: "var(--green-bg)",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        padding: "12px 16px",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "baseline",
+          marginBottom: 8,
+        }}
+      >
+        <div style={{ fontSize: 13, fontWeight: 600 }}>
+          {providers.length} provider{providers.length !== 1 ? "s" : ""}{" "}
+          connected
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          <button
+            type="button"
+            className="btn btn-sm btn-ghost"
+            onClick={goToSettings}
+          >
+            Settings
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-ghost"
+            onClick={goToHealthCheck}
+          >
+            Provider Doctor
+          </button>
+        </div>
+      </div>
+      {providers.map((provider) => (
+        <div
+          key={provider.id}
+          style={{
+            fontSize: 13,
+            color: "var(--text)",
+            marginBottom: 4,
+            display: "flex",
+            alignItems: "center",
+            gap: 6,
+          }}
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              background: "var(--green)",
+              flexShrink: 0,
+            }}
+          />
+          <strong>{provider.label}</strong>
+          {" — ready"}
+          <span style={{ color: "var(--text-tertiary)", fontSize: 11 }}>
+            ({provider.desc})
+          </span>
+        </div>
+      ))}
+      <div
+        style={{
+          marginTop: 8,
+          fontSize: 12,
+          color: "var(--warning-400, #ce6b09)",
+        }}
+      >
+        Task creation and runtime switching only show configured providers that
+        pass connection checks.
+      </div>
+    </section>
+  );
+}
 
 interface StatCardProps {
   kicker: string;

--- a/web/src/components/apps/OfficeOverviewApp.test.tsx
+++ b/web/src/components/apps/OfficeOverviewApp.test.tsx
@@ -4,7 +4,9 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  get,
   getAllRequests,
+  getConfig,
   getLocalProvidersStatus,
   getOfficeMembers,
   getScheduler,
@@ -16,7 +18,9 @@ import { OfficeOverviewApp } from "./OfficeOverviewApp";
 // ── Mocks ──────────────────────────────────────────────────────────
 
 vi.mock("../../api/client", () => ({
+  get: vi.fn(),
   getAllRequests: vi.fn(),
+  getConfig: vi.fn(),
   getLocalProvidersStatus: vi.fn(),
   getOfficeMembers: vi.fn(),
   getScheduler: vi.fn(),
@@ -33,6 +37,8 @@ vi.mock("../../lib/router", () => ({
 }));
 
 const mockGetOfficeTasks = vi.mocked(getOfficeTasks);
+const mockGet = vi.mocked(get);
+const mockGetConfig = vi.mocked(getConfig);
 const mockGetOfficeMembers = vi.mocked(getOfficeMembers);
 const mockGetAllRequests = vi.mocked(getAllRequests);
 const mockGetSkillsList = vi.mocked(getSkillsList);
@@ -55,6 +61,10 @@ function emptyDefaults() {
   mockGetSkillsList.mockResolvedValue({ skills: [] });
   mockGetScheduler.mockResolvedValue({ jobs: [] });
   mockGetLocalProvidersStatus.mockResolvedValue([]);
+  mockGetConfig.mockResolvedValue({
+    llm_provider_priority: [],
+  });
+  mockGet.mockResolvedValue({ prereqs: [] });
 }
 
 // ── Tests ──────────────────────────────────────────────────────────
@@ -63,305 +73,331 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("OfficeOverviewApp", () => {
-  describe("full data render", () => {
-    it("renders all section headings with data loaded", async () => {
-      mockGetOfficeTasks.mockResolvedValue({
-        tasks: [
-          {
-            id: "t1",
-            title: "Ship landing page",
-            status: "in_progress",
-            owner: "alex",
-            channel: "general",
-            updated_at: new Date().toISOString(),
-          },
-          {
-            id: "t2",
-            title: "Fix auth bug",
-            status: "blocked",
-            owner: "riley",
-            channel: "eng",
-            updated_at: new Date().toISOString(),
-          },
-        ],
-      });
-      mockGetOfficeMembers.mockResolvedValue({
-        members: [
-          {
-            slug: "alex",
-            name: "Alex",
-            role: "engineer",
-            status: "shipping",
-            task: "Ship landing page",
-          },
-        ],
-      });
-      mockGetAllRequests.mockResolvedValue({
-        requests: [
-          {
-            id: "r1",
-            from: "alex",
-            question: "Should I proceed with the deployment?",
-            status: "open",
-            blocking: true,
-          },
-        ],
-      });
-      mockGetSkillsList.mockResolvedValue({
-        skills: [
-          {
-            name: "deploy-frontend",
-            title: "Deploy frontend",
-            status: "proposed" as const,
-            created_by: "alex",
-          },
-        ],
-      });
-      mockGetScheduler.mockResolvedValue({
-        jobs: [
-          {
-            slug: "daily-digest",
-            label: "Daily digest",
-            next_run: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
-            enabled: true,
-          },
-        ],
-      });
-      mockGetLocalProvidersStatus.mockResolvedValue([]);
-
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByTestId("office-overview-app"),
-      ).toBeInTheDocument();
-
-      expect(screen.getByText("Office overview")).toBeInTheDocument();
-      expect(screen.getByText("Active runs")).toBeInTheDocument();
-      expect(screen.getByText("Blocked tasks")).toBeInTheDocument();
-      expect(screen.getByText("Agents working now")).toBeInTheDocument();
-      expect(screen.getByText("Pending reviews")).toBeInTheDocument();
-      expect(screen.getByText("Wiki proposals")).toBeInTheDocument();
-      expect(screen.getByText("Next scheduled routines")).toBeInTheDocument();
-      expect(screen.getByText("Recent artifacts")).toBeInTheDocument();
-
-      // Spot-check data in sections. Task titles, questions, etc. can appear
-      // in multiple sections (active runs, recent artifacts, agent task label,
-      // request label + body). Use getAllByText to allow duplicates.
-      const shipLandingMatches =
-        await screen.findAllByText("Ship landing page");
-      expect(shipLandingMatches.length).toBeGreaterThanOrEqual(1);
-      const fixAuthMatches = screen.getAllByText("Fix auth bug");
-      expect(fixAuthMatches.length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("Alex")).toBeInTheDocument();
-      // The question text shows up as both label and body in the request card.
-      const deployQuestionMatches = screen.getAllByText(
-        "Should I proceed with the deployment?",
-      );
-      expect(deployQuestionMatches.length).toBeGreaterThanOrEqual(1);
-      expect(screen.getByText("Deploy frontend")).toBeInTheDocument();
-      expect(screen.getByText("Daily digest")).toBeInTheDocument();
+describe("OfficeOverviewApp full data render", () => {
+  it("renders all section headings with data loaded", async () => {
+    mockGetOfficeTasks.mockResolvedValue({
+      tasks: [
+        {
+          id: "t1",
+          title: "Ship landing page",
+          status: "in_progress",
+          owner: "alex",
+          channel: "general",
+          updated_at: new Date().toISOString(),
+        },
+        {
+          id: "t2",
+          title: "Fix auth bug",
+          status: "blocked",
+          owner: "riley",
+          channel: "eng",
+          updated_at: new Date().toISOString(),
+        },
+      ],
     });
+    mockGetOfficeMembers.mockResolvedValue({
+      members: [
+        {
+          slug: "alex",
+          name: "Alex",
+          role: "engineer",
+          status: "shipping",
+          task: "Ship landing page",
+        },
+      ],
+    });
+    mockGetAllRequests.mockResolvedValue({
+      requests: [
+        {
+          id: "r1",
+          from: "alex",
+          question: "Should I proceed with the deployment?",
+          status: "open",
+          blocking: true,
+        },
+      ],
+    });
+    mockGetSkillsList.mockResolvedValue({
+      skills: [
+        {
+          name: "deploy-frontend",
+          title: "Deploy frontend",
+          status: "proposed" as const,
+          created_by: "alex",
+        },
+      ],
+    });
+    mockGetScheduler.mockResolvedValue({
+      jobs: [
+        {
+          slug: "daily-digest",
+          label: "Daily digest",
+          next_run: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+          enabled: true,
+        },
+      ],
+    });
+    mockGetLocalProvidersStatus.mockResolvedValue([]);
+    mockGetConfig.mockResolvedValue({
+      llm_provider_priority: [],
+    });
+    mockGet.mockResolvedValue({ prereqs: [] });
+
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(
+      await screen.findByTestId("office-overview-app"),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Office overview")).toBeInTheDocument();
+    expect(screen.getByText("Active runs")).toBeInTheDocument();
+    expect(screen.getByText("Blocked tasks")).toBeInTheDocument();
+    expect(screen.getByText("Agents working now")).toBeInTheDocument();
+    expect(screen.getByText("Pending reviews")).toBeInTheDocument();
+    expect(screen.getByText("Wiki proposals")).toBeInTheDocument();
+    expect(screen.getByText("Next scheduled routines")).toBeInTheDocument();
+    expect(screen.getByText("Recent artifacts")).toBeInTheDocument();
+
+    // Spot-check data in sections. Task titles, questions, etc. can appear
+    // in multiple sections (active runs, recent artifacts, agent task label,
+    // request label + body). Use getAllByText to allow duplicates.
+    const shipLandingMatches = await screen.findAllByText("Ship landing page");
+    expect(shipLandingMatches.length).toBeGreaterThanOrEqual(1);
+    const fixAuthMatches = screen.getAllByText("Fix auth bug");
+    expect(fixAuthMatches.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Alex")).toBeInTheDocument();
+    // The question text shows up as both label and body in the request card.
+    const deployQuestionMatches = screen.getAllByText(
+      "Should I proceed with the deployment?",
+    );
+    expect(deployQuestionMatches.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Deploy frontend")).toBeInTheDocument();
+    expect(screen.getByText("Daily digest")).toBeInTheDocument();
+  });
+});
+
+describe("OfficeOverviewApp empty states", () => {
+  beforeEach(() => {
+    emptyDefaults();
   });
 
-  describe("empty states", () => {
-    beforeEach(() => {
-      emptyDefaults();
-    });
+  it("shows empty states for active runs when no tasks are running", async () => {
+    render(wrap(<OfficeOverviewApp />));
 
-    it("shows empty states for active runs when no tasks are running", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("No tasks are running right now."),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state for blocked tasks when nothing is blocked", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText(
-          "Nothing is blocked. Agents are moving freely.",
-        ),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state for agents when all are idle", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("No agents are visibly active right now."),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state for pending reviews when no requests exist", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("No pending requests from agents."),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state for wiki proposals when none are pending", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("No skill proposals awaiting review."),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state for scheduled jobs when none exist", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("No upcoming scheduled routines."),
-      ).toBeInTheDocument();
-    });
-
-    it("shows empty state for recent artifacts when no tasks exist", async () => {
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("No recent task activity."),
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText("No tasks are running right now."),
+    ).toBeInTheDocument();
   });
 
-  describe("provider warnings", () => {
-    beforeEach(() => {
-      emptyDefaults();
-    });
+  it("shows empty state for blocked tasks when nothing is blocked", async () => {
+    render(wrap(<OfficeOverviewApp />));
 
-    it("shows provider warning section when a provider is unhealthy", async () => {
-      mockGetLocalProvidersStatus.mockResolvedValue([
-        {
-          kind: "ollama",
-          binary_installed: true,
-          binary_path: "/usr/local/bin/ollama",
-          endpoint: "http://localhost:11434",
-          model: "llama3",
-          reachable: false,
-          probed: true,
-          platform_supported: true,
-        },
-      ]);
-
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(
-        await screen.findByText("1 provider unreachable"),
-      ).toBeInTheDocument();
-      expect(screen.getByText("ollama")).toBeInTheDocument();
-    });
-
-    it("shows links to Settings and Provider Doctor when providers are unhealthy", async () => {
-      mockGetLocalProvidersStatus.mockResolvedValue([
-        {
-          kind: "exo",
-          binary_installed: false,
-          endpoint: "http://localhost:52415",
-          model: "llama-3.2-3b",
-          reachable: false,
-          probed: true,
-          platform_supported: true,
-        },
-      ]);
-
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(await screen.findByText("Settings")).toBeInTheDocument();
-      expect(screen.getByText("Provider Doctor")).toBeInTheDocument();
-    });
-
-    it("does not show provider warning section when all providers are healthy", async () => {
-      mockGetLocalProvidersStatus.mockResolvedValue([
-        {
-          kind: "ollama",
-          binary_installed: true,
-          endpoint: "http://localhost:11434",
-          model: "llama3",
-          reachable: true,
-          probed: true,
-          platform_supported: true,
-        },
-      ]);
-
-      render(wrap(<OfficeOverviewApp />));
-
-      // Wait for data to load; then confirm no warning banner.
-      await screen.findByText("Active runs");
-      expect(
-        screen.queryByText("1 provider unreachable"),
-      ).not.toBeInTheDocument();
-    });
-
-    it("does not show provider warning section when providers list is empty", async () => {
-      mockGetLocalProvidersStatus.mockResolvedValue([]);
-
-      render(wrap(<OfficeOverviewApp />));
-
-      await screen.findByText("Active runs");
-      expect(
-        screen.queryByText(/provider.*unreachable/),
-      ).not.toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText("Nothing is blocked. Agents are moving freely."),
+    ).toBeInTheDocument();
   });
 
-  describe("section links", () => {
-    beforeEach(() => {
-      emptyDefaults();
+  it("shows empty state for agents when all are idle", async () => {
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(
+      await screen.findByText("No agents are visibly active right now."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state for pending reviews when no requests exist", async () => {
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(
+      await screen.findByText("No pending requests from agents."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state for wiki proposals when none are pending", async () => {
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(
+      await screen.findByText("No skill proposals awaiting review."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state for scheduled jobs when none exist", async () => {
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(
+      await screen.findByText("No upcoming scheduled routines."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state for recent artifacts when no tasks exist", async () => {
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(
+      await screen.findByText("No recent task activity."),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("OfficeOverviewApp connected providers", () => {
+  beforeEach(() => {
+    emptyDefaults();
+  });
+
+  it("does not show offline providers", async () => {
+    mockGetConfig.mockResolvedValue({
+      llm_provider: "ollama",
+      llm_provider_priority: ["ollama"],
+    });
+    mockGetLocalProvidersStatus.mockResolvedValue([
+      {
+        kind: "ollama",
+        binary_installed: true,
+        binary_path: "/usr/local/bin/ollama",
+        endpoint: "http://localhost:11434",
+        model: "llama3",
+        reachable: false,
+        probed: true,
+        platform_supported: true,
+      },
+    ]);
+
+    render(wrap(<OfficeOverviewApp />));
+
+    await screen.findByText("Active runs");
+    expect(screen.queryByText("ollama")).not.toBeInTheDocument();
+  });
+
+  it("shows connected providers and links to Settings and Provider Doctor", async () => {
+    mockGetConfig.mockResolvedValue({
+      llm_provider: "exo",
+      llm_provider_priority: ["exo"],
+    });
+    mockGetLocalProvidersStatus.mockResolvedValue([
+      {
+        kind: "exo",
+        binary_installed: true,
+        endpoint: "http://localhost:52415",
+        model: "llama-3.2-3b",
+        reachable: true,
+        probed: true,
+        platform_supported: true,
+      },
+    ]);
+
+    render(wrap(<OfficeOverviewApp />));
+
+    expect(await screen.findByText("1 provider connected")).toBeInTheDocument();
+    expect(screen.getByText("Exo")).toBeInTheDocument();
+    expect(await screen.findByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Provider Doctor")).toBeInTheDocument();
+  });
+
+  it("does not show connected providers that are not configured", async () => {
+    mockGetConfig.mockResolvedValue({
+      llm_provider: "codex",
+      llm_provider_priority: ["codex"],
+    });
+    mockGetLocalProvidersStatus.mockResolvedValue([
+      {
+        kind: "exo",
+        binary_installed: true,
+        endpoint: "http://localhost:52415",
+        model: "llama-3.2-3b",
+        reachable: true,
+        probed: true,
+        platform_supported: true,
+      },
+    ]);
+
+    render(wrap(<OfficeOverviewApp />));
+
+    await screen.findByText("Active runs");
+    expect(screen.queryByText(/provider.*connected/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Exo")).not.toBeInTheDocument();
+  });
+
+  it("does not show provider section when providers list is empty", async () => {
+    mockGetLocalProvidersStatus.mockResolvedValue([]);
+
+    render(wrap(<OfficeOverviewApp />));
+
+    await screen.findByText("Active runs");
+    expect(screen.queryByText(/provider.*connected/)).not.toBeInTheDocument();
+  });
+
+  it("does not show provider section when no provider is connected", async () => {
+    mockGetLocalProvidersStatus.mockResolvedValue([
+      {
+        kind: "ollama",
+        binary_installed: false,
+        endpoint: "http://localhost:11434",
+        model: "llama3",
+        reachable: false,
+        probed: true,
+        platform_supported: true,
+      },
+    ]);
+
+    render(wrap(<OfficeOverviewApp />));
+
+    await screen.findByText("Active runs");
+    expect(screen.queryByText(/provider.*connected/)).not.toBeInTheDocument();
+  });
+});
+
+describe("OfficeOverviewApp section links", () => {
+  beforeEach(() => {
+    emptyDefaults();
+  });
+
+  it("renders View board link when active tasks exist", async () => {
+    mockGetOfficeTasks.mockResolvedValue({
+      tasks: [
+        {
+          id: "t1",
+          title: "Active task",
+          status: "in_progress",
+          updated_at: new Date().toISOString(),
+        },
+      ],
     });
 
-    it("renders View board link when active tasks exist", async () => {
-      mockGetOfficeTasks.mockResolvedValue({
-        tasks: [
-          {
-            id: "t1",
-            title: "Active task",
-            status: "in_progress",
-            updated_at: new Date().toISOString(),
-          },
-        ],
-      });
+    render(wrap(<OfficeOverviewApp />));
 
-      render(wrap(<OfficeOverviewApp />));
+    // There are two "View board" links (active + blocked sections).
+    const links = await screen.findAllByText("View board");
+    expect(links.length).toBeGreaterThanOrEqual(1);
+  });
 
-      // There are two "View board" links (active + blocked sections).
-      const links = await screen.findAllByText("View board");
-      expect(links.length).toBeGreaterThanOrEqual(1);
+  it("renders Answer link when pending requests exist", async () => {
+    mockGetAllRequests.mockResolvedValue({
+      requests: [
+        {
+          id: "r1",
+          from: "alex",
+          question: "Approve this?",
+          status: "open",
+        },
+      ],
     });
 
-    it("renders Answer link when pending requests exist", async () => {
-      mockGetAllRequests.mockResolvedValue({
-        requests: [
-          {
-            id: "r1",
-            from: "alex",
-            question: "Approve this?",
-            status: "open",
-          },
-        ],
-      });
+    render(wrap(<OfficeOverviewApp />));
 
-      render(wrap(<OfficeOverviewApp />));
+    expect(await screen.findByText("Answer")).toBeInTheDocument();
+  });
 
-      expect(await screen.findByText("Answer")).toBeInTheDocument();
+  it("renders Review link when skill proposals exist", async () => {
+    mockGetSkillsList.mockResolvedValue({
+      skills: [
+        {
+          name: "my-skill",
+          status: "proposed" as const,
+        },
+      ],
     });
 
-    it("renders Review link when skill proposals exist", async () => {
-      mockGetSkillsList.mockResolvedValue({
-        skills: [
-          {
-            name: "my-skill",
-            status: "proposed" as const,
-          },
-        ],
-      });
+    render(wrap(<OfficeOverviewApp />));
 
-      render(wrap(<OfficeOverviewApp />));
-
-      expect(await screen.findByText("Review")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("Review")).toBeInTheDocument();
   });
 });

--- a/web/src/components/apps/OfficeOverviewApp.tsx
+++ b/web/src/components/apps/OfficeOverviewApp.tsx
@@ -3,7 +3,9 @@ import { useQuery } from "@tanstack/react-query";
 
 import {
   type AgentRequest,
+  get,
   getAllRequests,
+  getConfig,
   getLocalProvidersStatus,
   getOfficeMembers,
   getScheduler,
@@ -15,12 +17,13 @@ import {
 } from "../../api/client";
 import { getOfficeTasks, type Task } from "../../api/tasks";
 import { formatRelativeTime } from "../../lib/format";
-import {
-  isAgentActive,
-  normalizeStatus,
-  taskMeta,
-} from "../../lib/officeStatus";
+import { isAgentActive, normalizeStatus } from "../../lib/officeStatus";
 import { router } from "../../lib/router";
+import {
+  configuredConnectedRuntimeProviders,
+  type RuntimeProviderOption,
+} from "../../lib/runtimeProviders";
+import type { PrereqResult } from "../onboarding/runtimes";
 import { ActiveTasksPanel } from "./shared/ActiveTasksPanel";
 import { AgentPulsePanel } from "./shared/AgentPulsePanel";
 
@@ -51,7 +54,7 @@ interface OverviewData {
   pendingRequests: AgentRequest[];
   proposedSkills: Skill[];
   upcomingJobs: SchedulerJob[];
-  unhealthyProviders: LocalProviderStatus[];
+  connectedProviders: RuntimeProviderOption[];
   taskIsLoading: boolean;
   membersIsLoading: boolean;
   requestsIsLoading: boolean;
@@ -94,10 +97,6 @@ function goToHealthCheck(): void {
 }
 
 // ── Data helpers ───────────────────────────────────────────────────
-
-function providerIsUnhealthy(p: LocalProviderStatus): boolean {
-  return p.probed && !p.reachable;
-}
 
 function taskBadgeClass(status: string): string {
   return status === "done" ? "badge badge-green" : "badge badge-accent";
@@ -142,6 +141,19 @@ function useOverviewData(): OverviewData {
     refetchInterval: 30_000,
   });
 
+  const config = useQuery({
+    queryKey: ["overview-config"],
+    queryFn: getConfig,
+    refetchInterval: 30_000,
+  });
+
+  const prereqs = useQuery({
+    queryKey: ["overview-runtime-prereqs"],
+    queryFn: () =>
+      get<{ prereqs?: PrereqResult[] } | PrereqResult[]>("/onboarding/prereqs"),
+    refetchInterval: 30_000,
+  });
+
   const allTasks: Task[] = tasks.data?.tasks ?? [];
   const allMembers: OfficeMember[] = members.data?.members ?? [];
   const allRequests: AgentRequest[] = requests.data?.requests ?? [];
@@ -150,6 +162,9 @@ function useOverviewData(): OverviewData {
   const allProviders: LocalProviderStatus[] = Array.isArray(providers.data)
     ? providers.data
     : [];
+  const prereqList = Array.isArray(prereqs.data)
+    ? prereqs.data
+    : (prereqs.data?.prereqs ?? []);
 
   const activeTasks = allTasks.filter((t) => {
     const s = normalizeStatus(t.status);
@@ -167,7 +182,12 @@ function useOverviewData(): OverviewData {
   );
 
   const proposedSkills = allSkills.filter((s) => s.status === "proposed");
-  const unhealthyProviders = allProviders.filter(providerIsUnhealthy);
+  const connectedProviders = config.data
+    ? configuredConnectedRuntimeProviders(config.data, {
+        prereqs: prereqList,
+        localStatuses: allProviders,
+      })
+    : [];
 
   const upcomingJobs = allJobs
     .filter((j) => j.next_run || j.due_at)
@@ -193,13 +213,14 @@ function useOverviewData(): OverviewData {
     pendingRequests,
     proposedSkills,
     upcomingJobs,
-    unhealthyProviders,
+    connectedProviders,
     taskIsLoading: tasks.isLoading,
     membersIsLoading: members.isLoading,
     requestsIsLoading: requests.isLoading,
     skillsIsLoading: skills.isLoading,
     schedulerIsLoading: scheduler.isLoading,
-    providersIsFetched: providers.isFetched,
+    providersIsFetched:
+      providers.isFetched && config.isFetched && prereqs.isFetched,
   };
 }
 
@@ -544,9 +565,8 @@ export function OfficeOverviewApp() {
         </div>
       </div>
 
-      {/* Provider warnings — always at top so they are impossible to miss */}
-      {data.providersIsFetched && data.unhealthyProviders.length > 0 ? (
-        <ProviderWarningsSection providers={data.unhealthyProviders} />
+      {data.providersIsFetched && data.connectedProviders.length > 0 ? (
+        <ConnectedProvidersSection providers={data.connectedProviders} />
       ) : null}
 
       {/* Section grid */}
@@ -591,20 +611,22 @@ export function OfficeOverviewApp() {
   );
 }
 
-// ── Provider warnings section ──────────────────────────────────────
+// ── Connected providers section ────────────────────────────────────
 
-interface ProviderWarningsSectionProps {
-  providers: LocalProviderStatus[];
+interface ConnectedProvidersSectionProps {
+  providers: RuntimeProviderOption[];
 }
 
-function ProviderWarningsSection({ providers }: ProviderWarningsSectionProps) {
+function ConnectedProvidersSection({
+  providers,
+}: ConnectedProvidersSectionProps) {
   return (
     <section
-      id="provider-warnings"
-      aria-label="Provider warnings"
+      id="connected-providers"
+      aria-label="Connected providers"
       style={{
-        background: "var(--warning-100, #fbf5dc)",
-        border: "1px solid var(--warning-300, #ffb647)",
+        background: "var(--green-bg)",
+        border: "1px solid var(--border)",
         borderRadius: 8,
         padding: "12px 16px",
       }}
@@ -621,11 +643,11 @@ function ProviderWarningsSection({ providers }: ProviderWarningsSectionProps) {
           style={{
             fontSize: 13,
             fontWeight: 600,
-            color: "var(--warning-500, #994200)",
+            color: "var(--text)",
           }}
         >
           {providers.length} provider{providers.length !== 1 ? "s" : ""}{" "}
-          unreachable
+          connected
         </div>
         <div style={{ display: "flex", gap: 8 }}>
           <SectionLink onClick={goToSettings}>Settings</SectionLink>
@@ -634,10 +656,10 @@ function ProviderWarningsSection({ providers }: ProviderWarningsSectionProps) {
       </div>
       {providers.map((p) => (
         <div
-          key={p.kind}
+          key={p.id}
           style={{
             fontSize: 13,
-            color: "var(--warning-500, #994200)",
+            color: "var(--text)",
             marginBottom: 4,
             display: "flex",
             alignItems: "center",
@@ -649,21 +671,15 @@ function ProviderWarningsSection({ providers }: ProviderWarningsSectionProps) {
               width: 6,
               height: 6,
               borderRadius: "50%",
-              background: "var(--warning-400, #ce6b09)",
+              background: "var(--green)",
               flexShrink: 0,
             }}
           />
-          <strong>{p.kind}</strong>
-          {p.binary_installed && !p.reachable
-            ? " — installed but not running"
-            : " — not reachable"}
-          {p.endpoint ? (
-            <span
-              style={{ color: "var(--warning-400, #ce6b09)", fontSize: 11 }}
-            >
-              ({p.endpoint})
-            </span>
-          ) : null}
+          <strong>{p.label}</strong>
+          {" — ready"}
+          <span style={{ color: "var(--text-tertiary)", fontSize: 11 }}>
+            ({p.desc})
+          </span>
         </div>
       ))}
       <div
@@ -673,8 +689,8 @@ function ProviderWarningsSection({ providers }: ProviderWarningsSectionProps) {
           color: "var(--warning-400, #ce6b09)",
         }}
       >
-        Agents assigned to these providers will stall. Open Settings or Provider
-        Doctor to fix the connection.
+        Task creation and runtime switching only show configured providers that
+        pass connection checks.
       </div>
     </section>
   );

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Refresh, WarningTriangle } from "iconoir-react";
 
@@ -16,6 +16,7 @@ import {
 } from "../../api/client";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { router } from "../../lib/router";
+import { normalizeProviderList } from "../../lib/runtimeProviders";
 import { useAppStore } from "../../stores/app";
 import { CredentialRegistrationPanel } from "../cosign";
 import { CommandRow } from "../ui/CommandRow";
@@ -31,6 +32,7 @@ import { NexConnectPanel } from "./NexConnectPanel";
 import { ImageGenSection } from "./SettingsApp.imageGen";
 import { Field, KeyField, SaveButton } from "./settings/components";
 import { SECTION_GROUPS } from "./settings/constants";
+import { RuntimeProviderChecklist } from "./settings/RuntimeProviderChecklist";
 import { styles } from "./settings/styles";
 import type { SectionId, SectionProps } from "./settings/types";
 
@@ -68,20 +70,6 @@ function useShredAction() {
     }
   };
 }
-
-const PROVIDER_LABELS: Record<LLMRuntimeKind, string> = {
-  "claude-code": "Claude Code",
-  codex: "Codex",
-  opencode: "Opencode",
-  "mlx-lm": "MLX-LM (Apple Silicon)",
-  ollama: "Ollama",
-  exo: "Exo",
-};
-const CLOUD_KINDS: ReadonlySet<LLMRuntimeKind> = new Set([
-  "claude-code",
-  "codex",
-  "opencode",
-]);
 
 // TeamLeadPicker reads the office roster so the human picks from real
 // agents rather than typing a slug. The saved value persists as a slug on
@@ -128,10 +116,22 @@ function TeamLeadPicker({
   );
 }
 
+function sameProviders(
+  a: readonly LLMRuntimeKind[] | null,
+  b: readonly LLMRuntimeKind[],
+) {
+  if (a === null) return false;
+  return a.length === b.length && a.every((provider, i) => provider === b[i]);
+}
+
 function GeneralSection({ cfg, save }: SectionProps) {
-  const [provider, setProvider] = useState<LLMRuntimeKind | "">(
-    (cfg.llm_provider as LLMRuntimeKind | undefined) ?? "claude-code",
-  );
+  const initialProviders =
+    cfg.llm_provider_priority && cfg.llm_provider_priority.length > 0
+      ? cfg.llm_provider_priority
+      : cfg.llm_provider
+        ? [cfg.llm_provider]
+        : [];
+  const [providers, setProviders] = useState<string[]>(initialProviders);
   const [teamLead, setTeamLead] = useState(cfg.team_lead_slug ?? "");
   const [maxConcurrent, setMaxConcurrent] = useState(
     cfg.max_concurrent_agents ? String(cfg.max_concurrent_agents) : "",
@@ -143,21 +143,19 @@ function GeneralSection({ cfg, save }: SectionProps) {
   const [blueprint, setBlueprint] = useState(cfg.blueprint ?? "");
   const [email, setEmail] = useState(cfg.email ?? "");
   const [devUrl, setDevUrl] = useState(cfg.dev_url ?? "");
-
-  const llmKinds: LLMRuntimeKind[] = (cfg.llm_provider_kinds ?? [
-    "claude-code",
-    "codex",
-    "opencode",
-    "mlx-lm",
-    "ollama",
-    "exo",
-  ]) as LLMRuntimeKind[];
-  const cloudKinds = llmKinds.filter((k) => CLOUD_KINDS.has(k));
-  const localKinds = llmKinds.filter((k) => !CLOUD_KINDS.has(k));
+  const [connectedProviders, setConnectedProviders] = useState<
+    LLMRuntimeKind[] | null
+  >(null);
+  const updateConnectedProviders = useCallback((next: LLMRuntimeKind[]) => {
+    setConnectedProviders((prev) => (sameProviders(prev, next) ? prev : next));
+  }, []);
 
   const onSave = async () => {
+    const providerPriority =
+      connectedProviders ?? normalizeProviderList(providers);
     const patch: ConfigUpdate = {
-      llm_provider: provider as ConfigUpdate["llm_provider"],
+      llm_provider: providerPriority[0] ?? "",
+      llm_provider_priority: providerPriority,
       default_format: format,
       blueprint,
       email,
@@ -177,47 +175,12 @@ function GeneralSection({ cfg, save }: SectionProps) {
         Core runtime settings. These map to CLI flags and config file entries.
       </p>
 
-      <div style={styles.groupTitle}>Default runtime for new agents</div>
-      <p
-        style={{
-          fontSize: 12,
-          color: "var(--text-tertiary)",
-          margin: "0 0 12px 0",
-          lineHeight: 1.5,
-        }}
-      >
-        Picked for new agents at creation time. Existing agents keep whatever
-        runtime they already have — change those one at a time from each agent's
-        profile (Runtime section). To import OpenClaw or Hermes agents into the
-        team, use the Integrations app — those gateways are not runtimes you
-        assign here.
-      </p>
-      <Field label="Runtime" hint="--provider">
-        <select
-          style={styles.input}
-          value={provider}
-          onChange={(e) => setProvider(e.target.value as LLMRuntimeKind | "")}
-        >
-          {cloudKinds.length > 0 && (
-            <optgroup label="Cloud">
-              {cloudKinds.map((kind) => (
-                <option key={kind} value={kind}>
-                  {PROVIDER_LABELS[kind] ?? kind}
-                </option>
-              ))}
-            </optgroup>
-          )}
-          {localKinds.length > 0 && (
-            <optgroup label="Local">
-              {localKinds.map((kind) => (
-                <option key={kind} value={kind}>
-                  {PROVIDER_LABELS[kind] ?? kind}
-                </option>
-              ))}
-            </optgroup>
-          )}
-        </select>
-      </Field>
+      <RuntimeProviderChecklist
+        configuredKinds={cfg.llm_provider_kinds}
+        selectedProviders={providers}
+        onSelectedProvidersChange={setProviders}
+        onConnectedProvidersChange={updateConnectedProviders}
+      />
       <div style={{ ...styles.groupTitle, marginTop: 24 }}>Agents</div>
       <Field label="Team Lead" hint="Agent that leads operations">
         <TeamLeadPicker value={teamLead} onChange={setTeamLead} />

--- a/web/src/components/apps/settings/RuntimeProviderChecklist.tsx
+++ b/web/src/components/apps/settings/RuntimeProviderChecklist.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  get,
+  getLocalProvidersStatus,
+  type LLMRuntimeKind,
+} from "../../../api/client";
+import {
+  prereqByBinary,
+  RUNTIME_PROVIDER_OPTIONS,
+  runtimeProviderIsConnected,
+  runtimeProviderLabel,
+  statusByLocalProvider,
+} from "../../../lib/runtimeProviders";
+import type { PrereqResult } from "../../onboarding/runtimes";
+import { Field } from "./components";
+
+interface RuntimeProviderChecklistProps {
+  configuredKinds?: readonly string[];
+  selectedProviders: string[];
+  onSelectedProvidersChange: (providers: string[]) => void;
+  onConnectedProvidersChange: (providers: LLMRuntimeKind[]) => void;
+}
+
+export function RuntimeProviderChecklist({
+  configuredKinds,
+  selectedProviders,
+  onSelectedProvidersChange,
+  onConnectedProvidersChange,
+}: RuntimeProviderChecklistProps) {
+  const prereqs = useQuery({
+    queryKey: ["settings-runtime-prereqs"],
+    queryFn: () =>
+      get<{ prereqs?: PrereqResult[] } | PrereqResult[]>("/onboarding/prereqs"),
+    staleTime: 10_000,
+  });
+  const localStatuses = useQuery({
+    queryKey: ["settings-runtime-local-providers"],
+    queryFn: getLocalProvidersStatus,
+    staleTime: 10_000,
+  });
+
+  const prereqList = useMemo(
+    () =>
+      Array.isArray(prereqs.data)
+        ? prereqs.data
+        : (prereqs.data?.prereqs ?? []),
+    [prereqs.data],
+  );
+  const prereqMap = useMemo(() => prereqByBinary(prereqList), [prereqList]);
+  const localStatusMap = useMemo(
+    () => statusByLocalProvider(localStatuses.data),
+    [localStatuses.data],
+  );
+  const runtimeKindSet = useMemo(
+    () => new Set(configuredKinds ?? []),
+    [configuredKinds],
+  );
+  const providerOptions = useMemo(
+    () =>
+      runtimeKindSet.size > 0
+        ? RUNTIME_PROVIDER_OPTIONS.filter((option) =>
+            runtimeKindSet.has(option.id),
+          )
+        : RUNTIME_PROVIDER_OPTIONS,
+    [runtimeKindSet],
+  );
+
+  const connectedProviders = useMemo(
+    () =>
+      selectedProviders.filter((id): id is LLMRuntimeKind => {
+        const option = RUNTIME_PROVIDER_OPTIONS.find((p) => p.id === id);
+        return option
+          ? runtimeProviderIsConnected(option, {
+              prereqs: prereqMap,
+              localStatuses: localStatusMap,
+            })
+          : false;
+      }),
+    [localStatusMap, prereqMap, selectedProviders],
+  );
+
+  useEffect(() => {
+    if (prereqs.isError || localStatuses.isError) return;
+    if (prereqs.data === undefined || localStatuses.data === undefined) return;
+    onConnectedProvidersChange(connectedProviders);
+  }, [
+    connectedProviders,
+    localStatuses.data,
+    localStatuses.isError,
+    onConnectedProvidersChange,
+    prereqs.data,
+    prereqs.isError,
+  ]);
+
+  function toggleProvider(id: string): void {
+    onSelectedProvidersChange(
+      selectedProviders.includes(id)
+        ? selectedProviders.filter((p) => p !== id)
+        : [...selectedProviders, id],
+    );
+  }
+
+  return (
+    <>
+      <div style={{ marginTop: 24, fontSize: 14, fontWeight: 600 }}>
+        Default runtime for new agents
+      </div>
+      <p
+        style={{
+          fontSize: 12,
+          color: "var(--text-tertiary)",
+          margin: "0 0 12px 0",
+          lineHeight: 1.5,
+        }}
+      >
+        Picked for new agents at creation time. Existing agents keep whatever
+        runtime they already have - change those one at a time from each agent's
+        profile (Runtime section). To import OpenClaw or Hermes agents into the
+        team, use the Integrations app - those gateways are not runtimes you
+        assign here.
+      </p>
+      <Field label="Available providers" hint="Verified runtimes">
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {providerOptions.map((option) => {
+            const connected = runtimeProviderIsConnected(option, {
+              prereqs: prereqMap,
+              localStatuses: localStatusMap,
+            });
+            const checked = selectedProviders.includes(option.id);
+            return (
+              <label
+                key={option.id}
+                style={{
+                  display: "flex",
+                  gap: 10,
+                  alignItems: "flex-start",
+                  padding: "10px 12px",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--radius-sm)",
+                  background: checked ? "var(--accent-bg)" : "var(--bg-card)",
+                  opacity: connected ? 1 : 0.58,
+                }}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={!connected}
+                  onChange={() => toggleProvider(option.id)}
+                  style={{ marginTop: 2 }}
+                />
+                <span>
+                  <span
+                    style={{ display: "block", fontSize: 13, fontWeight: 600 }}
+                  >
+                    {option.label}
+                  </span>
+                  <span
+                    style={{
+                      display: "block",
+                      fontSize: 11,
+                      color: "var(--text-tertiary)",
+                      lineHeight: 1.4,
+                    }}
+                  >
+                    {connected ? option.desc : "Not connected or not running"}
+                  </span>
+                </span>
+              </label>
+            );
+          })}
+          {selectedProviders.length > 0 ? (
+            <div style={{ fontSize: 12, color: "var(--text-secondary)" }}>
+              Task creation will show:{" "}
+              {selectedProviders.map(runtimeProviderLabel).join(", ")}
+            </div>
+          ) : null}
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/web/src/components/lifecycle/TaskNewForm.tsx
+++ b/web/src/components/lifecycle/TaskNewForm.tsx
@@ -7,11 +7,17 @@
  * detail surface so they can iterate from there.
  */
 
-import { type FormEvent, useEffect, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { get, getConfig, getLocalProvidersStatus } from "../../api/client";
 import { createTasks } from "../../api/tasks";
 import { router } from "../../lib/router";
+import {
+  configuredConnectedRuntimeProviders,
+  runtimeProviderLabel,
+} from "../../lib/runtimeProviders";
+import type { PrereqResult } from "../onboarding/runtimes";
 
 const DEFAULT_CHANNEL = "general";
 
@@ -20,6 +26,7 @@ export function TaskNewForm() {
   const [details, setDetails] = useState("");
   const [channel, setChannel] = useState(DEFAULT_CHANNEL);
   const [assignee, setAssignee] = useState("");
+  const [provider, setProvider] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement | null>(null);
@@ -30,10 +37,42 @@ export function TaskNewForm() {
   const submitLockRef = useRef(false);
 
   const queryClient = useQueryClient();
+  const configQuery = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    staleTime: 10_000,
+  });
+  const prereqsQuery = useQuery({
+    queryKey: ["task-create-runtime-prereqs"],
+    queryFn: () =>
+      get<{ prereqs?: PrereqResult[] } | PrereqResult[]>("/onboarding/prereqs"),
+    staleTime: 10_000,
+  });
+  const localProvidersQuery = useQuery({
+    queryKey: ["task-create-local-providers"],
+    queryFn: getLocalProvidersStatus,
+    staleTime: 10_000,
+  });
+  const availableProviders = useMemo(() => {
+    const cfg = configQuery.data;
+    if (!cfg) return [];
+    const prereqs = Array.isArray(prereqsQuery.data)
+      ? prereqsQuery.data
+      : (prereqsQuery.data?.prereqs ?? []);
+    return configuredConnectedRuntimeProviders(cfg, {
+      prereqs,
+      localStatuses: localProvidersQuery.data,
+    });
+  }, [configQuery.data, prereqsQuery.data, localProvidersQuery.data]);
 
   useEffect(() => {
     titleRef.current?.focus();
   }, []);
+
+  useEffect(() => {
+    if (provider && availableProviders.some((p) => p.id === provider)) return;
+    setProvider(availableProviders[0]?.id ?? "");
+  }, [availableProviders, provider]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -55,6 +94,7 @@ export function TaskNewForm() {
             assignee: assignee.trim() || "human",
             details: details.trim() || undefined,
             task_type: "issue",
+            provider: provider || undefined,
           },
         ],
         { channel: channel.trim() || DEFAULT_CHANNEL, createdBy: "human" },
@@ -151,6 +191,27 @@ export function TaskNewForm() {
               data-testid="issue-new-assignee"
             />
           </div>
+        </div>
+
+        <div className="issue-new-form-field">
+          <label htmlFor="issue-new-provider">Provider</label>
+          <select
+            id="issue-new-provider"
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            disabled={availableProviders.length === 0}
+            data-testid="issue-new-provider"
+          >
+            {availableProviders.length === 0 ? (
+              <option value="">No connected provider configured</option>
+            ) : (
+              availableProviders.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {runtimeProviderLabel(p.id)}
+                </option>
+              ))
+            )}
+          </select>
         </div>
 
         {error ? (

--- a/web/src/components/onboarding/LocalProviderPicker.tsx
+++ b/web/src/components/onboarding/LocalProviderPicker.tsx
@@ -5,13 +5,13 @@ import { getLocalProvidersStatus } from "../../api/client";
 import { LOCAL_PROVIDER_LABELS } from "./runtimeConstants";
 
 interface LocalProviderPickerProps {
-  /** Currently selected provider kind, empty string if none selected. */
-  selected: string;
-  onSelect: (kind: string) => void;
+  /** Currently selected provider kinds. */
+  selected: readonly string[];
+  onToggle: (kind: string) => void;
 }
 
 /**
- * Single-select grid of local OpenAI-compatible runtime tiles.
+ * Multi-select grid of local OpenAI-compatible runtime tiles.
  *
  * Ported from the deleted wizard/LocalLLMPicker.tsx. Probes
  * /status/local-providers on mount to show install status per tile.
@@ -20,7 +20,7 @@ interface LocalProviderPickerProps {
  */
 export function LocalProviderPicker({
   selected,
-  onSelect,
+  onToggle,
 }: LocalProviderPickerProps) {
   const [status, setStatus] = useState<LocalProviderStatus[]>([]);
   const [loading, setLoading] = useState(true);
@@ -64,8 +64,9 @@ export function LocalProviderPicker({
           data-testid="pre-pick-local-fetch-error"
         >
           Could not reach the broker to check installed runtimes:{" "}
-          <code>{fetchError}</code>. You can still pick one — install commands
-          are in <strong>Settings &rarr; Local LLMs</strong> after onboarding.
+          <code>{fetchError}</code>. You can still pick providers — install
+          commands are in <strong>Settings &rarr; Local LLMs</strong> after
+          onboarding.
         </div>
       ) : null}
       {!loading ? (
@@ -81,7 +82,7 @@ export function LocalProviderPicker({
             const running = Boolean(s?.reachable);
             const supported = statusKnown ? s.platform_supported : true;
             const selectable = supported && installed;
-            const isSelected = selected === meta.kind;
+            const isSelected = selected.includes(meta.kind);
 
             const classes = [
               "runtime-tile",
@@ -108,7 +109,7 @@ export function LocalProviderPicker({
                 className={classes}
                 onClick={() => {
                   if (!selectable) return;
-                  onSelect(isSelected ? "" : meta.kind);
+                  onToggle(meta.kind);
                 }}
                 disabled={!selectable}
                 aria-pressed={isSelected}

--- a/web/src/components/onboarding/PrePickScreen.test.tsx
+++ b/web/src/components/onboarding/PrePickScreen.test.tsx
@@ -87,7 +87,7 @@ function mockPrereqs(
   });
 }
 
-describe("PrePickScreen", () => {
+describe("PrePickScreen runtime selection", () => {
   it("renders the three dispatchable runtime cards plus a skip affordance", async () => {
     mockPrereqs({ claude: true, codex: true });
     render(<PrePickScreen onComplete={vi.fn()} />);
@@ -100,14 +100,19 @@ describe("PrePickScreen", () => {
     expect(screen.getByTestId("pre-pick-skip")).toBeInTheDocument();
   });
 
-  it("posts /config and hands off to the onboarding wizard when a detected runtime is picked", async () => {
-    mockPrereqs({ claude: true });
+  it("posts /config and hands off to the onboarding wizard with selected runtimes", async () => {
+    mockPrereqs({ claude: true, codex: true });
     const onComplete = vi.fn();
     render(<PrePickScreen onComplete={onComplete} />);
 
-    const card = await screen.findByTestId("pre-pick-card-claude-code");
-    await waitFor(() => expect(card).not.toBeDisabled());
-    fireEvent.click(card);
+    const claudeCard = await screen.findByTestId("pre-pick-card-claude-code");
+    const codexCard = await screen.findByTestId("pre-pick-card-codex");
+    await waitFor(() => expect(claudeCard).not.toBeDisabled());
+    fireEvent.click(claudeCard);
+    fireEvent.click(codexCard);
+
+    const submit = await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(submit);
 
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
 
@@ -115,7 +120,7 @@ describe("PrePickScreen", () => {
       "/config",
       expect.objectContaining({
         llm_provider: "claude-code",
-        llm_provider_priority: ["claude-code"],
+        llm_provider_priority: ["claude-code", "codex"],
         memory_backend: "markdown",
       }),
     );
@@ -340,6 +345,7 @@ describe("PrePickScreen", () => {
     const card = await screen.findByTestId("pre-pick-card-claude-code");
     await waitFor(() => expect(card).not.toBeDisabled());
     fireEvent.click(card);
+    fireEvent.click(await screen.findByTestId("pre-pick-form-submit"));
 
     await waitFor(() =>
       expect(onComplete).toHaveBeenCalledWith({ phaseAlreadyComplete: true }),
@@ -370,321 +376,318 @@ describe("PrePickScreen", () => {
     const card = await screen.findByTestId("pre-pick-card-codex");
     await waitFor(() => expect(card).not.toBeDisabled());
     fireEvent.click(card);
+    fireEvent.click(await screen.findByTestId("pre-pick-form-submit"));
 
     expect(await screen.findByRole("alert")).toHaveTextContent(
       /broker unreachable/i,
     );
     expect(onComplete).not.toHaveBeenCalled();
   });
+});
 
-  // ── New tests for Phase 5 ported sections ──────────────────────────────
+// ── New tests for Phase 5 ported sections ──────────────────────────────
 
-  describe("API key row", () => {
-    it("renders API key rows for Anthropic, OpenAI, and Google", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-api-keys");
-      expect(
-        screen.getByTestId("pre-pick-api-row-ANTHROPIC_API_KEY"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("pre-pick-api-row-OPENAI_API_KEY"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByTestId("pre-pick-api-row-GOOGLE_API_KEY"),
-      ).toBeInTheDocument();
-    });
-
-    it("defaults to CLI login mode (no password input visible)", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-api-keys");
-      // In CLI mode the paste tab is present but the password input is not rendered
-      expect(
-        screen.queryByTestId("pre-pick-api-input-ANTHROPIC_API_KEY"),
-      ).toBeNull();
-    });
-
-    it("switches to paste mode and shows password input when API key tab clicked", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-api-keys");
-
-      const pasteTab = screen.getByTestId(
-        "pre-pick-api-paste-ANTHROPIC_API_KEY",
-      );
-      fireEvent.click(pasteTab);
-
-      expect(
-        screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY"),
-      ).toBeInTheDocument();
-    });
-
-    it("posts anthropic_api_key to /config after paste and submit", async () => {
-      mockPrereqs({});
-      const onComplete = vi.fn();
-      render(<PrePickScreen onComplete={onComplete} />);
-      await screen.findByTestId("pre-pick-api-keys");
-
-      // Switch to paste mode
-      fireEvent.click(
-        screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY"),
-      );
-      const input = screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY");
-      fireEvent.change(input, { target: { value: "sk-ant-test123" } });
-
-      // Submit button should now appear
-      const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-      fireEvent.click(submitBtn);
-
-      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-      expect(postMock).toHaveBeenCalledWith(
-        "/config",
-        expect.objectContaining({ anthropic_api_key: "sk-ant-test123" }),
-      );
-    });
-
-    it("strips control characters from a pasted API key before posting", async () => {
-      mockPrereqs({});
-      const onComplete = vi.fn();
-      render(<PrePickScreen onComplete={onComplete} />);
-      await screen.findByTestId("pre-pick-api-keys");
-
-      fireEvent.click(
-        screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY"),
-      );
-      const input = screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY");
-      // Include a null byte in the value to verify sanitization
-      fireEvent.change(input, { target: { value: "sk-\x00bad\x1Fkey" } });
-
-      const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-      fireEvent.click(submitBtn);
-
-      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-      expect(postMock).toHaveBeenCalledWith(
-        "/config",
-        expect.objectContaining({ anthropic_api_key: "sk-badkey" }),
-      );
-    });
+describe("API key row", () => {
+  it("renders API key rows for Anthropic, OpenAI, and Google", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-api-keys");
+    expect(
+      screen.getByTestId("pre-pick-api-row-ANTHROPIC_API_KEY"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pre-pick-api-row-OPENAI_API_KEY"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pre-pick-api-row-GOOGLE_API_KEY"),
+    ).toBeInTheDocument();
   });
 
-  describe("local provider picker", () => {
-    it("renders the local provider section", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-local-section");
-      expect(screen.getByTestId("pre-pick-local-picker")).toBeInTheDocument();
-    });
-
-    it("selecting a local provider and submitting form posts llm_provider", async () => {
-      mockPrereqs({});
-      // Make ollama tile available
-      getLocalProvidersStatusMock.mockResolvedValue([
-        {
-          kind: "ollama",
-          binary_installed: true,
-          endpoint: "http://localhost:11434",
-          model: "llama3",
-          reachable: true,
-          probed: true,
-          platform_supported: true,
-        },
-      ]);
-      const onComplete = vi.fn();
-      render(<PrePickScreen onComplete={onComplete} />);
-
-      // Wait for local picker to load
-      const tile = await screen.findByTestId("pre-pick-local-tile-ollama");
-      await waitFor(() => expect(tile).not.toBeDisabled());
-      fireEvent.click(tile);
-
-      const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-      fireEvent.click(submitBtn);
-
-      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-      expect(postMock).toHaveBeenCalledWith(
-        "/config",
-        expect.objectContaining({
-          llm_provider: "ollama",
-          llm_provider_priority: ["ollama"],
-        }),
-      );
-    });
-
-    it("deselecting a local provider hides the submit button when no other form input filled", async () => {
-      mockPrereqs({});
-      getLocalProvidersStatusMock.mockResolvedValue([
-        {
-          kind: "ollama",
-          binary_installed: true,
-          endpoint: "http://localhost:11434",
-          model: "llama3",
-          reachable: false,
-          probed: true,
-          platform_supported: true,
-        },
-      ]);
-      render(<PrePickScreen onComplete={vi.fn()} />);
-
-      const tile = await screen.findByTestId("pre-pick-local-tile-ollama");
-      await waitFor(() => expect(tile).not.toBeDisabled());
-
-      // Select then deselect
-      fireEvent.click(tile);
-      await screen.findByTestId("pre-pick-form-submit");
-      fireEvent.click(tile);
-
-      await waitFor(() =>
-        expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull(),
-      );
-    });
+  it("defaults to CLI login mode (no password input visible)", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-api-keys");
+    // In CLI mode the paste tab is present but the password input is not rendered
+    expect(
+      screen.queryByTestId("pre-pick-api-input-ANTHROPIC_API_KEY"),
+    ).toBeNull();
   });
 
-  describe("OpenAI-compatible endpoint", () => {
-    it("renders the OAI-compatible section", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-oai-section");
-      expect(screen.getByTestId("pre-pick-oai-compat")).toBeInTheDocument();
+  it("switches to paste mode and shows password input when API key tab clicked", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-api-keys");
+
+    const pasteTab = screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY");
+    fireEvent.click(pasteTab);
+
+    expect(
+      screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY"),
+    ).toBeInTheDocument();
+  });
+
+  it("posts anthropic_api_key to /config after paste and submit", async () => {
+    mockPrereqs({});
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+    await screen.findByTestId("pre-pick-api-keys");
+
+    // Switch to paste mode
+    fireEvent.click(screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY"));
+    const input = screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY");
+    fireEvent.change(input, { target: { value: "sk-ant-test123" } });
+
+    // Submit button should now appear
+    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(postMock).toHaveBeenCalledWith(
+      "/config",
+      expect.objectContaining({ anthropic_api_key: "sk-ant-test123" }),
+    );
+  });
+
+  it("strips control characters from a pasted API key before posting", async () => {
+    mockPrereqs({});
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+    await screen.findByTestId("pre-pick-api-keys");
+
+    fireEvent.click(screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY"));
+    const input = screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY");
+    // Include a null byte in the value to verify sanitization
+    fireEvent.change(input, { target: { value: "sk-\x00bad\x1Fkey" } });
+
+    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(postMock).toHaveBeenCalledWith(
+      "/config",
+      expect.objectContaining({ anthropic_api_key: "sk-badkey" }),
+    );
+  });
+});
+
+describe("local provider picker", () => {
+  it("renders the local provider section", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-local-section");
+    expect(screen.getByTestId("pre-pick-local-picker")).toBeInTheDocument();
+  });
+
+  it("selecting local providers and submitting form posts provider priority", async () => {
+    mockPrereqs({});
+    getLocalProvidersStatusMock.mockResolvedValue([
+      {
+        kind: "ollama",
+        binary_installed: true,
+        endpoint: "http://localhost:11434",
+        model: "llama3",
+        reachable: true,
+        probed: true,
+        platform_supported: true,
+      },
+      {
+        kind: "exo",
+        binary_installed: true,
+        endpoint: "http://localhost:52415",
+        model: "llama3",
+        reachable: true,
+        probed: true,
+        platform_supported: true,
+      },
+    ]);
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+
+    const ollamaTile = await screen.findByTestId("pre-pick-local-tile-ollama");
+    const exoTile = await screen.findByTestId("pre-pick-local-tile-exo");
+    await waitFor(() => expect(ollamaTile).not.toBeDisabled());
+    fireEvent.click(ollamaTile);
+    fireEvent.click(exoTile);
+
+    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(postMock).toHaveBeenCalledWith(
+      "/config",
+      expect.objectContaining({
+        llm_provider: "ollama",
+        llm_provider_priority: ["ollama", "exo"],
+      }),
+    );
+  });
+
+  it("deselecting a local provider hides the submit button when no other form input filled", async () => {
+    mockPrereqs({});
+    getLocalProvidersStatusMock.mockResolvedValue([
+      {
+        kind: "ollama",
+        binary_installed: true,
+        endpoint: "http://localhost:11434",
+        model: "llama3",
+        reachable: false,
+        probed: true,
+        platform_supported: true,
+      },
+    ]);
+    render(<PrePickScreen onComplete={vi.fn()} />);
+
+    const tile = await screen.findByTestId("pre-pick-local-tile-ollama");
+    await waitFor(() => expect(tile).not.toBeDisabled());
+
+    // Select then deselect
+    fireEvent.click(tile);
+    await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(tile);
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull(),
+    );
+  });
+});
+
+describe("OpenAI-compatible endpoint", () => {
+  it("renders the OAI-compatible section", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-oai-section");
+    expect(screen.getByTestId("pre-pick-oai-compat")).toBeInTheDocument();
+  });
+
+  it("does not show submit button when only an invalid URL is entered", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-oai-url");
+
+    fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
+      target: { value: "not-a-url" },
     });
 
-    it("does not show submit button when only an invalid URL is entered", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-oai-url");
+    // URL error message should appear
+    expect(
+      await screen.findByTestId("pre-pick-oai-url-error"),
+    ).toBeInTheDocument();
+    // Submit button must NOT appear
+    expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull();
+  });
 
-      fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
-        target: { value: "not-a-url" },
-      });
+  it("shows submit button and posts provider_endpoints when a valid URL is entered", async () => {
+    mockPrereqs({});
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+    await screen.findByTestId("pre-pick-oai-url");
 
-      // URL error message should appear
-      expect(
-        await screen.findByTestId("pre-pick-oai-url-error"),
-      ).toBeInTheDocument();
-      // Submit button must NOT appear
-      expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull();
+    fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
+      target: { value: "https://my-server.example.com/v1" },
     });
 
-    it("shows submit button and posts provider_endpoints when a valid URL is entered", async () => {
-      mockPrereqs({});
-      const onComplete = vi.fn();
-      render(<PrePickScreen onComplete={onComplete} />);
-      await screen.findByTestId("pre-pick-oai-url");
+    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(submitBtn);
 
-      fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
-        target: { value: "https://my-server.example.com/v1" },
-      });
-
-      const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-      fireEvent.click(submitBtn);
-
-      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-      expect(postMock).toHaveBeenCalledWith(
-        "/config",
-        expect.objectContaining({
-          provider_endpoints: expect.objectContaining({
-            "openai-compatible": expect.objectContaining({
-              base_url: "https://my-server.example.com/v1",
-            }),
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(postMock).toHaveBeenCalledWith(
+      "/config",
+      expect.objectContaining({
+        provider_endpoints: expect.objectContaining({
+          "openai-compatible": expect.objectContaining({
+            base_url: "https://my-server.example.com/v1",
           }),
         }),
-      );
-    });
-
-    it("does not conflate the OAI-compat endpoint with OpenClaw config", async () => {
-      // Locks in the redesign: filling the Custom endpoint section must
-      // write only to provider_endpoints, never to openclaw_token /
-      // openclaw_gateway_url. OpenClaw is a gateway managed through the
-      // Integrations app; persisting an unrelated OAI-compat URL as the
-      // OpenClaw gateway was the exact "OpenClaw treated as a provider"
-      // bug this redesign closes.
-      mockPrereqs({});
-      const onComplete = vi.fn();
-      render(<PrePickScreen onComplete={onComplete} />);
-      await screen.findByTestId("pre-pick-oai-url");
-
-      fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
-        target: { value: "https://example.com/v1" },
-      });
-      fireEvent.change(screen.getByTestId("pre-pick-oai-key"), {
-        target: { value: "tok-secret" },
-      });
-
-      const submitBtn = await screen.findByTestId("pre-pick-form-submit");
-      fireEvent.click(submitBtn);
-
-      await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
-      const calledPayload = postMock.mock.calls[0]?.[1] as Record<
-        string,
-        unknown
-      >;
-      expect(calledPayload.openclaw_token).toBeUndefined();
-      expect(calledPayload.openclaw_gateway_url).toBeUndefined();
-      expect(calledPayload.provider_endpoints).toMatchObject({
-        "openai-compatible": { base_url: "https://example.com/v1" },
-      });
-    });
+      }),
+    );
   });
 
-  describe("canContinue predicate", () => {
-    it("does not show form submit button when no form section is filled", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-api-keys");
-      expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull();
+  it("does not conflate the OAI-compat endpoint with OpenClaw config", async () => {
+    // Filling the Custom endpoint section writes only to provider_endpoints.
+    // OpenClaw is a gateway managed through Integrations, not a runtime.
+    mockPrereqs({});
+    const onComplete = vi.fn();
+    render(<PrePickScreen onComplete={onComplete} />);
+    await screen.findByTestId("pre-pick-oai-url");
+
+    fireEvent.change(screen.getByTestId("pre-pick-oai-url"), {
+      target: { value: "https://example.com/v1" },
+    });
+    fireEvent.change(screen.getByTestId("pre-pick-oai-key"), {
+      target: { value: "tok-secret" },
     });
 
-    it("shows form submit button as soon as one API key is entered", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-api-keys");
+    const submitBtn = await screen.findByTestId("pre-pick-form-submit");
+    fireEvent.click(submitBtn);
 
-      fireEvent.click(screen.getByTestId("pre-pick-api-paste-OPENAI_API_KEY"));
-      fireEvent.change(
-        screen.getByTestId("pre-pick-api-input-OPENAI_API_KEY"),
-        { target: { value: "sk-openai-xyz" } },
-      );
-
-      expect(
-        await screen.findByTestId("pre-pick-form-submit"),
-      ).toBeInTheDocument();
-    });
-
-    it("skip button always remains visible as sandbox path regardless of form state", async () => {
-      mockPrereqs({});
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      await screen.findByTestId("pre-pick-skip");
-
-      // Fill an API key
-      fireEvent.click(
-        screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY"),
-      );
-      fireEvent.change(
-        screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY"),
-        { target: { value: "sk-ant-hello" } },
-      );
-
-      // Skip button must still be present
-      expect(screen.getByTestId("pre-pick-skip")).toBeInTheDocument();
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    const calledPayload = postMock.mock.calls[0]?.[1] as Record<
+      string,
+      unknown
+    >;
+    expect(calledPayload.openclaw_token).toBeUndefined();
+    expect(calledPayload.openclaw_gateway_url).toBeUndefined();
+    expect(calledPayload.provider_endpoints).toMatchObject({
+      "openai-compatible": { base_url: "https://example.com/v1" },
     });
   });
+});
 
-  describe("CodeRabbit click-handler guard (PR #889)", () => {
-    it("cards are disabled until prereqs have loaded", () => {
-      // Prereqs never resolves in this test -- cards stay disabled.
-      getMock.mockReturnValue(new Promise(() => {}));
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      // Cards should be in the DOM but disabled (prereqsLoaded=false)
-      const claudeCard = screen.getByTestId("pre-pick-card-claude-code");
-      expect(claudeCard).toBeDisabled();
+describe("canContinue predicate", () => {
+  it("does not show form submit button when no form section is filled", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-api-keys");
+    expect(screen.queryByTestId("pre-pick-form-submit")).toBeNull();
+  });
+
+  it("shows form submit button as soon as one API key is entered", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-api-keys");
+
+    fireEvent.click(screen.getByTestId("pre-pick-api-paste-OPENAI_API_KEY"));
+    fireEvent.change(screen.getByTestId("pre-pick-api-input-OPENAI_API_KEY"), {
+      target: { value: "sk-openai-xyz" },
     });
 
-    it("cards become enabled after prereqs load", async () => {
-      mockPrereqs({ claude: true });
-      render(<PrePickScreen onComplete={vi.fn()} />);
-      const card = await screen.findByTestId("pre-pick-card-claude-code");
-      await waitFor(() => expect(card).not.toBeDisabled());
-    });
+    expect(
+      await screen.findByTestId("pre-pick-form-submit"),
+    ).toBeInTheDocument();
+  });
+
+  it("skip button always remains visible as sandbox path regardless of form state", async () => {
+    mockPrereqs({});
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    await screen.findByTestId("pre-pick-skip");
+
+    // Fill an API key
+    fireEvent.click(screen.getByTestId("pre-pick-api-paste-ANTHROPIC_API_KEY"));
+    fireEvent.change(
+      screen.getByTestId("pre-pick-api-input-ANTHROPIC_API_KEY"),
+      { target: { value: "sk-ant-hello" } },
+    );
+
+    // Skip button must still be present
+    expect(screen.getByTestId("pre-pick-skip")).toBeInTheDocument();
+  });
+});
+
+describe("CodeRabbit click-handler guard (PR #889)", () => {
+  it("cards are disabled until prereqs have loaded", () => {
+    // Prereqs never resolves in this test -- cards stay disabled.
+    getMock.mockReturnValue(new Promise(() => {}));
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    // Cards should be in the DOM but disabled (prereqsLoaded=false)
+    const claudeCard = screen.getByTestId("pre-pick-card-claude-code");
+    expect(claudeCard).toBeDisabled();
+  });
+
+  it("cards become enabled after prereqs load", async () => {
+    mockPrereqs({ claude: true });
+    render(<PrePickScreen onComplete={vi.fn()} />);
+    const card = await screen.findByTestId("pre-pick-card-claude-code");
+    await waitFor(() => expect(card).not.toBeDisabled());
   });
 
   // ── Guided setup + verify loop (spec section B) ────────────────────────

--- a/web/src/components/onboarding/PrePickScreen.tsx
+++ b/web/src/components/onboarding/PrePickScreen.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import type { LLMRuntimeKind } from "../../api/client";
 import { get, post } from "../../api/client";
+import { runtimeProviderLabel } from "../../lib/runtimeProviders";
 import { showNotice } from "../ui/Toast";
 import { LocalProviderPicker } from "./LocalProviderPicker";
 import { isValidUrl, OpenAICompatibleInput } from "./OpenAICompatibleInput";
@@ -56,7 +58,8 @@ interface RuntimeCardProps {
   isSubmitting: boolean;
   anySubmitting: boolean;
   expanded: boolean;
-  onPick: (spec: RuntimeSpec) => void;
+  selected: boolean;
+  onToggle: (spec: RuntimeSpec) => void;
   onInstall: (url: string) => void;
   onCopySignIn: (command: string) => void;
   onToggleGuide: (binary: string) => void;
@@ -94,7 +97,8 @@ function RuntimeCard({
   isSubmitting,
   anySubmitting,
   expanded,
-  onPick,
+  selected,
+  onToggle,
   onInstall,
   onCopySignIn,
   onToggleGuide,
@@ -133,8 +137,9 @@ function RuntimeCard({
     >
       <button
         type="button"
-        className={`pre-pick-card${available ? " available" : " missing"}${isUnauthed ? " unauthed" : ""}`}
+        className={`pre-pick-card${available ? " available" : " missing"}${isUnauthed ? " unauthed" : ""}${selected ? " selected" : ""}`}
         data-testid={`pre-pick-card-${spec.provider}`}
+        aria-pressed={selected}
         data-signed-in={signedIn === undefined ? "unknown" : String(signedIn)}
         // CodeRabbit fix (PR #889): guard against clicks during prereq detection
         // and any in-flight submission. Both disable conditions must hold.
@@ -160,7 +165,7 @@ function RuntimeCard({
             }
             return;
           }
-          onPick(spec);
+          onToggle(spec);
         }}
       >
         <div className="pre-pick-card-head">
@@ -227,13 +232,13 @@ function isCliProvider(provider: RuntimeSpec["provider"] | string): boolean {
 /** Returns true when any of the form sections has meaningful content. */
 function hasConfigContent(
   isCliRuntime: boolean,
-  localProvider: string,
+  localProviders: readonly LLMRuntimeKind[],
   oaiUrl: string,
   apiKeys: Record<string, string>,
 ): boolean {
   return (
     isCliRuntime ||
-    localProvider.trim().length > 0 ||
+    localProviders.length > 0 ||
     oaiCompatFilled(oaiUrl) ||
     anyApiKeyFilled(apiKeys)
   );
@@ -242,7 +247,7 @@ function hasConfigContent(
 type ConfigPayload = {
   memory_backend: "markdown";
   llm_provider?: string;
-  llm_provider_priority?: string[];
+  llm_provider_priority?: LLMRuntimeKind[];
   anthropic_api_key?: string;
   openai_api_key?: string;
   gemini_api_key?: string;
@@ -255,9 +260,8 @@ type ConfigPayload = {
  * All user-supplied strings are sanitized via sanitizeConfigString.
  */
 function buildConfigPayload(
-  isCliRuntime: boolean,
-  provider: string,
-  localProvider: string,
+  selectedProviders: LLMRuntimeKind[],
+  localProviders: LLMRuntimeKind[],
   oaiUrl: string,
   // _oaiKey is intentionally unused on the current write path: the OAI-
   // compatible endpoint section writes only to provider_endpoints, never
@@ -269,13 +273,17 @@ function buildConfigPayload(
   apiKeys: Record<string, string>,
 ): ConfigPayload {
   const payload: ConfigPayload = { memory_backend: "markdown" };
+  const providerPriority = Array.from(
+    new Set(
+      [...selectedProviders, ...localProviders].filter(
+        Boolean,
+      ) as LLMRuntimeKind[],
+    ),
+  );
 
-  if (isCliRuntime) {
-    payload.llm_provider = provider;
-    payload.llm_provider_priority = [provider];
-  } else if (localProvider.trim().length > 0) {
-    payload.llm_provider = localProvider;
-    payload.llm_provider_priority = [localProvider];
+  if (providerPriority.length > 0) {
+    payload.llm_provider = providerPriority[0];
+    payload.llm_provider_priority = providerPriority;
   } else if (oaiCompatFilled(oaiUrl)) {
     // Custom OAI-compatible endpoint goes into provider_endpoints. We do
     // NOT write to openclaw_* here — that conflated OpenClaw (a gateway
@@ -335,13 +343,15 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   const [prereqsLoaded, setPrereqsLoaded] = useState(false);
   const [submitting, setSubmitting] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string>("");
+  const [selectedProviders, setSelectedProviders] = useState<LLMRuntimeKind[]>(
+    [],
+  );
 
   // API key state (one entry per API_KEY_FIELDS entry)
   const [apiKeys, setApiKeys] =
     useState<Record<string, string>>(EMPTY_API_KEYS);
 
-  // Local provider single-select
-  const [localProvider, setLocalProvider] = useState<string>("");
+  const [localProviders, setLocalProviders] = useState<LLMRuntimeKind[]>([]);
 
   // OpenAI-compatible custom endpoint
   const [oaiUrl, setOaiUrl] = useState<string>("");
@@ -396,15 +406,15 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
     [prereqs],
   );
 
-  // canContinue is true when any of the five paths is ready:
-  // (a) a CLI runtime card was clicked (handled by commitChoice immediately)
+  // canContinue is true when any setup path is ready:
+  // (a) at least one detected CLI runtime card is selected
   // (b) at least one API key is entered
   // (c) a local provider is selected
-  // (d) OAI-compatible URL+key filled and URL valid
-  // (e) "I'll add one later" skip (also handled directly)
+  // (d) OAI-compatible URL is valid
   const canContinueFromForm =
+    selectedProviders.length > 0 ||
     anyApiKeyFilled(apiKeys) ||
-    localProvider.trim().length > 0 ||
+    localProviders.length > 0 ||
     oaiCompatFilled(oaiUrl);
 
   function handleApiKeyChange(key: string, value: string): void {
@@ -471,18 +481,23 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
       // typed into the form sections — the contract is "sandbox until you
       // configure later". Trigger: provider === null only.
       const isSkipChoice = provider === null;
-      const providerStr = isCli ? (provider as string) : "";
+      const selected =
+        isCli && typeof provider === "string"
+          ? Array.from(
+              new Set([...selectedProviders, provider as LLMRuntimeKind]),
+            )
+          : selectedProviders;
       const configPayload = buildConfigPayload(
-        isCli,
-        providerStr,
-        localProvider,
+        selected,
+        localProviders,
         oaiUrl,
         oaiKey,
         apiKeys,
       );
       if (
         !isSkipChoice &&
-        hasConfigContent(isCli, localProvider, oaiUrl, apiKeys)
+        (selected.length > 0 ||
+          hasConfigContent(isCli, localProviders, oaiUrl, apiKeys))
       ) {
         await post("/config", configPayload);
       }
@@ -533,6 +548,25 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
   }
 
   const anySubmitting = Boolean(submitting);
+  function toggleProvider(provider: LLMRuntimeKind): void {
+    setSelectedProviders((prev) =>
+      prev.includes(provider)
+        ? prev.filter((id) => id !== provider)
+        : [...prev, provider],
+    );
+  }
+
+  function toggleLocalProvider(provider: string): void {
+    setLocalProviders((prev) =>
+      prev.includes(provider as LLMRuntimeKind)
+        ? prev.filter((id) => id !== provider)
+        : [...prev, provider as LLMRuntimeKind],
+    );
+  }
+
+  const selectedProviderLabels = [...selectedProviders, ...localProviders].map(
+    runtimeProviderLabel,
+  );
 
   return (
     <div className="pre-pick-screen" data-testid="pre-pick-screen">
@@ -559,7 +593,13 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
               isSubmitting={submitting === state.spec.label}
               anySubmitting={anySubmitting}
               expanded={expandedGuide === state.spec.binary}
-              onPick={(spec) => void commitChoice(spec.provider, spec.label)}
+              selected={
+                state.spec.provider !== null &&
+                selectedProviders.includes(state.spec.provider)
+              }
+              onToggle={(spec) => {
+                if (spec.provider) toggleProvider(spec.provider);
+              }}
               onInstall={openInstallPage}
               onCopySignIn={handleCopySignIn}
               onToggleGuide={handleToggleGuide}
@@ -641,8 +681,8 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
             Run inference on this machine. No cloud key required.
           </p>
           <LocalProviderPicker
-            selected={localProvider}
-            onSelect={(kind) => setLocalProvider(kind)}
+            selected={localProviders}
+            onToggle={toggleLocalProvider}
           />
         </section>
 
@@ -680,6 +720,11 @@ export function PrePickScreen({ onComplete }: PrePickScreenProps) {
             >
               {submitting === "form" ? "Opening your office…" : "Continue  →"}
             </button>
+            {selectedProviderLabels.length > 0 ? (
+              <div className="pre-pick-selected-summary">
+                Selected: {selectedProviderLabels.join(", ")}
+              </div>
+            ) : null}
           </div>
         ) : null}
 

--- a/web/src/components/ui/ProviderSwitcher.tsx
+++ b/web/src/components/ui/ProviderSwitcher.tsx
@@ -2,7 +2,18 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { getConfig, type LLMProvider, updateConfig } from "../../api/client";
+import {
+  get,
+  getConfig,
+  getLocalProvidersStatus,
+  type LLMProvider,
+  updateConfig,
+} from "../../api/client";
+import {
+  configuredConnectedRuntimeProviders,
+  type RuntimeProviderOption,
+} from "../../lib/runtimeProviders";
+import type { PrereqResult } from "../onboarding/runtimes";
 import { confirm } from "./ConfirmDialog";
 import { showNotice } from "./Toast";
 
@@ -17,39 +28,10 @@ export function openProviderSwitcher() {
   requestOpen();
 }
 
-interface ProviderOption {
-  id: LLMProvider;
-  name: string;
-  desc: string;
-}
-
-const PROVIDERS: ProviderOption[] = [
-  {
-    id: "claude-code",
-    name: "Claude Code",
-    desc: "Anthropic Claude via Claude Code CLI",
-  },
-  { id: "codex", name: "Codex", desc: "OpenAI Codex CLI agent" },
-  {
-    id: "opencode",
-    name: "Opencode",
-    desc: "Opencode CLI — routes to Claude, OpenAI, or local/Ollama",
-  },
-  {
-    id: "hermes-agent",
-    name: "Hermes Agent",
-    desc: "Local Hermes gateway via OpenAI-compatible API",
-  },
-  {
-    id: "openclaw-http",
-    name: "OpenClaw Gateway",
-    desc: "Local OpenClaw Gateway via OpenAI-compatible API",
-  },
-];
-
 export function ProviderSwitcherHost() {
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState<LLMProvider | null>(null);
+  const [providers, setProviders] = useState<RuntimeProviderOption[]>([]);
   const [loading, setLoading] = useState(false);
   const [pending, setPending] = useState<LLMProvider | null>(null);
   const queryClient = useQueryClient();
@@ -58,9 +40,32 @@ export function ProviderSwitcherHost() {
     requestOpen = () => {
       setOpen(true);
       setLoading(true);
-      getConfig()
-        .then((cfg) => setCurrent(cfg.llm_provider ?? "claude-code"))
-        .catch(() => setCurrent("claude-code"))
+      Promise.all([
+        getConfig(),
+        get<{ prereqs?: PrereqResult[] } | PrereqResult[]>(
+          "/onboarding/prereqs",
+        ),
+        getLocalProvidersStatus(),
+      ])
+        .then(([cfg, prereqsPayload, localStatuses]) => {
+          const prereqs = Array.isArray(prereqsPayload)
+            ? prereqsPayload
+            : (prereqsPayload.prereqs ?? []);
+          const available = configuredConnectedRuntimeProviders(cfg, {
+            prereqs,
+            localStatuses,
+          });
+          setProviders(available);
+          setCurrent(
+            available.find((option) => option.id === cfg.llm_provider)?.id ??
+              available[0]?.id ??
+              null,
+          );
+        })
+        .catch(() => {
+          setProviders([]);
+          setCurrent(null);
+        })
         .finally(() => setLoading(false));
     };
     return () => {
@@ -79,20 +84,28 @@ export function ProviderSwitcherHost() {
 
   if (!open) return null;
 
-  async function switchTo(p: ProviderOption) {
+  async function switchTo(p: RuntimeProviderOption) {
     if (!current || p.id === current) return;
     confirm({
       title: "Switch runtime provider?",
-      message: `Agents will be restarted on ${p.name}.`,
+      message: `Agents will be restarted on ${p.label}.`,
       confirmLabel: "Switch",
       onConfirm: async () => {
         setPending(p.id);
         try {
-          await updateConfig({ llm_provider: p.id });
+          await updateConfig({
+            llm_provider: p.id,
+            llm_provider_priority: [
+              p.id,
+              ...providers
+                .filter((option) => option.id !== p.id)
+                .map((option) => option.id),
+            ],
+          });
           await queryClient.invalidateQueries({ queryKey: ["config"] });
           await queryClient.invalidateQueries({ queryKey: ["health"] });
           setCurrent(p.id);
-          showNotice(`Provider switched to ${p.name}`, "success");
+          showNotice(`Provider switched to ${p.label}`, "success");
           setOpen(false);
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : "Switch failed";
@@ -120,9 +133,13 @@ export function ProviderSwitcherHost() {
         </h3>
         {loading ? (
           <p className="provider-loading">Loading current provider...</p>
+        ) : providers.length === 0 ? (
+          <p className="provider-loading">
+            No configured provider is connected. Check Settings.
+          </p>
         ) : (
           <div className="provider-options">
-            {PROVIDERS.map((p) => {
+            {providers.map((p) => {
               const isActive = current === p.id;
               const isPending = pending === p.id;
               return (
@@ -134,7 +151,7 @@ export function ProviderSwitcherHost() {
                   disabled={isActive || isPending}
                 >
                   <div className="provider-option-text">
-                    <div className="provider-option-name">{p.name}</div>
+                    <div className="provider-option-name">{p.label}</div>
                     <div className="provider-option-desc">{p.desc}</div>
                   </div>
                   {isActive && (

--- a/web/src/lib/runtimeProviders.ts
+++ b/web/src/lib/runtimeProviders.ts
@@ -1,0 +1,151 @@
+import type {
+  ConfigSnapshot,
+  LLMRuntimeKind,
+  LocalProviderStatus,
+} from "../api/client";
+import type { PrereqResult } from "../components/onboarding/runtimes";
+
+export interface RuntimeProviderOption {
+  id: LLMRuntimeKind;
+  label: string;
+  desc: string;
+  kind: "cli" | "local";
+  binary?: string;
+}
+
+export const RUNTIME_PROVIDER_OPTIONS: readonly RuntimeProviderOption[] = [
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    desc: "Anthropic Claude via Claude Code CLI",
+    kind: "cli",
+    binary: "claude",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    desc: "OpenAI Codex CLI agent",
+    kind: "cli",
+    binary: "codex",
+  },
+  {
+    id: "opencode",
+    label: "Opencode",
+    desc: "Opencode CLI with your configured model backend",
+    kind: "cli",
+    binary: "opencode",
+  },
+  {
+    id: "mlx-lm",
+    label: "MLX-LM",
+    desc: "Apple Silicon local OpenAI-compatible runtime",
+    kind: "local",
+  },
+  {
+    id: "ollama",
+    label: "Ollama",
+    desc: "Local model runner via OpenAI-compatible API",
+    kind: "local",
+  },
+  {
+    id: "exo",
+    label: "Exo",
+    desc: "Distributed local inference pool",
+    kind: "local",
+  },
+] as const;
+
+const OPTION_BY_ID = new Map(RUNTIME_PROVIDER_OPTIONS.map((p) => [p.id, p]));
+
+export function runtimeProviderLabel(id: string): string {
+  return OPTION_BY_ID.get(id as LLMRuntimeKind)?.label ?? id;
+}
+
+export function normalizeProviderList(
+  values: readonly string[] | undefined,
+): LLMRuntimeKind[] {
+  const seen = new Set<string>();
+  const out: LLMRuntimeKind[] = [];
+  for (const raw of values ?? []) {
+    const id = raw.trim().toLowerCase() as LLMRuntimeKind;
+    if (!OPTION_BY_ID.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+export function configuredRuntimeProviders(
+  cfg: ConfigSnapshot,
+): LLMRuntimeKind[] {
+  const priority = normalizeProviderList(cfg.llm_provider_priority);
+  if (priority.length > 0) return priority;
+  return cfg.llm_provider ? normalizeProviderList([cfg.llm_provider]) : [];
+}
+
+export function statusByLocalProvider(
+  statuses: readonly LocalProviderStatus[] | undefined,
+): Map<string, LocalProviderStatus> {
+  const byKind = new Map<string, LocalProviderStatus>();
+  for (const s of statuses ?? []) byKind.set(s.kind, s);
+  return byKind;
+}
+
+export function prereqByBinary(
+  prereqs: readonly PrereqResult[] | undefined,
+): Map<string, PrereqResult> {
+  const byBinary = new Map<string, PrereqResult>();
+  for (const p of prereqs ?? []) byBinary.set(p.name, p);
+  return byBinary;
+}
+
+export function runtimeProviderIsConnected(
+  option: RuntimeProviderOption,
+  deps: {
+    prereqs?: Map<string, PrereqResult>;
+    localStatuses?: Map<string, LocalProviderStatus>;
+  },
+): boolean {
+  if (option.kind === "cli") {
+    if (!option.binary) return false;
+    const prereq = deps.prereqs?.get(option.binary);
+    if (!prereq?.found) return false;
+    if (prereq.session_probed === true) return prereq.signed_in === true;
+    return true;
+  }
+  const status = deps.localStatuses?.get(option.id);
+  return Boolean(
+    status?.platform_supported && status.binary_installed && status.reachable,
+  );
+}
+
+export function connectedRuntimeProviders(deps: {
+  prereqs?: readonly PrereqResult[];
+  localStatuses?: readonly LocalProviderStatus[];
+}): RuntimeProviderOption[] {
+  const prereqs = prereqByBinary(deps.prereqs);
+  const localStatuses = statusByLocalProvider(deps.localStatuses);
+  return RUNTIME_PROVIDER_OPTIONS.filter((option) =>
+    runtimeProviderIsConnected(option, { prereqs, localStatuses }),
+  );
+}
+
+export function configuredConnectedRuntimeProviders(
+  cfg: ConfigSnapshot,
+  deps: {
+    prereqs?: readonly PrereqResult[];
+    localStatuses?: readonly LocalProviderStatus[];
+  },
+): RuntimeProviderOption[] {
+  const configured = configuredRuntimeProviders(cfg);
+  if (configured.length === 0) return [];
+  const connectedById = new Set(
+    connectedRuntimeProviders(deps).map((option) => option.id),
+  );
+  return configured
+    .map((id) => OPTION_BY_ID.get(id))
+    .filter(
+      (option): option is RuntimeProviderOption =>
+        option !== undefined && connectedById.has(option.id),
+    );
+}

--- a/web/src/styles/lifecycle.css
+++ b/web/src/styles/lifecycle.css
@@ -3271,7 +3271,9 @@ html[data-theme="noir-gold"] {
   font-size: var(--text-sm);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
 }
 .issue-doc-sub-issues-add:hover {
   border-color: var(--accent);
@@ -3312,7 +3314,10 @@ html[data-theme="noir-gold"] {
   transition: background 120ms ease;
 }
 .issue-doc-sub-issue-link:hover {
-  background: var(--bg-row-active, color-mix(in srgb, var(--accent) 6%, transparent));
+  background: var(
+    --bg-row-active,
+    color-mix(in srgb, var(--accent) 6%, transparent)
+  );
 }
 .issue-doc-sub-issue-id {
   font-family: var(--font-mono);
@@ -3431,7 +3436,9 @@ html[data-theme="noir-gold"] {
   background: var(--bg-card);
   color: var(--text-secondary);
   cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
 }
 .issue-doc-owner-pill:hover {
   border-color: var(--accent);
@@ -3505,7 +3512,9 @@ html[data-theme="noir-gold"] {
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-pill, 999px);
   cursor: pointer;
-  transition: border-color 120ms ease, color 120ms ease;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
 }
 .issue-doc-parent-breadcrumb:hover {
   border-color: var(--accent);
@@ -3553,7 +3562,10 @@ html[data-theme="noir-gold"] {
   font-weight: 500;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
   border: 1px solid var(--border-subtle);
   background: var(--bg-card);
   color: var(--text);
@@ -3575,7 +3587,11 @@ html[data-theme="noir-gold"] {
   filter: brightness(1.05);
 }
 .issue-action-button--danger {
-  border-color: color-mix(in srgb, var(--text-danger, #b42318) 60%, var(--border-subtle));
+  border-color: color-mix(
+    in srgb,
+    var(--text-danger, #b42318) 60%,
+    var(--border-subtle)
+  );
   color: var(--text-danger, #b42318);
 }
 .issue-action-button--danger:hover:not(:disabled) {
@@ -3771,8 +3787,16 @@ html[data-theme="noir-gold"] {
 /* [SUGGESTION] comments stand out so CEO can scan them. Amber border +
  * subtle tint, "Suggestion" badge next to the author. */
 .issue-comment--suggestion {
-  border-color: color-mix(in srgb, var(--amber-600, #d97706) 60%, var(--border-subtle));
-  background: color-mix(in srgb, var(--amber-600, #d97706) 5%, var(--bg-primary));
+  border-color: color-mix(
+    in srgb,
+    var(--amber-600, #d97706) 60%,
+    var(--border-subtle)
+  );
+  background: color-mix(
+    in srgb,
+    var(--amber-600, #d97706) 5%,
+    var(--bg-primary)
+  );
 }
 .issue-comment-suggestion-badge {
   display: inline-flex;
@@ -4326,6 +4350,7 @@ html[data-theme="noir-gold"] {
 }
 
 .issue-new-form-field input,
+.issue-new-form-field select,
 .issue-new-form-field textarea {
   font: inherit;
   font-size: var(--text-md);
@@ -4343,6 +4368,7 @@ html[data-theme="noir-gold"] {
 }
 
 .issue-new-form-field input:focus,
+.issue-new-form-field select:focus,
 .issue-new-form-field textarea:focus {
   outline: none;
   border-color: var(--accent, #5b8def);
@@ -4834,7 +4860,11 @@ html[data-theme="noir-gold"] {
 }
 
 .issue-activity-stream[data-state="running"] {
-  border-color: color-mix(in srgb, var(--green-500, #16a34a) 30%, var(--border));
+  border-color: color-mix(
+    in srgb,
+    var(--green-500, #16a34a) 30%,
+    var(--border)
+  );
 }
 
 .issue-activity-stream[data-state="blocked"] {
@@ -4842,7 +4872,11 @@ html[data-theme="noir-gold"] {
 }
 
 .issue-activity-stream[data-state="needs-input"] {
-  border-color: color-mix(in srgb, var(--orange-500, #f97316) 30%, var(--border));
+  border-color: color-mix(
+    in srgb,
+    var(--orange-500, #f97316) 30%,
+    var(--border)
+  );
 }
 
 .issue-activity-stream .issue-activity-dot {
@@ -4927,7 +4961,9 @@ html[data-theme="noir-gold"] {
   font-weight: 500;
   color: var(--text-secondary);
   cursor: pointer;
-  transition: color 120ms ease, border-color 120ms ease;
+  transition:
+    color 120ms ease,
+    border-color 120ms ease;
 }
 
 .issue-doc-tab:hover {
@@ -5363,7 +5399,9 @@ html[data-theme="noir-gold"] {
   text-orientation: mixed;
   white-space: nowrap;
 }
-.issues-kanban-column.is-collapsed .issues-kanban-column-toggle .issues-kanban-column-count {
+.issues-kanban-column.is-collapsed
+  .issues-kanban-column-toggle
+  .issues-kanban-column-count {
   margin-left: 0;
 }
 

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -2174,6 +2174,11 @@
   color: var(--warning-500);
 }
 
+.pre-pick-card.selected {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
 .pre-pick-card-install {
   font-size: 12px;
   color: var(--accent);
@@ -2192,7 +2197,15 @@
 
 .pre-pick-secondary-row {
   display: flex;
+  flex-direction: column;
+  align-items: center;
   justify-content: center;
+}
+
+.pre-pick-selected-summary {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-secondary);
 }
 
 .pre-pick-secondary-button {


### PR DESCRIPTION
## Summary

- filter runtime provider surfaces to configured providers that pass connection checks
- allow multi-provider selection during onboarding and Settings updates
- pass selected providers through task creation and validate/persist task provider on the broker
- add Anthropic `claude-fable-5` to the built-in model pricing table

## Validation

- `git diff --check`
- `bash scripts/test-go.sh ./internal/team`
- `bunx tsc --noEmit`
- `bash scripts/test-web.sh`
- `bash scripts/test-web.sh web/src/components/onboarding/PrePickScreen.test.tsx web/src/components/apps/OfficeOverviewApp.test.tsx web/src/api/tasks.test.ts`
- `bun run --cwd packages/llm-router typecheck`
- `bun run --cwd packages/llm-router test tests/providers/anthropic.spec.ts`

## Browser Matrix

Headed Chromium permutations exercised against the real app UI with deterministic provider API responses:

- onboarding CLI multi-select: `claude-code + codex`
- onboarding local multi-select: `ollama + exo`
- onboarding mixed priority: `claude-code + opencode + ollama`
- overview renders only configured and connected providers
- Settings disables disconnected configured providers and saves only connected selections
- task creation offers only connected configured providers and posts the selected provider
- task creation disables provider selection when no configured provider is connected




## Screenshots

![01-onboarding-multi-provider-selection](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1067/01-onboarding-multi-provider-selection.png)

![02-overview-connected-providers](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1067/02-overview-connected-providers.png)

![03-settings-provider-row](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1067/03-settings-provider-row.png)

![04-task-create-provider-select](https://github.com/nex-crm/wuphf/raw/screenshots/pr-1067/04-task-create-provider-select.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select & prioritized LLM provider selection across onboarding, settings, and task creation
  * “Connected Providers” overview with per-provider readiness and navigation to provider settings/doctor
  * Dynamic provider discovery, runtime-aware provider checklist, and added Claude Fable 5 pricing/model

* **Bug Fixes**
  * Server-side provider validation now rejects unconfigured providers and returns appropriate error codes

* **Tests**
  * Expanded integration, unit, and E2E tests plus a screenshot script covering provider selection and validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->